### PR TITLE
Hidden members should not be shown in QuickInfo

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1504,8 +1504,8 @@ module private TastDefinitionPrinting =
                                       // Don't print individual methods forming interface implementations - these are currently never exported 
                                       not (isInterfaceTy denv.g oty)
                                   | [] -> true)
-              |> List.filter (fun v -> denv.showObsoleteMembers || not (HasFSharpAttribute denv.g denv.g.attrib_SystemObsolete v.Attribs))
-              |> List.filter (fun v -> not (Infos.AttributeChecking.CheckFSharpAttributesForHidden denv.g v.Attribs))
+              |> List.filter (fun v -> denv.showObsoleteMembers || not (Infos.AttributeChecking.CheckFSharpAttributesForObsolete denv.g v.Attribs))
+              |> List.filter (fun v -> denv.showHiddenMembers || not (Infos.AttributeChecking.CheckFSharpAttributesForHidden denv.g v.Attribs))
           // sort 
           let sortKey (v:ValRef) = (not v.IsConstructor,    // constructors before others 
                                     v.Id.idText,            // sort by name 

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1505,6 +1505,7 @@ module private TastDefinitionPrinting =
                                       not (isInterfaceTy denv.g oty)
                                   | [] -> true)
               |> List.filter (fun v -> denv.showObsoleteMembers || not (HasFSharpAttribute denv.g denv.g.attrib_SystemObsolete v.Attribs))
