### PR TITLE
enable one PCL test lib build

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -49,9 +49,11 @@ REM Dropped for faster build
 REM %_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable259
 REM @if ERRORLEVEL 1 echo Error: library portable259 debug build failed && goto :eof
 
+
+
+
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true
 @if ERRORLEVEL 1 echo Error: library unittests debug build failed && goto :eof
-
 
 REM Dropped for faster build
 REM %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47
@@ -61,9 +63,8 @@ REM Dropped for faster build
 REM %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
 REM @if ERRORLEVEL 1 echo Error: library unittests debug build failed portable7 && goto :eof
 
-REM Dropped for faster build
-REM %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78
-REM @if ERRORLEVEL 1 echo Error: library unittests debug build failed portable78 && goto :eof
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78
+@if ERRORLEVEL 1 echo Error: library unittests debug build failed portable78 && goto :eof
 
 
 @echo on


### PR DESCRIPTION
Per @latkin's request, enable one PCL build of the core library unit tests in CI