### PR TITLE
Make sure that EnableOpenSource is installed on VS 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,8 @@ tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Utils.dll
 tests/fsharpqa/Source/CodeGen/EmittedIL/ComputationExpressions/ComputationExprLibrary.dll
 
 *.csproj.user
+
+*.ide
+*.log
+*.jrs
+*.chk

--- a/vsintegration/src/deployment/EnableOpenSource/EnableOpenSource.csproj
+++ b/vsintegration/src/deployment/EnableOpenSource/EnableOpenSource.csproj
@@ -68,6 +68,12 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="..\..\..\..\License.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="EnableOpenSource.pkgdef">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/vsintegration/src/deployment/EnableOpenSource/source.extension.vsixmanifest
+++ b/vsintegration/src/deployment/EnableOpenSource/source.extension.vsixmanifest
@@ -5,9 +5,10 @@
     <Identity Id="EnableOpenSource..4c74b903-4a32-44da-8c3f-c004633ab0f2" Version="3.2" Language="en-US" Publisher="Microsoft.VisualFSharpTools" />
     <DisplayName>Microsoft.VisualFSharpTools.EnableOpenSource</DisplayName>
     <Description xml:space="preserve">Enable FSharp.VS.FSI. </Description>
-  </Metadata>
+    <License>License.txt</License>
+  </Metadata>  
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
I ran EnableOpenSource from fsharp4 branch. The vsix was installed in VS 2013, which is misleading.

The PR changes the target installation to VS 2015 and includes the License file as part of the vsix.