### PR TITLE
fix path combine

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net20.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net20.fs
@@ -3278,4 +3278,4 @@ System.Tuple`8[T1,T2,T3,T4,T5,T6,T7,TRest]: TRest Rest
 System.Tuple`8[T1,T2,T3,T4,T5,T6,T7,TRest]: TRest get_Rest()
 System.Tuple`8[T1,T2,T3,T4,T5,T6,T7,TRest]: Void .ctor(T1, T2, T3, T4, T5, T6, T7, TRest)
 "
-        SurfaceArea.verify expected "net20" (sprintf "%s\\%s" __SOURCE_DIRECTORY__ __SOURCE_FILE__)
+        SurfaceArea.verify expected "net20" (System.IO.Path.Combine(__SOURCE_DIRECTORY__,__SOURCE_FILE__))

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net40.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net40.fs
@@ -3462,4 +3462,4 @@ Microsoft.FSharp.Reflection.UnionCaseInfo: System.Type DeclaringType
 Microsoft.FSharp.Reflection.UnionCaseInfo: System.Type GetType()
 Microsoft.FSharp.Reflection.UnionCaseInfo: System.Type get_DeclaringType()
 "
-        SurfaceArea.verify expected "net40" (sprintf "%s\\%s" __SOURCE_DIRECTORY__ __SOURCE_FILE__)
+        SurfaceArea.verify expected "net40" (System.IO.Path.Combine(__SOURCE_DIRECTORY__,__SOURCE_FILE__))

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable259.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable259.fs
@@ -3446,4 +3446,4 @@ System.Numerics.BigInteger: System.Type GetType()
 System.Numerics.BigInteger: Void .ctor(Int32)
 System.Numerics.BigInteger: Void .ctor(Int64)
 "
-        SurfaceArea.verify expected "portable259" (sprintf "%s\\%s" __SOURCE_DIRECTORY__ __SOURCE_FILE__)
+        SurfaceArea.verify expected "portable259" (System.IO.Path.Combine(__SOURCE_DIRECTORY__,__SOURCE_FILE__))

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable7.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable7.fs
@@ -3422,4 +3422,4 @@ Microsoft.FSharp.Reflection.UnionCaseInfo: System.Type DeclaringType
 Microsoft.FSharp.Reflection.UnionCaseInfo: System.Type GetType()
 Microsoft.FSharp.Reflection.UnionCaseInfo: System.Type get_DeclaringType()
 "
-        SurfaceArea.verify expected "portable7" (sprintf "%s\\%s" __SOURCE_DIRECTORY__ __SOURCE_FILE__)
+        SurfaceArea.verify expected "portable7" (System.IO.Path.Combine(__SOURCE_DIRECTORY__,__SOURCE_FILE__))

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable78.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable78.fs
@@ -3446,4 +3446,4 @@ System.Numerics.BigInteger: System.Type GetType()
 System.Numerics.BigInteger: Void .ctor(Int32)
 System.Numerics.BigInteger: Void .ctor(Int64)
 "
-        SurfaceArea.verify expected "portable78" (sprintf "%s\\%s" __SOURCE_DIRECTORY__ __SOURCE_FILE__)
+        SurfaceArea.verify expected "portable78" (System.IO.Path.Combine(__SOURCE_DIRECTORY__,__SOURCE_FILE__))


### PR DESCRIPTION
This is a code cleanup to fix cross plat directory separators, and easier align openfsharp and visualfsharp.

Edit by kevinr.