### PR TITLE
fix add file reference (com dll)

### DIFF
--- a/vsintegration/src/unittests/Tests.ProjectSystem.References.fs
+++ b/vsintegration/src/unittests/Tests.ProjectSystem.References.fs
@@ -16,6 +16,7 @@ open UnitTests.TestLib.ProjectSystem
 open Microsoft.VisualStudio.FSharp.ProjectSystem
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.Win32
+open System.Xml.Linq
 
 [<TestFixture>]
 type References() = 
@@ -619,3 +620,59 @@ type References() =
             let contents = File.ReadAllText(newProjFileName)
             AssertContains contents newPropVal
         )
+
+            
+    [<Test>]
+    member public this.``AddReference.COM`` () = 
+        DoWithTempFile "Test.fsproj" (fun projFile ->
+            File.AppendAllText(projFile, TheTests.SimpleFsprojText([], [], ""))
+            use project = TheTests.CreateProject(projFile)
+
+            let guid = Guid("50a7e9b0-70ef-11d1-b75a-00a0c90564fe")
+
+            let selectorData = VSCOMPONENTSELECTORDATA (
+                ``type`` = VSCOMPONENTTYPE.VSCOMPONENTTYPE_Com2,
+                guidTypeLibrary = guid,
+                wTypeLibraryMinorVersion = 0us,
+                wTypeLibraryMajorVersion = 1us,
+                bstrTitle = "Microsoft Shell Controls And Automation" )
+            let refContainer = GetReferenceContainerNode(project)
+
+            let comReference = refContainer.AddReferenceFromSelectorData(selectorData)
+
+            // check reference node properties
+            Assert.IsNotNull comReference
+            Assert.IsInstanceOf(typeof<ComReferenceNode>, comReference)
+            let comRef = comReference :?> ComReferenceNode
+            Assert.AreEqual(1, comRef.MajorVersionNumber)
+            Assert.AreEqual(0, comRef.MinorVersionNumber)
+            Assert.AreEqual(guid, comRef.TypeGuid)
+            Assert.AreEqual("Microsoft Shell Controls And Automation", comRef.Caption)
+            let sysDirectory = Environment.GetFolderPath(Environment.SpecialFolder.SystemX86)
+            StringAssert.AreEqualIgnoringCase(Path.Combine(sysDirectory, "shell32.dll"), comRef.InstalledFilePath)
+
+            // check node exists under references
+            let l = new List<ComReferenceNode>()
+            project.FindNodesOfType(l)
+
+            Assert.AreEqual(1, l.Count)
+            let referenceNode = l.[0]
+            Assert.AreSame(comRef, referenceNode)
+
+            // check saved msbuild item
+            SaveProject(project)
+            let fsproj = XDocument.Load(project.FileName)
+            printfn "%O" fsproj
+            let xn s = fsproj.Root.GetDefaultNamespace().GetName(s)
+            let comReferencesXml = fsproj.Descendants(xn "COMReference") |> Seq.toList
+
+            Assert.AreEqual(1, comReferencesXml |> List.length)
+
+            let comRefXml = comReferencesXml |> List.head
+
+            Assert.AreEqual("Microsoft Shell Controls And Automation", comRefXml.Attribute(XName.Get("Include")).Value)
+            Assert.AreEqual(guid, Guid(comRefXml.Element(xn "Guid").Value))
+            Assert.AreEqual("1", comRefXml.Element(xn "VersionMajor").Value)
+            Assert.AreEqual("0", comRefXml.Element(xn "VersionMinor").Value)
+            Assert.AreEqual("0", comRefXml.Element(xn "Lcid").Value)
+            )

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAComReference.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAComReference.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 int locale = 0;
                 try
                 {
-                    locale = int.Parse(BaseReferenceNode.LCID, CultureInfo.InvariantCulture);
+                    locale = BaseReferenceNode.LCID;
                 }
                 catch (System.FormatException)
                 {

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAComReference.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAComReference.cs
@@ -24,15 +24,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         {
             get
             {
-                int locale = 0;
-                try
-                {
-                    locale = BaseReferenceNode.LCID;
-                }
-                catch (System.FormatException)
-                {
-                    // Do Nothing
-                }
+                var locale = BaseReferenceNode.LCID;
+
                 if (0 == locale)
                 {
                     return string.Empty;

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Microsoft.VisualStudio.Package.Project.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Microsoft.VisualStudio.Package.Project.cs
@@ -153,6 +153,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /*internal, but public for FSharp.Project.dll*/ public const string ProjectProperties = "ProjectProperties";
         /*internal, but public for FSharp.Project.dll*/ public const string Quiet = "Quiet";
         /*internal, but public for FSharp.Project.dll*/ public const string QueryReloadNestedProject = "QueryReloadNestedProject";
+        /*internal, but public for FSharp.Project.dll*/ public const string ReferenceCouldNotBeAdded = "ReferenceCouldNotBeAdded";
         /*internal, but public for FSharp.Project.dll*/ public const string ReferenceAlreadyExists = "ReferenceAlreadyExists";
         /*internal, but public for FSharp.Project.dll*/ public const string ReferenceWithAssemblyNameAlreadyExists = "ReferenceWithAssemblyNameAlreadyExists";
         /*internal, but public for FSharp.Project.dll*/ public const string ReferencesNodeName = "ReferencesNodeName";

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Microsoft.VisualStudio.Package.Project.resx
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Microsoft.VisualStudio.Package.Project.resx
@@ -125,6 +125,10 @@
     <value>Advanced</value>
     <comment>Project Property Page Caption</comment>
   </data>
+  <data name="ReferenceCouldNotBeAdded" xml:space="preserve">
+    <value>A reference to '{0}' could not be added.</value>
+    <comment>ReferenceCouldNotBeAdded error message</comment>
+  </data>
   <data name="ReferenceAlreadyExists" xml:space="preserve">
     <value>A reference to '{0}' could not be added. A reference to the component '{1}' already exists in the project.</value>
     <comment>ReferenceAlreadyExists error message</comment>


### PR DESCRIPTION
lcid is an integer
fix typelib registry path, the lcid part is the hexadecimal string representation of the lcid value
added exception on failed add reference
fix nre on if registry key not found

fix #278