### PR TITLE
Include declaring source directory in #r search path

### DIFF
--- a/src/fsharp/build.fs
+++ b/src/fsharp/build.fs
@@ -2708,6 +2708,10 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
            || isNetModule then
 
             let searchPaths =
+                // if this is a #r reference (not from dummy range), make sure the directory of the declaring
+                // file is included in the search path. This should ideally already be one of the search paths, but
+                // during some global checks it won't be.  We append to the end of the search list so that this is the last
+                // place that is checked.
                 if m <> range0 && m <> rangeStartup && m <> rangeCmdArgs && FileSystem.IsPathRootedShim m.FileName then
                     tcConfig.SearchPathsForLibraryFiles @ [Path.GetDirectoryName(m.FileName)]
                 else    

--- a/src/fsharp/build.fs
+++ b/src/fsharp/build.fs
@@ -2705,9 +2705,15 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
         let isNetModule = String.Compare(ext,".netmodule",StringComparison.OrdinalIgnoreCase)=0 
         if String.Compare(ext,".dll",StringComparison.OrdinalIgnoreCase)=0 
            || String.Compare(ext,".exe",StringComparison.OrdinalIgnoreCase)=0 
-           || isNetModule then 
+           || isNetModule then
 
-            let resolved = TryResolveFileUsingPaths(tcConfig.SearchPathsForLibraryFiles,m,nm)
+            let searchPaths =
+                if m <> range0 && m <> rangeStartup && m <> rangeCmdArgs && FileSystem.IsPathRootedShim m.FileName then
+                    tcConfig.SearchPathsForLibraryFiles @ [Path.GetDirectoryName(m.FileName)]
+                else    
+                    tcConfig.SearchPathsForLibraryFiles
+
+            let resolved = TryResolveFileUsingPaths(searchPaths,m,nm)
             match resolved with 
             | Some(resolved) -> 
                 let sysdir = tcConfig.IsSystemAssembly resolved

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/RelativeHashRResolution02_2.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/RelativeHashRResolution02_2.fsx
@@ -1,0 +1,6 @@
+#r "./lib.dll"
+
+module Foo =
+    let Y = 22
+    do
+        printfn "%O" (Lib.X())

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/RelativeHashRResolution03_2.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/RelativeHashRResolution03_2.fsx
@@ -1,0 +1,6 @@
+#r "lib.dll"
+
+module Foo =
+    let Y = 22
+    do
+        printfn "%O" (Lib.X())

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/RelativeHashRResolution05_2.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/RelativeHashRResolution05_2.fsx
@@ -1,0 +1,6 @@
+#r "lib.dll"
+
+module Foo =
+    let Y = 22
+    do
+        printfn "%O" (Lib.X())

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution01_2.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution01_2.fsx
@@ -1,0 +1,6 @@
+#r "../lib.dll"
+
+module Foo =
+    let Y = 22
+    do
+        printfn "%O" (Lib.X())

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution04_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution04_1.fsx
@@ -1,4 +1,8 @@
+#if PIPED_FROM_TEST_DIR
+#load "aaa/bbb/RelativeHashRResolution04_2.fsx"
+#else
 #load "RelativeHashRResolution04_2.fsx"
+#endif
 
 printfn "%O" (Lib.X())
 printfn "%O" RelativeHashRResolution04_2.Foo.Y

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution04_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution04_1.fsx
@@ -1,0 +1,6 @@
+#load "RelativeHashRResolution04_2.fsx"
+
+printfn "%O" (Lib.X())
+printfn "%O" RelativeHashRResolution04_2.Foo.Y
+
+#q ;;

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution04_2.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution04_2.fsx
@@ -1,0 +1,6 @@
+#r "../lib.dll"
+
+module Foo =
+    let Y = 22
+    do
+        printfn "%O" (Lib.X())

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution05_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution05_1.fsx
@@ -1,0 +1,6 @@
+#load "..\RelativeHashRResolution05_2.fsx"
+
+printfn "%O" (Lib.X())
+printfn "%O" RelativeHashRResolution05_2.Foo.Y
+
+#q ;;

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution05_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/aaa/bbb/RelativeHashRResolution05_1.fsx
@@ -1,4 +1,8 @@
-#load "..\RelativeHashRResolution05_2.fsx"
+#if PIPED_FROM_TEST_DIR
+#load "./aaa/RelativeHashRResolution05_2.fsx"
+#else
+#load "../RelativeHashRResolution05_2.fsx"
+#endif
 
 printfn "%O" (Lib.X())
 printfn "%O" RelativeHashRResolution05_2.Foo.Y

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution01_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution01_1.fsx
@@ -1,0 +1,6 @@
+#load "../aaa/bbb/RelativeHashRResolution01_2.fsx"
+
+printfn "%O" (Lib.X())
+printfn "%O" RelativeHashRResolution01_2.Foo.Y
+
+#q ;;

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution01_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution01_1.fsx
@@ -1,4 +1,8 @@
+#if PIPED_FROM_TEST_DIR
+#load "aaa/bbb/RelativeHashRResolution01_2.fsx"
+#else
 #load "../aaa/bbb/RelativeHashRResolution01_2.fsx"