+              |> List.filter (fun v -> not (Infos.AttributeChecking.CheckFSharpAttributesForHidden denv.g v.Attribs))
           // sort 
           let sortKey (v:ValRef) = (not v.IsConstructor,    // constructors before others 
                                     v.Id.idText,            // sort by name 

--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -51,7 +51,7 @@ type XmlDocCollector() =
         lazy (savedLines.ToArray() |> Array.sortWith (fun (_,p1) (_,p2) -> posCompare p1 p2))
 
     let check() = 
-        assert (not savedLinesAsArray.IsValueCreated && "can't add more XmlDoc elements to XmlDocCOllector after extracting first XmlDoc from the overall results" <> "")
+        assert (not savedLinesAsArray.IsValueCreated && "can't add more XmlDoc elements to XmlDocCollector after extracting first XmlDoc from the overall results" <> "")
 
     member x.AddGrabPoint(pos) = 
         check()

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -548,11 +548,13 @@ let runFromCommandLineToImportingAssemblies(displayPSTypeProviderSecurityDialogB
 // Code from here on down is just used by fsc.exe
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-let BuildInitialDisplayEnvForDocGeneration tcGlobals = 
+let BuildInitialDisplayEnvForSigFileGeneration tcGlobals = 
     let denv = DisplayEnv.Empty tcGlobals
     let denv = 
         { denv with 
            showImperativeTyparAnnotations=true;
+           showHiddenMembers=true;
+           showObsoleteMembers=true;
            showAttributes=true; }
     denv.SetOpenPaths 
         [ FSharpLib.RootPath 
@@ -577,7 +579,7 @@ module InterfaceFileWriter =
             fprintfn os "" 
 
         for (TImplFile(_,_,mexpr,_,_)) in declaredImpls do
-            let denv = BuildInitialDisplayEnvForDocGeneration tcGlobals
+            let denv = BuildInitialDisplayEnvForSigFileGeneration tcGlobals
             writeViaBufferWithEnvironmentNewLines os (fun os s -> Printf.bprintf os "%s\n\n" s)
               (NicePrint.layoutInferredSigOfModuleExpr true denv infoReader AccessibleFromSomewhere range0 mexpr |> Layout.squashTo 80 |> Layout.showL)
        

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -2650,14 +2650,16 @@ module AttributeChecking =
          | _ -> false)
 
     /// Indicate if a list of F# attributes contains 'ObsoleteAttribute'. Used to suppress the item in intellisense.
+    let CheckFSharpAttributesForObsolete g attribs = 
+        nonNil attribs && (HasFSharpAttribute g g.attrib_SystemObsolete attribs)
+
+    /// Indicate if a list of F# attributes contains 'ObsoleteAttribute'. Used to suppress the item in intellisense.
     /// Also check the attributes for CompilerMessageAttribute, which has an IsHidden argument that allows
     /// items to be suppressed from intellisense.
     let CheckFSharpAttributesForUnseen g attribs _m = 
-        nonNil attribs && 
-        (let isObsolete = isSome (TryFindFSharpAttribute g g.attrib_SystemObsolete attribs) 
-         let isHidden = CheckFSharpAttributesForHidden g attribs
-         isObsolete || isHidden
-        )
+        nonNil attribs &&         
+        (CheckFSharpAttributesForObsolete g attribs ||
+         CheckFSharpAttributesForHidden g attribs)
       
 #if EXTENSIONTYPING
     /// Indicate if a list of provided attributes contains 'ObsoleteAttribute'. Used to suppress the item in intellisense.

--- a/src/fsharp/tastops.fs
+++ b/src/fsharp/tastops.fs
@@ -2354,6 +2354,7 @@ type DisplayEnv =
       suppressNestedTypes: bool;
       maxMembers : int option;
       showObsoleteMembers: bool; 
+      showHiddenMembers: bool; 
       showTyparBinding: bool; 
       showImperativeTyparAnnotations: bool;
       suppressInlineKeyword: bool;
@@ -2384,7 +2385,8 @@ type DisplayEnv =
         shortTypeNames=false;
         suppressNestedTypes=false;
         maxMembers=None;
-        showObsoleteMembers=true;
+        showObsoleteMembers=false;
+        showHiddenMembers=false;
         showTyparBinding = false;
         showImperativeTyparAnnotations=false;
         suppressInlineKeyword=false;

--- a/src/fsharp/tastops.fsi
+++ b/src/fsharp/tastops.fsi
@@ -590,6 +590,7 @@ type DisplayEnv =
       suppressNestedTypes: bool;
       maxMembers : int option;
       showObsoleteMembers: bool; 
+      showHiddenMembers: bool; 
       showTyparBinding: bool;
       showImperativeTyparAnnotations: bool;
       suppressInlineKeyword:bool;

--- a/vsintegration/src/unittests/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/src/unittests/Tests.LanguageService.QuickInfo.fs
@@ -166,6 +166,27 @@ type QuickInfoTests() =
             )
     
     [<Test>]
+    member public this.``QuickInfo.HiddenMember``() =
+        // Tooltips showed hidden members - #50
+        let source = """
+            open System.ComponentModel
+
+            type TypeU = { Element : string }
+                with
+                  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>] 
+                  [<CompilerMessageAttribute("This method is intended for use in generated code only.", 10001, IsHidden=true, IsError=false)>] 
+                  member x._Print = x.Element.ToString() 
+
+            let u = { Element = "abc" }
+            """
+        this.CheckTooltip(
+            code = source,
+            marker = "ypeU =",
+            atStart = true,
+            f = (fun ((text, _), _) -> printfn "actual %s" text; Assert.IsFalse(text.Contains "member _Print"))
+            )
+    
+    [<Test>]
     member public this.``QuickInfo.OverriddenMethods``() =
         let source = """
             type A() =

--- a/vsintegration/src/unittests/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/src/unittests/Tests.LanguageService.QuickInfo.fs
@@ -185,6 +185,25 @@ type QuickInfoTests() =
             atStart = true,
             f = (fun ((text, _), _) -> printfn "actual %s" text; Assert.IsFalse(text.Contains "member _Print"))
             )
+
+    [<Test>]
+    member public this.``QuickInfo.ObsoleteMember``() =
+        // Tooltips showed obsolete members - #50
+        let source = """
+            type TypeU = { Element : string }
+                with
+                    [<System.ObsoleteAttribute("This is replaced with Print2")>]
+                    member x.Print1 = x.Element.ToString() 
+                    member x.Print2 = x.Element.ToString() 
+
+            let u = { Element = "abc" }
+            """
+        this.CheckTooltip(
+            code = source,
+            marker = "ypeU =",
+            atStart = true,
+            f = (fun ((text, _), _) -> printfn "actual %s" text; Assert.IsFalse(text.Contains "member Print1"))
+            )
     
     [<Test>]
     member public this.``QuickInfo.OverriddenMethods``() =

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/XmlDocumentation.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/XmlDocumentation.fs
@@ -26,7 +26,7 @@ module internal XmlDocumentation =
                     "<root>" + xml + "</root>"
             else xml
 
-    /// Provide Xml Documentatation             
+    /// Provide Xml Documentation             
     type Provider(xmlIndexService:IVsXMLMemberIndexService) = 
         /// Index of assembly name to xml member index.
         let mutable xmlCache = new AgedLookup<string,IVsXMLMemberIndex>(10,areSame=(fun (x,y) -> x = y))


### PR DESCRIPTION
this fixes #50

I added a testcase and I used `CheckFSharpAttributesForUnseen` to ask for the `hidden` attribute.

I had to split `CheckFSharpAttributesForUnseen` since `NicePrint.fs` has a mode `denv.showObsoleteMembers` which allows to show obsolete members but `CheckFSharpAttributesForUnseen` checked for hidden and obsolote.
