### PR TITLE
Fixes #319, Projects with target runtime 3.0 don't show up correctly on ...

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/SupportedRuntimes/SupportedRuntimes.xml
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/SupportedRuntimes/SupportedRuntimes.xml
@@ -5,7 +5,6 @@
     </TargetFramework>
     <TargetFramework Identifier=".NETFramework" Version="v4.0">
         <Assembly Version="4.3.0.0" Description="F# 3.0 (FSharp.Core, 4.3.0.0)"/>
-        <Assembly Version="4.3.1.0" Description="F# 3.1 (FSharp.Core, 4.3.1.0)"/>
     </TargetFramework>    
     <TargetFramework Identifier=".NETFramework" Version="v4.5">
         <Assembly Version="4.3.0.0" Description="F# 3.0 (FSharp.Core, 4.3.0.0)"/>

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/SupportedRuntimes/SupportedRuntimes.xml
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/SupportedRuntimes/SupportedRuntimes.xml
@@ -5,8 +5,10 @@
     </TargetFramework>
     <TargetFramework Identifier=".NETFramework" Version="v4.0">
         <Assembly Version="4.3.0.0" Description="F# 3.0 (FSharp.Core, 4.3.0.0)"/>
+        <Assembly Version="4.3.1.0" Description="F# 3.1 (FSharp.Core, 4.3.1.0)"/>
     </TargetFramework>    
     <TargetFramework Identifier=".NETFramework" Version="v4.5">
+        <Assembly Version="4.3.0.0" Description="F# 3.0 (FSharp.Core, 4.3.0.0)"/>
         <Assembly Version="4.3.1.0" Description="F# 3.1 (FSharp.Core, 4.3.1.0)"/>
         <Assembly Version="4.4.0.0" Description="F# 4.0 (FSharp.Core, 4.4.0.0)"/>
     </TargetFramework>    


### PR DESCRIPTION
Fixes #319,   Projects with target runtime 3.0 don't show up correctly on the VS project dialog

Ensuring that .Net 4.0 can target 4.3.0.0 and 4.3.1.0
and that .Net 4.5.0 - 4.5.6 can target 4.3.0.0, 4.3.1.0, 4.4.0.0