### PR TITLE
Fix #44 - Problems using FSI on a project

### DIFF
--- a/src/fsharp/tc.fs
+++ b/src/fsharp/tc.fs
@@ -607,14 +607,15 @@ let BuildRootModuleExpr enclosingNamespacePath cpath mexpr =
         ||> List.foldBack (fun id (cpath, mexpr) -> (parentCompPath cpath, wrapModuleOrNamespaceExprInNamespace id (parentCompPath cpath) mexpr))
         |> snd
 
-let ImplicitlyOpenOwnNamespace tcSink g amap scopem (enclosingNamespacePath: Ident list) env = 
+let ImplicitlyOpenOwnNamespace tcSink (g:TcGlobals) amap scopem (enclosingNamespacePath: Ident list) env = 
     if isNil enclosingNamespacePath then 
         env
     else
-        // Skip "FSI_0002" prefixes when determining the path to open implicitly
+        // For F# interactive, skip "FSI_0002" prefixes when determining the path to open implicitly
         let enclosingNamespacePathToOpen = 
             match enclosingNamespacePath with 
-            | p::rest when  p.idText.StartsWith(FsiDynamicModulePrefix,System.StringComparison.Ordinal) && 
+            | p::rest when  g.isInteractive &&
+                            p.idText.StartsWith(FsiDynamicModulePrefix,System.StringComparison.Ordinal) && 
                             p.idText.[FsiDynamicModulePrefix.Length..] |> String.forall System.Char.IsDigit &&
                             rest.Length > 0 -> rest
             | rest -> rest

--- a/tests/fsharp/core/fsi-reload/a1.fs
+++ b/tests/fsharp/core/fsi-reload/a1.fs
@@ -1,0 +1,3 @@
+namespace Project
+
+type DU = A | B

--- a/tests/fsharp/core/fsi-reload/a2.fs
+++ b/tests/fsharp/core/fsi-reload/a2.fs
@@ -1,0 +1,3 @@
+namespace Project
+
+type B = { Prop : DU }

--- a/tests/fsharp/core/fsi-reload/b1.fs
+++ b/tests/fsharp/core/fsi-reload/b1.fs
@@ -1,0 +1,3 @@
+namespace Project
+
+type DU = A | B

--- a/tests/fsharp/core/fsi-reload/b2.fs
+++ b/tests/fsharp/core/fsi-reload/b2.fs
@@ -1,0 +1,3 @@
+namespace Project
+
+type B = { Prop : DU }

--- a/tests/fsharp/core/fsi-reload/b2.fsi
+++ b/tests/fsharp/core/fsi-reload/b2.fsi
@@ -1,0 +1,3 @@
+namespace Project
+
+type B = { Prop : DU }

--- a/tests/fsharp/core/fsi-reload/load1.fsx
+++ b/tests/fsharp/core/fsi-reload/load1.fsx
@@ -1,0 +1,5 @@
+// Test the case where a2.fs is in the same namespace as a1.fs, and so the namespace is implicitly opened
+#load "a1.fs"
+#load "a2.fs"
+
+let os = System.IO.File.CreateText "test.ok" in os.Close() 

--- a/tests/fsharp/core/fsi-reload/load2.fsx
+++ b/tests/fsharp/core/fsi-reload/load2.fsx
@@ -1,0 +1,5 @@
+// Test the case where b2.fsi/fs is in the same namespace as b1.fs, and so the namespace is implicitly opened
+#load "b1.fs"
+#load "b2.fsi" "b2.fs" 
+
+let os = System.IO.File.CreateText "test.ok" in os.Close() 

--- a/tests/fsharp/core/fsi-reload/run.bat
+++ b/tests/fsharp/core/fsi-reload/run.bat
@@ -9,6 +9,23 @@ call %~d0%~p0..\..\..\config.bat
   "%FSI%" %fsi_flags%  --maxerrors:1 < test1.ml
   if NOT EXIST test.ok goto SetError
 
+  if exist test.ok (del /f /q test.ok)
+  "%FSI%" %fsi_flags%  --maxerrors:1 load1.fsx
+  if NOT EXIST test.ok goto SetError
+
+  if exist test.ok (del /f /q test.ok)
+  "%FSI%" %fsi_flags%  --maxerrors:1 load2.fsx
+  if NOT EXIST test.ok goto SetError
+
+  REM Check we can alo compile, for sanity's sake
+  "%FSC%" load1.fsx
+  @if ERRORLEVEL 1 goto Error
+
+  REM Check we can alo compile, for sanity's sake
+  "%FSC%" load2.fsx
+  @if ERRORLEVEL 1 goto Error
+
+
 :Ok
 echo Ran fsharp %~f0 ok.
 endlocal

--- a/tests/fsharp/core/fsi-reload/run.bat
+++ b/tests/fsharp/core/fsi-reload/run.bat
@@ -17,11 +17,11 @@ call %~d0%~p0..\..\..\config.bat
   "%FSI%" %fsi_flags%  --maxerrors:1 load2.fsx
   if NOT EXIST test.ok goto SetError
 
-  REM Check we can alo compile, for sanity's sake
+  REM Check we can also compile, for sanity's sake
   "%FSC%" load1.fsx
   @if ERRORLEVEL 1 goto Error
 
-  REM Check we can alo compile, for sanity's sake
+  REM Check we can also compile, for sanity's sake
   "%FSC%" load2.fsx
   @if ERRORLEVEL 1 goto Error
 


### PR DESCRIPTION
This fixes #44, where 

    #load "a1.fs"
    #load "a2.fs"

I've noticed this bug before and it is very irritating when preparing #load lists.

was being a given a different intepretation by fsi.exe and fsc.exe when a1.fs and a2.fs both contribute to the same namespace.  This is because of a mistake in how the "implicitly open own namespace" rule is applied in the presence of the magically inserted FSI_dddd prefixes to all the items defined in each file.  The first file uses prefix FSI_0001 to define namespace N, the second uses FSI_0002 to define namespace N, and the "implicit open own namespace" rule meant that FSI_0002.N was being implicitly opened.

As it happens, there is no need to implicitly open using the prefix path FSI_0002.N, and instead we can implicitly open using just N. This is implemented by filtering the first entry in the impicit open path for the pattern FSI_dddd when running F# Interactive. 


