### PR TITLE
Swap AppVeyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Issue Stats](http://issuestats.com/github/Microsoft/visualfsharp/badge/pr)](http://issuestats.com/github/microsoft/visualfsharp)
 [![Issue Stats](http://issuestats.com/github/Microsoft/visualfsharp/badge/issue)](http://issuestats.com/github/microsoft/visualfsharp)
-[![Build status](https://ci.appveyor.com/api/projects/status/sf3s485t5utl31b7/branch/fsharp4?svg=true)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/fsharp4)
+[![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/fsharp4.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/fsharp4)
 
 #Visual F# Tools
 


### PR DESCRIPTION
Swap AppVeyor badge for one from http://shields.io/ to match the PR and issue badges.

I didn't see a 'minimum bar' for doc changes in the contributing guidelines; sorry if I missed it.