### PR TITLE
Add support for hexadecimal values (like 0xFF) ​​to msbuild property BaseAddress

### DIFF
--- a/vsintegration/src/unittests/Tests.ProjectSystem.Miscellaneous.fs
+++ b/vsintegration/src/unittests/Tests.ProjectSystem.Miscellaneous.fs
@@ -768,6 +768,15 @@ type Utilities() =
         ()
 
 
+    [<Test>]
+    member public this.``Parse MSBuild property of type Int64`` () = 
+        Assert.AreEqual(123L, ProjectNode.ParsePropertyValueToInt64("123"))
+        Assert.AreEqual(255L, ProjectNode.ParsePropertyValueToInt64("0xFF"))
+        Assert.AreEqual(null, ProjectNode.ParsePropertyValueToInt64(""))
+        Assert.AreEqual(null, ProjectNode.ParsePropertyValueToInt64(null))
+        Assert.Throws<Exception>(fun () -> ignore (ProjectNode.ParsePropertyValueToInt64("abc"))) |> ignore
+        Assert.Throws<Exception>(fun () -> ignore (ProjectNode.ParsePropertyValueToInt64("12333333333333333333333333"))) |> ignore
+
 
 #if DEBUGGERVISUALIZER
 module internal DebugViz =


### PR DESCRIPTION
This was a bug, because loading a project with

```xml
    <BaseAddress>0x06800000</BaseAddress>
```

the property value was silently ignored

Fix an exception when loading projects (like on fsharp.sln with [FSharp.Compiler.fsproj](https://github.com/Microsoft/visualfsharp/blob/0b7bee8d6982361828eae6d717f03364fa364ca1/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj#L17) )
