### PR TITLE
More complete nuget integration

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -27,42 +27,38 @@ if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :eof
 
 %_ngenexe% install lib\proto\fsc-proto.exe
 
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true 
+%_msbuildexe% src/fsharp-library-build.proj
 @if ERRORLEVEL 1 echo Error: library debug build failed && goto :eof
 
-%_msbuildexe% src/fsharp-compiler-build.proj /p:UseNugetPackages=true 
+%_msbuildexe% src/fsharp-compiler-build.proj
 @if ERRORLEVEL 1 echo Error: compile debug build failed && goto :eof
 
 REM We don't build new net20 FSharp.Core anymore
-REM %_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=net20
+REM %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=net20
 REM @if ERRORLEVEL 1 echo Error: library net20 debug build failed && goto :eof
 
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47
+%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable47
 @if ERRORLEVEL 1 echo Error: library portable47 debug build failed && goto :eof
 
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
+%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable7
 @if ERRORLEVEL 1 echo Error: library portable7 debug build failed && goto :eof
 
-
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78
+%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable78
 @if ERRORLEVEL 1 echo Error: library portable78 debug build failed && goto :eof
 
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable259
+%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable259
 @if ERRORLEVEL 1 echo Error: library portable259 debug build failed && goto :eof
-
-
-
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true
 @if ERRORLEVEL 1 echo Error: library unittests debug build failed && goto :eof
 
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47
 @if ERRORLEVEL 1 echo Error: library unittests debug build failed portable47 && goto :eof
 
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7
 @if ERRORLEVEL 1 echo Error: library unittests debug build failed portable7 && goto :eof
 
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78
 @if ERRORLEVEL 1 echo Error: library unittests debug build failed portable78 && goto :eof
 
 
@@ -90,6 +86,3 @@ call RunTests.cmd debug coreunit
 @if ERRORLEVEL 1 echo Error: 'RunTests.cmd debug coreunit' failed && goto :eof
 
 popd
-
-
-

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -81,7 +81,6 @@ REM Disabled while working out perl problem, see https://github.com/Microsoft/vi
 REM call RunTests.cmd debug fsharpqa Smoke
 REM @if ERRORLEVEL 1 echo Error: 'RunTests.cmd debug fsharpqa Smoke' failed && goto :eof
 
-set PATH=%PATH%;%~dp0%packages\NUnit.Runners.2.6.3\tools\
 call RunTests.cmd debug coreunit
 @if ERRORLEVEL 1 echo Error: 'RunTests.cmd debug coreunit' failed && goto :eof
 

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -740,4 +740,7 @@
         <CompileBefore Remove="@(CompileBefore)"/>   
     </ItemGroup>
   </Target>
+  <Target Name="BeforeBuild" BeforeTargets="Build">
+    <Exec Command=".\.nuget\NuGet.exe restore packages.config -PackagesDirectory packages" WorkingDirectory="$(FSharpSourcesRoot)\.."/>
+  </Target>
 </Project>

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
@@ -20,12 +20,6 @@
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
     <TargetProfile Condition=" '$(TargetFramework)' == 'portable7' or '$(TargetFramework)' == 'portable78' or '$(TargetFramework)' == 'portable259' ">netcore</TargetProfile>
-    <!-- workaround for msbuild narrowing the assembly search paths when building portable libs -->
-    <AssemblySearchPaths Condition="$(TargetFramework.Contains('portable'))">
-      {CandidateAssemblyFiles};
-      {TargetFrameworkDirectory};
-      {Registry:Software\Microsoft\.NETFramework,v4.5,AssemblyFoldersEx};
-    </AssemblySearchPaths>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition=" '$(TargetFramework)' == 'sl5' ">$(DefineConstants);SILVERLIGHT</DefineConstants>
@@ -52,6 +46,7 @@
     <!-- need full name and SpecificVersion = true in order to convince msbuild to allow this reference when targeting portable47 -->
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77" Condition="'$(TargetFramework)' != 'sl5' AND '$(TargetFramework)' != 'sl3-wp'" >
         <SpecificVersion>true</SpecificVersion>
+        <HintPath>$(FSharpSourcesRoot)\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="NUnitFramework" Condition="'$(TargetFramework)' == 'sl5' OR '$(TargetFramework)' == 'sl3-wp'" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
@@ -110,10 +105,4 @@
     <Compile Include="SurfaceArea.$(TargetFramework).fs" />
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
-  <Target Name="BeforeResolveReferences" Condition="'$(UseNugetPackages)'=='true'">
-    <CreateProperty Value="$(ProjectDir)..\..\..\packages\NUnit.2.6.3\lib\;$(AssemblySearchPaths)">
-      <Output TaskParameter="Value"
-              PropertyName="AssemblySearchPaths" />
-    </CreateProperty>
-  </Target>
 </Project>

