### PR TITLE
Correct writeXmlDoc.addMembers

### DIFF
--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -648,8 +648,9 @@ module XmlDocWriter =
         (* the xmlDocSigOf* functions encode type into string to be used in "id" *)
         let members = ref []
         let addMember id xmlDoc = 
-            let doc = getDoc xmlDoc
-            members := (id,doc) :: !members
+            if hasDoc xmlDoc then
+                let doc = getDoc xmlDoc
+                members := (id,doc) :: !members
         let doVal (v:Val) = addMember v.XmlDocSig v.XmlDoc
         let doUnionCase (uc:UnionCase) = addMember uc.XmlDocSig uc.XmlDoc
         let doField (rf:RecdField) = addMember rf.XmlDocSig rf.XmlDoc

--- a/tests/fsharpqa/Source/XmlDoc/Basic/env.lst
+++ b/tests/fsharpqa/Source/XmlDoc/Basic/env.lst
@@ -2,5 +2,6 @@
 	SOURCE=xmlDoc002.fs SCFLAGS="-r:System.Xml.dll --doc:xmlDoc002.xml --define:WITHXMLVERIFICATION"	# xmlDoc002.fs
 	SOURCE=xmlDoc003.fs SCFLAGS="-r:System.Xml.dll --doc:xmlDoc003.xml --define:WITHXMLVERIFICATION"	# xmlDoc003.fs
 	SOURCE=xmlDoc004.fs SCFLAGS="-r:System.Xml.dll --doc:xmlDoc004.xml --define:WITHXMLVERIFICATION"	# xmlDoc004.fs
+	SOURCE=xmlDoc005.fs SCFLAGS="-r:System.Xml.dll --doc:xmlDoc005.xml --define:WITHXMLVERIFICATION"	# xmlDoc005.fs
 	SOURCE=XMLDocOnEnum01.fs SCFLAGS="-r:System.Xml.dll --doc:XMLDocOnEnum01.xml --define:WITHXMLVERIFICATION"	# XMLDocOnEnum01.fs
 

--- a/tests/fsharpqa/Source/XmlDoc/Basic/xmlDoc005.fs
+++ b/tests/fsharpqa/Source/XmlDoc/Basic/xmlDoc005.fs
@@ -1,0 +1,49 @@
+// #Regression #XMLDoc
+// Verify that XmlDoc names are generated, but no empty members are generated re: issue #148
+//<Expects status=success></Expects>
+
+#light 
+
+namespace MyRather.MyDeep.MyNamespace 
+open System.Xml
+
+/// class1
+type Class1() = 
+    /// x
+    member this.X = "X"
+
+type Class2() =
+    member this.Y = "Y"
+    
+///testModule
+module MyModule =
+
+    let check (xml:XmlDocument) name xmlDoc =
+        let foundDoc = ((xml.SelectSingleNode ("/doc/members/member[@name='" + name + "']")).SelectSingleNode "summary").InnerText.Trim()
+        if xmlDoc <> foundDoc then
+            printfn "%s: generated xmlDoc <%s> differs from excpected <%s>" name foundDoc xmlDoc
+        xmlDoc = foundDoc
+    
+    let hasEmptyMembers (xml:XmlDocument) =
+        let node = xml.SelectSingleNode ("/doc/members/member[@name='']")
+        if node <> null then
+            printfn "Empty member name entries found." 
+        node <> null
+        
+    let test =
+        let myname = System.Reflection.Assembly.GetExecutingAssembly().Location
+        let xmlname = System.IO.Path.ChangeExtension(myname, "xml")
+
+
+#if WITHXMLVERIFICATION
+        let xml = new XmlDocument()
+        xml.Load xmlname
+        if    check xml "P:MyRather.MyDeep.MyNamespace.Class1.X" "x"
+           && check xml "T:MyRather.MyDeep.MyNamespace.Class1" "class1"
+           && not(hasEmptyMembers xml)
+        then 0 else 1
+#else
+        0
+#endif
+
+    test |> exit

