### PR TITLE
add script to replace F# 4.0 SDK on machine

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -27,19 +27,15 @@ See the script for what this does.  After you do this, you can do further testin
 The compiler is compiled as a set of .NET 4.0 components using a bootstrap process. This uses the Last Known Good (LKG) compiler to build.  
 Note that you need the .NET framework 3.5 installed on your machine in order to complete this step.
 
-```
-gacutil /i lkg\FSharp-2.0.50726.900\bin\FSharp.Core.dll
-msbuild src\fsharp-proto-build.proj
-```
+    gacutil /i lkg\FSharp-2.0.50726.900\bin\FSharp.Core.dll
+    msbuild src\fsharp-proto-build.proj
     
 ## 2.  Building an F# (Debug) library and compiler
 
 This uses the proto compiler to build `FSharp.Core.dll`, `FSharp.Compiler.dll`, `fsc.exe`, and `fsi.exe`.
 
-```
-msbuild src/fsharp-library-build.proj 
-msbuild src/fsharp-compiler-build.proj 
-```
+    msbuild src/fsharp-library-build.proj 
+    msbuild src/fsharp-compiler-build.proj 
     
 You can now use the updated F# compiler in `debug\net40\bin\fsc.exe` and F# Interactive in `debug\net40\bin\fsi.exe` to develop and test basic language and tool features.
 
@@ -51,75 +47,81 @@ See [TESTGUIDE.md](TESTGUIDE.md) for full details on how to run tests.
     
 Prior to a **Debug** test run, you need to complete **all** of these steps:
 
-```
-msbuild src/fsharp-library-build.proj
-msbuild src/fsharp-compiler-build.proj
-msbuild src/fsharp-typeproviders-build.proj
-msbuild src/fsharp-compiler-unittests-build.proj
-msbuild src/fsharp-library-build.proj /p:TargetFramework=net20
-msbuild src/fsharp-library-build.proj /p:TargetFramework=portable47
-msbuild src/fsharp-library-build.proj /p:TargetFramework=portable7
-msbuild src/fsharp-library-build.proj /p:TargetFramework=portable78
-msbuild src/fsharp-library-build.proj /p:TargetFramework=portable259
-msbuild src/fsharp-library-unittests-build.proj
-msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47
-msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7
-msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78
-msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259
-src\update.cmd debug -ngen
-tests\BuildTestTools.cmd debug 
-```
+    msbuild src/fsharp-library-build.proj
+    msbuild src/fsharp-compiler-build.proj
+    msbuild src/fsharp-typeproviders-build.proj
+    msbuild src/fsharp-compiler-unittests-build.proj
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=net20
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=portable47
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=portable7
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=portable78
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=portable259
+    msbuild src/fsharp-library-unittests-build.proj
+    msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47
+    msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7
+    msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78
+    msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259
+    src\update.cmd debug -ngen
+    tests\BuildTestTools.cmd debug 
+
 
 [Optional] If testing the Visual Studio bits (see below) you will also need:
 
-```
-msbuild vsintegration\fsharp-vsintegration-build.proj
-msbuild vsintegration\fsharp-vsintegration-unittests-build.proj
-```    
+    msbuild vsintegration\fsharp-vsintegration-build.proj
+    msbuild vsintegration\fsharp-vsintegration-unittests-build.proj
 
 Prior to a **Release** test run, you need to do **all** of these:
 
-```
-msbuild src/fsharp-library-build.proj  /p:Configuration=Release
-msbuild src/fsharp-compiler-build.proj  /p:Configuration=Release
-msbuild src/fsharp-typeproviders-build.proj  /p:Configuration=Release
-msbuild src/fsharp-compiler-unittests-build.proj  /p:Configuration=Release
-msbuild src/fsharp-library-build.proj /p:TargetFramework=net20 /p:Configuration=Release
-msbuild src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
-msbuild src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
-msbuild src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
-msbuild src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
-msbuild src/fsharp-library-unittests-build.proj  /p:Configuration=Release
-msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
-msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
-msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
-msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
-src\update.cmd release -ngen
-tests\BuildTestTools.cmd release 
-```
+    msbuild src/fsharp-library-build.proj  /p:Configuration=Release
+    msbuild src/fsharp-compiler-build.proj  /p:Configuration=Release
+    msbuild src/fsharp-typeproviders-build.proj  /p:Configuration=Release
+    msbuild src/fsharp-compiler-unittests-build.proj  /p:Configuration=Release
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=net20 /p:Configuration=Release
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
+    msbuild src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
+    msbuild src/fsharp-library-unittests-build.proj  /p:Configuration=Release
+    msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
+    msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
+    msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
+    msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
+    src\update.cmd release -ngen
+    tests\BuildTestTools.cmd release 
+
 
 [Optional] If testing the Visual F# IDE Tools (see below) you will also need:
 
