### PR TITLE
Fixes #157 -- should not allow Framework 4 / F# 3.1 combination in proje...

### DIFF
--- a/vsintegration/src/deployment/EnableOpenSource/EnableOpenSource.csproj
+++ b/vsintegration/src/deployment/EnableOpenSource/EnableOpenSource.csproj
@@ -27,6 +27,12 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'VSRelease'">
+    <DeployExtension>True</DeployExtension>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DeployExtension>True</DeployExtension>
+  </PropertyGroup>
   <Import Project="..\..\FSharp.Common.props" />
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
@@ -505,9 +505,8 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
                                             then 
                                                 // for .NETFramework we distinguish between 2.0, 4.0 and 4.5
                                                 if targetFramework.Version.Major < 4 then v2 
-                                                else 
-                                                    if targetFramework.Version.Major = 4 && targetFramework.Version.Minor < 5 then v4 
-                                                    else v45
+                                                elif targetFramework.Version.Major = 4 && targetFramework.Version.Minor < 5 then v4 
+                                                else v45
                                             else 
                                                 // for other target frameworks we assume that they are distinguished by the profile
                                                 let result = 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
@@ -497,13 +497,17 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
                                     |> Seq.toList
                                 let (_, _, v2) = flatList |> List.find(fun (k1, k2, _) -> k1 = FSharpSDKHelper.NETFramework && k2 = FSharpSDKHelper.v20)
                                 let (_, _, v4) = flatList |> List.find(fun (k1, k2, _) -> k1 = FSharpSDKHelper.NETFramework && k2 = FSharpSDKHelper.v40)
+                                let (_, _, v45) = flatList |> List.find(fun (k1, k2, _) -> k1 = FSharpSDKHelper.NETFramework && k2 = FSharpSDKHelper.v45)
                                 {
                                     new Microsoft.VisualStudio.FSharp.ProjectSystem.IFSharpCoreVersionLookupService with
                                         member this.ListAvailableFSharpCoreVersions(targetFramework) =
                                             if targetFramework.Identifier = FSharpSDKHelper.NETFramework
                                             then 
-                                                // for .NETFramework we distinguish only between 2.0 and 4.0
-                                                if targetFramework.Version.Major < 4 then v2 else v4
+                                                // for .NETFramework we distinguish between 2.0, 4.0 and 4.5
+                                                if targetFramework.Version.Major < 4 then v2 
+                                                else 
+                                                    if targetFramework.Version.Major = 4 && targetFramework.Version.Minor < 5 then v4 
+                                                    else v45
                                             else 
                                                 // for other target frameworks we assume that they are distinguished by the profile
                                                 let result = 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/ProjectPrelude.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/ProjectPrelude.fs
@@ -91,6 +91,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         [<Literal>]
         let v40 = "v4.0"
         [<Literal>]
+        let v45 = "v4.5"
+        [<Literal>]
         let NETCore = ".NETCore"
         [<Literal>]
         let NETPortable = ".NETPortable"
@@ -119,6 +121,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             seq {
                 yield! listReferenceFoldersForPlatform (Path.Combine(NETFramework, v20))
                 yield! listReferenceFoldersForPlatform (Path.Combine(NETFramework, v40))
+                yield! listReferenceFoldersForPlatform (Path.Combine(NETFramework, v45))
                 yield! listReferenceFoldersForPlatform NETCore
                 yield! listReferenceFoldersForPlatform NETPortable
             }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/SupportedRuntimes/SupportedRuntimes.xml
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/SupportedRuntimes/SupportedRuntimes.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TargetFrameworks>
+    <TargetFramework Identifier=".NETFramework" Version="v2.0">
+        <Assembly Version="2.3.0.0" Description="F# 3.0 (FSharp.Core, 2.3.0.0)"/>
+    </TargetFramework>
+    <TargetFramework Identifier=".NETFramework" Version="v4.0">
+        <Assembly Version="4.3.0.0" Description="F# 3.0 (FSharp.Core, 4.3.0.0)"/>
+    </TargetFramework>    
+    <TargetFramework Identifier=".NETFramework" Version="v4.5">
+        <Assembly Version="4.3.1.0" Description="F# 3.1 (FSharp.Core, 4.3.1.0)"/>
+        <Assembly Version="4.4.0.0" Description="F# 4.0 (FSharp.Core, 4.4.0.0)"/>
+    </TargetFramework>    
+    <TargetFramework Identifier=".NETPortable" Profile="Profile47">
+        <Assembly Version="2.3.5.0" Description="F# 3.0 (FSharp.Core, 2.3.5.0)"/>
+        <Assembly Version="2.3.5.1" Description="F# 3.1 (FSharp.Core, 2.3.5.1)"/>
+        <Assembly Version="3.47.4.0" Description="F# 4.0 (FSharp.Core, 3.47.4.0)"/>
+    </TargetFramework>
+    <TargetFramework Identifier=".NETPortable" Profile="Profile7">
+        <Assembly Version="3.3.1.0" Description="F# 3.1 (FSharp.Core, 3.3.1.0)"/>
+        <Assembly Version="3.7.4.0" Description="F# 4.0 (FSharp.Core, 3.7.4.0)"/>
+    </TargetFramework>    
+    <TargetFramework Identifier=".NETPortable" Profile="Profile78">
+        <Assembly Version="3.78.3.1" Description="F# 3.1 (FSharp.Core, 3.78.3.1)"/>
+        <Assembly Version="3.78.4.0" Description="F# 4.0 (FSharp.Core, 3.78.4.0)"/>
+    </TargetFramework>    
+    <TargetFramework Identifier=".NETPortable" Profile="Profile259">
+        <Assembly Version="3.259.3.1" Description="F# 3.1 (FSharp.Core, 3.259.3.1)"/>
+        <Assembly Version="3.259.4.0" Description="F# 4.0 (FSharp.Core, 3.259.4.0)"/>
+    </TargetFramework>    
+</TargetFrameworks>


### PR DESCRIPTION
...ct properties

Improves FSharp.Core selection given a specific .Net Framework.

When a new target framework is selected if the currently selected fsharp.core is not compatible
with the newly selected .net framework then it is selected according to the following:

.NetFrameworks 2.0, 3.0 and 3.5 select fsharp.core, v 2.3.0.0
.NetFramework 4.0 selects fsharp.core v 4.3.0.0
.NetFramework 4.5, 4.51, 4.52 and 4.6 selects fsharp.core 4.4.0.0

If a compatible fsharp.core is selected when a new .netframework is selected then the selection remains unchanged.
.NetFramework 4.5, 4.51, 4.52 and 4.6 are compatible with fsharp.core and 4.3.1.0, 4.4.0.0

Note:
1.  Internal build "copydependencies.proj" needs to be updated with a new SupportedRuntimes.xml location.
2.  OSS supportedruntimes.xml needs to be manually copied to the %ProgramFiles(x86)%\Microsoft SDKs\F#\4.0\Framework\v4.0 directory.
    until OSS vsix installer is updated to integrate the compiler into VS.