+#endif
 
 printfn "%O" (Lib.X())
 printfn "%O" RelativeHashRResolution01_2.Foo.Y

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution02_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution02_1.fsx
@@ -1,4 +1,8 @@
+#if PIPED_FROM_TEST_DIR
+#load "./aaa/RelativeHashRResolution02_2.fsx"
+#else
 #load "../aaa/RelativeHashRResolution02_2.fsx"
+#endif
 
 printfn "%O" (Lib.X())
 printfn "%O" RelativeHashRResolution02_2.Foo.Y

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution02_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution02_1.fsx
@@ -1,0 +1,6 @@
+#load "../aaa/RelativeHashRResolution02_2.fsx"
+
+printfn "%O" (Lib.X())
+printfn "%O" RelativeHashRResolution02_2.Foo.Y
+
+#q ;;

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution03_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution03_1.fsx
@@ -1,4 +1,8 @@
+#if PIPED_FROM_TEST_DIR
+#load "aaa/RelativeHashRResolution03_2.fsx"
+#else
 #load "../aaa/RelativeHashRResolution03_2.fsx"
+#endif
 
 printfn "%O" (Lib.X())
 printfn "%O" RelativeHashRResolution03_2.Foo.Y

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution03_1.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/ccc/RelativeHashRResolution03_1.fsx
@@ -1,0 +1,6 @@
+#load "../aaa/RelativeHashRResolution03_2.fsx"
+
+printfn "%O" (Lib.X())
+printfn "%O" RelativeHashRResolution03_2.Foo.Y
+
+#q ;;

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/env.lst
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/env.lst
@@ -99,3 +99,10 @@ NoMT	SOURCE=E_NoNoFrameworkWithFSCore.fs  COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="-
 
 	SOURCE="ScriptTest\\LoadScriptResolution01.fsx"   SCFLAGS="--nologo"					# LoadScriptResolution01.fsx - fsc
 	SOURCE="ScriptTest\\LoadScriptResolution01.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# LoadScriptResolution01.fsx - fsi
+
+# relative paths used in #r references
+	SOURCE=ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution01_1.fsx
+	SOURCE=ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution02_1.fsx
+	SOURCE=ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution03_1.fsx
+	SOURCE=aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution04_1.fsx
+	SOURCE=aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution05_1.fsx

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/env.lst
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/env.lst
@@ -100,9 +100,63 @@ NoMT	SOURCE=E_NoNoFrameworkWithFSCore.fs  COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="-
 	SOURCE="ScriptTest\\LoadScriptResolution01.fsx"   SCFLAGS="--nologo"					# LoadScriptResolution01.fsx - fsc
 	SOURCE="ScriptTest\\LoadScriptResolution01.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# LoadScriptResolution01.fsx - fsi
 
