### PR TITLE
Throw error if unicode is in reserved space

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1139,6 +1139,7 @@ lexIndentOffForML,"Consider using a file with extension '.ml' or '.mli' instead"
 1242,parsMissingGreaterThan,"Unmatched '<'. Expected closing '>'"
 1243,parsUnexpectedQuotationOperatorInTypeAliasDidYouMeanVerbatimString,"Unexpected quotation operator '<@' in type definition. If you intend to pass a verbatim string as a static argument to a type provider, put a space between the '<' and '@' characters."
 1244,parsErrorParsingAsOperatorName,"Attempted to parse this as an operator name, but failed"
+1245,lexInvalidUnicodeLiteral,"This is not a valid UTF-16 literal"
 # Fsc.exe resource strings
 fscTooManyErrors,"Exiting - too many errors"
 2001,docfileNoXmlSuffix,"The documentation file has no .xml suffix"

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -752,8 +752,12 @@ and string sargs skip = parse
       
  | unicodeGraphShort
     { let (buf,_fin,m,args) = sargs 
-      addUnicodeChar buf (int (unicodeGraphShort (lexemeTrimLeft lexbuf 2)));
-      if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m)))  else string sargs skip lexbuf  }
+      let c = int (unicodeGraphShort (lexemeTrimLeft lexbuf 2))
+      if c >= 0xD800 && c <= 0xDFFF then
+          fail args lexbuf (FSComp.SR.lexInvalidUnicodeLiteral()) (CHAR (char c))
+      else
+          addUnicodeChar buf c;
+          if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m)))  else string sargs skip lexbuf  }
      
  | unicodeGraphLong
     { let (buf,_fin,m,args) = sargs 

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/E_InvalidUnicodeChar01.fs
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/E_InvalidUnicodeChar01.fs
@@ -1,0 +1,13 @@
+// #Regression #Conformance #LexicalAnalysis 
+#light
+
+// Verify error when trying to access U+D800 in string
+
+//<Expects id="FS1245" status="error">This is not a valid UTF-16 literal</Expects>
+
+let _ = '\uD7FF' // Ok
+let _ = "\uE000" // Ok
+
+let _ = "\uD800"
+
+exit 1

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/E_InvalidUnicodeChar02.fs
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/E_InvalidUnicodeChar02.fs
@@ -1,0 +1,10 @@
+// #Regression #Conformance #LexicalAnalysis 
+#light
+
+// Verify error when trying to access U+DFFF in string
+
+//<Expects id="FS1245" status="error">This is not a valid UTF-16 literal</Expects>
+
+let _ = "\uDFFF"
+
+exit 1

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/env.lst
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/env.lst
@@ -23,6 +23,8 @@
 
 	SOURCE=E_ByteStrUnicodeChar01.fs	# E_ByteStrUnicodeChar01.fs
 	SOURCE=E_ByteCharUnicodeChar01.fs	# E_ByteCharUnicodeChar01.fs
+	SOURCE=E_InvalidUnicodeChar01.fs	# E_InvalidUnicodeChar01.fs
+	SOURCE=E_InvalidUnicodeChar02.fs	# E_InvalidUnicodeChar02.fs
 
 	SOURCE=E_MalformedShortUnicode01.fs  SCFLAGS="--test:ErrorRanges"	# E_MalformedShortUnicode01.fs
 	SOURCE=UnicodeString03.fs						# UnicodeString03.fs

--- a/tests/fsharpqa/Source/test.lst
+++ b/tests/fsharpqa/Source/test.lst
@@ -172,7 +172,7 @@ Conformance05			Conformance\LexicalAnalysis\LineDirectives
 Conformance05			Conformance\LexicalAnalysis\NumericLiterals
 Conformance05			Conformance\LexicalAnalysis\Shift\Generics
 
-Conformance06			Conformance\LexicalAnalysis\StringsAndCharacters
+Conformance06,Smoke			Conformance\LexicalAnalysis\StringsAndCharacters
 Conformance06			Conformance\LexicalAnalysis\SymbolicKeywords
 Conformance06			Conformance\LexicalAnalysis\SymbolicOperators
 Conformance06			Conformance\LexicalAnalysis\Whitespace


### PR DESCRIPTION
This fixes #338

![image](https://cloud.githubusercontent.com/assets/57396/6938007/4cffcce0-d860-11e4-99c1-5900cad603a7.png)
