### PR TITLE
Only catch exceptions raised by MD5.Create()

### DIFF
--- a/src/absil/ilsupp.fs
+++ b/src/absil/ilsupp.fs
@@ -1092,7 +1092,7 @@ let internal setCheckSum (url:string, writer:ISymUnmanagedDocumentWriter) =
         let checkSum = md5.ComputeHash(file)
         if (checkSum.Length = hashSizeOfMD5) then
             writer.SetCheckSum (guidSourceHashMD5, hashSizeOfMD5, checkSum)
-    with _ -> ()
+    with :? System.Reflection.TargetInvocationException -> ()
 
 let pdbDefineDocument (writer:PdbWriter) (url:string) = 
      //3F5162F8-07C6-11D3-9053-00C04FA302A1
@@ -1102,7 +1102,11 @@ let pdbDefineDocument (writer:PdbWriter) (url:string) =
     let mutable corSymDocumentTypeText = System.Guid(0x5a869d0bu, 0x6611us, 0x11d3us, 0xbduy, 0x2auy, 0x0uy, 0x0uy, 0xf8uy, 0x8uy, 0x49uy, 0xbduy)
     let mutable docWriter = Unchecked.defaultof<ISymUnmanagedDocumentWriter>
     writer.symWriter.DefineDocument(url, &corSymLanguageTypeFSharp, &corSymLanguageVendorMicrosoft, &corSymDocumentTypeText, &docWriter)
-    setCheckSum (url, docWriter)
+
+    // Only set the checksum if this file actually exists on disk.
+    if System.IO.File.Exists url then
+        setCheckSum (url, docWriter)
+
     { symDocWriter = docWriter }
 
 let pdbOpenMethod (writer:PdbWriter) (methodToken:int32) = 


### PR DESCRIPTION
I noticed the ``setCheckSum`` function was catching and suppressing all exceptions (with a wildcard pattern). I changed the code so it only catches the one exception type (``TargetInvocationException``) that can be raised by the call to ``MD5.Create()``, but then saw some strange behavior in the compiler. It turns out the compiler seems to create an additional, internal "document" beyond the input source files (see below for details); but since this file does not exist on disk, it causes the call to ``File.Open()`` within ``setCheckSum`` to raise a ``FileNotFoundException``. The call to ``setCheckSum`` within ``pdbDefineDocument`` is now guarded using ``File.Exists`` so the existing behavior is preserved.

I thought this non-existent file was a bit strange so I added some temporary logging code to dump a stack trace when ``pdbDefineDocument`` was called for a non-existent file, then I re-ran the source build (proto-compiler, core, compiler, etc.). Here's an example of the output I got, in case someone wants to investigate.

```
  pdbDefineDocument: Defining non-existent document 'C:\visualfsharp\src\fsharp\Fsi\unknown'. Stack Trace:
     at Microsoft.FSharp.Compiler.AbstractIL.Internal.Support.pdbDefineDocument(PdbWriter writer, String url) in C:\visualfsharp\src\absil\ilsupp.fs:line 975
     at Microsoft.FSharp.Compiler.AbstractIL.ILBinaryWriter.WritePdbInfo(Boolean fixupOverlappingSequencePoints, Boolean showTimes, String f, String fpdb, PdbData info) in C:\visualfsharp\src\absil\ilwrite.fs:line 238
     at Microsoft.FSharp.Compiler.AbstractIL.ILBinaryWriter.writeBinaryAndReportMappings$cont@4513(Boolean showTimes, FSharpOption`1 pdbfile, String outfile, Boolean fixupOverlappingSequencePoints, Int32 timestamp, FSharpFunc`2 textV2P, PdbData pdbData, BinaryChunk debugDirectoryChunk, BinaryChunk debugDataChunk, Unit unitVar) in C:\visualfsharp\src\absil\ilwrite.fs:line 4514
     at Microsoft.FSharp.Compiler.AbstractIL.ILBinaryWriter.writeBinaryAndReportMappings(String outfile, ILGlobals ilg,FSharpOption`1 pdbfile, FSharpOption`1 signer, Boolean fixupOverlappingSequencePoints, Boolean emitTailcalls, Boolean showTimes, Boolean dumpDebugInfo, ILModuleDef modul, Boolean noDebugData) in C:\visualfsharp\src\absil\ilwrite.fs:line 4513
     at Microsoft.FSharp.Compiler.AbstractIL.ILBinaryWriter.WriteILBinary(String filename, options options, ILModuleDefinput, Boolean noDebugData) in C:\visualfsharp\src\absil\ilwrite.fs:line 4584
     at Microsoft.FSharp.Compiler.Driver.FileWriter.EmitIL(TcConfig tcConfig, ILGlobals ilGlobals, ErrorLogger _errorLogger, String outfile, FSharpOption`1 pdbfile, ILModuleDef ilxMainModule, SigningInfo signingInfo, Exiter exiter) in C:\visualfsharp\src\fsharp\fsc.fs:line 1785
     at Microsoft.FSharp.Compiler.Driver.main4[a](Args`1 _arg1) in C:\visualfsharp\src\fsharp\fsc.fs:line 2101
     at Microsoft.FSharp.Compiler.Driver.typecheckAndCompile(String[] argv, Boolean bannerAlreadyPrinted, Exiter exiter, ErrorLoggerProvider errorLoggerProvider) in C:\visualfsharp\src\fsharp\fsc.fs:line 2118
     at Microsoft.FSharp.Compiler.Driver.mainCompile(String[] argv, Boolean bannerAlreadyPrinted, Exiter exiter) in C:\visualfsharp\src\fsharp\fsc.fs:line 2128
     at Microsoft.FSharp.Compiler.CommandLineMain.Driver.main(String[] argv) in C:\visualfsharp\src\fsharp\fscmain.fs:line 271
     at Microsoft.FSharp.Compiler.CommandLineMain.main(String[] argv) in C:\visualfsharp\src\fsharp\fscmain.fs:line 285
```