### PR TITLE
Fix #38 - System.ArgumentException: not a measure abbreviation, or in correct kind

### DIFF
--- a/src/fsharp/tc.fs
+++ b/src/fsharp/tc.fs
@@ -4538,7 +4538,14 @@ and TcTypeOrMeasureAndRecover optKind cenv newOk checkCxs occ env tpenv ty   =
     try TcTypeOrMeasure optKind cenv newOk checkCxs occ env tpenv ty 
     with e -> 
         errorRecovery e ty.Range 
-        (if newOk <> NoNewTypars then NewErrorType () else cenv.g.obj_ty),tpenv 
+        let rty = 
+            match optKind, newOk with 
+            | Some TyparKind.Measure, NoNewTypars -> TType_measure MeasureOne
+            | Some TyparKind.Measure, _ -> TType_measure (NewErrorMeasure ())
+            | _, NoNewTypars -> cenv.g.obj_ty
+            | _ -> NewErrorType () 
+        rty,tpenv 
+
 
 and TcTypeAndRecover cenv newOk checkCxs occ env tpenv ty   =
     TcTypeOrMeasureAndRecover (Some TyparKind.Type) cenv newOk checkCxs occ env tpenv ty

--- a/tests/fsharp/typecheck/sigs/neg90.bsl
+++ b/tests/fsharp/typecheck/sigs/neg90.bsl
@@ -1,2 +1,6 @@
 
 neg90.fs(4,9,4,12): typecheck error FS0001: A generic construct requires that the type 'Recd' have a public default constructor
+
+neg90.fs(7,22,7,25): typecheck error FS0039: The type 'foo' is not defined
+
+neg90.fs(7,22,7,25): typecheck error FS0039: The type 'foo' is not defined

--- a/tests/fsharp/typecheck/sigs/neg90.fs
+++ b/tests/fsharp/typecheck/sigs/neg90.fs
@@ -2,3 +2,7 @@ module Test
 let foo<'a when 'a : (new : unit -> 'a)>() = new 'a()
 type Recd = {f : int}
 let _ = foo<Recd>()
+
+// See https://github.com/Microsoft/visualfsharp/issues/38
+type [<Measure>] N = foo // foo is undefined
+type M2 = float<N>


### PR DESCRIPTION
This fixes #38 by doing valid error recovery when a unit-of-measure expression is expected, rather than generating an internally invalid type-where-a-unit-of-measure-expression-is-expected condition.

I haven't run full tests, but have added a test case for the specific bug.