### PR TITLE
Test - enable hosted compiler and parallel test execution in CI build

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -5,78 +5,83 @@ set APPVEYOR_CI=1
 :: Check prerequisites
 set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see http://www.microsoft.com/en-us/download/details.aspx?id=40760. && goto :eof
+if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see http://www.microsoft.com/en-us/download/details.aspx?id=40760. && goto :failure
 
 set _ngenexe="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ngen.exe"
-if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :eof
+if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
 
 .\.nuget\NuGet.exe restore packages.config -PackagesDirectory packages
-@if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :eof
+@if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
 
 ::Build
 %_msbuildexe% src\fsharp-proto-build.proj
-@if ERRORLEVEL 1 echo Error: compiler proto build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: compiler proto build failed && goto :failure
 
 %_ngenexe% install Proto\net40\bin\fsc-proto.exe
-@if ERRORLEVEL 1 echo Error: NGen of proto failed  && goto :eof
+@if ERRORLEVEL 1 echo Error: NGen of proto failed  && goto :failure
 
 %_msbuildexe% src/fsharp-library-build.proj /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: library build failed && goto :failure
 
 %_msbuildexe% src/fsharp-compiler-build.proj /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: compiler build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: compiler build failed && goto :failure
 
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library portable47 build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: library portable47 build failed && goto :failure
 
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library portable7 build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: library portable7 build failed && goto :failure
 
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library portable78 build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: library portable78 build failed && goto :failure
 
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library portable259 build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: library portable259 build failed && goto :failure
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library unittests build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: library unittests build failed && goto :failure
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library unittests build failed portable47 && goto :eof
+@if ERRORLEVEL 1 echo Error: library unittests build failed portable47 && goto :failure
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library unittests build failed portable7 && goto :eof
+@if ERRORLEVEL 1 echo Error: library unittests build failed portable7 && goto :failure
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library unittests build failed portable78 && goto :eof
+@if ERRORLEVEL 1 echo Error: library unittests build failed portable78 && goto :failure
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: library unittests build failed portable259 && goto :eof
+@if ERRORLEVEL 1 echo Error: library unittests build failed portable259 && goto :failure
 
 %_msbuildexe% vsintegration\fsharp-vsintegration-build.proj /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: VS integration build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: VS integration build failed && goto :failure
 
 %_msbuildexe% vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=Release
-@if ERRORLEVEL 1 echo Error: VS integration unit tests build failed && goto :eof
+@if ERRORLEVEL 1 echo Error: VS integration unit tests build failed && goto :failure
 
 @echo on
 call src\update.cmd release -ngen
 
 @echo on
 call tests\BuildTestTools.cmd release 
-@if ERRORLEVEL 1 echo Error: 'tests\BuildTestTools.cmd release' failed && goto :eof
+@if ERRORLEVEL 1 echo Error: 'tests\BuildTestTools.cmd release' failed && goto :failure
 
 @echo on
 
 pushd tests
 
 call RunTests.cmd release fsharp Smoke
-@if ERRORLEVEL 1 type testresults\fsharp_failures.log && echo Error: 'RunTests.cmd release fsharp Smoke' failed && goto :eof
+@if ERRORLEVEL 1 type testresults\fsharp_failures.log && echo Error: 'RunTests.cmd release fsharp Smoke' failed && goto :failure
 
 call RunTests.cmd release fsharpqa Smoke
-@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :eof
+@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :failure
 
 call RunTests.cmd release coreunit
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunit' failed && goto :eof
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunit' failed && goto :failure
 
 popd
+
+goto :eof
+
+:failure
+exit /b 1

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -1,5 +1,7 @@
 @echo on
 
+set APPVEYOR_CI=1
+
 :: Check prerequisites
 set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -69,10 +69,10 @@ call tests\BuildTestTools.cmd release
 pushd tests
 
 call RunTests.cmd release fsharp Smoke
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release fsharp Smoke' failed && goto :eof
+@if ERRORLEVEL 1 type testresults\fsharp_failures.log && echo Error: 'RunTests.cmd release fsharp Smoke' failed && goto :eof
 
 call RunTests.cmd release fsharpqa Smoke
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :eof
+@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :eof
 
 call RunTests.cmd release coreunit
 @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunit' failed && goto :eof

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -1,7 +1,5 @@
 @echo on
 
-set APPVEYOR_CI=1
-
 :: Check prerequisites
 set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