-# relative paths used in #r references
-	SOURCE=ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution01_1.fsx
-	SOURCE=ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution02_1.fsx
-	SOURCE=ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution03_1.fsx
-	SOURCE=aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution04_1.fsx
-	SOURCE=aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC PRECMD="\$FSC_PIPE -a lib.fs -o aaa\\lib.dll" SCFLAGS="--nologo"			# RelativeHashRResolution05_1.fsx
+#### relative paths used in #r references
+
+# create required reference library once
+	SOURCE=lib.fs COMPILE_ONLY=1 SCFLAGS="--nologo -a -o aaa\\lib.dll"			# RelativeHashRResolution_makelib
+
+# via FSI, invoking like `fsi.exe --exec path\script.fsx`
+	SOURCE=ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution01_exec
+	SOURCE=ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution02_exec
+	SOURCE=ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution03_exec
+	SOURCE=aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution04_exec
+	SOURCE=aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution05_exec
+
+# via FSI, invoking like `fsi.exe --exec ..\path\path\script.fsx`
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution01_execrelative
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution02_execrelative
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution03_execrelative
+	SOURCE=..\\Misc\\aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution04_execrelative
+	SOURCE=..\\Misc\\aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution05_execrelative
+
+# via FSI, invoking like `fsi.exe --exec c:\full\path\script.fsx`
+	SOURCE="\$CWD\\ccc\\RelativeHashRResolution01_1.fsx" COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution01_execfull
+	SOURCE="\$CWD\\ccc\\RelativeHashRResolution02_1.fsx" COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution02_execfull
+	SOURCE="\$CWD\\ccc\\RelativeHashRResolution03_1.fsx" COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution03_execfull
+	SOURCE="\$CWD\\aaa\\bbb\\RelativeHashRResolution04_1.fsx" COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution04_execfull
+	SOURCE="\$CWD\\aaa\\bbb\\RelativeHashRResolution05_1.fsx" COMPILE_ONLY=1 FSIMODE=EXEC SCFLAGS="--nologo"			# RelativeHashRResolution05_execfull
+
+# via FSI, invoking like `fsi.exe < path\script.fsx`
+	SOURCE=ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="--nologo --define:PIPED_FROM_TEST_DIR"			# RelativeHashRResolution01_pipe
+	SOURCE=ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="--nologo --define:PIPED_FROM_TEST_DIR"			# RelativeHashRResolution02_pipe
+	SOURCE=ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="--nologo --define:PIPED_FROM_TEST_DIR"			# RelativeHashRResolution03_pipe
+	SOURCE=aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="--nologo --define:PIPED_FROM_TEST_DIR"			# RelativeHashRResolution04_pipe
+	SOURCE=aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="--nologo --define:PIPED_FROM_TEST_DIR"			# RelativeHashRResolution05_pipe
+
+# via FSC, invoking like `fsc.exe path\script.fsx`
+	SOURCE=ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution01_fsc
+	SOURCE=ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution02_fsc
+	SOURCE=ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution03_fsc
+	SOURCE=aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution04_fsc
+	SOURCE=aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution05_fsc
+
+# via FSC, invoking like `fsc.exe ..\path\path\script.fsx`
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution01_fscrelative
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution02_fscrelative
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution03_fscrelative
+	SOURCE=..\\Misc\\aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution04_fscrelative
+	SOURCE=..\\Misc\\aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo"			# RelativeHashRResolution05_fscrelative
+
+# via FSC, invoking like `fsc.exe --simpleresolution path\script.fsx`
+	SOURCE=ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution01_fscsimple
+	SOURCE=ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution02_fscsimple
+	SOURCE=ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution03_fscsimple
+	SOURCE=aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution04_fscsimple
+	SOURCE=aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution05_fscsimple
+
+# via FSC, invoking like `fsc.exe ..\path\path\script.fsx`
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution01_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution01_fscrelativesimple
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution02_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution02_fscrelativesimple
+	SOURCE=..\\Misc\\ccc\\RelativeHashRResolution03_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution03_fscrelativesimple
+	SOURCE=..\\Misc\\aaa\\bbb\\RelativeHashRResolution04_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution04_fscrelativesimple
+	SOURCE=..\\Misc\\aaa\\bbb\\RelativeHashRResolution05_1.fsx COMPILE_ONLY=1 SCFLAGS="--nologo --simpleresolution --noframework -r:%FSCOREDLLPATH%"			# RelativeHashRResolution05_fscrelativesimple

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/keep.lst
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/keep.lst
@@ -1,0 +1,1 @@
+aaa\lib.dll

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/lib.fs
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/lib.fs
@@ -1,0 +1,2 @@
+module Lib
+let X () = 42

--- a/tests/fsharpqa/Source/run.pl
+++ b/tests/fsharpqa/Source/run.pl
@@ -459,8 +459,12 @@ sub RunCommand {
 # GetSrc -- Find the source file to build
 #
 sub GetSrc() {
+  my $cwd = cwd();
+  
   # The environment SOURCE var usually defines what to compile
-  my $source = $ENV{SOURCE};
+  $_ = $ENV{SOURCE};
+  s/\$CWD/$cwd/;
+  my $source = $_;
   return($source) if defined($source);
 
   # Or if there's only one source file in the directory

--- a/tests/fsharpqa/Source/test.lst
+++ b/tests/fsharpqa/Source/test.lst
@@ -289,7 +289,7 @@ Misc01			EntryPoint
 Misc01			Globalization
 Misc01,NoMT		Import
 Misc01,NoMT		..\..\..\testsprivate\fsharpqa\Source\InteractiveSession\AssemblyLoading
-Misc01,NoMT		InteractiveSession\Misc
+Misc01,NoMT,Smoke		InteractiveSession\Misc
 Misc01			Libraries\Control
 Misc01			Libraries\Core\collections
 Misc01			Libraries\Core\ExtraTopLevelOperators


### PR DESCRIPTION
fixes #273
fixes #293

FSI attempts to generate [an up-front closure](https://github.com/Microsoft/visualfsharp/blob/fsharp4/src/fsharp/build.fs#L4806-L4810) of all `#r`'ed references, but unfortunately picks [a single root file](https://github.com/Microsoft/visualfsharp/blob/fsharp4/src/fsharp/build.fs#L4795) as the base for relative resolutions.  [If it can't find the reference via direct file paths, FSI delegates to MSBuild](https://github.com/Microsoft/visualfsharp/blob/fsharp4/src/fsharp/build.fs#L2835-L2847) to do extended search.  If the MSBuild search results in certain errors or warnings, FSI issues an error.

For some reason refs like `#r "foo.dll"` cause fatal MSBuild error but refs like `#r "./foo.dll"` go down [a different codepath](https://github.com/Microsoft/visualfsharp/blob/fsharp4/src/fsharp/ReferenceResolution.fs#L388-L395) and end up not causing a fatal error (even though in both cases the reference is not resolved).  The latter case ends up succeeding in the end because FSI does another traversal through the files later, this time with proper working directory adjustments.

The change appears to clear up the problems in both #293 and #273.

![image](https://cloud.githubusercontent.com/assets/5943573/6631887/850114d0-c8ea-11e4-9b42-25ef72f60a07.png)


Need to add tests still, will update.  This did not break any existing tests.