### PR TITLE
Change CI so it builds everything in release configuration

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -27,67 +27,67 @@ if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :eof
 
 %_ngenexe% install lib\proto\fsc-proto.exe
 
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true 
-@if ERRORLEVEL 1 echo Error: library debug build failed && goto :eof
+%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library build failed && goto :eof
 
-%_msbuildexe% src/fsharp-compiler-build.proj /p:UseNugetPackages=true 
-@if ERRORLEVEL 1 echo Error: compile debug build failed && goto :eof
+%_msbuildexe% src/fsharp-compiler-build.proj /p:UseNugetPackages=true /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: compiler build failed && goto :eof
 
 REM We don't build new net20 FSharp.Core anymore
 REM %_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=net20
-REM @if ERRORLEVEL 1 echo Error: library net20 debug build failed && goto :eof
+REM @if ERRORLEVEL 1 echo Error: library net20 build failed && goto :eof
 
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47
-@if ERRORLEVEL 1 echo Error: library portable47 debug build failed && goto :eof
+%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library portable47 build failed && goto :eof
 
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
-@if ERRORLEVEL 1 echo Error: library portable7 debug build failed && goto :eof
-
-
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78
-@if ERRORLEVEL 1 echo Error: library portable78 debug build failed && goto :eof
-
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable259
-@if ERRORLEVEL 1 echo Error: library portable259 debug build failed && goto :eof
+%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library portable7 build failed && goto :eof
 
 
+%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library portable78 build failed && goto :eof
+
+%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable259 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library portable259 build failed && goto :eof
 
 
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true
-@if ERRORLEVEL 1 echo Error: library unittests debug build failed && goto :eof
-
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47
-@if ERRORLEVEL 1 echo Error: library unittests debug build failed portable47 && goto :eof
-
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7
-@if ERRORLEVEL 1 echo Error: library unittests debug build failed portable7 && goto :eof
-
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78
-@if ERRORLEVEL 1 echo Error: library unittests debug build failed portable78 && goto :eof
 
 
-@echo on
-call src\update.cmd debug -ngen
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library unittests build failed && goto :eof
+
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable47 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library unittests build failed portable47 && goto :eof
+
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable7 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library unittests build failed portable7 && goto :eof
+
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:UseNugetPackages=true /p:TargetFramework=portable78 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library unittests build failed portable78 && goto :eof
+
 
 @echo on
-call tests\BuildTestTools.cmd debug 
-REM @if ERRORLEVEL 1 echo Error: 'tests\BuildTestTools.cmd debug' failed && goto :eof
+call src\update.cmd release -ngen
+
+@echo on
+call tests\BuildTestTools.cmd release 
+@if ERRORLEVEL 1 echo Error: 'tests\BuildTestTools.cmd release' failed && goto :eof
 
 @echo on
 
 pushd tests
 
 REM Disabled while working out perl problem, see https://github.com/Microsoft/visualfsharp/pull/169
-REM call RunTests.cmd debug fsharp Smoke
-REM @if ERRORLEVEL 1 echo Error: 'RunTests.cmd debug fsharpqa Smoke' failed && goto :eof
+REM call RunTests.cmd release fsharp Smoke
+REM @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :eof
 
 REM Disabled while working out perl problem, see https://github.com/Microsoft/visualfsharp/pull/169
-REM call RunTests.cmd debug fsharpqa Smoke
-REM @if ERRORLEVEL 1 echo Error: 'RunTests.cmd debug fsharpqa Smoke' failed && goto :eof
+REM call RunTests.cmd release fsharpqa Smoke
+REM @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :eof
 
 set PATH=%PATH%;%~dp0%packages\NUnit.Runners.2.6.3\tools\
-call RunTests.cmd debug coreunit
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd debug coreunit' failed && goto :eof
+call RunTests.cmd release coreunit
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunit' failed && goto :eof
 
 popd
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,5 +4,5 @@ build_script:
 test: off 
 version: 0.0.1.{build} 
 artifacts: 
-  - path: Debug
-    name: Debug
+  - path: Release
+    name: Release


### PR DESCRIPTION
CI builds everything in debug config today. I see a few problems with that, and only 1 potential benefit.

Cons
- Causes tests to run more slowly
- Prevents all tests from working (fsharpqa and ideunit tests trigger many bogus asserts)
- [Build output](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/build/0.0.1.99/artifacts) is slow/asserty, so we can't use it to run full local validation here.

Pros
- Easier to debug if someone is testing the new feature/behavior
  - But to debug, user will still need updated sources...

Changing to release config means tests will execute faster (i.e. CI build will go faster), and CI output can be used to bootstrap full local validation by maintainers.