@@ -26,25 +24,17 @@ if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :eof
 %_msbuildexe% src/fsharp-compiler-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: compiler build failed && goto :eof
 
-REM We don't build new net20 FSharp.Core anymore
-REM %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=net20
-REM @if ERRORLEVEL 1 echo Error: library net20 build failed && goto :eof
-
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library portable47 build failed && goto :eof
 
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library portable7 build failed && goto :eof
 
-
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library portable78 build failed && goto :eof
 
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library portable259 build failed && goto :eof
-
-
-
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library unittests build failed && goto :eof
@@ -58,6 +48,14 @@ REM @if ERRORLEVEL 1 echo Error: library net20 build failed && goto :eof
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable78 && goto :eof
 
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: library unittests build failed portable259 && goto :eof
+
+%_msbuildexe% vsintegration\fsharp-vsintegration-build.proj /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: VS integration build failed && goto :eof
+
+%_msbuildexe% vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=Release
+@if ERRORLEVEL 1 echo Error: VS integration unit tests build failed && goto :eof
 
 @echo on
 call src\update.cmd release -ngen
@@ -70,13 +68,11 @@ call tests\BuildTestTools.cmd release
 
 pushd tests
 
-REM Disabled while working out perl problem, see https://github.com/Microsoft/visualfsharp/pull/169
-REM call RunTests.cmd release fsharp Smoke
-REM @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :eof
+call RunTests.cmd release fsharp Smoke
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release fsharp Smoke' failed && goto :eof
 
-REM Disabled while working out perl problem, see https://github.com/Microsoft/visualfsharp/pull/169
-REM call RunTests.cmd release fsharpqa Smoke
-REM @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :eof
+call RunTests.cmd release fsharpqa Smoke
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :eof
 
 call RunTests.cmd release coreunit
 @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunit' failed && goto :eof

--- a/tests/RunTests.cmd
+++ b/tests/RunTests.cmd
@@ -18,13 +18,7 @@ set NO_TTAGS_ARG=-nottags:ReqPP
 set _tmp=%4
 if not '%_tmp%' == '' set NO_TTAGS_ARG=-nottags:ReqPP,%_tmp:"=%
 
-rem Use commented line to enable parallel execution of tests
-rem 
-rem Disabled for APPVEYOR_CI due to anaemic Perl implementation
-rem 
-IF NOT DEFINED APPVEYOR_CI (
-    set PARALLEL_ARG=-procs:%NUMBER_OF_PROCESSORS%
-)
+set PARALLEL_ARG=-procs:%NUMBER_OF_PROCESSORS%
 
 rem This can be set to 1 to reduce the number of permutations used and avoid some of the extra-time-consuming tests
 set REDUCED_RUNTIME=1
@@ -33,12 +27,7 @@ if "%REDUCED_RUNTIME%" == "1" set NO_TTAGS_ARG=%NO_TTAGS_ARG%,Expensive
 rem Set this to 1 in order to use an external compiler host process
 rem    This only has an effect when running the FSHARPQA tests, but can
 rem    greatly speed up execution since fsc.exe does not need to be spawned thousands of times
-rem 
-rem Disabled for APPVEYOR_CI due to anaemic Perl implementation
-rem 
-IF NOT DEFINED APPVEYOR_CI (
-    set HOSTED_COMPILER=1
-)
+set HOSTED_COMPILER=1
 
 rem path to fsc.exe which will be used by tests
 set FSCBINPATH=%~dp0..\%FLAVOR%\net40\bin

--- a/tests/fsharp/core/libtest/test.fsx
+++ b/tests/fsharp/core/libtest/test.fsx
@@ -5037,7 +5037,8 @@ module TripleQuoteStrings =
     check "ckjenew-0ecwe3" """Hello ""world""" "Hello \"\"world"
 #if INTERACTIVE // FSI prints \r\n or \n depending on PIPE vs FEED so we'll just skip it
 #else
-    check "ckjenew-0ecwe4" """Hello 
+    if System.Environment.GetEnvironmentVariable("APPVEYOR_CI") <> "1" then
+        check "ckjenew-0ecwe4" """Hello 
 ""world""" "Hello \r\n\"\"world"
 #endif
     // cehcek there is no escaping...


### PR DESCRIPTION
This was originally avoided back when we were having issues with the Perl distro on the CI servers.

Now that Perl seems to be working ok, testing if it is safe to bring back parallel execution and hosted compiler.