### PR TITLE
Add more profiles to appveyor build

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -40,17 +40,15 @@ REM @if ERRORLEVEL 1 echo Error: library net20 debug build failed && goto :eof
 %_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47
 @if ERRORLEVEL 1 echo Error: library portable47 debug build failed && goto :eof
 
-REM Dropped for faster build
-REM %_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
-REM @if ERRORLEVEL 1 echo Error: library portable7 debug build failed && goto :eof
+%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
+@if ERRORLEVEL 1 echo Error: library portable7 debug build failed && goto :eof
 
 
 %_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78
 @if ERRORLEVEL 1 echo Error: library portable78 debug build failed && goto :eof
 
-REM Dropped for faster build
-REM %_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable259
-REM @if ERRORLEVEL 1 echo Error: library portable259 debug build failed && goto :eof
+%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable259
+@if ERRORLEVEL 1 echo Error: library portable259 debug build failed && goto :eof
 
 
 
@@ -58,13 +56,11 @@ REM @if ERRORLEVEL 1 echo Error: library portable259 debug build failed && goto 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true
 @if ERRORLEVEL 1 echo Error: library unittests debug build failed && goto :eof
 
-REM Dropped for faster build
-REM %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47
-@REM if ERRORLEVEL 1 echo Error: library unittests debug build failed portable47 && goto :eof
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47
+@if ERRORLEVEL 1 echo Error: library unittests debug build failed portable47 && goto :eof
 
-REM Dropped for faster build
-REM %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
-REM @if ERRORLEVEL 1 echo Error: library unittests debug build failed portable7 && goto :eof
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
+@if ERRORLEVEL 1 echo Error: library unittests debug build failed portable7 && goto :eof
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78
 @if ERRORLEVEL 1 echo Error: library unittests debug build failed portable78 && goto :eof


### PR DESCRIPTION
NGEN'ing fsc-proto.exe seems to have reduced build time on AppVeyor.  Trialling adding more PCL libraries to the build (profile 259 is still missing)