### PR TITLE
teach F# 4.0 compiler about future 4.1+ native intrinsics

### DIFF
--- a/src/fsharp/ilxgen.fs
+++ b/src/fsharp/ilxgen.fs
@@ -3137,6 +3137,8 @@ and GenAsmCode cenv cgbuf eenv (il,tyargs,args,returnTys,m) sequel =
             | I_stobj (a,b,ILType.TypeVar _)           ,[tyarg] -> I_stobj (a,b,tyarg)
             | I_ldtoken (ILToken.ILType (ILType.TypeVar _)),[tyarg] -> I_ldtoken (ILToken.ILType (tyarg))
             | I_sizeof (ILType.TypeVar _)              ,[tyarg] -> I_sizeof (tyarg)
+            | I_cpobj (ILType.TypeVar _)               ,[tyarg] -> I_cpobj (tyarg)      // currently unused, added for forward compat, see https://visualfsharp.codeplex.com/SourceControl/network/forks/jackpappas/fsharpcontrib/contribution/7134
+            | I_initobj (ILType.TypeVar _)             ,[tyarg] -> I_initobj (tyarg)       // currently unused, added for forward compat, see https://visualfsharp.codeplex.com/SourceControl/network/forks/jackpappas/fsharpcontrib/contribution/7134
             | I_ldfld (al,vol,fspec)                 ,_       -> I_ldfld (al,vol,modFieldSpec fspec)
             | I_ldflda (fspec)                       ,_       -> I_ldflda (modFieldSpec fspec)
             | I_stfld (al,vol,fspec)                 ,_       -> I_stfld (al,vol,modFieldSpec fspec)


### PR DESCRIPTION
In short, I recommend we incorporate this otherwise-harmless change to F# 4.0.

In [this comment thread](https://visualfsharp.codeplex.com/SourceControl/network/forks/jackpappas/fsharpcontrib/contribution/7134#!/tab/comments), we are quite concerned about the impact of the F# 4.0 library using new F# library metadata formats that would cause a failure-on-startup if FSharp.Core 4.4.0.0 is fed to an F# 3.1 compiler, regardless of whether the new NativePtr functions are actually used by user code or not.

It is getting harder to do much about F# 3.1 compiler behaviour, but we can at least make sure that the F# 4.0 compiler doesn't suffer the same problem. We can minimally do this by adding the necessary contstructs to the metadata format reader inn the F# 4.0 compiler.  These should reeally have been present from the start in all editions of the F# compiler anyway.


