### PR TITLE
Remove 'Execute Line in F# Interactive' command

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
@@ -549,7 +549,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                     Microsoft.VisualStudio.FSharp.Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), null, null);
                     return true;
                 }
-
             }
 #endif
             return false;

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
@@ -423,10 +423,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 {
                     return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
                 }
-                else if (nCmdId == (uint)Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteLineInInteractive)
-                {
-                    return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
-                }
             }
 #endif
             return (int)NativeMethods.E_FAIL; // delegate to next command target.
@@ -550,14 +546,10 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             {
                 if (nCmdId == (uint)Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteSelectionInInteractive)
                 {
-                    Microsoft.VisualStudio.FSharp.Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), false, null, null);
+                    Microsoft.VisualStudio.FSharp.Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), null, null);
                     return true;
                 }
-                else if (nCmdId == (uint)Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteLineInInteractive)
-                {
-                    Microsoft.VisualStudio.FSharp.Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), true, null, null);
-                    return true;
-                }
+
             }
 #endif
             return false;

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
@@ -60,13 +60,11 @@ module internal Guids =
     let guidInteractive                 = Microsoft.VisualStudio.VSConstants.VsStd11 
     let cmdIDSendSelection              = int Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteSelectionInInteractive
     let guidInteractive2                = Microsoft.VisualStudio.VSConstants.VsStd11
-    let cmdIDSendLine                   = int Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteLineInInteractive
 #else
     // hybrid still uses own commands
     let guidInteractive                 = Guid("8B9BF77B-AF94-4588-8847-2EB2BFFD29EB")
     let cmdIDSendSelection              = 0x01
     let guidInteractive2                = Guid("B607E86C-A761-4685-8D98-71A3BB73233A")
-    let cmdIDSendLine                   = 0x01
 #endif
 
     let guidFsiPackage                  = "eeeeeeee-9342-42f1-8ea9-42f0e8a6be55" // FSI-LINKAGE-POINT: when packaged here

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
@@ -231,10 +231,6 @@
     <KeyBinding Condition="!Defined(FX_ATLEAST_45)" guid="guidInteractive" id="cmdidSendSelection" editor="GUID_TextEditorFactory" key1="VK_RETURN" mod1="Alt"  />
     <KeyBinding Condition="Defined(FX_ATLEAST_45)" guid ="guidVSStd11" id ="cmdidExecuteSelectionInInteractive" editor="GUID_TextEditorFactory" key1="VK_RETURN" mod1="Alt"  />
 
-    <!-- VK_OEM_7 is the ' mark -->
-    <KeyBinding Condition="!Defined(FX_ATLEAST_45)" guid="guidInteractive2" id="cmdidSendLine" editor="GUID_TextEditorFactory" key1="VK_OEM_7" mod1="Alt"  />
-    <KeyBinding Condition="Defined(FX_ATLEAST_45)" guid ="guidVSStd11" id ="cmdidExecuteLineInInteractive" editor="GUID_TextEditorFactory" key1="VK_OEM_7" mod1="Alt"  />
-
     <!-- CRTL-ALT-F for FSI window - following similar bindings for "other windows" -->
     <KeyBinding guid="guidFsiPackageCmdSet" id="cmdidFsiToolWindow"    editor="guidVSStd97" key1="F" mod1="Control Alt"  />
 
@@ -302,7 +298,6 @@
 
     <GuidSymbol name="guidVSStd11" value="{D63DB1F0-404E-4B21-9648-CA8D99245EC3}" >
       <IDSymbol name="cmdidExecuteSelectionInInteractive" value ="0x018"/>
-      <IDSymbol name="cmdidExecuteLineInInteractive" value ="0x019"/>
       <IDSymbol name="cmdidInteractiveSessionInterrupt" value ="0x01A"/>
       <IDSymbol name="cmdidInteractiveSessionRestart" value ="0x01B"/>
     </GuidSymbol>
@@ -311,10 +306,7 @@
     <GuidSymbol Condition="!Defined(FX_ATLEAST_45)" name="guidInteractive" value="{8B9BF77B-AF94-4588-8847-2EB2BFFD29EB}" >
       <IDSymbol name="cmdidSendSelection" value ="0x01"/>
     </GuidSymbol>
-    <GuidSymbol Condition="!Defined(FX_ATLEAST_45)" name="guidInteractive2" value="{B607E86C-A761-4685-8D98-71A3BB73233A}" >
-      <IDSymbol name="cmdidSendLine" value ="0x01"/>
-    </GuidSymbol>
-
+  
   </Symbols>
 
 </CommandTable>

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
@@ -119,7 +119,6 @@
       <!-- The following places a button on the F# Editor Context Menu -->
       <!-- In Dev11, shell now has 
       <Button guid ="guidVSStd11" id ="cmdidExecuteSelectionInInteractive" priority ="0x100" type ="Button">
