### PR TITLE
Clear XmlDoc caches after closing a solution

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/Vs.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/Vs.fs
@@ -85,6 +85,7 @@ type internal ServiceProvider(getService:Type->obj) =
     member sp.TextManager:IVsTextManager = downcast (getService (typeof<SVsTextManager>))
     member sp.Rdt:IVsRunningDocumentTable = downcast (getService (typeof<SVsRunningDocumentTable>))
     member sp.XmlService:IVsXMLMemberIndexService = downcast (getService (typeof<SVsXMLMemberIndexService>))
+    member sp.DTE:EnvDTE.DTE = downcast (getService (typeof<SDTE>))
     static member Stub = ServiceProvider(fun _t->raise (Error.UseOfUnitializedServiceProvider))
 
 /// Isolate VsTextManager as much as possible to ease transition into new editor architecture

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/XmlDocumentation.fsi
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/XmlDocumentation.fsi
@@ -5,12 +5,12 @@ open System
 open System.Text
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.FSharp.Compiler.SourceCodeServices
-
+open EnvDTE
 
 module internal XmlDocumentation = 
     type Provider =
         interface IdealDocumentationProvider
-        new : xmlIndexService:IVsXMLMemberIndexService -> Provider
+        new : xmlIndexService:IVsXMLMemberIndexService * dte: DTE -> Provider
 
     /// Build a data tip text string with xml comments injected.
     val BuildDataTipText :  IdealDocumentationProvider * DataTipText -> string

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
@@ -1593,7 +1593,7 @@ and [<Guid(FSharpConstants.languageServiceGuidString)>]
                 Source.CreateSource(fls, buffer, fls.GetColorizer(buffer), fileChangeEx)                
             ls.Initialize
                (sp,
-                (XmlDocumentation.Provider(sp.XmlService) :> IdealDocumentationProvider),
+                (XmlDocumentation.Provider(sp.XmlService, sp.DTE) :> IdealDocumentationProvider),
                 (preferences :> LanguagePreferences),
                 enableStandaloneFileIntellisense,
                 createSource)


### PR DESCRIPTION
Reference #57.

This PR makes sure that XmlDoc caches will be cleared when closing solutions. It helps release locks on Xml documentation files so that external clients can use these files. 

As @latkin said in https://github.com/Microsoft/visualfsharp/issues/57#issuecomment-71557706, the issue requires a fix in Visual Studio itself. The PR doesn't completely solve #57 but the bug should be less severe now.