### PR TITLE
1.  Revert AppVeyor to use Dev 12, until AppVeyor provide Pro support fo...

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -29,10 +29,10 @@ if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :eof
 %_ngenexe% install proto\net40\bin\FSharp.Build-proto.dll
 %_ngenexe% install proto\net40\bin\fsc-proto.exe
 
-%_msbuildexe% src/fsharp-library-build.proj /p:UseNugetPackages=true  /p:Configuration=Release
+%_msbuildexe% src/fsharp-library-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library release build failed && goto :eof
 
-%_msbuildexe% src/fsharp-compiler-build.proj /p:UseNugetPackages=true  /p:Configuration=Release
+%_msbuildexe% src/fsharp-compiler-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: compile Release build failed && goto :eof
 
 REM We don't build new net20 FSharp.Core anymore
@@ -67,6 +67,12 @@ REM @if ERRORLEVEL 1 echo Error: library net20 build failed && goto :eof
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable259 && goto :eof
+
+%_msbuildexe% vsintegration\fsharp-vsintegration-build.proj /p:TargetFramework=net40 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library unittests build failed vsintegration-unittests && goto :eof
+
+%_msbuildexe% vsintegration\fsharp-vsintegration-unittests-build.proj /p:TargetFramework=net40 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library unittests build failed vsintegration-unittests && goto :eof
 
 @echo on
 call src\update.cmd release -ngen

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2015 CTP
+os: Windows Server 2012 R2
 
 init: 
 build_script: 

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -745,4 +745,11 @@
   <Target Name="BeforeBuild" BeforeTargets="Build">
     <Exec Command=".\.nuget\NuGet.exe restore packages.config -PackagesDirectory packages" WorkingDirectory="$(FSharpSourcesRoot)\.."/>
   </Target>
+
+  <Target Name="BeforeResolveReferences">
+    <CreateProperty Value="$(ProjectDir)..\..\..\packages\NUnit.2.6.3\lib\;$(ProjectDir)..\..\..\packages\NUnit.Runners.2.6.3\tools\lib\;$(AssemblySearchPaths)">
+      <Output TaskParameter="Value"
+              PropertyName="AssemblySearchPaths" />
+    </CreateProperty>
+  </Target>
 </Project>

--- a/tests/BuildTestTools.cmd
+++ b/tests/BuildTestTools.cmd
@@ -15,11 +15,23 @@ exit /b 1
 
 :ok
 
+:: Check prerequisites
+if not '%VisualStudioVersion%' == '' goto vsversionset
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
+if not '%VisualStudioVersion%' == '' goto vsversionset
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
+:vsversionset
+if '%VisualStudioVersion%' == '' echo Error: Could not find a Visual Studio Installed.MSBuild.exe.  Please see http://www.visualstudio.com/en-us/news/vs2015-vs.aspx. && goto :eof
+
+if '%VisualStudioVersion%'=='14.0' set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+if '%VisualStudioVersion%'=='12.0' set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
+if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see http://www.microsoft.com/en-us/download/details.aspx?id=40760. && goto :eof
+
 if not exist "%~dp0\fsharpqa\testenv\bin" mkdir "%~dp0\fsharpqa\testenv\bin"  || goto :error
-msbuild %~dp0\fsharpqa\testenv\src\ILComparer\ILComparer.fsproj /p:Configuration=%1 /t:Build  || goto :error
+%_msbuildexe% %~dp0\fsharpqa\testenv\src\ILComparer\ILComparer.fsproj /p:Configuration=%1 /t:Build  || goto :error
 xcopy /Y %~dp0\fsharpqa\testenv\src\ILComparer\bin\%1\* %~dp0\fsharpqa\testenv\bin  || goto :error
 
-msbuild %~dp0\fsharpqa\testenv\src\HostedCompilerServer\HostedCompilerServer.fsproj /p:Configuration=%1 /t:Build  || goto :error
+%_msbuildexe% %~dp0\fsharpqa\testenv\src\HostedCompilerServer\HostedCompilerServer.fsproj /p:Configuration=%1 /t:Build  || goto :error
 xcopy /Y %~dp0\fsharpqa\testenv\src\HostedCompilerServer\bin\%1\* %~dp0\fsharpqa\testenv\bin  || goto :error
 
 if exist %~dp0\..\%1\net40\bin (

--- a/vsintegration/src/Salsa/Salsa.fsproj
+++ b/vsintegration/src/Salsa/Salsa.fsproj
@@ -104,10 +104,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
-  <Target Name="BeforeResolveReferences" Condition="'$(UseNugetPackages)'=='true'">
-    <CreateProperty Value="$(ProjectDir)..\..\..\packages\NUnit.2.6.3\lib\;$(ProjectDir)..\..\..\packages\NUnit.Runners.2.6.3\tools\lib\;$(AssemblySearchPaths)">
-      <Output TaskParameter="Value"
-              PropertyName="AssemblySearchPaths" />
-    </CreateProperty>
-  </Target>
 </Project>

--- a/vsintegration/src/unittests/Unittests.fsproj
+++ b/vsintegration/src/unittests/Unittests.fsproj
@@ -112,16 +112,8 @@
     <Reference Include="Microsoft.VisualStudio.Designer.Interfaces" />
     <Reference Include="Microsoft.VisualStudio.CommonIDE" />
     <Reference Include="Microsoft.VisualStudio.VSHelp.dll" />
-    <Reference Include="nunit.framework.dll">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.util.dll">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-        <SpecificVersion>true</SpecificVersion>
-        <HintPath>$(FSharpSourcesRoot)\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-    </Reference>
+    <Reference Include="nunit.util.dll"><Private>True</Private></Reference>
+    <Reference Include="nunit.framework.dll"><Private>True</Private></Reference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\Fsc\Fsc.fsproj">
       <Project>{ffde9e47-9675-4498-b540-69b2583dd600}</Project>
       <Name>Fsc</Name>
@@ -178,11 +170,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
-  <Target Name="BeforeResolveReferences" Condition="'$(UseNugetPackages)'=='true'">
-    <CreateProperty Value="$(ProjectDir)..\..\..\packages\NUnit.2.6.3\lib\;$(ProjectDir)..\..\..\packages\NUnit.Runners.2.6.3\tools\lib\;$(AssemblySearchPaths)">
-      <Output TaskParameter="Value"
-              PropertyName="AssemblySearchPaths" />
-    </CreateProperty>
-  </Target>
- 
 </Project>

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/ProjectSystem.fsproj
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/ProjectSystem.fsproj
@@ -136,6 +136,6 @@
     <Win32Resource>$(IntermediateOutputPath)\ProjectResources.rc.res</Win32Resource>
   </PropertyGroup>
   <Target Name="BeforeBuild">
-      <Exec Command="rc.exe /fo $(IntermediateOutputPath)$(RCResourceFile).res $(RCResourceFile)" />
+      <Exec Command='"$(ProgramFiles)\Windows Kits\8.1\bin\x86\rc.exe" /fo $(IntermediateOutputPath)$(RCResourceFile).res $(RCResourceFile)' />
   </Target>
 </Project>


### PR DESCRIPTION
...r custom builds

2.  Update vs projects to eliminate UseNuget build configuration option
3.  Add vsintegration and vsintegrationunittests to build.
    Will add ideunit tests in a later checkin