### PR TITLE
'refanytype' and 'sizeof' instructions are also pure

### DIFF
--- a/src/fsharp/opt.fs
+++ b/src/fsharp/opt.fs
@@ -1249,7 +1249,8 @@ let IlAssemblyCodeInstrHasEffect i =
     | (  AI_nop | AI_ldc _ | AI_add | AI_sub | AI_mul | AI_xor | AI_and | AI_or 
                | AI_ceq | AI_cgt | AI_cgt_un | AI_clt | AI_clt_un | AI_conv _ | AI_shl 
                | AI_shr | AI_shr_un | AI_neg | AI_not | AI_ldnull )
-    | I_ldstr _ | I_ldtoken _  -> false
+    | I_ldstr _ | I_ldtoken _
+    | I_refanytype | I_sizeof _ -> false
     | _ -> true
   
 let IlAssemblyCodeHasEffect instrs = List.exists IlAssemblyCodeInstrHasEffect instrs


### PR DESCRIPTION
I've added the ``refanytype`` and ``sizeof`` instructions to the list of instructions classified as side-effect-free. According to [ECMA-335](http://www.ecma-international.org/publications/standards/Ecma-335.htm), 6th ed., sections *III.4.22* and *III.4.25*, these instructions never raise exceptions and are always verifiable.