-      <Button guid ="guidVSStd11" id ="cmdidExecuteLineInInteractive" priority ="0x105" type ="Button">
       -->
       <!-- In Dev10 hybrid, we need buttons below -->
       <Button Condition="!Defined(FX_ATLEAST_45)" guid ="guidInteractive" id ="cmdidSendSelection" priority ="0x100" type ="Button">
@@ -128,15 +127,6 @@
         <Strings>
           <ButtonText>Send To Interactive</ButtonText>
           <CommandName>Interactive.Send.Selection.Context</CommandName>
-        </Strings>
-        <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>
-      </Button>
-      <Button Condition="!Defined(FX_ATLEAST_45)" guid ="guidInteractive2" id ="cmdidSendLine" priority ="0x101" type ="Button">
-        <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_LANGUAGE"/>
-        <Icon guid="guidFsiConsoleBmp" id="bmpConsole"/>
-        <Strings>
-          <ButtonText>Send Line To Interactive</ButtonText>
-          <CommandName>Interactive.Send.Line.Context</CommandName>
         </Strings>
         <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>
       </Button>

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
@@ -69,17 +69,14 @@ module internal Hooks =
         with e2 ->
             (System.Windows.Forms.MessageBox.Show(VFSIstrings.SR.exceptionRaisedWhenRequestingToolWindow(e2.ToString())) |> ignore)
 
-    let OnMLSend (this:Package) (selectLine : bool) (sender:obj) (e:EventArgs) =
-        withFSIToolWindow this (fun window ->
-            if selectLine then window.MLSendLine(sender,e)
-            else window.MLSend(sender,e)
-        )
+    let OnMLSend (this:Package) (sender:obj) (e:EventArgs) =
+        withFSIToolWindow this (fun window -> window.MLSend(sender, e))
 
     let AddReferencesToFSI (this:Package) references =
         withFSIToolWindow this (fun window -> window.AddReferences references)
 
     // FxCop request this function not be public
-    let private supportWhenFSharpDocument (selectLine : bool) (sender:obj) (e:EventArgs) =    
+    let private supportWhenFSharpDocument (sender:obj) (e:EventArgs) =    
         let command = sender :?> OleMenuCommand       
         if command <> null then                        
             let looksLikeFSharp,haveSelection = 
@@ -135,12 +132,8 @@ module internal Hooks =
                 // Add OLECommand to OleCommandTarget at the package level,
                 // for when it is fired from other contexts, e.g. text editor.
                 let id  = new CommandID(Guids.guidInteractive,int32 Guids.cmdIDSendSelection)
-                let cmd = new OleMenuCommand(new EventHandler(OnMLSend this false), id)
-                cmd.BeforeQueryStatus.AddHandler(new EventHandler(supportWhenFSharpDocument false))
+                let cmd = new OleMenuCommand(new EventHandler(OnMLSend this id)
+                cmd.BeforeQueryStatus.AddHandler(new EventHandler(supportWhenFSharpDocument))
                 commandService.AddCommand(cmd)
 
-                let id  = new CommandID(Guids.guidInteractive2,int32 Guids.cmdIDSendLine)
-                let cmd = new OleMenuCommand(new EventHandler(OnMLSend this true), id)
-                cmd.BeforeQueryStatus.AddHandler(new EventHandler(supportWhenFSharpDocument true))
-                commandService.AddCommand(cmd)
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
@@ -132,7 +132,7 @@ module internal Hooks =
                 // Add OLECommand to OleCommandTarget at the package level,
                 // for when it is fired from other contexts, e.g. text editor.
                 let id  = new CommandID(Guids.guidInteractive,int32 Guids.cmdIDSendSelection)
-                let cmd = new OleMenuCommand(new EventHandler(OnMLSend this id)
+                let cmd = new OleMenuCommand(new EventHandler(OnMLSend this), id)
                 cmd.BeforeQueryStatus.AddHandler(new EventHandler(supportWhenFSharpDocument))
                 commandService.AddCommand(cmd)
 


### PR DESCRIPTION
Continue #257, this PR removes 'Execute Line in F# Interactive' command, which has been covered by new behaviours of Alt + Enter.

With the upcoming support for Script Debugging, this will reduces the clutter of context menu. (Sorry if merging this makes rebasing #225 much harder.)