### PR TITLE
Fix lexing for unicode escape sequences

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1139,6 +1139,7 @@ lexIndentOffForML,"Consider using a file with extension '.ml' or '.mli' instead"
 1242,parsMissingGreaterThan,"Unmatched '<'. Expected closing '>'"
 1243,parsUnexpectedQuotationOperatorInTypeAliasDidYouMeanVerbatimString,"Unexpected quotation operator '<@' in type definition. If you intend to pass a verbatim string as a static argument to a type provider, put a space between the '<' and '@' characters."
 1244,parsErrorParsingAsOperatorName,"Attempted to parse this as an operator name, but failed"
+1245,lexInvalidUnicodeLiteral,"\U%s is not a valid Unicode character escape sequence"
 # Fsc.exe resource strings
 fscTooManyErrors,"Exiting - too many errors"
 2001,docfileNoXmlSuffix,"The documentation file has no .xml suffix"

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -757,17 +757,17 @@ and string sargs skip = parse
  | unicodeGraphLong
     { let (buf,_fin,m,args) = sargs
       let hexChars = lexemeTrimLeft lexbuf 2
-      let result = lazy (if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m))) else string sargs skip lexbuf)
+      let result () = if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m))) else string sargs skip lexbuf
       match unicodeGraphLong hexChars with
       | Invalid ->
-          fail args lexbuf (FSComp.SR.lexInvalidUnicodeLiteral hexChars) (result.Force())
+          fail args lexbuf (FSComp.SR.lexInvalidUnicodeLiteral hexChars) (result ())
       | SingleChar(c) ->
           addUnicodeChar buf (int c)
-          result.Force()
+          result ()
       | SurrogatePair(hi, lo) -> 
           addUnicodeChar buf (int hi)
           addUnicodeChar buf (int lo)
-          result.Force() }
+          result () }
      
  |  '"' 
     { let (buf,fin,_m,_args) = sargs 

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -411,7 +411,7 @@ rule token args skip = parse
  | '\'' unicodeGraphShort '\'' { CHAR (char (int32 (unicodeGraphShort (lexemeTrimBoth lexbuf 3 1)))) }
  | '\'' unicodeGraphLong '\''  
      { match unicodeGraphLong (lexemeTrimBoth lexbuf 3 1) with
-       | Some(None, lo) -> CHAR (char lo)
+       | SingleChar(c) -> CHAR (char c)
        | _ -> fail args lexbuf  (FSComp.SR.lexThisUnicodeOnlyInStringLiterals()) (CHAR (char 0)) }
  | "(*IF-FSHARP"    
      { if not skip then (COMMENT (LexCont.Token !args.ifdefStack)) else token args skip lexbuf }
@@ -757,13 +757,17 @@ and string sargs skip = parse
  | unicodeGraphLong
     { let (buf,_fin,m,args) = sargs
       let hexChars = lexemeTrimLeft lexbuf 2
+      let result = lazy (if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m))) else string sargs skip lexbuf)
       match unicodeGraphLong hexChars with
-      | None ->
-          fail args lexbuf (FSComp.SR.lexInvalidUnicodeLiteral hexChars) (if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m))) else string sargs skip lexbuf)
-      | Some(hi, lo) -> 
-          (match hi with | None -> () | Some c -> addUnicodeChar buf (int c));
-          addUnicodeChar buf (int lo);
-          (if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m))) else string sargs skip lexbuf)  }
+      | Invalid ->
+          fail args lexbuf (FSComp.SR.lexInvalidUnicodeLiteral hexChars) (result.Force())
+      | SingleChar(c) ->
+          addUnicodeChar buf (int c)
+          result.Force()
+      | SurrogatePair(hi, lo) -> 
+          addUnicodeChar buf (int hi)
+          addUnicodeChar buf (int lo)
+          result.Force() }
      
  |  '"' 
     { let (buf,fin,_m,_args) = sargs 

--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -124,7 +124,7 @@ let startString args (lexbuf: UnicodeLexing.Lexbuf) =
                             BYTEARRAY (Lexhelp.stringBufferAsBytes buf)
                         )
                      else
-                        STRING (System.Text.Encoding.Unicode.GetString(s,0,s.Length)))  
+                        STRING (Lexhelp.stringBufferAsString s))  
     buf,fin,m
              
 // Utility functions for processing XML documentation 
