### PR TITLE
fix LanguagePrimitives.ErrorStrings messages depends on culture

### DIFF
--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -11,7 +11,6 @@ namespace Microsoft.FSharp.Collections
     open Microsoft.FSharp.Core.Operators
     open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
     open Microsoft.FSharp.Core.SR
-    open Microsoft.FSharp.Core.LanguagePrimitives.ErrorStrings
 #if FX_NO_ICLONEABLE
     open Microsoft.FSharp.Core.ICloneableExtensions            
 #else
@@ -462,7 +461,7 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "array" array
             let len = array.Length
             if len = 0 then 
-                invalidArg "array" InputArrayEmptyString
+                invalidArg "array" LanguagePrimitives.ErrorStrings.InputArrayEmptyString
             else 
                 let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
                 let mutable res = array.[0]
@@ -474,7 +473,7 @@ namespace Microsoft.FSharp.Collections
         let reduceBack f (array : _[]) = 
             checkNonNull "array" array
             let len = array.Length
-            if len = 0 then invalidArg "array" InputArrayEmptyString
+            if len = 0 then invalidArg "array" LanguagePrimitives.ErrorStrings.InputArrayEmptyString
             else foldSubRight f array 0 (len - 2) array.[len - 1]
 
         [<CompiledName("SortInPlaceWith")>]
@@ -575,7 +574,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Min")>]
         let inline min (array:_[]) = 
             checkNonNull "array" array
-            if array.Length = 0 then invalidArg "array" InputArrayEmptyString
+            if array.Length = 0 then invalidArg "array" LanguagePrimitives.ErrorStrings.InputArrayEmptyString
             let mutable acc = array.[0]
             for i = 1 to array.Length - 1 do
                 let curr = array.[i]
@@ -586,7 +585,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("MinBy")>]
         let inline minBy f (array:_[]) = 
             checkNonNull "array" array
-            if array.Length = 0 then invalidArg "array" InputArrayEmptyString
+            if array.Length = 0 then invalidArg "array" LanguagePrimitives.ErrorStrings.InputArrayEmptyString
             let mutable accv = array.[0]
             let mutable acc = f accv
             for i = 1 to array.Length - 1 do
@@ -600,7 +599,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Max")>]
         let inline max (array:_[]) = 
             checkNonNull "array" array
-            if array.Length = 0 then invalidArg "array" InputArrayEmptyString
+            if array.Length = 0 then invalidArg "array" LanguagePrimitives.ErrorStrings.InputArrayEmptyString
             let mutable acc = array.[0]
             for i = 1 to array.Length - 1 do
                 let curr = array.[i]
@@ -611,7 +610,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("MaxBy")>]
         let inline maxBy f (array:_[]) = 
             checkNonNull "array" array
-            if array.Length = 0 then invalidArg "array" InputArrayEmptyString
+            if array.Length = 0 then invalidArg "array" LanguagePrimitives.ErrorStrings.InputArrayEmptyString
             let mutable accv = array.[0]
             let mutable acc = f accv
             for i = 1 to array.Length - 1 do

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -4,7 +4,6 @@ namespace Microsoft.FSharp.Primitives.Basics
 
 open Microsoft.FSharp.Core
 open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
-open Microsoft.FSharp.Core.LanguagePrimitives.ErrorStrings
 open Microsoft.FSharp.Collections
 open Microsoft.FSharp.Core.Operators
 open System.Diagnostics.CodeAnalysis                                    
@@ -242,7 +241,7 @@ module internal List =
            
       
     let init count f = 
-        if count < 0 then  invalidArg "count" InputMustBeNonNegativeString
+        if count < 0 then  invalidArg "count" LanguagePrimitives.ErrorStrings.InputMustBeNonNegativeString
         if count = 0 then [] 
         else 
             let res = freshConsNoTail (f 0)
