### PR TITLE
Change pdbClose to test if files are locked before inducing GCs

### DIFF
--- a/src/absil/ilsupp.fsi
+++ b/src/absil/ilsupp.fsi
@@ -95,7 +95,7 @@ val pdbInitialize:
     string (* .exe/.dll already written and closed *) -> 
     string  (* .pdb to write *) ->
     PdbWriter
-val pdbClose: PdbWriter -> unit
+val pdbClose: PdbWriter -> string -> string -> unit
 val pdbCloseDocument : PdbDocumentWriter -> unit
 val pdbSetUserEntryPoint: PdbWriter -> int32 -> unit
 val pdbDefineDocument: PdbWriter -> string -> PdbDocumentWriter

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -330,7 +330,7 @@ let WritePdbInfo fixupOverlappingSequencePoints showTimes f fpdb info =
     for pdbDoc in docs do
         pdbCloseDocument pdbDoc
 
-    pdbClose !pdbw;
+    pdbClose !pdbw f fpdb;
     reportTime showTimes "PDB: Closed";
     res
 


### PR DESCRIPTION
Background:
After writing PDBs there is a bit of a kludge in the compiler to work around the native PDB writer holding locks until it is garbage collected. The comment explaining this is here: https://github.com/Microsoft/visualfsharp/blob/fsharp4/src/absil/ilsupp.fs#L1053

The original code triggers 6 full GCs, regardless of anything being locked. The time is a multiple of the size of the output binary since all of the IL/metadata structures are still on the heap at this point. This takes ~600ms on my test project (of a 10s total compile). If you run the compiler with `--times` there is a line for pdbClose.

You can see the big pause at the end of compilation on the profiler:
![image](https://cloud.githubusercontent.com/assets/124030/6993729/25a6f0ce-dab3-11e4-8be4-a4665e8bfe93.png)

This change performs a check if the file is locked before inducing GC. I have been running the change and notice that occasionally one iteration of the loop is required, so the detection is working. If you remove all the code you will get a compiler error in the case that the file is locked, so this will not cause a silent regression.