@@ -410,10 +410,9 @@ rule token args skip = parse
  | '\'' hexGraphShort '\'' { CHAR (char (int32 (hexGraphShort (lexemeTrimBoth lexbuf 3 1)))) }
  | '\'' unicodeGraphShort '\'' { CHAR (char (int32 (unicodeGraphShort (lexemeTrimBoth lexbuf 3 1)))) }
  | '\'' unicodeGraphLong '\''  
-     { let hi,lo = unicodeGraphLong (lexemeTrimBoth lexbuf 3 1) 
-       match hi with 
-       | None -> CHAR (char lo)
-       | Some _ -> fail args lexbuf  (FSComp.SR.lexThisUnicodeOnlyInStringLiterals()) (CHAR (char lo)) }
+     { match unicodeGraphLong (lexemeTrimBoth lexbuf 3 1) with
+       | Some(None, lo) -> CHAR (char lo)
+       | _ -> fail args lexbuf  (FSComp.SR.lexThisUnicodeOnlyInStringLiterals()) (CHAR (char 0)) }
  | "(*IF-FSHARP"    
      { if not skip then (COMMENT (LexCont.Token !args.ifdefStack)) else token args skip lexbuf }
  | "(*F#"            
@@ -756,11 +755,15 @@ and string sargs skip = parse
       if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m)))  else string sargs skip lexbuf  }
      
  | unicodeGraphLong
