### PR TITLE
Quickfix for #9 and #10

### DIFF
--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -387,7 +387,7 @@ module internal Microsoft.FSharp.Compiler.PrettyNaming
 
     let MangledGlobalName = "`global`"
     
-    let IllegalCharactersInTypeAndNamespaceNames = [| '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '\"'; '`'  |]
+    let IllegalCharactersInTypeAndNamespaceNames = [| '.'; ','; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '\"'; '`'  |]
 
     let IsActivePatternName (nm:string) =
         (nm.IndexOf '|' = 0) &&

--- a/src/fsharp/ilxgen.fs
+++ b/src/fsharp/ilxgen.fs
@@ -282,16 +282,16 @@ let NestedTypeRefForCompLoc cloc n =
         mkILTyRef(cloc.clocScope,tyname)
     | h::t -> mkILNestedTyRef(cloc.clocScope,mkTopName cloc.clocNamespace h :: t,n)
         
-let CleanUpGeneratedTypeName (nm:string) = 
+let CleanUpGeneratedName (nm:string) = 
     if nm.IndexOfAny IllegalCharactersInTypeAndNamespaceNames = -1 then 
         nm
     else
         (nm,IllegalCharactersInTypeAndNamespaceNames) ||> Array.fold (fun nm c -> nm.Replace(string c, "-"))
   
 
-let TypeNameForInitClass cloc = "<StartupCode$" + (CleanUpGeneratedTypeName cloc.clocQualifiedNameOfFile) + ">.$" + cloc.clocTopImplQualifiedName 
+let TypeNameForInitClass cloc = "<StartupCode$" + (CleanUpGeneratedName cloc.clocQualifiedNameOfFile) + ">.$" + (CleanUpGeneratedName cloc.clocTopImplQualifiedName)
 let TypeNameForImplicitMainMethod cloc = TypeNameForInitClass cloc + "$Main"
-let TypeNameForPrivateImplementationDetails cloc = "<PrivateImplementationDetails$" + (CleanUpGeneratedTypeName cloc.clocQualifiedNameOfFile) + ">"
+let TypeNameForPrivateImplementationDetails cloc = "<PrivateImplementationDetails$" + (CleanUpGeneratedName cloc.clocQualifiedNameOfFile) + ">"
 
 let CompLocForInitClass cloc = 
     {cloc with clocEncl=[TypeNameForInitClass cloc]; clocNamespace=None}
@@ -3878,7 +3878,7 @@ and GetIlxClosureFreeVars cenv m selfv eenvouter takenNames expr =
     // Choose a name for the closure
     let ilCloTypeRef = 
         // FSharp 1.0 bug 3404: System.Reflection doesn't like '.' and '`' in type names
-        let basenameSafeForUseAsTypename = CleanUpGeneratedTypeName basename
+        let basenameSafeForUseAsTypename = CleanUpGeneratedName basename
         let suffixmark = expr.Range
         let cloName = globalStableNameGenerator.GetUniqueCompilerGeneratedName(basenameSafeForUseAsTypename,suffixmark,uniq)
         NestedTypeRefForCompLoc eenvouter.cloc cloName


### PR DESCRIPTION
The FSI has an issue with `,` in identifiers.

reported in #9:

    // error FS0192: internal error: binding null type in envBindTypeRef
    let ``1,`` x = [||] |> Array.fold (+) ",";;

reported in #10:

    module ``Generic IKEv1, AuthIP, and IKEv2`` =
      [<Literal>]
      let Category = "Generic IKEv1, AuthIP, and IKEv2";;

Both issue are caused by an encapsulated identifier in modB (see https://github.com/forki/visualfsharp/compare/Microsoft:fsharp4...forki:fsicomma?expand=1#diff-ee96c09c03afcf797a979eb48d7f7f09L1725).

We ask for `***.1,@***` but the dictionary in `modB` has only a value for `***.1\,@***`.

My fix encapsulates the `,` and this fixes both issues.

I know this is not the correct fix, but it's a start and I'd like to get this in.

1) Since this can only be reproduced in fsi - how can we write a test?
2) Where and how should we fix this? Inside of `GetTypeAndLog`? Are there other chars that need to be encapsulated?