### PR TITLE
WIP: Script debugging

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -1186,7 +1186,7 @@ and ILFilterBlock =
 type ILLocal = 
     { Type: ILType;
       IsPinned: bool;
-      DebugInfo : (string * int * int) option }
+      DebugInfo: (string * int * int) option }
       
 type ILLocals = ILList<ILLocal>
 let emptyILLocals = (ILList.empty : ILLocals)

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -1185,7 +1185,8 @@ and ILFilterBlock =
 [<NoComparison; NoEquality>]
 type ILLocal = 
     { Type: ILType;
-      IsPinned: bool }
+      IsPinned: bool;
+      DebugInfo : (string * int * int) option }
       
 type ILLocals = ILList<ILLocal>
 let emptyILLocals = (ILList.empty : ILLocals)
@@ -3022,9 +3023,10 @@ let mkILReturn ty : ILReturn =
       Type=ty;
       CustomAttrs=emptyILCustomAttrs  }
 
-let mkILLocal ty = 
+let mkILLocal ty dbgInfo = 
     { IsPinned=false;
-      Type=ty; }
+      Type=ty;
+      DebugInfo=dbgInfo }
 
 type ILFieldSpec with
   member fr.ActualType = 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -970,7 +970,8 @@ type ILNativeType =
 [<NoComparison; NoEquality>]
 type ILLocal = 
     { Type: ILType;
-      IsPinned: bool }
+      IsPinned: bool;
+      DebugInfo : (string * int * int) option }
      
 
 type ILLocals = ILList<ILLocal>
@@ -1955,7 +1956,7 @@ val mkILParam: string option * ILType -> ILParameter
 val mkILParamAnon: ILType -> ILParameter
 val mkILParamNamed: string * ILType -> ILParameter
 val mkILReturn: ILType -> ILReturn
-val mkILLocal: ILType -> ILLocal
+val mkILLocal: ILType -> (string * int * int) option -> ILLocal
 val mkILLocals : ILLocal list -> ILLocals
 val emptyILLocals : ILLocals
 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -971,7 +971,7 @@ type ILNativeType =
 type ILLocal = 
     { Type: ILType;
       IsPinned: bool;
-      DebugInfo : (string * int * int) option }
+      DebugInfo: (string * int * int) option }
      
 
 type ILLocals = ILList<ILLocal>

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2206,7 +2206,8 @@ and sigptrGetLocal ctxt numtypars bytes sigptr =
             false, sigptr
     let typ, sigptr = sigptrGetTy ctxt numtypars bytes sigptr
     { IsPinned = pinned;
-      Type = typ }, sigptr
+      Type = typ;
+      DebugInfo = None }, sigptr
          
 and readBlobHeapAsMethodSig ctxt numtypars blobIdx  =
     ctxt.readBlobHeapAsMethodSig (BlobAsMethodSigIdx (numtypars,blobIdx))

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1252,7 +1252,11 @@ let emitCode cenv modB emEnv (ilG:ILGenerator) code =
 
 let emitLocal cenv emEnv (ilG : ILGenerator) (local: ILLocal) =
     let ty = convType cenv emEnv  local.Type
-    ilG.DeclareLocalAndLog(ty,local.IsPinned)
+    let locBuilder = ilG.DeclareLocalAndLog(ty, local.IsPinned)
+    match local.DebugInfo with
+    | Some(nm, start, finish) -> locBuilder.SetLocalSymInfo(nm, start, finish)
+    | None -> ()
+    locBuilder
 
 let emitILMethodBody cenv modB emEnv (ilG:ILGenerator) ilmbody =
     // XXX - REVIEW:

