### PR TITLE
Provided type quickinfo shouldn't show hidden and obsolete members

### DIFF
--- a/vsintegration/src/unittests/Resources.MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fs
+++ b/vsintegration/src/unittests/Resources.MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fs
@@ -209,6 +209,29 @@ module TypeProviderThatThrowsErrorsModule =
 type TypeProviderThatThrowsErrors() = 
     inherit TypeProviderForNamespaces(TypeProviderThatThrowsErrorsModule.rootNamespace, TypeProviderThatThrowsErrorsModule.types)
 
+open System.ComponentModel
+type TPBaseTy() =
+    [<EditorBrowsableAttribute(EditorBrowsableState.Never)>] 
+    [<CompilerMessageAttribute("This method is intended for use in generated code only.", 10001, IsHidden=true, IsError=false)>]
+    member this.DoNotShowHidden = ()
+
+    [<System.ObsoleteAttribute("TP base type obsolete member")>]
+    member this.DoNotShowObsolete = ()
+
+    member this.ShowThisProp = ()
+
+[<TypeProvider>]
+type HiddenMembersInBaseClassProvider() as this = 
+    inherit TypeProviderForNamespaces()
+    let namespaceName = "HiddenMembersInBaseClass"    
+    let thisAssembly  = System.Reflection.Assembly.GetExecutingAssembly()
+
+    let typeT = ProvidedTypeDefinition(thisAssembly, namespaceName, "HiddenBaseMembersTP", Some typeof<TPBaseTy>)
+    let types = [ typeT ]
+
+    do
+        this.AddNamespace(namespaceName,types)
+
 module TypeProviderForTestingTuplesErasureModule = 
     type private Marker = interface end
     let assembly = typeof<Marker>.Assembly

--- a/vsintegration/src/unittests/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/src/unittests/Tests.LanguageService.QuickInfo.fs
@@ -204,6 +204,16 @@ type QuickInfoTests() =
             atStart = true,
             f = (fun ((text, _), _) -> printfn "actual %s" text; Assert.IsFalse(text.Contains "member Print1"))
             )
+
+    [<Test>]
+    member public this.``QuickInfo.HideBaseClassMembersTP``() =
+        let fileContents = "type foo = HiddenMembersInBaseClass.HiddenBaseMembersTP(*Marker*)"
+        
+        this.AssertQuickInfoContainsAtStartOfMarker(
+            fileContents,
+            marker = "MembersTP(*Marker*)",
+            expected = "type HiddenBaseMembersTP =\n  inherit TPBaseTy\n  member ShowThisProp : unit",
+            addtlRefAssy = [System.IO.Path.Combine(System.Environment.CurrentDirectory,@"UnitTestsResources\MockTypeProviders\DummyProviderForLanguageServiceTesting.dll")])
     
     [<Test>]
     member public this.``QuickInfo.OverriddenMethods``() =


### PR DESCRIPTION
Fixes #321, an extended case of #50.

Needed to add similar logic to `layoutProvidedTycon` as was added to `layoutTycon` in #73