### PR TITLE
UI to help configure FSI for script debugging

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/Properties.resx
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/Properties.resx
@@ -128,7 +128,7 @@
     <value>F# Interactive options</value>
   </data>
   <data name="FSharpInteractiveOptionsDescr" xml:space="preserve">
-    <value>The command line arguments passed to the F# Interactive executable by Visual Studio.</value>
+    <value>Additional command line arguments passed to the F# Interactive executable by Visual Studio. (optimization and debug flags are ignored if script debugging is enabled)</value>
   </data>
   <data name="FSharpInteractiveMisc" xml:space="preserve">
     <value>Misc</value>
@@ -138,5 +138,14 @@
   </data>
   <data name="FSharpInteractiveShadowCopyDescr" xml:space="preserve">
     <value>Prevents referenced assemblies from being locked by the F# Interactive process.</value>
+  </data>
+  <data name="FSharpInteractiveDebugMode" xml:space="preserve">
+    <value>Enable script debugging</value>
+  </data>
+  <data name="FSharpInteractiveDebugModeDescr" xml:space="preserve">
+    <value>Enable debugging of F# scripts (may impact script performance, requires reset of F# Interactive)</value>
+  </data>
+  <data name="FSharpInteractiveDebugging" xml:space="preserve">
+    <value>Debugging</value>
   </data>
 </root>

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/VFSIstrings.txt
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/VFSIstrings.txt
@@ -8,3 +8,4 @@ sessionTerminationDetected,"Session termination detected. Press Enter to restart
 fsharpInteractive,"F# Interactive"
 couldNotFindFsiExe,"Could not find fsi.exe, the F# Interactive executable.\nThis file does not exist:\n\n%s\n"
 killingProcessRaisedException,"Killing process raised exception:\n%s"
+sessionIsNotDebugFriendly,"The current F# Interactive session is not configured for debugging. For the best experience, enable debugging in F# Interactive settings, then reset the session."

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/VFSIstrings.txt
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/VFSIstrings.txt
@@ -8,4 +8,5 @@ sessionTerminationDetected,"Session termination detected. Press Enter to restart
 fsharpInteractive,"F# Interactive"
 couldNotFindFsiExe,"Could not find fsi.exe, the F# Interactive executable.\nThis file does not exist:\n\n%s\n"
 killingProcessRaisedException,"Killing process raised exception:\n%s"
-sessionIsNotDebugFriendly,"The current F# Interactive session is not configured for debugging. For the best experience, enable debugging in F# Interactive settings, then reset the session.\n\nPress OK to debug with the current settings, or Cancel to abort."
+sessionIsNotDebugFriendly,"The current F# Interactive session is not configured for debugging. For the best experience, enable debugging in F# Interactive settings, then reset the session.\n\nAttempt debugging with current settings?"
+doNotShowWarningInFuture,"Don't show this warning again"

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/VFSIstrings.txt
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/VFSIstrings.txt
@@ -8,4 +8,4 @@ sessionTerminationDetected,"Session termination detected. Press Enter to restart
 fsharpInteractive,"F# Interactive"
 couldNotFindFsiExe,"Could not find fsi.exe, the F# Interactive executable.\nThis file does not exist:\n\n%s\n"
 killingProcessRaisedException,"Killing process raised exception:\n%s"
-sessionIsNotDebugFriendly,"The current F# Interactive session is not configured for debugging. For the best experience, enable debugging in F# Interactive settings, then reset the session."
+sessionIsNotDebugFriendly,"The current F# Interactive session is not configured for debugging. For the best experience, enable debugging in F# Interactive settings, then reset the session.\n\nPress OK to debug with the current settings, or Cancel to abort."

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiLanguageService.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiLanguageService.fs
@@ -32,10 +32,12 @@ module SP = Microsoft.VisualStudio.FSharp.Interactive.Session.SessionsProperties
 [<Guid("4489e9de-6ac1-3cd6-bff8-a904fd0e82d4")>]
 type FsiPropertyPage() = 
     inherit DialogPage()    
+       
     [<SRProperties.Category(SRProperties.FSharpInteractiveMisc)>]
     [<SRProperties.DisplayName(SRProperties.FSharpInteractive64Bit)>] 
     [<SRProperties.Description(SRProperties.FSharpInteractive64BitDescr)>] 
     member this.FsiPreferAnyCPUVersion with get() = SP.useAnyCpuVersion and set (x:bool) = SP.useAnyCpuVersion <- x
+
     [<SRProperties.Category(SRProperties.FSharpInteractiveMisc)>]
     [<SRProperties.DisplayName(SRProperties.FSharpInteractiveOptions)>]
     [<SRProperties.Description(SRProperties.FSharpInteractiveOptionsDescr)>] 
@@ -45,6 +47,12 @@ type FsiPropertyPage() =
     [<SRProperties.DisplayName(SRProperties.FSharpInteractiveShadowCopy)>]
     [<SRProperties.Description(SRProperties.FSharpInteractiveShadowCopyDescr)>] 
     member this.FsiShadowCopy with get() = SP.fsiShadowCopy and set (x:bool) = SP.fsiShadowCopy <- x
+
+    [<SRProperties.Category(SRProperties.FSharpInteractiveDebugging)>]
+    [<SRProperties.DisplayName(SRProperties.FSharpInteractiveDebugMode)>]
+    [<SRProperties.Description(SRProperties.FSharpInteractiveDebugModeDescr)>] 
+    member this.FsiDebugMode with get() = SP.fsiDebugMode and set (x:bool) = SP.fsiDebugMode <- x
+
 // CompletionSet
 type internal FsiCompletionSet(imageList,source:Source) = 
     inherit CompletionSet(imageList, source)

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/srProperties.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/srProperties.fs
@@ -31,7 +31,16 @@ let FSharpInteractiveShadowCopyDescr = "FSharpInteractiveShadowCopyDescr"
 let FSharpInteractiveShadowCopy = "FSharpInteractiveShadowCopy"
 
 [<Literal>]
+let FSharpInteractiveDebugMode = "FSharpInteractiveDebugMode"
+
+[<Literal>]
+let FSharpInteractiveDebugModeDescr = "FSharpInteractiveDebugModeDescr"
+
+[<Literal>]
 let FSharpInteractiveMisc = "FSharpInteractiveMisc"
+
+[<Literal>]
+let FSharpInteractiveDebugging = "FSharpInteractiveDebugging"
 
 type DisplayNameAttribute(resName) =
     inherit System.ComponentModel.DisplayNameAttribute(GetString(resName))


### PR DESCRIPTION
Following up on [this Twitter thread](https://twitter.com/isaac_abraham/status/576390029834129408), this change provides some stuff to make script debugging more user-friendly:

- Adds F# Interactive option that auto-configures session for optimal debugging (optimizations **off**, debug info **on**)
- When attaching debugger, will now check if session is suitably configured
  - If yes, continue with attach
  - If not, pop a warning dialog recommending the above option

![image](https://cloud.githubusercontent.com/assets/5943573/6722404/5c0f4ab4-cd96-11e4-8102-241a7a32c490.png)

![image](https://cloud.githubusercontent.com/assets/5943573/6722425/85aaa2b0-cd96-11e4-881f-fe2d5d034e6f.png)
