### PR TITLE
Profile 47 targets .Net 4.5 rather than .Net 4.0.

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/VSPackage.resx
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/VSPackage.resx
@@ -384,10 +384,10 @@
     <value>A blank XML file</value>
   </data>
   <data name="5034" xml:space="preserve">
-    <value>Portable Library (.NET 4.0+, Windows 8, Silverlight 5, Xamarin)</value>
+    <value>Portable Library (.NET 4.5, Windows Store, Silverlight 5, Xamarin)</value>
   </data>
   <data name="5035" xml:space="preserve">
-    <value>A project for creating an F# library (.dll) that can run on .NET Framework 4.0+, Windows Store, Silverlight 5, Xamarin.iOS, Xamarin.Android and Xamarin.iOS(Classic).  Profile 47</value>
+    <value>A project for creating an F# library (.dll) that can run on .NET Framework 4.5, Windows Store, Silverlight 5, Xamarin.iOS, Xamarin.Android and Xamarin.iOS(Classic).  Profile 47</value>
   </data>
   <data name="5036" xml:space="preserve">
     <value>Data</value>


### PR DESCRIPTION
Fixes#114

When we originally created the Portable Library for F#, In VS 2012, we chose Profile 47 to target 
.Net Framework 4.0, Windows Store and Silverlight.  

It has come to our attention that in fact 47 targets .Net 4.5, Windows Store and Silverlight.  So this change fixes the labelling so that it is correct.

We need to decide whether to ship a profile that targets .Net 4.0, Windows Store and Silverlight.  My inclination is to not to.