@@ -560,7 +559,7 @@ module internal Array =
         (# "newarr !0" type ('T) count : 'T array #)
 
     let inline init (count:int) (f: int -> 'T) = 
-        if count < 0 then invalidArg "count" InputMustBeNonNegativeString
+        if count < 0 then invalidArg "count" LanguagePrimitives.ErrorStrings.InputMustBeNonNegativeString
         let arr = (zeroCreateUnchecked count : 'T array)  
         for i = 0 to count - 1 do 
             arr.[i] <- f i

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -646,17 +646,17 @@ namespace Microsoft.FSharp.Core
 
     module LanguagePrimitives =  
    
-
-        module (* internal *) ErrorStrings =
+        [<Sealed>]
+        type (* internal *) ErrorStrings =
             // inline functions cannot call GetString, so we must make these bits public
-            let AddressOpNotFirstClassString = SR.GetString(SR.addressOpNotFirstClass)
-            let NoNegateMinValueString = SR.GetString(SR.noNegateMinValue)
+            static member AddressOpNotFirstClassString with get () = SR.GetString(SR.addressOpNotFirstClass)
+            static member NoNegateMinValueString with get () = SR.GetString(SR.noNegateMinValue)
             // needs to be public to be visible from inline function 'average' and others
-            let InputSequenceEmptyString = SR.GetString(SR.inputSequenceEmpty) 
+            static member InputSequenceEmptyString with get () = SR.GetString(SR.inputSequenceEmpty) 
             // needs to be public to be visible from inline function 'average' and others
-            let InputArrayEmptyString = SR.GetString(SR.arrayWasEmpty) 
+            static member InputArrayEmptyString with get () = SR.GetString(SR.arrayWasEmpty) 
             // needs to be public to be visible from inline function 'average' and others
-            let InputMustBeNonNegativeString = SR.GetString(SR.inputMustBeNonNegative)
+            static member InputMustBeNonNegativeString with get () = SR.GetString(SR.inputMustBeNonNegative)
             
         [<CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")>]  // nested module OK              
         module IntrinsicOperators =        

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -983,22 +983,23 @@ namespace Microsoft.FSharp.Core
         val inline DivideByInt< ^T >  : x:^T -> y:int -> ^T when ^T : (static member DivideByInt : ^T * int -> ^T) 
 
         /// <summary>For internal use only</summary>
-        module (* internal *) ErrorStrings = 
+        [<Sealed>]
+        type (* internal *) ErrorStrings = 
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val InputSequenceEmptyString : string
+            static member InputSequenceEmptyString : string with get
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val InputArrayEmptyString : string
+            static member InputArrayEmptyString : string with get
         
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val AddressOpNotFirstClassString : string
+            static member AddressOpNotFirstClassString : string with get
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val NoNegateMinValueString : string
+            static member NoNegateMinValueString : string with get
                 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val InputMustBeNonNegativeString : string
+            static member InputMustBeNonNegativeString : string with get
                 
 
         //-------------------------------------------------------------------------

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -803,7 +803,6 @@ namespace Microsoft.FSharp.Collections
     open System.Collections.Generic
     open Microsoft.FSharp.Core
     open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
-    open Microsoft.FSharp.Core.LanguagePrimitives.ErrorStrings
     open Microsoft.FSharp.Core.Operators
     open Microsoft.FSharp.Core.CompilerServices
     open Microsoft.FSharp.Control
@@ -1047,7 +1046,7 @@ namespace Microsoft.FSharp.Collections
         let reduce f (source : seq<'T>)  = 
             checkNonNull "source" source
             use e = source.GetEnumerator() 
-            if not (e.MoveNext()) then invalidArg "source" InputSequenceEmptyString;
+            if not (e.MoveNext()) then invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
             let mutable state = e.Current 
             while e.MoveNext() do
@@ -1375,7 +1374,7 @@ namespace Microsoft.FSharp.Collections
                 acc <- Checked.(+) acc e.Current
                 count <- count + 1
             if count = 0 then 
-                invalidArg "source" InputSequenceEmptyString
+                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
             LanguagePrimitives.DivideByInt< (^a) > acc count
 
         [<CompiledName("AverageBy")>]
@@ -1388,7 +1387,7 @@ namespace Microsoft.FSharp.Collections
                 acc <- Checked.(+) acc (f e.Current)
                 count <- count + 1
             if count = 0 then 
-                invalidArg "source" InputSequenceEmptyString;
+                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             LanguagePrimitives.DivideByInt< (^U) > acc count
             
         [<CompiledName("Min")>]
@@ -1396,7 +1395,7 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source" source
             use e = source.GetEnumerator() 
             if not (e.MoveNext()) then 
-                invalidArg "source" InputSequenceEmptyString;
+                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             let mutable acc = e.Current
             while e.MoveNext() do
                 let curr = e.Current 
@@ -1409,7 +1408,7 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source" source
             use e = source.GetEnumerator() 
             if not (e.MoveNext()) then 
-                invalidArg "source" InputSequenceEmptyString;
+                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             let first = e.Current
             let mutable acc = f first
             let mutable accv = first
@@ -1443,7 +1442,7 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source" source
             use e = source.GetEnumerator() 
             if not (e.MoveNext()) then 
-                invalidArg "source" InputSequenceEmptyString;
+                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             let mutable acc = e.Current
             while e.MoveNext() do
                 let curr = e.Current 
@@ -1456,7 +1455,7 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source" source
             use e = source.GetEnumerator() 
             if not (e.MoveNext()) then 
-                invalidArg "source" InputSequenceEmptyString;
+                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             let first = e.Current
             let mutable acc = f first
             let mutable accv = first
@@ -1546,7 +1545,7 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source" source
             use e = source.GetEnumerator() 
             if (e.MoveNext()) then e.Current
-            else invalidArg "source" InputSequenceEmptyString
+            else invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
 
         [<CompiledName("Last")>]
         let last (source : seq<_>) =
@@ -1557,7 +1556,7 @@ namespace Microsoft.FSharp.Collections
                 while (e.MoveNext()) do res <- e.Current
                 res
             else
-                invalidArg "source" InputSequenceEmptyString
+                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString
 
 
         [<CompiledName("ExactlyOne")>]
@@ -1571,4 +1570,4 @@ namespace Microsoft.FSharp.Collections
                 else
                     v
             else
-                invalidArg "source" InputSequenceEmptyString
+                invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString


### PR DESCRIPTION
the SR.GetString use CultureInfo.CurrentUICulture, so need to be invoked at runtime not bound when the module ErrorStrings is opened

the public surface area is not changed (checked with surface unit test and decompile ) because i  converted to the LanguagePrimitives.ErrorStrings module -> type to maintain same signature

Now messages are not initialized at module open, so there is a little performance improvemenet, but is ~ zero, also for programs like:
```fsharp
[<EntryPoint>]
let main argv = 
    let d = (1,2)
    printfn "%A" d
    0 // return an integer exit code
```
There are 5 less invocation of SR.GetString ( i can see it with profiler ), but there is .exe startup cost

![yes_res](https://cloud.githubusercontent.com/assets/147243/5920825/bfa3fd5a-a63f-11e4-9811-a2e60ce87b52.png)
