### PR TITLE
Optimize Array.empty

### DIFF
--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -80,7 +80,7 @@ namespace Microsoft.FSharp.Collections
     
         [<AbstractClass; Sealed>]
         type internal EmptyStorage<'T>() =
-            static let empty = ([||] : 'T[])
+            static let empty = (zeroCreate 0 : 'T[])
             static member Empty = empty
 
         [<CompiledName("Empty")>]

--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -77,9 +77,14 @@ namespace Microsoft.FSharp.Collections
             if array.Length = 0 then invalidArg "array" (SR.GetString(SR.notEnoughElements))
             let len = array.Length - 1
             Microsoft.FSharp.Primitives.Basics.Array.subUnchecked 1 len array
+    
+        [<AbstractClass; Sealed>]
+        type internal EmptyStorage<'T>() =
+            static let empty = ([||] : 'T[])
+            static member Empty = empty
 
         [<CompiledName("Empty")>]
-        let empty<'T> = ([| |] : 'T [])
+        let empty<'T> = EmptyStorage<'T>.Empty
 
         [<CodeAnalysis.SuppressMessage("Microsoft.Naming","CA1704:IdentifiersShouldBeSpelledCorrectly")>]
         [<CompiledName("CopyTo")>]

--- a/src/fsharp/env.fs
+++ b/src/fsharp/env.fs
@@ -518,6 +518,7 @@ type public TcGlobals =
 
       array_get_info             : IntrinsicValRef;
       array_length_info          : IntrinsicValRef;
+      array_empty_info           : IntrinsicValRef;
       array2D_get_info           : IntrinsicValRef;
       array3D_get_info           : IntrinsicValRef;
       array4D_get_info           : IntrinsicValRef;
@@ -947,6 +948,7 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
   let new_decimal_info           = makeIntrinsicValRef(fslib_MFIntrinsicFunctions_nleref,                    "MakeDecimal"                          ,None                 ,None                          ,[],         ([[int_ty]; [int_ty]; [int_ty]; [bool_ty]; [byte_ty]], decimal_ty))
   let array_get_info             = makeIntrinsicValRef(fslib_MFIntrinsicFunctions_nleref,                    "GetArray"                             ,None                 ,None                          ,[vara],     ([[mkArrayType 1 varaTy]; [int_ty]], varaTy))
   let array_length_info          = makeIntrinsicValRef(fslib_MFArrayModule_nleref,                           "length"                               ,None                 ,Some "Length"                 ,[vara],     ([[mkArrayType 1 varaTy]], int_ty))
+  let array_empty_info           = makeIntrinsicValRef(fslib_MFArrayModule_nleref,                           "empty"                                ,None                 ,Some "Empty"                  ,[vara],     ([], mkArrayType 1 varaTy))
   let deserialize_quoted_FSharp_20_plus_info    = makeIntrinsicValRef(fslib_MFQuotations_nleref,             "Deserialize"                          ,Some "Expr"          ,None                          ,[],          ([[system_Type_typ ;mkListTy system_Type_typ ;mkListTy mkRawQuotedExprTy ; mkArrayType 1 byte_ty]], mkRawQuotedExprTy ))
   let deserialize_quoted_FSharp_40_plus_info    = makeIntrinsicValRef(fslib_MFQuotations_nleref,             "Deserialize40"                        ,Some "Expr"          ,None                          ,[],          ([[system_Type_typ ;mkArrayType 1 system_Type_typ; mkArrayType 1 system_Type_typ; mkArrayType 1 mkRawQuotedExprTy; mkArrayType 1 byte_ty]], mkRawQuotedExprTy ))
   let cast_quotation_info        = makeIntrinsicValRef(fslib_MFQuotations_nleref,                            "Cast"                                 ,Some "Expr"          ,None                          ,[vara],      ([[mkRawQuotedExprTy]], mkQuotedExprTy varaTy))
@@ -1361,6 +1363,7 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
     range_int32_op_vref        = ValRefForIntrinsic range_int32_op_info;
     //range_step_op_vref         = ValRefForIntrinsic range_step_op_info;
     array_length_info          = array_length_info
+    array_empty_info           = array_empty_info
     array_get_vref             = ValRefForIntrinsic array_get_info;
     array2D_get_vref           = ValRefForIntrinsic array2D_get_info;
     array3D_get_vref           = ValRefForIntrinsic array3D_get_info;

--- a/src/fsharp/tastops.fs
+++ b/src/fsharp/tastops.fs
@@ -5941,6 +5941,7 @@ let mkCallGenericHashWithComparerOuter       g m ty comp e1       = mkApps g (ty
 let mkCallSubtractionOperator g m ty e1 e2 = mkApps g (typedExprForIntrinsic g m g.unchecked_subtraction_info, [[ty; ty; ty]], [e1;e2], m)
 
 let mkCallArrayLength g m ty el                    = mkApps g (typedExprForIntrinsic g m g.array_length_info, [[ty]], [el], m)
+let mkCallArrayEmpty g m ty                        = mkApps g (typedExprForIntrinsic g m g.array_empty_info,  [[ty]], [ ],  m)
 let mkCallArrayGet   g m ty e1 e2                  = mkApps g (typedExprForIntrinsic g m g.array_get_info, [[ty]], [ e1 ; e2 ],  m)
 let mkCallArray2DGet g m ty e1 idx1 idx2           = mkApps g (typedExprForIntrinsic g m g.array2D_get_info, [[ty]], [ e1 ; idx1; idx2 ],  m)
 let mkCallArray3DGet g m ty e1 idx1 idx2 idx3      = mkApps g (typedExprForIntrinsic g m g.array3D_get_info, [[ty]], [ e1 ; idx1; idx2; idx3 ],  m)

--- a/src/fsharp/tastops.fsi
+++ b/src/fsharp/tastops.fsi
@@ -1134,6 +1134,7 @@ val mkCallTypeDefOf   : TcGlobals -> range -> TType -> Expr
 val mkCallCreateInstance     : TcGlobals -> range -> TType -> Expr
 val mkCallCreateEvent        : TcGlobals -> range -> TType -> TType -> Expr -> Expr -> Expr -> Expr
 val mkCallArrayLength        : TcGlobals -> range -> TType -> Expr -> Expr
+val mkCallArrayEmpty         : TcGlobals -> range -> TType -> Expr
 val mkCallArrayGet           : TcGlobals -> range -> TType -> Expr -> Expr -> Expr
 val mkCallArray2DGet         : TcGlobals -> range -> TType -> Expr -> Expr -> Expr -> Expr 
 val mkCallArray3DGet         : TcGlobals -> range -> TType -> Expr -> Expr -> Expr -> Expr -> Expr


### PR DESCRIPTION
Changes `Array.empty` and `[| |]` to refer to a static field rather than allocating a new empty array each time it is called. It is often convenient for a function to return an empty array but the allocation can be a problem. Additionally since Array.empty looks like a value and not a function it is easy to forget this hidden cost.