--- a/src/fsharp/vs/ServiceLexing.fs
+++ b/src/fsharp/vs/ServiceLexing.fs
@@ -733,6 +733,7 @@ type internal LineTokenizer(text:string,
                     | true,"I" 
                     | true,"load" 
                     | true,"time" 
+                    | true,"dbgbreak" 
                     | true,"cd" 
 #if DEBUG
                     | true,"terms" 

--- a/src/ilx/cu_erase.fs
+++ b/src/ilx/cu_erase.fs
@@ -377,7 +377,7 @@ let rec convInstr cenv (tmps: ILLocalsAllocator) inplab outlab instr =
                         InstrMorph [ AI_pop; (AI_ldc (DT_I4, ILConst.I4 0)) ] 
                 | RuntimeTypes -> 
                         let baseTy = baseTyOfUnionSpec cuspec
-                        let locn = tmps.AllocLocal (mkILLocal baseTy)
+                        let locn = tmps.AllocLocal (mkILLocal baseTy None)
 
                         let mkCase last inplab cidx failLab = 
                             let alt = altOfUnionSpec cuspec cidx
@@ -495,7 +495,7 @@ let rec convInstr cenv (tmps: ILLocalsAllocator) inplab outlab instr =
         
             match cuspecRepr.DiscriminationTechnique cuspec with 
             | RuntimeTypes ->  
-                let locn = tmps.AllocLocal (mkILLocal baseTy)
+                let locn = tmps.AllocLocal (mkILLocal baseTy None)
                 let mkCase _last inplab (cidx,tg) failLab = 
                     let alt = altOfUnionSpec cuspec cidx
                     let altTy = tyForAlt cuspec alt

--- a/src/ilx/pubclo.fs
+++ b/src/ilx/pubclo.fs
@@ -226,7 +226,7 @@ let rec convInstr cenv (tmps: ILLocalsAllocator, thisGenParams: ILGenericParamet
                 | Apps_app (arg,rest) -> 
                     let storers, loaders = unwind rest
                     let argStorers,argLoaders = 
-                          let locn = tmps.AllocLocal (mkILLocal arg)
+                          let locn = tmps.AllocLocal (mkILLocal arg None)
                           [mkStloc locn], [mkLdloc locn]
                     argStorers :: storers, argLoaders :: loaders  
                 | Apps_done _ -> 
@@ -348,7 +348,7 @@ let mkILFreeVarForParam (p : ILParameter) =
     let nm = (match p.Name with Some x -> x | None -> failwith "closure parameters must be given names")
     mkILFreeVar(nm, false,p.Type)
 
-let mkILLocalForFreeVar (p: IlxClosureFreeVar) = mkILLocal p.fvType
+let mkILLocalForFreeVar (p: IlxClosureFreeVar) = mkILLocal p.fvType None
 
 let mkILCloFldSpecs _cenv flds = 
     flds |> Array.map (fun fv -> (fv.fvName,fv.fvType)) |> Array.toList

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
@@ -95,12 +95,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return this.projectSystemPackage;
         }
 
-        private bool DebuggerIsRunning()
-        {
-            var debugger = this.service.GetIVsDebugger();
-            return debugger != null && this.mgr.LanguageService.IsDebugging;
-        }
-
         private bool EditorSelectionIsEmpty()
         {
             string selection;
@@ -222,16 +216,16 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             get { return this.textView; }
         }
 
-		/// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ViewFilter.IsExpansionUIActive"]/*' />
-		public virtual bool IsExpansionUIActive {
-			get {
-				IVsTextViewEx tve = this.textView as IVsTextViewEx;
-				if (tve != null && tve.IsExpansionUIActive() == VSConstants.S_OK) {
-					return true;
-				}
-				return false;
-			}
-		}
+        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ViewFilter.IsExpansionUIActive"]/*' />
+        public virtual bool IsExpansionUIActive {
+            get {
+                IVsTextViewEx tve = this.textView as IVsTextViewEx;
+                if (tve != null && tve.IsExpansionUIActive() == VSConstants.S_OK) {
+                    return true;
+                }
+                return false;
+            }
+        }
 
         #region IVsTextViewFilter methods
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.GetWordExtent"]/*' />
@@ -362,76 +356,86 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         /// OLECMDF_ENABLED | OLECMDF_SUPPORTED.  
         /// Return E_FAIL if want to delegate to the next command target.
         /// </returns>
-        protected virtual int QueryCommandStatus(ref Guid guidCmdGroup, uint nCmdId) {
+        protected virtual int QueryCommandStatus(ref Guid guidCmdGroup, uint nCmdId)
+        {
             ExpansionProvider ep = GetExpansionProvider();
-            if (ep != null && ep.InTemplateEditingMode) {
+            if (ep != null && ep.InTemplateEditingMode)
+            {
                 int hr = 0;
                 if (ep.HandleQueryStatus(ref guidCmdGroup, nCmdId, out hr))
                     return hr;
             }
-            if (guidCmdGroup == typeof(VsCommands).GUID) {
+            if (guidCmdGroup == typeof(VsCommands).GUID)
+            {
                 VsCommands cmd = (VsCommands)nCmdId;
 
-                switch (cmd) {
-                    case VsCommands.GotoDefn:
-                    case VsCommands.GotoDecl:
-                    case VsCommands.GotoRef:
-                    case VsCommands.Goto:
-                        return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
+                switch (cmd)
+                {
+                case VsCommands.GotoDefn:
+                case VsCommands.GotoDecl:
+                case VsCommands.GotoRef:
+                case VsCommands.Goto:
+                    return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
                 }
-            } else if (guidCmdGroup == typeof(VsCommands2K).GUID) {
+            }
+            else if (guidCmdGroup == typeof(VsCommands2K).GUID)
+            {
                 VsCommands2K cmd = (VsCommands2K)nCmdId;
 
-                switch (cmd) {
-                    case VsCommands2K.FORMATDOCUMENT:
-                        if (this.CanReformat())
-                            return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                        break;
-                    case VsCommands2K.FORMATSELECTION:
-                        if (this.CanReformat())
-                            return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                        break;
-
-                    case VsCommands2K.COMMENT_BLOCK:
-                    case VsCommands2K.UNCOMMENT_BLOCK:
-                        if (this.commentSupported)
-                            return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                        break;
-
-                    case VsCommands2K.SHOWMEMBERLIST:
-                    case VsCommands2K.COMPLETEWORD:
-                    case VsCommands2K.PARAMINFO:
+                switch (cmd)
+                {
+                case VsCommands2K.FORMATDOCUMENT:
+                    if (this.CanReformat())
                         return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-
-                    case VsCommands2K.QUICKINFO:
-                        if (this.service.Preferences.EnableQuickInfo) {
-                            return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                        }
-                        break;
-
-                    //                    case VsCommands2K.HANDLEIMEMESSAGE:
-                    //                        return 0;
-
-                    // Let the core editor handle this.  Stop outlining also removes user
-                    // defined hidden sections so it is handy to keep this enabled.
-                    //                    case VsCommands2K.OUTLN_STOP_HIDING_ALL: 
-                    //                        int rc = (int)OLECMDF.OLECMDF_SUPPORTED;
-                    //                        if (this.source.OutliningEnabled) {
-                    //                            rc |= (int)OLECMDF.OLECMDF_ENABLED;
-                    //                        }
-                    //                        return rc;
-
-                    case VsCommands2K.OUTLN_START_AUTOHIDING:
-                        if (this.source.OutliningEnabled) {
-                            return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
-                        }
+                    break;
+                case VsCommands2K.FORMATSELECTION:
+                    if (this.CanReformat())
                         return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                        
-                    case VsCommands2K.OUTLN_STOP_HIDING_ALL: //"stop outlining" on context menu
-                        if (this.source.OutliningEnabled) {
-                            return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                        }
+                    break;
+
+                case VsCommands2K.COMMENT_BLOCK:
+                case VsCommands2K.UNCOMMENT_BLOCK:
+                    if (this.commentSupported)
+                        return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
+                    break;
+
+                case VsCommands2K.SHOWMEMBERLIST:
+                case VsCommands2K.COMPLETEWORD:
+                case VsCommands2K.PARAMINFO:
+                    return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
+
+                case VsCommands2K.QUICKINFO:
+                    if (this.service.Preferences.EnableQuickInfo)
+                    {
+                        return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
+                    }
+                    break;
+
+                //                    case VsCommands2K.HANDLEIMEMESSAGE:
+                //                        return 0;
+
+                // Let the core editor handle this.  Stop outlining also removes user
+                // defined hidden sections so it is handy to keep this enabled.
+                //                    case VsCommands2K.OUTLN_STOP_HIDING_ALL: 
+                //                        int rc = (int)OLECMDF.OLECMDF_SUPPORTED;
+                //                        if (this.source.OutliningEnabled) {
+                //                            rc |= (int)OLECMDF.OLECMDF_ENABLED;
+                //                        }
+                //                        return rc;
+
+                case VsCommands2K.OUTLN_START_AUTOHIDING:
+                    if (this.source.OutliningEnabled)
+                    {
                         return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
+                    }
+                    return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
+
+                case VsCommands2K.OUTLN_STOP_HIDING_ALL: //"stop outlining" on context menu
+                    if (this.source.OutliningEnabled)
+                    {
+                        return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
+                    }
+                    return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
                 }
             }
             else if (guidCmdGroup == Microsoft.VisualStudio.VSConstants.VsStd11)
@@ -445,19 +449,21 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             {
                 if (nCmdId == cmdIDDebugSelection)
                 {
-                    if (DebuggerIsRunning())
+                    var dbgState = Interactive.Hooks.GetDebuggerState(GetProjectSystemPackage());
+
+                    if (dbgState == Interactive.FsiDebuggerState.AttachedNotToFSI)
                         return (int)OLECMDF.OLECMDF_INVISIBLE;
+                    else if (EditorSelectionIsEmpty())
+                        return (int)OLECMDF.OLECMDF_SUPPORTED;
                     else
-                    {
-                        if (EditorSelectionIsEmpty())
-                            return (int)OLECMDF.OLECMDF_SUPPORTED;
-                        else
-                            return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                    }
+                        return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
                 }
+
                 else if (nCmdId == cmdIDDebugLine)
                 {
-                    if (DebuggerIsRunning())
+                    var dbgState = Interactive.Hooks.GetDebuggerState(GetProjectSystemPackage());
+
+                    if (dbgState == Interactive.FsiDebuggerState.AttachedNotToFSI)
                         return (int)OLECMDF.OLECMDF_INVISIBLE;
                     else
                         return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
@@ -584,7 +590,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             {
                 if (nCmdId == (uint)Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteSelectionInInteractive)
                 {
-                    Microsoft.VisualStudio.FSharp.Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), null, null);
+                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), false, null, null);
                     return true;
                 }
             }
@@ -592,12 +598,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             {
                 if (nCmdId == cmdIDDebugSelection)
                 {
-                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), false, true, null, null);
-                    return true;
-                }
-                else if (nCmdId == cmdIDDebugLine)
-                {
-                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), true, true, null, null);
+                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), true, null, null);
                     return true;
                 }
             }

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
@@ -67,7 +67,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         private VsCommands gotoCmd;
         private readonly Guid guidInteractive = new Guid("8B9BF77B-AF94-4588-8847-2EB2BFFD29EB");
         private readonly uint cmdIDDebugSelection = 0x01;
