### PR TITLE
Fix #337: skip interfaces-that-lie-outside-the-set-of-referenced-assemblies

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1419,7 +1419,7 @@ module private TastDefinitionPrinting =
             if suppressInheritanceAndInterfacesForTyInSimplifiedDisplays g amap m ty then 
                 []
             else 
-                GetImmediateInterfacesOfType g amap m ty |> List.map (fun ity -> wordL (if isInterfaceTy g ty then "inherit" else "interface") --- layoutType denv ity)
+                GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes g amap m ty |> List.map (fun ity -> wordL (if isInterfaceTy g ty then "inherit" else "interface") --- layoutType denv ity)
 
         let props = 
             GetIntrinsicPropInfosOfType infoReader (None,ad,AllowMultiIntfInstantiations.Yes)  PreferOverrides m ty

--- a/src/fsharp/check.fs
+++ b/src/fsharp/check.fs
@@ -1369,7 +1369,7 @@ let CheckEntityDefn cenv env (tycon:Entity) =
     if cenv.reportErrors then 
         if not tycon.IsTypeAbbrev then 
             let typ = generalizedTyconRef (mkLocalTyconRef tycon)
-            let immediateInterfaces = GetImmediateInterfacesOfType cenv.g cenv.amap m typ
+            let immediateInterfaces = GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes cenv.g cenv.amap m typ
             let interfaces = 
               [ for ty in immediateInterfaces do
                     yield! AllSuperTypesOfType cenv.g cenv.amap m AllowMultiIntfInstantiations.Yes ty  ]

--- a/src/fsharp/import.fsi
+++ b/src/fsharp/import.fsi
@@ -48,8 +48,14 @@ type ImportMap =
 /// Import a reference to a type definition, given an AbstractIL ILTypeRef, with caching
 val internal ImportILTypeRef : ImportMap -> range -> ILTypeRef -> TyconRef
 
+/// Pre-check for ability to import a reference to a type definition, given an AbstractIL ILTypeRef, with caching
+val internal CanImportILTypeRef : ImportMap -> range -> ILTypeRef -> bool
+
 /// Import an IL type as an F# type.
 val internal ImportILType : ImportMap -> range -> TType list -> ILType -> TType
+
+/// Pre-check for ability to import an IL type as an F# type.
+val internal CanImportILType : ImportMap -> range -> ILType -> bool
 
 #if EXTENSIONTYPING
 

--- a/src/fsharp/typrelns.fs
+++ b/src/fsharp/typrelns.fs
@@ -73,7 +73,7 @@ let rec TypeDefinitelySubsumesTypeNoCoercion ndeep g amap m ty1 ty2 =
            | Some ty -> TypeDefinitelySubsumesTypeNoCoercion (ndeep+1) g amap m ty1 ty) ||
 
            (isInterfaceTy g ty1 &&
-            ty2 |> GetImmediateInterfacesOfType g amap m 
+            ty2 |> GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes g amap m 
                 |> List.exists (TypeDefinitelySubsumesTypeNoCoercion (ndeep+1) g amap m ty1))))
 
 
@@ -129,7 +129,7 @@ let rec TypeFeasiblySubsumesType ndeep g amap m ty1 canCoerce ty2 =
          | None -> false
          | Some ty -> TypeFeasiblySubsumesType (ndeep+1) g amap m ty1 NoCoerce ty
          end ||
-         ty2 |> GetImmediateInterfacesOfType g amap m 
+         ty2 |> GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes g amap m 
              |> List.exists (TypeFeasiblySubsumesType (ndeep+1) g amap m ty1 NoCoerce))
                    
 
@@ -1993,7 +1993,7 @@ let FinalTypeDefinitionChecksAtEndOfInferenceScope (infoReader:InfoReader) isImp
 /// Look for the unique supertype of ty2 for which ty2 :> ty1 might feasibly hold
 let FindUniqueFeasibleSupertype g amap m ty1 ty2 =  
     if not (isAppTy g ty2) then None else
-    let supertypes = Option.toList (GetSuperTypeOfType g amap m ty2) @ (GetImmediateInterfacesOfType g amap m ty2)
+    let supertypes = Option.toList (GetSuperTypeOfType g amap m ty2) @ (GetImmediateInterfacesOfType SkipUnrefInterfaces.Yes g amap m ty2)
     supertypes |> List.tryFind (TypeFeasiblySubsumesType 0 g amap m ty1 NoCoerce) 
     
 

--- a/tests/fsharp/typecheck/sigs/build.bat
+++ b/tests/fsharp/typecheck/sigs/build.bat
@@ -5,6 +5,9 @@ REM Configure the sample, i.e. where to find the F# compiler and C# compiler.
 
 call %~d0%~p0..\..\..\config.bat
 
+"%FSC%" --noframework -r:"%FSCOREDLLPATH%" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Core.dll" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Data.dll" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.dll" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Numerics.dll" -a -o:pos21.dll  pos21.fs
+@if ERRORLEVEL 1 goto Error
+
 call ..\..\single-neg-test.bat neg91
 @if ERRORLEVEL 1 goto Error
 
@@ -516,7 +519,6 @@ call ..\..\single-neg-test.bat neg35
 
 "%FSC%" %fsc_flags% -a -o:pos05.dll  pos05.fs
 @if ERRORLEVEL 1 goto Error
-
 
 :Ok
 echo Built fsharp %~f0 ok.

--- a/tests/fsharp/typecheck/sigs/pos21.fs
+++ b/tests/fsharp/typecheck/sigs/pos21.fs
@@ -1,0 +1,9 @@
+namespace Library2
+
+open System
+open System.Data
+
+module M = 
+    let dataset = new DataSet("test add reference")
+    Console.WriteLine(dataset.DataSetName)
+    Console.ReadKey(true)


### PR DESCRIPTION
When the assembly reference set for the compilation is incomplete, some interfaces to types relevant to compilation may lie in assemblies outside the assembly reference set.  This applies particularly to private ("internals visible to") interfaces found in .NET assemblies.

This causes very substantial usability bugs in practice as various parts of type inference and other checking "give up" when you get this condition. The C# compiler doesn't give up in the same way.

In most cases it is reasonable to simply skip interfaces-that-lie-outside-the-set-of-referenced-assemblies during F# compilation.  Skipping unresolvable interfaces is pretty much harmless: any substantive analysis on the interface type (such as implementing it) will require the assembly holding the interface type.

There are some exceptions: if an interface I1 lies outside the referenceable set and you try to implement I2 inheriting from I1 then we'd better not skip I1.  Indeed if you even try to find the methods on I2 then we'd better not skip I1.  These are covered by "FoldPrimaryHierarchyOfType" in the code.

I've tested this manually on the example in #337, though not added testing as part of this fix.  Constructing compilations with incomplete reference sets is a bit of a PITA - @latkin, do we have any of these compilations already?