--- a/tests/fsharpqa/Source/XmlDoc/UnitOfMeasure/UnitOfMeasure01.fs
+++ b/tests/fsharpqa/Source/XmlDoc/UnitOfMeasure/UnitOfMeasure01.fs
@@ -21,16 +21,24 @@ let test =
     xml.Load(xmlname)
 
     let a1 = xml.GetElementsByTagName("summary").Item(0).FirstChild.Value = "This is B"
-    if not a1 then printfn "a1: expected: This is B"; exit 1
+    if not a1 then 
+        printfn "a1: expected: This is B" 
+        exit 1
 
     let a2 = xml.GetElementsByTagName("summary").Item(1).FirstChild.Value = "This is A"
-    if not a2 then printfn "a2: expected: This is A"; exit 1
+    if not a2 then 
+        printfn "a2: expected: This is A"
+        exit 1
 
-    let a3 = xml.GetElementsByTagName("member").Item(1).Attributes.Item(0).Value = "M:UnitOfMeasure01.B(System.Single)"
-    if not a3 then printfn "a3: expected: M:UnitOfMeasure01.B(System.Single)"; exit 1
+    let a3 = xml.GetElementsByTagName("member").Item(0).Attributes.Item(0).Value = "M:UnitOfMeasure01.B(System.Single)"
+    if not a3 then 
+        printfn "a3: expected: M:UnitOfMeasure01.B(System.Single)"
+        exit 1
 
-    let a4 = xml.GetElementsByTagName("member").Item(2).Attributes.Item(0).Value = "M:UnitOfMeasure01.A(System.Double)"
-    if not a4 then printfn "a4: expected: M:UnitOfMeasure01.A(System.Double)"; exit 1
+    let a4 = xml.GetElementsByTagName("member").Item(1).Attributes.Item(0).Value = "M:UnitOfMeasure01.A(System.Double)"
+    if not a4 then 
+        printfn "a4: expected: M:UnitOfMeasure01.A(System.Double)" 
+        exit 1
 #endif
     0
 

--- a/tests/fsharpqa/Source/XmlDoc/UnitOfMeasure/UnitOfMeasure02.fs
+++ b/tests/fsharpqa/Source/XmlDoc/UnitOfMeasure/UnitOfMeasure02.fs
@@ -24,16 +24,24 @@ let test =
     xml.Load(xmlname)
 
     let a1 = xml.GetElementsByTagName("summary").Item(0).FirstChild.Value = "This is B"
-    if not a1 then printfn "a1: expected: This is B"; exit 1
+    if not a1 then 
+        printfn "a1: expected: This is B" 
+        exit 1
 
     let a2 = xml.GetElementsByTagName("summary").Item(1).FirstChild.Value = "This is A"
-    if not a2 then printfn "a2: expected: This is A"; exit 1
+    if not a2 then 
+        printfn "a2: expected: This is A" 
+        exit 1
     
-    let a3 = xml.GetElementsByTagName("member").Item(1).Attributes.Item(0).Value = "M:UnitOfMeasure02.B(System.Int32,System.Int32)"
-    if not a3 then printfn "a3: expected: M:UnitOfMeasure02.B(System.Int32,System.Int32)"; exit 1
+    let a3 = xml.GetElementsByTagName("member").Item(0).Attributes.Item(0).Value = "M:UnitOfMeasure02.B(System.Int32,System.Int32)"
+    if not a3 then 
+        printfn "a3: expected: M:UnitOfMeasure02.B(System.Int32,System.Int32)" 
+        exit 1
 
-    let a4 = xml.GetElementsByTagName("member").Item(2).Attributes.Item(0).Value = "M:UnitOfMeasure02.A(System.Double)"
-    if not a4 then printfn "a4: expected: M:UnitOfMeasure02.A(System.Double)"; exit 1
+    let a4 = xml.GetElementsByTagName("member").Item(1).Attributes.Item(0).Value = "M:UnitOfMeasure02.A(System.Double)"
+    if not a4 then 
+        printfn "a4: expected: M:UnitOfMeasure02.A(System.Double)" 
+        exit 1
 #endif
     0
 


### PR DESCRIPTION
Prevent members from being added to the global member list when the
xmlDoc contains no content.

Fixes #148 