-        private readonly uint cmdIDDebugLine = 0x02;
 
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.SnippetBound"]/*' />
         protected bool SnippetBound {
@@ -93,13 +92,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 this.projectSystemPackage = (Microsoft.VisualStudio.Shell.Package)pkg; // we know our object is an instance of this type
             }
             return this.projectSystemPackage;
-        }
-
-        private bool EditorSelectionIsEmpty()
-        {
-            string selection;
-            this.textView.GetSelectedText(out selection);
-            return selection == "";
         }
 
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.ViewFilter"]/*' />
@@ -448,18 +440,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             else if (guidCmdGroup == guidInteractive)
             {
                 if (nCmdId == cmdIDDebugSelection)
-                {
-                    var dbgState = Interactive.Hooks.GetDebuggerState(GetProjectSystemPackage());
-
-                    if (dbgState == Interactive.FsiDebuggerState.AttachedNotToFSI)
-                        return (int)OLECMDF.OLECMDF_INVISIBLE;
-                    else if (EditorSelectionIsEmpty())
-                        return (int)OLECMDF.OLECMDF_SUPPORTED;
-                    else
-                        return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                }
-
-                else if (nCmdId == cmdIDDebugLine)
                 {
                     var dbgState = Interactive.Hooks.GetDebuggerState(GetProjectSystemPackage());
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
@@ -42,30 +42,21 @@ module internal Guids =
 #endif
     
     // FSI Session command set
-    let cmdIDFsiConsoleContextMenu      = 0x2100 
-    let guidFsiConsoleCmdSet            = Guid("0E455B35-F2EB-431b-A0BE-B268D8A7D17F")
-#if FX_ATLEAST_45
     let guidInteractiveCommands         = Microsoft.VisualStudio.VSConstants.VsStd11 
     let cmdIDSessionInterrupt           = int Microsoft.VisualStudio.VSConstants.VSStd11CmdID.InteractiveSessionInterrupt
     let cmdIDSessionRestart             = int Microsoft.VisualStudio.VSConstants.VSStd11CmdID.InteractiveSessionRestart
-#else
-    let guidInteractiveCommands         = guidFsiConsoleCmdSet
-    let cmdIDSessionInterrupt           = 0x102
-    let cmdIDSessionRestart             = 0x103
-#endif
+
+    let guidFsiConsoleCmdSet            = Guid("0E455B35-F2EB-431b-A0BE-B268D8A7D17F")
+    let cmdIDAttachDebugger             = 0x104
+    let cmdIDFsiConsoleContextMenu      = 0x2100 
    
     // Command set for SendToInteractive
-#if FX_ATLEAST_45
-    // commands moved to VS Shell
-    let guidInteractive                 = Microsoft.VisualStudio.VSConstants.VsStd11 
+    // some commands moved to VS Shell
+    let guidInteractiveShell            = Microsoft.VisualStudio.VSConstants.VsStd11 
     let cmdIDSendSelection              = int Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteSelectionInInteractive
-    let guidInteractive2                = Microsoft.VisualStudio.VSConstants.VsStd11
-#else
-    // hybrid still uses own commands
+    // some commands not in VS Shell
     let guidInteractive                 = Guid("8B9BF77B-AF94-4588-8847-2EB2BFFD29EB")
-    let cmdIDSendSelection              = 0x01
-    let guidInteractive2                = Guid("B607E86C-A761-4685-8D98-71A3BB73233A")
-#endif
+    let cmdIDDebugSelection             = 0x01
 
     let guidFsiPackage                  = "eeeeeeee-9342-42f1-8ea9-42f0e8a6be55" // FSI-LINKAGE-POINT: when packaged here
     let guidFSharpProjectPkgString      = "91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C" // FSI-LINKAGE-POINT: when packaged in project system

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
@@ -48,6 +48,7 @@ module internal Guids =
 
     let guidFsiConsoleCmdSet            = Guid("0E455B35-F2EB-431b-A0BE-B268D8A7D17F")
     let cmdIDAttachDebugger             = 0x104
+    let cmdIDDetachDebugger             = 0x105
     let cmdIDFsiConsoleContextMenu      = 0x2100 
    
     // Command set for SendToInteractive

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
@@ -99,7 +99,7 @@
       <Button guid="guidFsiConsoleCmdSet" id="cmdidAttachDebugger" priority="0x0100" type="Button">
         <Strings>
           <CommandName>FSharp.Interactive.AttachDebugger</CommandName>
-          <ButtonText>Attach Debugger</ButtonText>
+          <ButtonText>Start Debugging</ButtonText>
         </Strings>
         <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>
       </Button>
@@ -107,7 +107,7 @@
       <Button guid="guidFsiConsoleCmdSet" id="cmdidDetachDebugger" priority="0x0101" type="Button">
         <Strings>
           <CommandName>FSharp.Interactive.DetachDebugger</CommandName>
-          <ButtonText>Detach Debugger</ButtonText>
+          <ButtonText>Stop Debugging</ButtonText>
         </Strings>
         <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>
       </Button>
@@ -222,7 +222,7 @@
          Here we bind it in the Editor context of the standard TextEditor.
          Ideally, we would bind it for F# only editor.
     -->
-    <KeyBinding guid ="guidInteractive" id ="cmdidDebugSelection" editor="GUID_TextEditorFactory" key1="D" mod1="Control" key2="VK_RETURN" mod2="Alt"  />
+    <KeyBinding guid ="guidInteractive" id ="cmdidDebugSelection" editor="GUID_TextEditorFactory" key1="D" mod1="Alt" key2="VK_RETURN" mod2="Alt"  />
     <KeyBinding guid ="guidVSStd11" id ="cmdidExecuteSelectionInInteractive" editor="GUID_TextEditorFactory" key1="VK_RETURN" mod1="Alt"  />
 
     <!-- CRTL-ALT-F for FSI window - following similar bindings for "other windows" -->

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
@@ -101,6 +101,15 @@
           <CommandName>FSharp.Interactive.AttachDebugger</CommandName>
           <ButtonText>Attach Debugger</ButtonText>
         </Strings>
+        <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>
+      </Button>
+      
+      <Button guid="guidFsiConsoleCmdSet" id="cmdidDetachDebugger" priority="0x0101" type="Button">
+        <Strings>
+          <CommandName>FSharp.Interactive.DetachDebugger</CommandName>
+          <ButtonText>Detach Debugger</ButtonText>
+        </Strings>
+        <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>
       </Button>
 
       <!-- The following places a button on the F# Editor Context Menu -->
@@ -173,7 +182,10 @@
     <CommandPlacement guid="guidFsiConsoleCmdSet" id="cmdidAttachDebugger" priority="0x0700">
       <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleSessionsGrp"/>
     </CommandPlacement>
-
+    <CommandPlacement guid="guidFsiConsoleCmdSet" id="cmdidDetachDebugger" priority="0x0800">
+      <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleSessionsGrp"/>
+    </CommandPlacement>
+    
     <!-- Adds MLSend to the context menu:
     <CommandPlacement guid="guidFsiConsoleCmdSet" id="cmdidMLSendSelection" priority="0x0500">
       <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleSessionsGrp"/>
@@ -226,7 +238,10 @@
     <KeyBinding guid="guidVSStd97" id="cmdidClearPane" editor="guidFsiToolWindow" key1="C" mod1="Control Alt"  />
     
     <!-- CRTL-Alt-D when in FSI ToolWindow is attach debugger -->
-    <KeyBinding guid="guidFsiConsoleCmdSet" id="cmdidAttachDebugger" editor="guidFsiToolWindow" key1="D" mod1="Control Alt"  />  
+    <KeyBinding guid="guidFsiConsoleCmdSet" id="cmdidAttachDebugger" editor="guidFsiToolWindow" key1="D" mod1="Control Alt"  />
+    
+    <!-- CRTL-Shift-D when in FSI ToolWindow is detach debugger -->
+    <KeyBinding guid="guidFsiConsoleCmdSet" id="cmdidDetachDebugger" editor="guidFsiToolWindow" key1="D" mod1="Control Shift"  /> 
   </KeyBindings>
 
   <Symbols>
@@ -263,6 +278,7 @@
       <IDSymbol name="FsiConsoleSessionsGrp" value="0x1050" />      
       <IDSymbol name="cmdidFsiConsole" value="0x101" />
       <IDSymbol name="cmdidAttachDebugger" value="0x104" />
+      <IDSymbol name="cmdidDetachDebugger" value="0x105" />
      </GuidSymbol>
 
     <GuidSymbol name="guidFsiConsoleBmp" value="{9074CE8B-8F1E-4c23-8EDC-82C25E0323A8}" >

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
@@ -92,43 +92,28 @@
         </Strings>
       </Button>
 
-      <!-- In Dev11, shell now has 
+      <!-- In Dev11+, shell now has 
       <Button guid ="guidVSStd11" id ="cmdidInteractiveSessionInterrupt" priority ="0x100" type ="Button">
       <Button guid ="guidVSStd11" id ="cmdidInteractiveSessionRestart" priority ="0x105" type ="Button">
       -->
-      <!-- In Dev10 hybrid, we need buttons below -->
-      <Button Condition="!Defined(FX_ATLEAST_45)" guid="guidFsiConsoleCmdSet" id="cmdidSessionInterrupt" priority="0x0100" type="Button">
-        <Parent guid="guidFsiConsoleCmdSet" id="IDG_VS_WNDO_OTRWNDWS1"/>
-        <!-- Icon guid="guidImages" id="bmpPic2" /-->
-        <Icon guid="guidCancelEvaluationBmp" id="bmpConsole" />        
+      <Button guid="guidFsiConsoleCmdSet" id="cmdidAttachDebugger" priority="0x0100" type="Button">
         <Strings>
-          <CommandName>FSharp.Interactive.Interrupt</CommandName>
-          <ButtonText>Cancel Evaluation</ButtonText> <!-- This was called "Interrupt Session" -->
-        </Strings>
-      </Button>
-      <Button Condition="!Defined(FX_ATLEAST_45)" guid="guidFsiConsoleCmdSet" id="cmdidSessionRestart" priority="0x0100" type="Button">
-        <Parent guid="guidFsiConsoleCmdSet" id="IDG_VS_WNDO_OTRWNDWS1"/>
-        <!-- Icon guid="guidImages" id="bmpPic2" /-->
-        <Icon guid="guidResetSessionBmp" id="bmpConsole" /> 
-        <Strings>
-          <CommandName>FSharp.Interactive.Restart</CommandName>
-          <ButtonText>Reset Session</ButtonText>
+          <CommandName>FSharp.Interactive.AttachDebugger</CommandName>
+          <ButtonText>Attach Debugger</ButtonText>
         </Strings>
       </Button>
 
       <!-- The following places a button on the F# Editor Context Menu -->
-      <!-- In Dev11, shell now has 
+      <!-- In Dev11+, shell now has 
       <Button guid ="guidVSStd11" id ="cmdidExecuteSelectionInInteractive" priority ="0x100" type ="Button">
       -->
-      <!-- In Dev10 hybrid, we need buttons below -->
-      <Button Condition="!Defined(FX_ATLEAST_45)" guid ="guidInteractive" id ="cmdidSendSelection" priority ="0x100" type ="Button">
-          <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_LANGUAGE"/>
-        <Icon guid="guidFsiConsoleBmp" id="bmpConsole"/>
+      <Button guid ="guidInteractive" id ="cmdidDebugSelection" priority ="0x106" type ="Button">
+        <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_LANGUAGE"/>
         <Strings>
-          <ButtonText>Send To Interactive</ButtonText>
-          <CommandName>Interactive.Send.Selection.Context</CommandName>
+          <ButtonText>Debug in F# Interactive</ButtonText>
+          <CommandName>Interactive.Debug.Selection.Context</CommandName>
         </Strings>
-        <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>
+       <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>
       </Button>
 
     </Buttons>
@@ -177,20 +162,18 @@
     <CommandPlacement guid="guidVSStd97" id="cmdidClearPane" priority="0x0200">
       <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleClearGrp"/>
     </CommandPlacement>
-    <!-- Context menu, session group: Hybrid -->  
-    <CommandPlacement Condition="!Defined(FX_ATLEAST_45)" guid="guidFsiConsoleCmdSet" id="cmdidSessionInterrupt" priority="0x0100">
+          
+    <!-- Context menu, session group -->
+    <CommandPlacement guid="guidVSStd11" id="cmdidInteractiveSessionInterrupt" priority="0x0100">
       <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleSessionsGrp"/>
     </CommandPlacement>
-    <CommandPlacement Condition="!Defined(FX_ATLEAST_45)" guid="guidFsiConsoleCmdSet" id="cmdidSessionRestart" priority="0x0300">
+    <CommandPlacement guid="guidVSStd11" id="cmdidInteractiveSessionRestart" priority="0x0300">
       <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleSessionsGrp"/>
     </CommandPlacement>
-    <!-- Context menu, session group: Dev11 -->
-    <CommandPlacement Condition="Defined(FX_ATLEAST_45)" guid="guidVSStd11" id="cmdidInteractiveSessionInterrupt" priority="0x0100">
+    <CommandPlacement guid="guidFsiConsoleCmdSet" id="cmdidAttachDebugger" priority="0x0700">
       <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleSessionsGrp"/>
     </CommandPlacement>
-    <CommandPlacement Condition="Defined(FX_ATLEAST_45)" guid="guidVSStd11" id="cmdidInteractiveSessionRestart" priority="0x0300">
-      <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleSessionsGrp"/>
-    </CommandPlacement>
+
     <!-- Adds MLSend to the context menu:
     <CommandPlacement guid="guidFsiConsoleCmdSet" id="cmdidMLSendSelection" priority="0x0500">
       <Parent guid="guidFsiConsoleCmdSet" id="FsiConsoleSessionsGrp"/>
@@ -226,24 +209,24 @@
          ALT-ENTER is globally bound to Diagram.Property.
          Here we bind it in the Editor context of the standard TextEditor.
          Ideally, we would bind it for F# only editor.
-         Both Hybrid and Dev11 are used here, to build both ways.
     -->
-    <KeyBinding Condition="!Defined(FX_ATLEAST_45)" guid="guidInteractive" id="cmdidSendSelection" editor="GUID_TextEditorFactory" key1="VK_RETURN" mod1="Alt"  />
-    <KeyBinding Condition="Defined(FX_ATLEAST_45)" guid ="guidVSStd11" id ="cmdidExecuteSelectionInInteractive" editor="GUID_TextEditorFactory" key1="VK_RETURN" mod1="Alt"  />
+    <KeyBinding guid ="guidInteractive" id ="cmdidDebugSelection" editor="GUID_TextEditorFactory" key1="D" mod1="Control" key2="VK_RETURN" mod2="Alt"  />
+    <KeyBinding guid ="guidVSStd11" id ="cmdidExecuteSelectionInInteractive" editor="GUID_TextEditorFactory" key1="VK_RETURN" mod1="Alt"  />
 
     <!-- CRTL-ALT-F for FSI window - following similar bindings for "other windows" -->
     <KeyBinding guid="guidFsiPackageCmdSet" id="cmdidFsiToolWindow"    editor="guidVSStd97" key1="F" mod1="Control Alt"  />
 
-    <!-- CRTL-Break when in FSI ToolWindow is Interrupt -->
-    <KeyBinding Condition="!Defined(FX_ATLEAST_45)" guid="guidFsiConsoleCmdSet" id="cmdidSessionInterrupt" editor="guidFsiToolWindow" key1="VK_CANCEL" mod1="Control"  />    
-    <KeyBinding Condition="Defined(FX_ATLEAST_45)" guid="guidVSStd11" id="cmdidInteractiveSessionInterrupt" editor="guidFsiToolWindow" key1="VK_CANCEL" mod1="Control"  />
+    <!-- CRTL-Break when in FSI ToolWindow is Interrupt --> 
+    <KeyBinding guid="guidVSStd11" id="cmdidInteractiveSessionInterrupt" editor="guidFsiToolWindow" key1="VK_CANCEL" mod1="Control"  />
   
-    <!-- CRTL-Alt-R when in FSI ToolWindow is Reset -->
-    <KeyBinding Condition="!Defined(FX_ATLEAST_45)" guid="guidFsiConsoleCmdSet" id="cmdidSessionRestart" editor="guidFsiToolWindow" key1="R" mod1="Control Alt"  />    
-    <KeyBinding Condition="Defined(FX_ATLEAST_45)" guid="guidVSStd11" id="cmdidInteractiveSessionRestart" editor="guidFsiToolWindow" key1="R" mod1="Control Alt"  />
+    <!-- CRTL-Alt-R when in FSI ToolWindow is Reset -->  
+    <KeyBinding guid="guidVSStd11" id="cmdidInteractiveSessionRestart" editor="guidFsiToolWindow" key1="R" mod1="Control Alt"  />
   
      <!-- CRTL-Alt-C when in FSI ToolWindow is Clear All -->
     <KeyBinding guid="guidVSStd97" id="cmdidClearPane" editor="guidFsiToolWindow" key1="C" mod1="Control Alt"  />
+    
+    <!-- CRTL-Alt-D when in FSI ToolWindow is attach debugger -->
+    <KeyBinding guid="guidFsiConsoleCmdSet" id="cmdidAttachDebugger" editor="guidFsiToolWindow" key1="D" mod1="Control Alt"  />  
   </KeyBindings>
 
   <Symbols>
@@ -279,9 +262,7 @@
       <IDSymbol name="FsiConsoleClearGrp" value="0x1040" /> 
       <IDSymbol name="FsiConsoleSessionsGrp" value="0x1050" />      
       <IDSymbol name="cmdidFsiConsole" value="0x101" />
-      <!-- below is only used by hybrid   -->
-      <IDSymbol Condition="!Defined(FX_ATLEAST_45)" name="cmdidSessionInterrupt" value="0x102" />
-      <IDSymbol Condition="!Defined(FX_ATLEAST_45)" name="cmdidSessionRestart" value="0x103" />
+      <IDSymbol name="cmdidAttachDebugger" value="0x104" />
      </GuidSymbol>
 
     <GuidSymbol name="guidFsiConsoleBmp" value="{9074CE8B-8F1E-4c23-8EDC-82C25E0323A8}" >
@@ -301,12 +282,11 @@
       <IDSymbol name="cmdidInteractiveSessionInterrupt" value ="0x01A"/>
       <IDSymbol name="cmdidInteractiveSessionRestart" value ="0x01B"/>
     </GuidSymbol>
-
-<!-- below is only used by hybrid   -->
-    <GuidSymbol Condition="!Defined(FX_ATLEAST_45)" name="guidInteractive" value="{8B9BF77B-AF94-4588-8847-2EB2BFFD29EB}" >
-      <IDSymbol name="cmdidSendSelection" value ="0x01"/>
-    </GuidSymbol>
   
+    <GuidSymbol name="guidInteractive" value="{8B9BF77B-AF94-4588-8847-2EB2BFFD29EB}" >
+      <IDSymbol name="cmdidDebugSelection" value ="0x01"/>
+    </GuidSymbol>
+
   </Symbols>
 
 </CommandTable>

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
@@ -74,8 +74,8 @@ module internal Hooks =
 
     let OnMLSend (this:Package) (debug : bool) (sender:obj) (e:EventArgs) =
         withFSIToolWindow this (fun window ->
-            if debug then window.MLSend(sender, e)
-            else window.MLDebugSelection(sender, e)
+            if debug then window.MLDebug(sender, e)
+            else window.MLSend(sender, e)
         )
 
     let AddReferencesToFSI (this:Package) references =

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
@@ -69,8 +69,11 @@ module internal Hooks =
         with e2 ->
             (System.Windows.Forms.MessageBox.Show(VFSIstrings.SR.exceptionRaisedWhenRequestingToolWindow(e2.ToString())) |> ignore)
 
-    let OnMLSend (this:Package) (sender:obj) (e:EventArgs) =
-        withFSIToolWindow this (fun window -> window.MLSend(sender, e))
+    let OnMLSend (this:Package) (debug : bool) (sender:obj) (e:EventArgs) =
+        withFSIToolWindow this (fun window ->
+            if debug then window.MLSend(sender, e)
+            else window.MLDebugSelection(sender, e)
+        )
 
     let AddReferencesToFSI (this:Package) references =
         withFSIToolWindow this (fun window -> window.AddReferences references)
@@ -124,16 +127,3 @@ module internal Hooks =
                 let id  = new CommandID(Guids.guidFsiPackageCmdSet,int32 Guids.cmdIDLaunchFsiToolWindow)
                 let cmd = new MenuCommand(new EventHandler(ShowToolWindow this), id)
                 commandService.AddCommand(cmd)
-
-#if FX_ATLEAST_45
-                // Dev11 handles FSI commands in LS ViewFilter
-#else
-                // See VS SDK docs on "Command Routing Algorithm".
-                // Add OLECommand to OleCommandTarget at the package level,
-                // for when it is fired from other contexts, e.g. text editor.
-                let id  = new CommandID(Guids.guidInteractive,int32 Guids.cmdIDSendSelection)
-                let cmd = new OleMenuCommand(new EventHandler(OnMLSend this), id)
-                cmd.BeforeQueryStatus.AddHandler(new EventHandler(supportWhenFSharpDocument))
-                commandService.AddCommand(cmd)
-
-#endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -543,7 +543,7 @@ type internal FsiToolWindow() as this =
     let onMLSend (sender:obj) (e:EventArgs) =       
         sendSelectionToFSI false
 
-    let onMLDebugSelection (sender:obj) (e:EventArgs) = 
+    let onMLDebug (sender:obj) (e:EventArgs) = 
         attachDebugger ()
         sendSelectionToFSI true
 
@@ -584,7 +584,7 @@ type internal FsiToolWindow() as this =
     do  this.Caption          <- VFSIstrings.SR.fsharpInteractive()
    
     member this.MLSend(obj,e) = onMLSend obj e
-    member this.MLDebugSelection(obj,e) = onMLDebugSelection obj e
+    member this.MLDebug(obj,e) = onMLDebug obj e
 
     member this.GetDebuggerState() =
         let (state, _) = getDebuggerState ()
@@ -662,7 +662,7 @@ type internal FsiToolWindow() as this =
             addCommand Guids.guidFsiConsoleCmdSet Guids.cmdIDDetachDebugger      onDetachDebugger  None
             
             addCommand Guids.guidInteractiveShell Guids.cmdIDSendSelection       onMLSend        None
-            addCommand Guids.guidInteractive Guids.cmdIDDebugSelection           onMLDebugSelection    None
+            addCommand Guids.guidInteractive Guids.cmdIDDebugSelection           onMLDebug       None
             
             addCommand guidVSStd2KCmdID (int32 VSConstants.VSStd2KCmdID.UP)      onHistory      (Some supportWhenInInputArea)
             addCommand guidVSStd2KCmdID (int32 VSConstants.VSStd2KCmdID.DOWN)    onHistory      (Some supportWhenInInputArea)            

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -432,7 +432,7 @@ type internal FsiToolWindow() as this =
         let frame = this.Frame :?> IVsWindowFrame
         frame.ShowNoActivate() |> ignore
     
-    let getDebugAttachedFSIProcess () =
+    let getDebugAttachedFSIProcess() =
         let fsiProcId = sessions.ProcessID
         let dte = provider.GetService(typeof<DTE>) :?> DTE
 
@@ -441,11 +441,11 @@ type internal FsiToolWindow() as this =
         |> Seq.cast<Process>
         |> Seq.tryFind (fun p -> p.ProcessID = fsiProcId)
 
-    let debuggerIsRunning () =
+    let debuggerIsRunning() =
         let dte = provider.GetService(typeof<DTE>) :?> DTE
         dte.Debugger.DebuggedProcesses <> null && dte.Debugger.DebuggedProcesses.Count > 0
 
-    let attachDebugger () =
+    let attachDebugger() =
         let fsiProcId = sessions.ProcessID
         let dte = provider.GetService(typeof<DTE>) :?> DTE
 
@@ -461,18 +461,18 @@ type internal FsiToolWindow() as this =
             | Some(p) -> p.Attach()
             | _ -> ()
 
-    let detachDebugger () =
+    let detachDebugger() =
         match getDebugAttachedFSIProcess () with
         | Some(p) -> p.Detach(true)
         | _ -> ()
 
     let onAttachDebugger (sender:obj) (args:EventArgs) =
-        attachDebugger ()
-        showNoActivate ()
+        attachDebugger()
+        showNoActivate()
 
     let onDetachDebugger (sender:obj) (args:EventArgs) =
-        detachDebugger ()
-        showNoActivate ()
+        detachDebugger()
+        showNoActivate()
 
     let sendTextToFSI text = 
         try
@@ -531,12 +531,12 @@ type internal FsiToolWindow() as this =
             Windows.Forms.MessageBox.Show("Could not find the 'active text view', error code = " + sprintf "0x%x" res) |> ignore
 *)
     let onMLDebugSelection (sender:obj) (e:EventArgs) = 
-        attachDebugger () 
-        sendSelectionToFSI false
+        attachDebugger() 
+        sendSelectionToFSI(false)
 
     let onMLDebugLine (sender:obj) (e:EventArgs) = 
-        attachDebugger () 
-        sendSelectionToFSI true
+        attachDebugger() 
+        sendSelectionToFSI(true)
 
     /// Handle UP and DOWN. Cycle history.    
     let onHistory (sender:obj) (e:EventArgs) =


### PR DESCRIPTION
Following the simple-but-effective method advocated by @rickasaurus, enable debug support for F# scripts by providing context menu entries and shortcut keys for attaching the VS debugger to the hosted fsi.exe process.

Editor context menu entries (hidden when VS is already debugging):
- "Debug in F# Interactive" `Ctrl+D, Alt-Enter`
  - Same as "Send to F# Interactive", but attaches debugger first
- "Debug Line in F# Interactive" `Ctrl+D, Alt-'`
  - Same as "Send Line to F# Interactive", but attaches debugger first

FSI tool window menu entry
- "Attach Debugger" `Ctrl+Alt+D`
  - Attaches debugger to the running fsi.exe process  

![scriptdebug](https://cloud.githubusercontent.com/assets/5943573/6150212/e3c9273a-b1c2-11e4-882b-eed932d52ea1.gif)

Unresolved items
- Is this useful?
- Tests
- Better suggestions for keyboard shortcuts?
- Can't figure out how to get tool window menu entry to be hidden when debugger is already attached
- No "detach" support at the moment
  - Already easy with VS "Stop" button, is detach menu item for FSI tool window needed?
  - When running a snippet, should debugger detach at the end or stay attached?
    - No way for VS currently to detect when a snippet is done executing
- Debug experience after attaching has a few rough edges