### PR TITLE
Fix test build when VS is not installed on the root drive

### DIFF
--- a/tests/BuildTestTools.cmd
+++ b/tests/BuildTestTools.cmd
@@ -19,9 +19,13 @@ exit /b 1
 if not '%VisualStudioVersion%' == '' goto vsversionset
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
 if exist "%ProgramFiles%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
+if exist "%VS140COMNTOOLS%" set VisualStudioVersion=14.0
 if not '%VisualStudioVersion%' == '' goto vsversionset
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
 if exist "%ProgramFiles%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
+if exist "%VS120COMNTOOLS%" set VisualStudioVersion=12.0
+
+
 
 :vsversionset
 if '%VisualStudioVersion%' == '' echo Error: Could not find an installation of Visual Studio && goto :eof


### PR DESCRIPTION
BuildTestTools.cmd currently fails if Visual Studio is installed in an odd place. The environment variable  VS120COMNTOOLS should have the correct path.