-```
-msbuild vsintegration\fsharp-vsintegration-build.proj /p:Configuration=Release
-msbuild vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=Release
-```
+    msbuild vsintegration\fsharp-vsintegration-build.proj /p:Configuration=Release
+    msbuild vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=Release
 
-## 4. [Optional] Build and Install the Visual F# IDE Tools
+## 4. [Optional] Install the Visual F# IDE Tools and Clobber the F# 4.0 SDK on the machine
 
-To build the VS components:
+NOTE: Step #2 will install a VSIX extension into Visual Studio 2015 that changes the Visual F# IDE Tools 
+components installed into Visual Studio 2015.  You can revert this step by disabling or uninstalling the addin.
 
-```
-msbuild vsintegration\fsharp-vsintegration-build.proj
-```
+NOTE: Step #3 will clobber the machine-wide installed F# 4.0 SDK on your machine. This replaces the ``fsi.exe``/``fsiAnyCpu.exe`` used 
+by Visual F# Interactive and the fsc.exe used by Microsoft.FSharp.targets.  Repairing Visual Studio 2015 is currently the 
+only way to revert this step.  
 
-To install the VS components:
+NOTE: After you complete the install, the FSharp.Core referenced by your projects will not be updated. If you want to make
+a project that references your updated FSharp.Core, you must explicitly change the ``TargetFSharpCoreVersion`` in the .fsproj
+file to ``4.4.0.5099`` (or a corresponding portable version number with suffix ``5099``).
 
