### PR TITLE
Small fixes to script debugging

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
@@ -119,7 +119,7 @@
       <Button guid ="guidInteractive" id ="cmdidDebugSelection" priority ="0x106" type ="Button">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_LANGUAGE"/>
         <Strings>
-          <ButtonText>Debug in F# Interactive</ButtonText>
+          <ButtonText>Debug In Interactive</ButtonText>
           <CommandName>Interactive.Debug.Selection.Context</CommandName>
         </Strings>
        <CommandFlag>DynamicVisibility | DefaultInvisible</CommandFlag>

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -591,7 +591,8 @@ type internal FsiToolWindow() as this =
         sendSelectionToFSI false
 
     let onMLDebug (sender:obj) (e:EventArgs) = 
-        attachDebugger ()
+        if checkDebuggability () then
+            attachDebugger ()
         sendSelectionToFSI true
 
     /// Handle UP and DOWN. Cycle history.    


### PR DESCRIPTION
- Wire in debuggability check from #314 to the 'debug in F# interactive' editor scenario (how did I miss that?!)
- Tweak menu text so it matches existing 'Execute In Interactive'