--- a/tests/RunTests.cmd
+++ b/tests/RunTests.cmd
@@ -43,6 +43,14 @@ IF NOT DEFINED APPVEYOR_CI (
 rem path to fsc.exe which will be used by tests
 set FSCBINPATH=%~dp0..\%FLAVOR%\net40\bin
 
+rem path to nunit runners
+set NUNITDIR=%~dp0..\packages\NUnit.Runners.2.6.3\tools
+if not exist "%NUNITDIR%" (
+    pushd %~dp0..
+    .\.nuget\nuget.exe restore packages.config -PackagesDirectory packages
+    popd
+)    
+
 rem folder where test logs/results will be dropped
 set RESULTSDIR=%~dp0\TestResults
 if not exist "%RESULTSDIR%" (mkdir "%RESULTSDIR%")
@@ -182,13 +190,8 @@ set XMLFILE=CoreUnit_%coreunitsuffix%_Xml.xml
 set OUTPUTFILE=CoreUnit_%coreunitsuffix%_Output.log
 set ERRORFILE=CoreUnit_%coreunitsuffix%_Error.log
 
-where.exe nunit-console.exe > NUL 2> NUL 
-if errorlevel 1 (
-  echo Error: nunit-console.exe is not in the PATH
-  exit /b 1
-)
-echo nunit-console.exe /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\..\..\%coreunitsuffix%\bin\FSharp.Core.Unittests.dll 
-     nunit-console.exe /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\..\..\%coreunitsuffix%\bin\FSharp.Core.Unittests.dll 
+echo "%NUNITDIR%\nunit-console.exe" /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\..\..\%coreunitsuffix%\bin\FSharp.Core.Unittests.dll 
+     "%NUNITDIR%\nunit-console.exe" /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\..\..\%coreunitsuffix%\bin\FSharp.Core.Unittests.dll 
 
 goto :EOF
 
@@ -198,13 +201,8 @@ set XMLFILE=ComplierUnit_%compilerunitsuffix%_Xml.xml
 set OUTPUTFILE=ComplierUnit_%compilerunitsuffix%_Output.log
 set ERRORFILE=ComplierUnit_%compilerunitsuffix%_Error.log
 
-where.exe nunit-console.exe > NUL 2> NUL
-if errorlevel 1 (
-  echo Error: nunit-console.exe is not in the PATH
-  exit /b 1
-)
-echo nunit-console.exe /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\..\..\%compilerunitsuffix%\bin\FSharp.Compiler.Unittests.dll 
-     nunit-console.exe /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\..\..\%compilerunitsuffix%\bin\FSharp.Compiler.Unittests.dll 
+echo "%NUNITDIR%\nunit-console.exe" /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\..\..\%compilerunitsuffix%\bin\FSharp.Compiler.Unittests.dll 
+     "%NUNITDIR%\nunit-console.exe" /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\..\..\%compilerunitsuffix%\bin\FSharp.Compiler.Unittests.dll 
 
 goto :EOF
 
@@ -214,16 +212,9 @@ set XMLFILE=IDEUnit_Xml.xml
 set OUTPUTFILE=IDEUnit_Output.log
 set ERRORFILE=IDEUnit_Error.log
 
-where.exe nunit-console-x86.exe > NUL 2> NUL 
-if errorlevel 1 (
-  echo Error: nunit-console-x86.exe is not in the PATH
-  exit /b 1
-)
+xcopy /y "%NUNITDIR%\lib\*.dll" "%FSCBINPATH%"
 
-for /f "tokens=*" %%a in  ('where.exe nunit-console-x86.exe')  do  (set nunitlocation=%%~dpa)
-xcopy /y "%nunitlocation%\lib\*.dll" "%FSCBINPATH%"
-
-echo nunit-console-x86.exe /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\Unittests.dll 
-     nunit-console-x86.exe /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\Unittests.dll 
+echo "%NUNITDIR%\nunit-console-x86.exe" /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\Unittests.dll 
+     "%NUNITDIR%\nunit-console-x86.exe" /nologo /result=%XMLFILE% /output=%OUTPUTFILE% /err=%ERRORFILE% /work=%RESULTSDIR% %FSCBINPATH%\Unittests.dll 
 
 goto :EOF

--- a/vsintegration/src/unittests/Unittests.fsproj
+++ b/vsintegration/src/unittests/Unittests.fsproj
@@ -112,7 +112,10 @@
     <Reference Include="Microsoft.VisualStudio.Designer.Interfaces" />
     <Reference Include="Microsoft.VisualStudio.CommonIDE" />
     <Reference Include="Microsoft.VisualStudio.VSHelp.dll" />
-    <Reference Include="nunit.framework.dll" />
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
+        <SpecificVersion>true</SpecificVersion>
+        <HintPath>$(FSharpSourcesRoot)\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\Fsc\Fsc.fsproj">
       <Project>{ffde9e47-9675-4498-b540-69b2583dd600}</Project>
       <Name>Fsc</Name>


### PR DESCRIPTION
Fixes #204 

- Remove requirement for build flag `/p:UseNugetPackages=true`
- Auto-package-restore in build and RunTests.cmd
- RunTests.cmd uses NUnit from packages directory across the board
- Remove various h4x from unit test projects now that we have a single, reliable location for NUnit