-1. Ensure that the VSIX package is uninstalled.
- - In VS, select Tools/Extensions and Updates
- - If the package `VisualStudio.FSharp.EnableOpenSource` is installed, select Uninstall
-1. Run ```debug\net40\bin\EnableOpenSource.vsix```
-1. Restart Visual Studio, it should now be running your freshly-built Visual F# IDE Tools.
+For debug:
+
+1. Ensure that the VSIX package is uninstalled. In VS, select Tools/Extensions and Updates and if the package `VisualStudio.FSharp.EnableOpenSource` is installed, select Uninstall
+1. Run ``debug\net40\bin\EnableOpenSource.vsix``
+1. Run ``vsintegration\update-vsintegration.cmd debug`` (clobbers the installed F# 4.0 SDK)
+
+For release:
+
+1. Ensure that the VSIX package is uninstalled. In VS, select Tools/Extensions and Updates and if the package `VisualStudio.FSharp.EnableOpenSource` is installed, select Uninstall
+1. Run ``release\net40\bin\EnableOpenSource.vsix``
+1. Run ``vsintegration\update-vsintegration.cmd release`` (clobbers the installed F# 4.0 SDK)
+
+Restart Visual Studio, it should now be running your freshly-built Visual F# IDE Tools with updated F# Interactive. 
+
 
 ### Notes on the build
 

--- a/vsintegration/update-vsintegration.cmd
+++ b/vsintegration/update-vsintegration.cmd
@@ -1,0 +1,136 @@
+@rem ===========================================================================================================
+@rem Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, 
+@rem               Version 2.0.  See License.txt in the project root for license information.
+@rem ===========================================================================================================
+
+rem @echo off
+setlocal
+
+if /i "%1" == "debug" goto :ok
+if /i "%1" == "release" goto :ok
+
+echo Clobbers existing Visual Studio installation of F# bits
+echo Usage:
+echo    update-vsintegration.cmd debug 
+echo    update-vsintegration.cmd release 
+exit /b 1
+
+:ok
+
+set BINDIR=%~dp0..\%1\net40\bin
+
+if /i "%PROCESSOR_ARCHITECTURE%"=="x86" set X86_PROGRAMFILES=%ProgramFiles%
+if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" set X86_PROGRAMFILES=%ProgramFiles(x86)%
+
+set GACUTIL="%X86_PROGRAMFILES%\Microsoft SDKs\Windows\v8.0A\bin\NETFX 4.0 Tools\gacutil.exe"
+set SN32="%X86_PROGRAMFILES%\Microsoft SDKs\Windows\v8.0A\bin\NETFX 4.0 Tools\sn.exe"
+set SN64="%X86_PROGRAMFILES%\Microsoft SDKs\Windows\v8.0A\bin\NETFX 4.0 Tools\x64\sn.exe"
+set NGEN32=%windir%\Microsoft.NET\Framework\v4.0.30319\ngen.exe
+set NGEN64=%windir%\Microsoft.NET\Framework64\v4.0.30319\ngen.exe
+
+copy /y "%BINDIR%\fsc.exe" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\fsc.exe.config" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\FSharp.Build.dll" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\FSharp.Compiler.dll" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\FSharp.Compiler.Interactive.Settings.dll" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\Fsi.exe" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\Fsi.exe.config" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\FsiAnyCPU.exe" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\FsiAnyCPU.exe.config" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\Microsoft.FSharp.targets" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+copy /y "%BINDIR%\Microsoft.Portable.FSharp.targets" "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0"
+
+mkdir "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055"
+copy /y "%BINDIR%\FSharp.Core.dll" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055"
+copy /y "%BINDIR%\FSharp.Core.optdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055"
+copy /y "%BINDIR%\FSharp.Core.sigdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055"
+copy /y "%BINDIR%\FSharp.Core.xml" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055"
+
+mkdir "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.7.4.9055"
+copy /y "%BINDIR%\..\..\portable7\bin\FSharp.Core.dll" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.7.4.9055"
+copy /y "%BINDIR%\..\..\portable7\bin\FSharp.Core.optdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.7.4.9055"
+copy /y "%BINDIR%\..\..\portable7\bin\FSharp.Core.sigdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.7.4.9055"
+copy /y "%BINDIR%\..\..\portable7\bin\FSharp.Core.xml" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.7.4.9055"
+
+mkdir "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.78.4.9055"
+copy /y "%BINDIR%\..\..\portable78\bin\FSharp.Core.dll" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.78.4.9055"
+copy /y "%BINDIR%\..\..\portable78\bin\FSharp.Core.optdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.78.4.9055"
+copy /y "%BINDIR%\..\..\portable78\bin\FSharp.Core.sigdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.78.4.9055"
+copy /y "%BINDIR%\..\..\portable78\bin\FSharp.Core.xml" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.78.4.9055"
+
+mkdir "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.259.4.9055"
+copy /y "%BINDIR%\..\..\portable259\bin\FSharp.Core.dll" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.259.4.9055"
+copy /y "%BINDIR%\..\..\portable259\bin\FSharp.Core.optdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.259.4.9055"
+copy /y "%BINDIR%\..\..\portable259\bin\FSharp.Core.sigdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.259.4.9055"
+copy /y "%BINDIR%\..\..\portable259\bin\FSharp.Core.xml" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETCore\3.259.4.9055"
+
+mkdir "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETPortable\3.47.4.9055"
+copy /y "%BINDIR%\..\..\portable47\bin\FSharp.Core.dll" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETPortable\3.47.4.9055"
+copy /y "%BINDIR%\..\..\portable47\bin\FSharp.Core.optdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETPortable\3.47.4.9055"
+copy /y "%BINDIR%\..\..\portable47\bin\FSharp.Core.sigdata" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETPortable\3.47.4.9055"
+copy /y "%BINDIR%\..\..\portable47\bin\FSharp.Core.xml" "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETPortable\3.47.4.9055"
+
+REM echo ^<configuration^>^<runtime^>^<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" appliesTo="v4.0.30319"^>^<dependentAssembly^>^<assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" /^> ^<bindingRedirect oldVersion="2.0.0.0-4.4.0.0" newVersion="4.4.0.9055"/^>^</dependentAssembly^>^</assemblyBinding^>^</runtime^>^</configuration^> > "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055\pub.config"
+
+if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    REG ADD "HKLM\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319\AssemblyFoldersEx\F# 4.0 Core Assemblies (Open Source)" /ve /t REG_SZ /f /d "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055\
+    REG ADD "HKLM\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.50709\AssemblyFoldersEx\F# 4.0 Core Assemblies (Open Source)" /ve /t REG_SZ /f /d "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055\
+)
+REG ADD "HKLM\SOFTWARE\Microsoft\.NETFramework\v4.0.30319\AssemblyFoldersEx\F# 4.0 Core Assemblies (Open Source)" /ve /t REG_SZ /f /d "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055\
+REG ADD "HKLM\SOFTWARE\Microsoft\.NETFramework\v4.0.50709\AssemblyFoldersEx\F# 4.0 Core Assemblies (Open Source)" /ve /t REG_SZ /f /d "%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.9055\
+
+
+
+rem Disable strong-name validation for F# binaries built from open source that are signed with the microsoft key
+%SN32% -Vr FSharp.Core,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.Build,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.Compiler.Interactive.Settings,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.Compiler.Hosted,b03f5f7f11d50a3a
+
+%SN32% -Vr FSharp.Compiler,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.Compiler.Server.Shared,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.Editor,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.LanguageService,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.LanguageService.Base,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.LanguageService.Compiler,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.ProjectSystem.Base,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.ProjectSystem.FSharp,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.ProjectSystem.PropertyPages,b03f5f7f11d50a3a
+%SN32% -Vr FSharp.VS.FSI,b03f5f7f11d50a3a
+%SN32% -Vr Unittests,b03f5f7f11d50a3a
+%SN32% -Vr Salsa,b03f5f7f11d50a3a
+
+if /i "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    %SN64% -Vr FSharp.Core,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.Build,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.Compiler.Interactive.Settings,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.Compiler.Hosted,b03f5f7f11d50a3a
+
+    %SN64% -Vr FSharp.Compiler,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.Compiler.Server.Shared,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.Editor,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.LanguageService,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.LanguageService.Base,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.LanguageService.Compiler,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.ProjectSystem.Base,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.ProjectSystem.FSharp,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.ProjectSystem.PropertyPages,b03f5f7f11d50a3a
+    %SN64% -Vr FSharp.VS.FSI,b03f5f7f11d50a3a
+    %SN64% -Vr Unittests,b03f5f7f11d50a3a
+    %SN64% -Vr Salsa,b03f5f7f11d50a3a
+)
+
+%GACUTIL% /if %BINDIR%\FSharp.Compiler.Interactive.Settings.dll
+%GACUTIL% /if %BINDIR%\FSharp.Compiler.Server.Shared.dll
+
+rem NGen fsc, fsi, fsiAnyCpu, and FSharp.Build.dll
+
+"%NGEN32%" install "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0\fsc.exe" /queue:1
+"%NGEN32%" install "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0\fsi.exe" /queue:1
+"%NGEN32%" install "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0\fsiAnyCpu.exe" /queue:1
+"%NGEN32%" install "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0\FSharp.Build.dll" /queue:1
+
+if /i "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    "%NGEN64%" install "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0\fsiAnyCpu.exe" /queue:1
+    "%NGEN64%" install "%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0\FSharp.Build.dll" /queue:1
+)


### PR DESCRIPTION
This adds a script that address the core of the infrastructure problems in #196, to at least unblock development of the Visual F# 4.0 IDE Tools in Visual Studio 2015 CTP.

The fix is not ideal - it does the following:

1. clobbers the installed F# 4.0 SDK on the machine
2. chucks the FSharp.Core 4.4.0.5099 libraries into places where assembly resolution mechanism can find them and adds the registry key which allows fsi.exe/fsiAnyCpu.exe and MSBuild to find them.

These steps can't be undone easily. Step 1 can be undone by repairing Visual Studio. Step 2 is pretty harmless but can only be done by deleting the files placed.

Anyway, with this script I get a Visual Studio 2015 where 
- You can use F# Interactive and it is using 4.4.0.5099 FSharp.Core
- You can open and edit F# scripts with the updated language service (14.0.0.5099 DLLs)
- You can open and edit existing F# projects with the language service (14.0.0.5099 DLLs)
- You can create new F# projects and manually adjust the ``TargetFSharpCoreVersion`` to 4.4.0.5099 in the .fsproj

For me this is enough to at least use Visual F# Tools 4.0 for my day to day work (including further development of the tools themselves).  I can always switch back to Visual Studio 2013 if I bust things.



