### PR TITLE
Improve performance and efficiency of Array.Parallel.choose

### DIFF
--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -975,37 +975,159 @@ namespace Microsoft.FSharp.Collections
 #if FX_NO_TPL_PARALLEL
 #else
         module Parallel =
+            open System.Threading
             open System.Threading.Tasks
-            
-            [<CompiledName("Choose")>]
-            let choose f (array: 'T[]) = 
-                checkNonNull "array" array
-                let inputLength = array.Length
-                let lastInputIndex = inputLength - 1
 
-                let isChosen : bool [] = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked inputLength
-                let results : 'U [] = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked inputLength
-                
-                Parallel.For(0, inputLength, (fun i -> 
-                    match f array.[i] with 
-                    | None -> () 
-                    | Some v -> 
-                        isChosen.[i] <- true; 
-                        results.[i] <- v
-                )) |> ignore         
-                                                                                      
-                let mutable outputLength = 0                
-                for i = 0 to lastInputIndex do 
-                    if isChosen.[i] then 
-                        outputLength <- outputLength + 1
-                        
-                let output = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked outputLength
-                let mutable curr = 0
-                for i = 0 to lastInputIndex do 
-                    if isChosen.[i] then 
-                        output.[curr] <- results.[i]
-                        curr <- curr + 1
-                output
+            /// Sorts key-value pairs with integer keys according to the value of the key.
+            [<Sealed>]
+            type private ElementIndexComparer<'T> () =
+                /// The single instance of this type.
+                static let instance = ElementIndexComparer<'T> ()
+                /// The single instance of the ElementIndexComparer`1 type.
+                static member Instance : IComparer<KeyValuePair<int, 'T>> =
+                    upcast instance
+
+                interface IComparer<KeyValuePair<int, 'T>> with
+                    member __.Compare (x, y) =
+                        // Compare key values (element indices).
+                        x.Key.CompareTo y.Key
+
+            //
+            [<Sealed>]
+            type private LastElementComparer<'T> () =
+                /// The single instance of this type.
+                static let instance = LastElementComparer<'T> ()
+                /// The single instance of the LastElementComparer`1 type.
+                static member Instance : IComparer<ResizeArray<KeyValuePair<int, 'T>>> =
+                    upcast instance
+
+                interface IComparer<ResizeArray<KeyValuePair<int, 'T>>> with
+                    member __.Compare (x, y) =
+                        // Assumes the lists are non-null.
+
+                        let count_x = x.Count
+                        let count_y = y.Count
+
+                        // Is 'x' empty?
+                        if count_x = 0 then
+                            // If 'y' is also empty, then the lists are considered equal.
+                            if count_y = 0 then 0
+                            else
+                                // x < y
+                                -1
+                        // Is 'y' empty?
+                        elif count_y = 0 then
+                            // y < x
+                            1
+                        else
+                            // Compare the key values of the last elements of the two lists to
+                            // determine how the lists compare to each other.
+                            ElementIndexComparer.Instance.Compare (x.[count_x - 1], y.[count_y - 1])
+
+            /// <summary>
+            /// Combines the results of individual workers (e.g., threads, tasks), according to the ordering
+            /// of elements in the original input array.
+            /// </summary>
+            /// <param name="workerResults"></param>
+            /// <returns></returns>
+            let internal combineWorkerResults (workerResults : ResizeArray<ResizeArray<KeyValuePair<int, 'T>>>) : 'T[] =
+                /// The total number of chosen values (i.e., the length of the results array).
+                let chosenValueCount =
+                    let mutable count = 0
+                    for results in workerResults do
+                        count <- Checked.(+) count results.Count
+                    count
+
+                /// The array of results (chosen values).
+                let results = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked chosenValueCount
+
+                /// The number of worker result lists.
+                let workerResultCount = workerResults.Count
+
+                // If there was only one worker result list (which may be the case if the array was small,
+                // or the system only has a single core), we don't need the fancy logic for merging result lists.
+                if workerResultCount = 1 then
+                    let singleWorkerResult = workerResults.[0]
+                    for i = 0 to results.Length - 1 do
+                        results.[i] <- singleWorkerResult.[i].Value
+                else
+                    // Sort the worker results before entering the loop.
+                    workerResults.Sort LastElementComparer<_>.Instance
+
+                    // Copy elements from the individual worker result lists into results.
+                    // Each local results list has the chosen elements sorted by their original index in ascending order.
+                    // Removing an element from the end of a list is a fast operation (only decrements an internal counter);
+                    // we take advantage of that by copying elements into the results list backwards.
+                    for resultIndex = chosenValueCount - 1 downto 0 do
+                        // If the greatest index in the "next" worker result list is greater than the greatest index in
+                        // the current best worker result list, we've finished processing a consecutive chunk of elements
+                        // from the current best result list. Sort the worker lists according to the last elements of the lists.
+                        // This avoids unnecessarily sorting the whole list of worker results on each iteration of the loop.
+                        if LastElementComparer<_>.Instance.Compare (workerResults.[workerResultCount - 1], workerResults.[workerResultCount - 2]) < 0 then
+                            workerResults.Sort LastElementComparer<_>.Instance
+
+                        /// The current worker result list.
+                        let currentResultList = workerResults.[workerResultCount - 1]
+
+                        /// The last index in the current worker result list.
+                        let currentResultListLastIndex = currentResultList.Count - 1
+
+                        // Copy the chosen value with the greatest element index into the current index of the results array.
+                        results.[resultIndex] <- currentResultList.[currentResultListLastIndex].Value
+
+                        // Remove the copied chosen value from the end of the current worker list.
+                        currentResultList.RemoveAt currentResultListLastIndex
+
+                // Return the results array.
+                results
+
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="chooser"></param>
+            /// <param name="array"></param>
+            /// <returns></returns>
+            [<CompiledName("Choose")>]
+            let choose (chooser : 'T -> 'U option) (array: 'T[]) : 'U[] =
+                // Preconditions
+                checkNonNull "array" array
+
+                // If the input array is empty, immediately return an empty output array.
+                if isEmpty array then empty
+                else
+
+                /// Holds ResizeArrays containing the values chosen by each worker task in the loop.
+                /// The index of each chosen value is included as a key so that the values can
+                /// be re-assembled in the same order as their original source elements.
+                let workerResults = ResizeArray<_> (System.Environment.ProcessorCount)
+
+                // Choose values from the array in parallel.
+                Parallel.For (0, array.Length,
+                    System.Func<_> (fun _ -> ResizeArray ()),
+                    System.Func<_,_,_,_> (fun idx _ (localResults : ResizeArray<_>) ->
+                        match chooser array.[idx] with
+                        | None -> ()
+                        | Some result ->
+                            // Add this result, along with it's original element index, to the list of local results for this worker.
+                            localResults.Add (KeyValuePair<_,_> (idx, result))
+                    
+                        // Return the local results so they're passed to the next loop iteration.
+                        localResults),
+                    System.Action<_> (fun (localResults : ResizeArray<_>) ->
+                        // Sort the local results from this worker in ascending order of element index.
+                        // This is necessary because workers may steal chunks of elements from each other, meaning workers
+                        // may process elements out of order.
+                        localResults.Sort (ElementIndexComparer<_>.Instance)
+
+                        // The worker results list must be locked when adding the results
+                        // from this worker, to avoid concurrency issues.
+                        lock workerResults <| fun () ->
+                            workerResults.Add localResults)
+                    )
+                |> ignore
+
+                // Combine worker results and return.
+                combineWorkerResults workerResults
                 
             [<CompiledName("Collect")>]
             let collect (f : 'T -> 'U[])  (array : 'T[]) : 'U[]=


### PR DESCRIPTION
I've re-implemented the ``Array.Parallel.choose`` function so it's more memory-efficient for typical use cases. The current implementation allocates two arrays (of ``'U`` and ``bool``, respectively) of the same length as the input array to hold intermediate results; this wastes a fair bit of memory when the input array is large, and especially when the proportion of 'chosen' elements is small.

The downside is that the new code is somewhat more complex than the existing implementation. I've introduced additional comparer types and the private ``combineWorkerResults`` function to merge intermediate results into the final result; this infrastructure can be re-used in the future if we want to add additional functions from the ``Array`` module to the ``Array.Parallel`` module (e.g., [``filter``](https://github.com/jack-pappas/ExtCore/blob/7e223623a9c1616d5070219c7885ab434064e9f3/ExtCore/Collections.Array.fs#L1272), [``choose2``](https://github.com/jack-pappas/ExtCore/blob/7e223623a9c1616d5070219c7885ab434064e9f3/ExtCore/Collections.Array.fs#L1324)) or retrofit existing functions like ``Array.Parallel.partition`` for more efficiency/performance.