### PR TITLE
initial version of completion for named parameters

### DIFF
--- a/src/fsharp/vs/ServiceUntypedParse.fsi
+++ b/src/fsharp/vs/ServiceUntypedParse.fsi
@@ -67,9 +67,9 @@ type internal CompletionContext =
     // completing records field
     | RecordField of RecordContext
     | RangeOperator
-    // completing property setters in constructor call
-    // end of constructor ast node * list of properties that were already set
-    | NewObject of pos * HashSet<string>
+    // completing named parameters\setters in parameter list of constructor\method calls
+    // end of name ast node * list of properties\parameters that were already set
+    | ParameterList of pos * HashSet<string>
 
 // implementation details used by other code in the compiler    
 module internal UntypedParseInfoImpl =

--- a/vsintegration/src/unittests/Tests.LanguageService.Completion.fs
+++ b/vsintegration/src/unittests/Tests.LanguageService.Completion.fs
@@ -557,6 +557,65 @@ type AutoCompletionListTests() as this  =
         AssertCtrlSpaceCompleteContains (typeDef @ ["open Ext"; "A((**))"]) "A((**)" ["XYZ"] [] // positive
         AssertCtrlSpaceCompleteContains (typeDef @ ["A((**))"]) "A((**)" [] ["XYZ"] // negative
 
+    [<Test>]
+    [<Category("Completion in object initializer")>]
+    member public this.``ObjectInitializer.CompletionForNamedParameters``() =
+        let typeDef1 = 
+            [
+                "type A = "
+                "   static member Run(xyz: int, zyx: string) = 1"
+            ]
+        AssertCtrlSpaceCompleteContains (typeDef1 @ ["A.Run()"]) ".Run(" ["xyz"; "zyx"] [] 
+        AssertCtrlSpaceCompleteContains (typeDef1 @ ["A.Run(x = 1)"]) ".Run(x" ["xyz"] [] 
+        AssertCtrlSpaceCompleteContains (typeDef1 @ ["A.Run(x = 1,)"]) ".Run(x = 1," ["xyz"; "zyx"] [] 
+
+        let typeDef2 = 
+            [
+                "type A = "
+                "   static member Run<'T>(xyz: 'T, zyx: string) = 1"
+            ]
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run()"]) ".Run(" ["xyz"; "zyx"] [] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run(x = 1)"]) ".Run(x" ["xyz"] [] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run(x = 1,)"]) ".Run(x = 1," ["xyz"; "zyx"] [] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run<_>()"]) ".Run<_>(" ["xyz"; "zyx"] [] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run<_>(x = 1)"]) ".Run<_>(x" ["xyz"] [] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run<_>(x = 1,)"]) ".Run<_>(x = 1," ["xyz"; "zyx"] [] 
+    
+    [<Test>]
+    [<Category("Completion in object initializer")>]
+    member public this.``ObjectInitializer.CompletionForSettablePropertiesInReturnValue``() =
+        let typeDef1 = 
+            [
+                "type A0() = member val Settable0 = 1 with get,set"
+                "type A() = "
+                "   member val Settable = 1 with get,set"
+                "   member val NonSettable = 1"
+                "   static member Run(): A0 =  Unchecked.defaultof<_>"
+                "   static member Run(a: string): A =  Unchecked.defaultof<_>"
+            ]
+        AssertCtrlSpaceCompleteContains (typeDef1 @ ["A.Run()"]) ".Run(" ["Settable"; "Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef1 @ ["A.Run(S = 1)"]) ".Run(S" ["Settable"; "Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef1 @ ["A.Run(S = 1,)"]) ".Run(S = 1," ["Settable"; "Settable0"] ["NonSettable"]  
+        AssertCtrlSpaceCompleteContains (typeDef1 @ ["A.Run(Settable = 1,)"]) ".Run(Settable = 1," ["Settable0"] ["NonSettable"]  
+
+        let typeDef2 = 
+            [
+                "type A0() = member val Settable0 = 1 with get,set"
+                "type A() = "
+                "   member val Settable = 1 with get,set"
+                "   member val NonSettable = 1"
+                "   static member Run<'T>(): A0 = Unchecked.defaultof<_>"
+                "   static member Run(a: int): A = Unchecked.defaultof<_>"
+            ]
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run()"]) ".Run(" ["Settable"; "Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run(S = 1)"]) ".Run(S" ["Settable"; "Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run(S = 1,)"]) ".Run(S = 1," ["Settable"; "Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run(Settable = 1,)"]) ".Run(Settable = 1," ["Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run<_>()"]) ".Run<_>(" ["Settable"; "Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run<_>(S = 1)"]) ".Run<_>(S" ["Settable"; "Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run<_>(S = 1,)"]) ".Run<_>(S = 1," ["Settable"; "Settable0"] ["NonSettable"] 
+        AssertCtrlSpaceCompleteContains (typeDef2 @ ["A.Run<_>(Settable = 1,)"]) ".Run<_>(Settable = 1," ["Settable0"] ["NonSettable"] 
+
 
     [<Test>]
     [<Category("RangeOperator")>]


### PR DESCRIPTION
This PR tracks the work of adding completion for named parameters\settable properties in methods.
Pending work: add tests
![parametercompletion](https://cloud.githubusercontent.com/assets/8052307/6091564/66b04b92-ae67-11e4-8dbc-bbb64ce53722.gif)