-    { let (buf,_fin,m,args) = sargs 
-      let hi,lo = unicodeGraphLong (lexemeTrimLeft lexbuf 2) 
-      (match hi with | None -> () | Some c -> addUnicodeChar buf (int c));
-      addUnicodeChar buf (int lo);
-      if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m))) else string sargs skip lexbuf  }
+    { let (buf,_fin,m,args) = sargs
+      let hexChars = lexemeTrimLeft lexbuf 2
+      match unicodeGraphLong hexChars with
+      | None ->
+          fail args lexbuf (FSComp.SR.lexInvalidUnicodeLiteral hexChars) (if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m))) else string sargs skip lexbuf)
+      | Some(hi, lo) -> 
+          (match hi with | None -> () | Some c -> addUnicodeChar buf (int c));
+          addUnicodeChar buf (int lo);
+          (if not skip then (STRING_TEXT (LexCont.String(!args.ifdefStack,m))) else string sargs skip lexbuf)  }
      
  |  '"' 
     { let (buf,fin,_m,_args) = sargs 

--- a/src/fsharp/lexhelp.fsi
+++ b/src/fsharp/lexhelp.fsi
@@ -43,6 +43,7 @@ val internal callStringFinisher : ('a -> 'b -> byte[] -> 'c) -> AbstractIL.Inter
 val internal addUnicodeString : AbstractIL.Internal.ByteBuffer -> string -> unit
 val internal addUnicodeChar : AbstractIL.Internal.ByteBuffer -> int -> unit
 val internal addByteChar : AbstractIL.Internal.ByteBuffer -> char -> unit
+val internal stringBufferAsString : byte[] -> string
 val internal stringBufferAsBytes : AbstractIL.Internal.ByteBuffer -> byte[]
 val internal stringBufferIsBytes : AbstractIL.Internal.ByteBuffer -> bool
 val internal newline : Lexing.LexBuffer<'a> -> unit
@@ -51,7 +52,7 @@ val internal digit : char -> int32
 val internal hexdigit : char -> int32
 val internal unicodeGraphShort : string -> uint16
 val internal hexGraphShort : string -> uint16
-val internal unicodeGraphLong : string -> uint16 option * uint16
+val internal unicodeGraphLong : string -> (uint16 option * uint16) option
 val internal escape : char -> char
 
 exception internal ReservedKeyword of string * Range.range

--- a/src/fsharp/lexhelp.fsi
+++ b/src/fsharp/lexhelp.fsi
@@ -33,6 +33,11 @@ type lexargs =
     lightSyntaxStatus: LightSyntaxStatus;
     errorLogger: ErrorLogger}
 
+type LongUnicodeLexResult =
+    | SurrogatePair of uint16 * uint16
+    | SingleChar of uint16
+    | Invalid
+
 val resetLexbufPos : string -> UnicodeLexing.Lexbuf -> unit
 val mkLexargs : 'a * string list * LightSyntaxStatus * LexResourceManager * LexerIfdefStack * ErrorLogger -> lexargs
 val reusingLexbufForParsing : UnicodeLexing.Lexbuf -> (unit -> 'a) -> 'a 
@@ -52,7 +57,7 @@ val internal digit : char -> int32
 val internal hexdigit : char -> int32
 val internal unicodeGraphShort : string -> uint16
 val internal hexGraphShort : string -> uint16
-val internal unicodeGraphLong : string -> (uint16 option * uint16) option
+val internal unicodeGraphLong : string -> LongUnicodeLexResult
 val internal escape : char -> char
 
 exception internal ReservedKeyword of string * Range.range

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -952,7 +952,7 @@ type TypeCheckInfo
                 | _ -> None
 
         match UntypedParseInfoImpl.TryGetCompletionContext(line, colAtEndOfNamesAndResidue, untypedParseInfoOpt) with
-        | Some Invalid -> None
+        | Some CompletionContext.Invalid -> None
         | Some (CompletionContext.Inherit(InheritanceContext.Class, (plid, _))) ->
             FindInEnv(plid, false) 
             |> FilterRelevantItemsBy None GetBaseClassCandidates

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/E_BogusLongUnicodeEscape.fs
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/E_BogusLongUnicodeEscape.fs
@@ -1,0 +1,14 @@
+// #Regression #Conformance #LexicalAnalysis 
+#light
+
+// Verify error with malformed long unicode escape sequences
+
+let tooBigForChar  = '\U00024B62'
+let bogusString01 = "\U00110000"
+let bogusString02 = "\UFFFF0000"
+
+exit 1
+
+//<Expects id="FS1159" span="(6,22-6,34)" status="error">This Unicode encoding is only valid in string literals</Expects>
+//<Expects id="FS1245" span="(7,21-7,33)" status="error">\\U00110000 is not a valid Unicode character escape sequence</Expects>
+//<Expects id="FS1245" span="(8,21-8,33)" status="error">\\UFFFF0000 is not a valid Unicode character escape sequence</Expects>

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/UnicodeString01.fs
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/UnicodeString01.fs
@@ -1,11 +1,29 @@
-// #Conformance #LexicalAnalysis 
-#light
-
 // Test string literals with short Unicode Literals
 
-let unicodeString = "\u2660 \u2663 \u2665 \u2666"
-let expectedResult = "♠ ♣ ♥ ♦"
+let mutable failure = false
 
-if unicodeString <> expectedResult then exit 1
+let checkStr (inputStr:string) expectedChars expectedStr =
+    let charCodes = inputStr.ToCharArray() |> Array.map int
+    if charCodes <> expectedChars then
+        printfn "Character encodings don't match"
+        printfn "  Expected %A" expectedChars
+        printfn "  Actual   %A" charCodes
+        false
+    else
+    match expectedStr with
+    | Some(exp) when exp <> inputStr ->
+        printfn "String representation doesn't match"
+        printfn "  Expected %s" exp
+        printfn "  Actual   %s" inputStr
+        false
+    | _ -> true
 
-exit 0
+let test (inputStr:string) expectedChars expectedStr =
+    failure <- (checkStr inputStr expectedChars expectedStr) && failure
+    
+test "\u2660\u2663\u2665\u2666" [| 0x2660; 0x2663; 0x2665; 0x2666 |] (Some("♠♣♥♦"))
+test "\uD800 \uDBFF \uDC00 \uDFFF" [| 0xD800; 32; 0xDBFF; 32; 0xDC00; 32; 0xDFFF |] None
+test "\u0000\u0000\uFFFE\uFFFD\uFFFC" [| 0; 0; 0xFFFE; 0xFFFD; 0xFFFC |] None
+test "\uD900\uD901\uD902" [| 0xD900; 0xD901; 0xD902 |] None
+
+exit (if failure then 1 else 0)

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/UnicodeString02.fs
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/UnicodeString02.fs
@@ -1,11 +1,31 @@
-// #Conformance #LexicalAnalysis 
-#light
-
 // Test string literals with long Unicode Literals
 
-let unicodeString = "\U00002660 \U00002663 \U00002665 \U00002666"
-let expectedResult = "♠ ♣ ♥ ♦"
+let mutable failure = false
 
-if unicodeString <> expectedResult then exit 1
+let checkStr (inputStr:string) expectedChars expectedStr =
+    let charCodes = inputStr.ToCharArray() |> Array.map int
+    if charCodes <> expectedChars then
+        printfn "Character encodings don't match"
+        printfn "  Expected %A" expectedChars
+        printfn "  Actual   %A" charCodes
+        false
+    else
+    match expectedStr with
+    | Some(exp) when exp <> inputStr ->
+        printfn "String representation doesn't match"
+        printfn "  Expected %s" exp
+        printfn "  Actual   %s" inputStr
+        false
+    | _ -> true
 
-exit 0
+let test (inputStr:string) expectedChars expectedStr =
+    failure <- (checkStr inputStr expectedChars expectedStr) && failure
+    
+test "\U00002660\U00002663\U00002665\U00002666" [| 0x2660; 0x2663; 0x2665; 0x2666 |] (Some("♠♣♥♦"))
+test "\U0000D800 \U0000DBFF \U0000DC00 \U0000DFFF" [| 0xD800; 32; 0xDBFF; 32; 0xDC00; 32; 0xDFFF |] None
+test "\U00000000\U00000000\U0000FFFE\U0000FFFD\U0000FFFC" [| 0; 0; 0xFFFE; 0xFFFD; 0xFFFC |] None
+test "\U0000D900\U0000D901\U0000D902" [| 0xD900; 0xD901; 0xD902 |] None
+test "\U00010437" [| 0xD801; 0xDC37;|] (Some("𐐷"))
+test "\U00024B62" [| 0xD852 ; 0xDF62 |] (Some("𤭢"))
+
+exit (if failure then 1 else 0)

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/env.lst
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/env.lst
@@ -20,6 +20,7 @@
 
 	SOURCE=UnicodeString01.fs		# UnicodeString01.fs
 	SOURCE=UnicodeString02.fs		# UnicodeString02.fs
+	SOURCE=E_BogusLongUnicodeEscape.fs SCFLAGS="--codepage:1252 --test:ErrorRanges"		# E_BogusLongUnicodeEscape.fs
 
 	SOURCE=E_ByteStrUnicodeChar01.fs	# E_ByteStrUnicodeChar01.fs
 	SOURCE=E_ByteCharUnicodeChar01.fs	# E_ByteCharUnicodeChar01.fs

--- a/tests/fsharpqa/Source/Conformance/PatternMatching/Simple/simplePatterns19.fs
+++ b/tests/fsharpqa/Source/Conformance/PatternMatching/Simple/simplePatterns19.fs
@@ -4,10 +4,10 @@
 // Pattern match long unicode literals
 
 [<Literal>]
-let UnicodeString1 = "\U00000000\UFFFFFFFF"
+let UnicodeString1 = "\U00000000\U0002FFFF"
 
 [<Literal>]
-let UnicodeString2 = "\U11111111\U22222222"
+let UnicodeString2 = "\U00101111\U000F2222"
 
 let testStr x =
     match x with
@@ -18,9 +18,9 @@ let testStr x =
 if testStr "foo" <> 0 then exit 1
 
 if testStr UnicodeString1         <> 1 then exit 1
-if testStr "\U00000000\UFFFFFFFF" <> 1 then exit 1
+if testStr "\U00000000\U0002FFFF" <> 1 then exit 1
 
 if testStr UnicodeString2         <> 2 then exit 1
-if testStr "\U11111111\U22222222" <> 2 then exit 1
+if testStr "\U00101111\U000F2222" <> 2 then exit 1
 
 exit 0


### PR DESCRIPTION
fixes #338

Changes lexing of unicode escape sequences to match the F# spec (which says things should work the same as C#).

- For short escape sequences, directly encode the hex value into a char, even if this is not valid by Unicode convention
- For long escape sequences, validate that the total codepoint is <= 0x0010FFFF
  - If it is, follow same logic as before (which was correct)
  - If it isn't, issue an error (same as C#)
