### PR TITLE
Cleanup vs ext 2

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/CodeWindowManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/CodeWindowManager.cs
@@ -143,7 +143,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             get { return this.codeWindow; }
         }
       
-        #region IVsCodeWindowManager methods
         /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.AddAdornments"]/*' />
         /// <summary>Install the optional TypeAndMemberDropdownBars, and primary and secondary view filters</summary>
         public virtual int AddAdornments() {
@@ -237,7 +236,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
 #endif
         }
-        #endregion
 
     }
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/CodeWindowManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/CodeWindowManager.cs
@@ -14,7 +14,6 @@ using IServiceProvider = System.IServiceProvider;
 using Microsoft.VisualStudio.FSharp.LanguageService.Resources;
 
 namespace Microsoft.VisualStudio.FSharp.LanguageService {
-    /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager"]/*' />
     /// <summary>
     /// CodeWindowManager provides a default implementation of the VSIP interface IVsCodeWindowManager
     /// and manages the LanguageService, Source, ViewFilter, and DocumentProperties objects associated
@@ -42,7 +41,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         DocumentProperties properties;
 #endif
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.CodeWindowManager"]/*' />
         /// <summary>
         /// The CodeWindowManager is constructed by the base LanguageService class when VS calls
         /// the IVsLanguageInfo.GetCodeWindowManager method.  You can override CreateCodeWindowManager
@@ -58,14 +56,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 #endif
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.Finalize"]/*' />
         ~CodeWindowManager() {
 #if	LANGTRACE
             Trace.WriteLine("~CodeWindowManager");
 #endif
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.Close"]/*' />
         /// <summary>Closes all view filters, and the document properties window</summary>
         internal void Close() {
 #if	LANGTRACE
@@ -93,17 +89,14 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.LanguageService;"]/*' />
         /// <summary>Returns the LanguageService object that created this code window manager</summary>
         internal LanguageService LanguageService {
             get { return this.service; }
         }
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.Source;"]/*' />
         /// <summary>returns the Source object associated with the IVsTextLines buffer for this code window</summary>
         internal ISource Source {
             get { return this.source; }
         }
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.GetFilter;"]/*' />
         /// <summary>
         /// Returns the ViewFilter for the given view or null if no matching filter is found.
         /// </summary>
@@ -118,7 +111,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
 #if DOCUMENT_PROPERTIES
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.Properties;"]/*' />
         /// <summary>Returns the DocumentProperties, if any.  You can update this property if you want to 
         /// change the document properties on the fly.</summary>
         internal DocumentProperties Properties {
@@ -132,18 +124,15 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 #endif
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.DropDownHelper"]/*' />
         /// <summary>Return the optional TypeAndMemberDropdownBars object for the drop down combos</summary>
         internal TypeAndMemberDropdownBars DropDownHelper {
             get { return this.dropDownHelper; }
         }
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.CodeWindow"]/*' />
         /// <summary>Return the IVsCodeWindow associated with this code window manager.</summary>
         internal IVsCodeWindow CodeWindow {
             get { return this.codeWindow; }
         }
       
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.AddAdornments"]/*' />
         /// <summary>Install the optional TypeAndMemberDropdownBars, and primary and secondary view filters</summary>
         public virtual int AddAdornments() {
 #if	LANGTRACE
@@ -181,7 +170,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.RemoveAdornments"]/*' />
         /// <summary>Remove drop down combos, view filters, and notify the LanguageService that the Source and
         /// CodeWindowManager is now closed</summary>
         public virtual int RemoveAdornments() {
@@ -211,7 +199,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.OnNewView"]/*' />
         /// <summary>Install a new view filter for the given view. This method calls your
         /// CreateViewFilter method.</summary>
         public virtual int OnNewView(IVsTextView newView) {
@@ -223,11 +210,9 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.OnKillFocus"]/*' />
         public virtual void OnKillFocus(IVsTextView textView) {
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="CodeWindowManager.OnSetFocus"]/*' />
         /// <summary>Refresh the document properties</summary>
         public virtual void OnSetFocus(IVsTextView textView) {
 #if DOCUMENT_PROPERTIES
@@ -241,7 +226,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
 
 
-    /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars"]/*' />
     /// <summary>
     /// Represents the two drop down bars on the top of a text editor window that allow 
     /// types and type members to be selected by name.
@@ -272,14 +256,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         const int DropClasses = 0;
         const int DropMethods = 1;
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.TypeAndMemberDropdownBars"]/*' />
         protected TypeAndMemberDropdownBars(LanguageService languageService) {
             this.languageService = languageService;
             this.dropDownTypes = new ArrayList();
             this.dropDownMembers = new ArrayList();
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.Done"]/*' />
         public void Done() { //TODO: use IDisposable pattern
             if (this.imageList != null) {
                 imageList.Dispose();
@@ -299,7 +281,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
 
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.OnSynchronizeDropdowns"]/*' />
         /// <summary>
         /// This method is called to update the drop down bars to match the current contents of the text editor window. 
         /// It is called during OnIdle when the caret position changes.  You can provide new drop down members here.
@@ -318,7 +299,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
 
         // IVsDropdownBarClient methods
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.GetComboAttributes"]/*' />
         public virtual int GetComboAttributes(int combo, out uint entries, out uint entryType, out IntPtr iList) {
             entries = 0;
             entryType = 0;
@@ -339,7 +319,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             HasImage = 4
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.GetComboTipText"]/*' />
         public virtual int GetComboTipText(int combo, out string text) {
             if (combo == TypeAndMemberDropdownBars.DropClasses)
                 text = SR.GetString(SR.ComboTypesTip);
@@ -348,7 +327,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.GetEntryAttributes"]/*' />
         public virtual int GetEntryAttributes(int combo, int entry, out uint fontAttrs) {
             fontAttrs = (uint)DROPDOWNFONTATTR.FONTATTR_PLAIN;
             DropDownMember member = GetMember(combo, entry);
@@ -358,7 +336,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.GetEntryImage"]/*' />
         public virtual int GetEntryImage(int combo, int entry, out int imgIndex) {
             // this happens during drawing and has to be fast 
             imgIndex = -1;
@@ -369,7 +346,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.GetEntryText"]/*' />
         public virtual int GetEntryText(int combo, int entry, out string text) {
             text = null;
             DropDownMember member = GetMember(combo, entry);
@@ -379,12 +355,10 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.OnComboGetFocus"]/*' />
         public virtual int OnComboGetFocus(int combo) {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.GetMember"]/*' />
         public DropDownMember GetMember(int combo, int entry) {
             if (combo == TypeAndMemberDropdownBars.DropClasses) {
                 if (this.dropDownTypes != null && entry >= 0 && entry < this.dropDownTypes.Count)
@@ -396,7 +370,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return null;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.OnItemChosen"]/*' />
         public virtual int OnItemChosen(int combo, int entry) {
             DropDownMember member = GetMember(combo, entry);
             if (!Object.ReferenceEquals(member,null)) {
@@ -415,11 +388,9 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.SetFocus"]/*' />
         [DllImport("user32.dll")]
         static extern void SetFocus(IntPtr hwnd);
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="TypeAndMemberDropdownBars.OnItemSelected"]/*' />
         public int OnItemSelected(int combo, int index) {
             //nop
             return NativeMethods.S_OK;
@@ -431,7 +402,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
     }
 
-    /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember"]/*' />
     internal class DropDownMember : IComparable {
 
         private string label;
@@ -439,7 +409,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         private int glyph;
         private DROPDOWNFONTATTR fontAttr;
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.Label;"]/*' />
         public string Label {
             get {
                 return this.label;
@@ -449,7 +418,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.Span;"]/*' />
         public TextSpan Span {
             get {
                 return this.span;
@@ -458,7 +426,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 this.span = value;
             }
         }
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.Glyph;"]/*' />
         public int Glyph {
             get {
                 return this.glyph;
@@ -467,7 +434,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 this.glyph = value;
             }
         }
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.FontAttr;"]/*' />
         public DROPDOWNFONTATTR FontAttr {
             get {
                 return this.fontAttr;
@@ -477,7 +443,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.DropDownMember"]/*' />
         public DropDownMember(string label, TextSpan span, int glyph, DROPDOWNFONTATTR fontAttribute) {
             if (label == null) {
                 throw new ArgumentNullException("label");
@@ -488,14 +453,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.FontAttr = fontAttribute;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.CompareTo"]/*' />
         public int CompareTo(object obj) {
             // if this overload is used then it assumes a case-sensitive current culture comparison
             // which allows for case-senstive languages to work
             return CompareTo(obj, StringComparison.CurrentCulture);
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.CompareTo"]/*' />
         public int CompareTo(object obj, StringComparison stringComparison)
         {
             if (obj is DropDownMember)
@@ -506,7 +469,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
         // Omitting Equals violates FxCop rule: IComparableImplementationsOverrideEquals.
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.Equals"]/*' />
         public override bool Equals(Object obj) {
             if (!(obj is DropDownMember))
                 return false;
@@ -514,7 +476,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
         // Omitting getHashCode violates FxCop rule: EqualsOverridesRequireGetHashCodeOverride.
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DropDownMember.GetHashCode"]/*' />
         public override int GetHashCode() {
             return this.Label.GetHashCode();
         }

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Colorizer.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Colorizer.cs
@@ -46,7 +46,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
     }
 
 #if COLORABLE_ITEM
-    /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem"]/*' />
     [CLSCompliant(false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public class ColorableItem : IVsColorableItem, IVsHiColorItem, IVsMergeableUIItem {
@@ -55,7 +54,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         Color hiForeColor, hiBackColor;
         FONTFLAGS fontFlags;
 
-        /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.ColorableItem"]/*' />
         internal ColorableItem(string name, string displayName, COLORINDEX foreColor, COLORINDEX backColor, Color hiForeColor, Color hiBackColor, FONTFLAGS fontFlags) {
             this.name = name;
             this.displayName = displayName;
@@ -66,24 +64,20 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             this.hiBackColor = hiBackColor;
         }
 
-        /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.GetDefaultColors"]/*' />
         public virtual int GetDefaultColors(COLORINDEX[] foreColor, COLORINDEX[] backColor) {
             if (foreColor != null) foreColor[0] = this.foreColor;
             if (backColor != null) backColor[0] = this.backColor;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.GetDefaultFontFlags"]/*' />
         public virtual int GetDefaultFontFlags(out uint fontFlags) {
             fontFlags = (uint)this.fontFlags;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.GetDisplayName"]/*' />
         public virtual int GetDisplayName(out string name) {
             name = this.displayName;
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\Colorizer.uex' path='docs/doc[@for="Colorizer.GetColorData"]/*' />
         public virtual int GetColorData(int cdElement, out uint crColor) 
         {
             crColor = 0;
@@ -125,13 +119,11 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
 
 
-        /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.GetCanonicalName"]/*' />
         public virtual int GetCanonicalName(out string name) {
             name = this.name;
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.GetDescription"]/*' />
         public virtual int GetDescription(out string desc) {
             // The reason this is not implemented is because the core text editor
             // doesn't use it.
@@ -139,7 +131,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return NativeMethods.E_NOTIMPL;
         }
 
-        /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.GetMergingPriority"]/*' />
         public virtual int GetMergingPriority(out int priority) {
             priority = -1;
             return NativeMethods.E_NOTIMPL;

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Colorizer.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Colorizer.cs
@@ -66,7 +66,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             this.hiBackColor = hiBackColor;
         }
 
-    #region IVsColorableItem methods
         /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.GetDefaultColors"]/*' />
         public virtual int GetDefaultColors(COLORINDEX[] foreColor, COLORINDEX[] backColor) {
             if (foreColor != null) foreColor[0] = this.foreColor;
@@ -83,9 +82,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             name = this.displayName;
             return NativeMethods.S_OK;
         }
-        #endregion
 
-    #region IVsHiColorItem methods
         /// <include file='doc\Colorizer.uex' path='docs/doc[@for="Colorizer.GetColorData"]/*' />
         public virtual int GetColorData(int cdElement, out uint crColor) 
         {
@@ -126,10 +123,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 
             return (uint)(red | (green << 8) | (blue << 16));
         }
-        #endregion
 
-
-    #region IVsMergeableUIItem Members
 
         /// <include file='doc\Colorizer.uex' path='docs/doc[@for="ColorableItem.GetCanonicalName"]/*' />
         public virtual int GetCanonicalName(out string name) {
@@ -151,7 +145,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return NativeMethods.E_NOTIMPL;
         }
 
-        #endregion
     }
 #endif
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/DocumentProperties.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/DocumentProperties.cs
@@ -72,9 +72,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.Dispose(true);
         }
 
-        #region IDisposable Members
-
-
         /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.Dispose"]/*' />
         public void Dispose() {
             Dispose(true);
@@ -100,9 +97,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         ~DocumentProperties() {
             Dispose(false);
         }
-        #endregion
 
-        #region ISelectionContainer methods.
         /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.CountObjects"]/*' />
         public virtual int CountObjects(uint flags, out uint pc) {
             pc = this.visible ? (uint)1 : (uint)0;
@@ -120,7 +115,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             // nop
             return NativeMethods.S_OK;
         }
-    #endregion
     }
 
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/DocumentProperties.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/DocumentProperties.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         internal IVsTrackSelectionEx tracker;
         private bool visible;
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.DocumentProperties"]/*' />
         protected DocumentProperties(CodeWindowManager mgr) {
             this.mgr = mgr;
             this.visible = true;
@@ -43,7 +42,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             set { if (this.visible != value) { this.visible = value; Refresh(); } }
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.UpdateSelection"]/*' />
         /// <summary>
         /// Call this method when you want the document properties window updated with new information.
         /// </summary>
@@ -64,7 +62,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return this.mgr;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.Close"]/*' />
         public void Close() {
             if (this.tracker != null && this.visible)
                 NativeMethods.ThrowOnFailure(tracker.OnSelectChange(null));
@@ -72,7 +69,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.Dispose(true);
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.Dispose"]/*' />
         public void Dispose() {
             Dispose(true);
             // This object will be cleaned up by the Dispose method.
@@ -81,7 +77,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.Dispose"]/*' />
         protected virtual void Dispose(bool disposing) {
             // If disposing equals true, dispose all managed 
             // and unmanaged resources.
@@ -93,24 +88,20 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.mgr = null;
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.Finalize"]/*' />
         ~DocumentProperties() {
             Dispose(false);
         }
 
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.CountObjects"]/*' />
         public virtual int CountObjects(uint flags, out uint pc) {
             pc = this.visible ? (uint)1 : (uint)0;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.GetObjects"]/*' />
         public virtual int GetObjects(uint flags, uint count, object[] ppUnk) {
             if (count == 1) {
                 ppUnk[0] = this;
             }
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\CodeWindowManager.uex' path='docs/doc[@for="DocumentProperties.SelectObjects"]/*' />
         public virtual int SelectObjects(uint sel, object[] selobj, uint flags) {
             // nop
             return NativeMethods.S_OK;

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/DocumentTask.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/DocumentTask.cs
@@ -423,8 +423,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             get { return this.textLineMarker; }
         }
 
-        #region IVsTextMarkerClient methods
-
         /*---------------------------------------------------------
             IVsTextMarkerClient
         -----------------------------------------------------------*/
@@ -471,7 +469,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         public virtual int ExecMarkerCommand(IVsTextMarker marker, int item) {
             return NativeMethods.S_OK;
         }
-        #endregion
 
         int IVsProvideUserContext.GetUserContext(out IVsUserContext ppctx)
         {

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/DocumentTask.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/DocumentTask.cs
@@ -184,7 +184,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
     // DocumentTask is associated with an IVsTextLineMarker in a specified document and 
     // implements Navigate() to jump to that marker.
-    /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask"]/*' />
     [CLSCompliant(false)]
     [System.Runtime.InteropServices.ComVisible(true)]
 #if DEBUG
@@ -201,7 +200,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         IVsTextLines buffer;
         MARKERTYPE markerType;
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.DocumentTask"]/*' />
         internal DocumentTask(IServiceProvider site, IVsTextLines buffer, MARKERTYPE markerType, TextSpan span, string fileName, string subcategory) {
             this.site = site;
             this.fileName = fileName;
@@ -214,7 +212,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.markerType = markerType;
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.Finalize"]/*' />
         ~DocumentTask() {
             Dispose();
         }
@@ -266,25 +263,21 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\TaskProvider.uex' path='docs/doc[@for="DocumentTask.IsMarkerValid"]/*' />
         public bool IsMarkerValid {
             get {
                 return this.markerValid;
             }
         }
 
-        /// <include file='doc\TaskProvider.uex' path='docs/doc[@for="DocumentTask.Site"]/*' />
         public IServiceProvider Site {
             get { return this.site; }
         }
 
-        /// <include file='doc\TaskProvider.uex' path='docs/doc[@for="DocumentTask.Dispose"]/*' />
         public void Dispose() {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        /// <include file='doc\TaskProvider.uex' path='docs/doc[@for="DocumentTask.Dispose1"]/*' />
         protected virtual void Dispose(bool disposing) {
             if (this.textLineMarker != null) {
                 NativeMethods.ThrowOnFailure(textLineMarker.Invalidate());
@@ -350,7 +343,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return 1;
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.OnNavigate"]/*' />
         // It is important that this function not throw an exception.
         protected override void OnNavigate(EventArgs e) {
             try {
@@ -397,7 +389,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.OnRemoved"]/*' />
         protected override void OnRemoved(EventArgs e) {
             if (this.textLineMarker != null) {
                 NativeMethods.ThrowOnFailure(textLineMarker.Invalidate());
@@ -406,7 +397,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             base.OnRemoved(e);
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.Span"]/*' />
         public TextSpan Span {
             get {
                 if (textLineMarker != null) {
@@ -418,7 +408,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.TextLineMarker"]/*' />
         public IVsTextLineMarker TextLineMarker {
             get { return this.textLineMarker; }
         }
@@ -426,35 +415,28 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         /*---------------------------------------------------------
             IVsTextMarkerClient
         -----------------------------------------------------------*/
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.MarkerInvalidated"]/*' />
         public virtual void MarkerInvalidated() {
             this.markerValid = false;
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.OnBufferSave"]/*' />
         public virtual void OnBufferSave(string fileName) {
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.OnBeforeBufferClose"]/*' />
         public virtual void OnBeforeBufferClose() {
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.OnAfterSpanReload"]/*' />
         public virtual void OnAfterSpanReload() {
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.OnAfterMarkerChange"]/*' />
         public virtual int OnAfterMarkerChange(IVsTextMarker marker) {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.GetTipText"]/*' />
         public virtual int GetTipText(IVsTextMarker marker, string[] tipText) {
             if (this.Text != null && this.Text.Length > 0) tipText[0] = this.Text;
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.GetMarkerCommandInfo"]/*' />
         public virtual int GetMarkerCommandInfo(IVsTextMarker marker, int item, string[] text, uint[] commandFlags) {
             // Returning S_OK results in error message appearing in editor's
             // context menu when you right click over the error message.
@@ -465,7 +447,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.E_NOTIMPL;
         }
 
-        /// <include file='doc\DocumentTask.uex' path='docs/doc[@for="DocumentTask.ExecMarkerCommand"]/*' />
         public virtual int ExecMarkerCommand(IVsTextMarker marker, int item) {
             return NativeMethods.S_OK;
         }

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditArray.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditArray.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using Microsoft.VisualStudio.FSharp.LanguageService.Resources;
 
 namespace Microsoft.VisualStudio.FSharp.LanguageService {
-    /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditSpan"]/*' />
     /// <summary>
     /// This class encapsulates one atomic edit operation.
     /// Add these to an EditArray then when you are ready call ApplyEdits().
@@ -19,7 +18,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         int lineCount;
         int lengthOfLastLine;
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditSpan.EditSpan"]/*' />
         /// <summary>
         /// Construct a new edit span object
         /// </summary>
@@ -34,18 +32,15 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.lineCount = -1;
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditSpan.Span"]/*' />
         internal TextSpan Span {
             get { return this.span; }
             set { this.span = value; }
         }
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditSpan.Text"]/*' />
         internal string Text {
             get { return this.text; }
             set { this.text = value; this.lineCount = -1; }
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditSpan.LineCount"]/*' />
         /// <summary>
         /// Returns the number of lines in the new text being inserted.
         /// </summary>
@@ -57,7 +52,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditSpan.LengthOfLastLine"]/*' />
         /// <summary>
         /// Returns the length of the last line of text being inserted.
         /// </summary>
@@ -89,7 +83,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
     }
 
-    /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray"]/*' />
     /// <summary>
     /// This class encapsulates a batch edit operation.  The reason this class exists is because
     /// performing thousands of tiny edits on a large document can be pretty slow, so the best thing
@@ -111,7 +104,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         CompoundAction ca;
         CompoundViewAction cva;
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray.EditArray1"]/*' />
         /// <summary>
         /// This constructor takes a view and will use CompoundViewAction to make the updates
         /// and it will update the current selection accordingly.
@@ -167,7 +159,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             Dispose(true);
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray.Count"]/*' />
         /// <summary>
         /// Return the number of edits in the array.
         /// </summary>
@@ -177,21 +168,18 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray.TextView"]/*' />
         internal IVsTextView TextView {
             get {
                 return this.view;
             }
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray.Source"]/*' />
         internal ISource Source {
             get {
                 return this.source;
             }
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray.ToString"]/*' />
         public override string ToString() {
             StringBuilder s=new StringBuilder();
             for (int i = this.editList.Count - 1; i >= 0; i--) {
@@ -202,7 +190,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return s.ToString();
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray.Add"]/*' />
         /// <summary>
         /// Add a new atomic edit to the array.  The edits cannot intersect each other.  
         /// The spans in each edit must be based on the current state of the buffer, 
@@ -472,7 +459,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray.ApplyEdits"]/*' />
         internal void ApplyEdits() {
             try {
                 if (this.editList.Count == 0) return;
@@ -528,7 +514,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.editList.Clear(); // done!
         }
 
-        /// <include file='doc\EditArray.uex' path='docs/doc[@for="EditArray.GetEnumerator"]/*' />
         /// <summary>Allows enumeration of EditSpan objects</summary>
         public IEnumerator GetEnumerator() {
             return editList.GetEnumerator();

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditorFactory.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditorFactory.cs
@@ -21,7 +21,6 @@ using System.Diagnostics;
 #if NEVER
 namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
-    /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory"]/*' />
     /// <summary>
     /// You must inherit from this class and simply add a [ComVisible] and 
     /// [GuidAttribute] and then specify the EditorFactoryGuid, EditorFactoryGuid 
@@ -34,37 +33,31 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         Microsoft.VisualStudio.Shell.Package package;
         IServiceProvider site;
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GUID_VsBufferDetectLangSID;"]/*' />
         public static readonly Guid GuidVSBufferDetectLangSid = new Guid(0x17F375AC, 0xC814, 0x11D1, 0x88, 0xAD, 0x00, 0x00, 0xF8, 0x75, 0x79, 0xD2);
 
         __PROMPTONLOADFLAGS promptFlags = __PROMPTONLOADFLAGS.codepageNoPrompt;
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.EditorInfo"]/*' />
         public class EditorInfo {
             private string name;
             private Guid guid;
             private int priority;
             private EditorInfo next;
 
-            /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.EditorInfo.Name"]/*' />
             public string Name {
                 get { return name; }
                 set { name = value; }
             }
 
-            /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.EditorInfo.Guid"]/*' />
             public Guid Guid {
                 get { return guid; }
                 set { guid = value; }
             }
 
-            /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.EditorInfo.Priority"]/*' />
             public int Priority {
                 get { return priority; }
                 set { priority = value; }
             }
 
-            /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.EditorInfo.Next"]/*' />
             public EditorInfo Next {
                 get { return next; }
                 set { next = value; }
@@ -80,16 +73,13 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         // all known extensions under HKLM\Software\Microsoft\Visual Studio\9.0\Language Services\Extensions
         static StringDictionary languageExtensions; // string -> language service guid.
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.EditorFactory"]/*' />
         public EditorFactory(Microsoft.VisualStudio.Shell.Package package) {
             this.package = package;
             this.site = package;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.EditorFactory"]/*' />
         public EditorFactory() { }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.Finalize"]/*' />
         ~EditorFactory() {
             site = null;
 #if LANGTRACE
@@ -97,22 +87,18 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 #endif
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GetSite"]/*' />
         protected IServiceProvider GetSite() {
             return this.site;
         }
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GetPackage"]/*' />
         protected Microsoft.VisualStudio.Shell.Package GetPackage() {
             return this.package;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.IsRegisteredExtension"]/*' />
         /// <summary>Returns true if the given extension is one of our registered extensions</summary>
         public virtual bool IsRegisteredExtension(string extension) {
             return GetEditorExtensions().ContainsKey(extension);
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GetExtensions"]/*' />
         /// <summary>Return list of file extensions registered for this editor factory under 
         /// HKLM\Software\Microsoft\Visual Studio\9.0\Editors\\{" + this.GetType().GUID.ToString() + "}\\Extensions
         /// </summary>
@@ -121,14 +107,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return (string[])list.ToArray(typeof(string));
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GetLanguageService"]/*' />
         /// <summary>Returns the guid of the language service registered for this file extension
         /// HKLM\Software\Microsoft\Visual Studio\9.0\Language Services\Extensions</summary>
         public virtual string GetLanguageService(string fileExtension) {
             return GetLanguageExtensions(this.site)[fileExtension] as string;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.WithEncoding"]/*' />
         public virtual __PROMPTONLOADFLAGS CodePagePrompt {
             get { return this.promptFlags; }
             set { this.promptFlags = value; }
@@ -140,12 +124,10 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
         // Return your language service Guid here, this is used to set the language service on the 
         // IVsTextLines buffer returned from CreateEditorInstance.
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GetLanguageServiceGuid"]/*' />
         public virtual Guid GetLanguageServiceGuid() {
             return Guid.Empty;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GetRegisteredEditor"]/*' />
         /// <summary>Returns the guid of the highest priority editor registered for this extension.
         /// This will also pick up user defined file extension to editor associations</summary>
         public virtual Guid GetRegisteredEditor(string extension) {
@@ -156,7 +138,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return Guid.Empty;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GetRegisteredEditor"]/*' />
         /// <summary>Returns the guid of the highest priority editor registered for this extension.
         /// This will also pick up user defined file extension to editor associations.
         /// You can then access all registered editors via the .Next property.</summary>
@@ -165,7 +146,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return (EditorInfo)GetEditors(this.site)[key];
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.GetUserDefinedEditor"]/*' />
         /// <summary>Returns the guid of the editor that the user has defined for this file extension or
         /// Guid.Empty if none is found</summary>
         public Guid GetUserDefinedEditor(string extension) {
@@ -209,7 +189,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.IsOurFileFormat"]/*' />
         // This method is called when the user has not explicitly requested your editor
         // and if the file extension doesn't match an explicit extension you registered,
         // and if you have registered the extension "*" to determine if this file is 
@@ -219,7 +198,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return true;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.CreateEditorInstance"]/*' />
         /// <summary>
         /// This method checks to see if the specified file is one that your editor supports
         /// and if so, creates the core text editor and associated your language service 
@@ -389,7 +367,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return hr;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.CreateEditorView"]/*' />
         /// <summary>Return docView IUnknown COM object.</summary>
         public virtual IntPtr CreateEditorView(string moniker, IVsTextLines buffer, string physicalView, out string editorCaption, out Guid cmdUI) {
             Type tcw = typeof(IVsCodeWindow);
@@ -409,7 +386,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return docView;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.MapLogicalView"]/*' />
         /// <devdoc>The default implementation supports LOGVIEWID_Code, LOGVIEWID_TextView,
         /// LOGVIEWID_Debugging, and LOGVIEWID_Primary returning null for
         /// the physicalView string.</devdoc>
@@ -426,7 +402,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.E_NOTIMPL;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.SetSite"]/*' />
         public virtual int SetSite(Microsoft.VisualStudio.OLE.Interop.IServiceProvider psp) {
             this.site = new ServiceProvider(psp);
             return NativeMethods.S_OK;
@@ -597,7 +572,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return map;
         }
 
-        /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.Close"]/*' />
         public virtual int Close() {
             this.site = null;
             this.package = null;

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditorFactory.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditorFactory.cs
@@ -219,8 +219,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return true;
         }
 
-        #region IVsEditorFactory
-
         /// <include file='doc\EditorFactory.uex' path='docs/doc[@for="EditorFactory.CreateEditorInstance"]/*' />
         /// <summary>
         /// This method checks to see if the specified file is one that your editor supports
@@ -605,7 +603,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.package = null;
             return NativeMethods.S_OK;
         }
-        #endregion
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditorView.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditorView.cs
@@ -17,7 +17,6 @@ using System.ComponentModel.Design;
 
 namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
-    /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView"]/*' />
     /// <summary>
     /// This class View provides an abstract base class for simple editor views
     /// that follow the VS simple embedding model.
@@ -45,33 +44,27 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
         internal SimpleEditorView() {}
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.Site;"]/*' />
         protected IServiceProvider Site {
             get { return this.site; }
             set { this.site = value; }
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.Buffer;"]/*' />
         protected IVsTextLines Buffer {
             get { return this.buffer; }
             set { this.buffer = value; }
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.ComponentManager;"]/*' />
         protected IOleComponentManager ComponentManager {
             get { return this.componentManager; }
             set { this.componentManager = value; }
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.ComponentId;"]/*' />
         protected uint ComponentId {
             get { return this.componentID; }
             set { this.componentID = value; }
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.SimpleEditorView"]/*' />
         protected SimpleEditorView(IVsTextLines buffer) {
             this.buffer = buffer;
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.QueryCommandStatus"]/*' />
         /// <summary>
         /// Override this method to provide custom command status, 
         /// e.g. (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED
@@ -90,7 +83,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
             return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.ExecCommand"]/*' />
         /// <summary>
         /// Override this method to intercept the IOleCommandTarget::Exec call.
         /// </summary>
@@ -109,7 +101,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
             return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.QueryParameterList"]/*' />
         /// <summary>
         /// This method is called when IOleCommandTarget.Exec is called with 
         /// nCmdexecopt equal to MAKELONG(OLECMDEXECOPT_SHOWHELP, VSCmdOptQueryParameterList).
@@ -121,7 +112,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 #endif
             return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.IOleCommandTarget.QueryStatus"]/*' />
         /// <internalonly/>
         /// <summary>
         /// IOleCommandTarget implementation
@@ -135,7 +125,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
             return 0;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.IOleCommandTarget.Exec"]/*' />
         /// <internalonly/>
         public virtual int Exec(ref Guid guidCmdGroup, uint id, uint options, IntPtr pvaIn, IntPtr pvaOut) {
             ushort lo = (ushort)(options & (uint)0xffff);
@@ -158,27 +147,21 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.ClosePane"]/*' />
         public virtual int ClosePane() {
             return this.componentManager.FRevokeComponent(this.componentID);
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.CreatePaneWindow"]/*' />
         public abstract int CreatePaneWindow(IntPtr hwndParent, int x, int y, int cx, int cy, out IntPtr hwnd);
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.GetDefaultSize"]/*' />
         public virtual int GetDefaultSize(SIZE[] size) {
             size[0].cx = 100;
             size[0].cy = 100;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.LoadViewState"]/*' />
         public virtual int LoadViewState(Microsoft.VisualStudio.OLE.Interop.IStream stream) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.SaveViewState"]/*' />
         public virtual int SaveViewState(Microsoft.VisualStudio.OLE.Interop.IStream stream) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.SetSite"]/*' />
         public virtual int SetSite(Microsoft.VisualStudio.OLE.Interop.IServiceProvider site) {
             this.site = new ServiceProvider(site);
 
@@ -214,67 +197,51 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.TranslateAccelerator"]/*' />
         public virtual int TranslateAccelerator(MSG[] msg) {
             return (int)NativeMethods.S_FALSE;
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.IsSupported"]/*' />
         public virtual int IsSupported(Microsoft.VisualStudio.OLE.Interop.IDataObject data) {
             return (int)NativeMethods.S_FALSE;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.ItemPicked"]/*' />
         public virtual int ItemPicked(Microsoft.VisualStudio.OLE.Interop.IDataObject data) {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.SetInfo"]/*' />
         public virtual int SetInfo() {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.CommitPendingEdit"]/*' />
         public virtual int CommitPendingEdit(out int fCommitFailed) {
             fCommitFailed = 0;
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.FDoIdle"]/*' />
         public virtual int FDoIdle(uint grfidlef) {
             return 0;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.Terminate"]/*' />
         public virtual void Terminate() {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.FPreTranslateMessage"]/*' />
         public virtual int FPreTranslateMessage(MSG[] msg) {
             return 0;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.OnEnterState"]/*' />
         public virtual void OnEnterState(uint uStateID, int fEnter) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.OnAppActivate"]/*' />
         public virtual void OnAppActivate(int fActive, uint dwOtherThreadID) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.OnLoseActivation"]/*' />
         public virtual void OnLoseActivation() {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.OnActivationChange"]/*' />
         public virtual void OnActivationChange(Microsoft.VisualStudio.OLE.Interop.IOleComponent pic, int fSameComponent, OLECRINFO[] pcrinfo, int fHostIsActivating, OLECHOSTINFO[] pchostinfo, uint dwReserved) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.FContinueMessageLoop"]/*' />
         public virtual int FContinueMessageLoop(uint uReason, IntPtr pvLoopData, MSG[] pMsgPeeked) {
             return 1;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.FQueryTerminate"]/*' />
         public virtual int FQueryTerminate(int fPromptUser) {
             return 1;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.HwndGetWindow"]/*' />
         public virtual IntPtr HwndGetWindow(uint dwWhich, uint dwReserved) {
             return IntPtr.Zero;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.FReserved1"]/*' />
         public virtual int FReserved1(uint reserved, uint message, IntPtr wParam, IntPtr lParam) {
             return 1;
         }
@@ -282,7 +249,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
 #if CUT
 
-    /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView"]/*' />
     /// <summary>
     /// This class View provides an abstract base class for custom editor views that
     /// support Ole Inplace activation (ActiveX controls).
@@ -309,90 +275,66 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         // ??? public IVsTextBufferDataEvents,
         {
         internal EventSinkCollection eventSinks = new EventSinkCollection();
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.pCompUIMgr;"]/*' />
         protected IOleComponentUIManager pCompUIMgr;
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.pIPCompSite;"]/*' />
         protected IOleInPlaceComponentSite pIPCompSite;
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.pClientSite;"]/*' />
         protected IOleClientSite pClientSite;
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.monikers"]/*' />
         protected Hashtable monikers = new Hashtable();
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.OleEditorView"]/*' />
         protected OleEditorView(IVsTextLines buffer) : base(buffer) {
         }
     
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.Advise"]/*' />
         public virtual void Advise(IAdviseSink sink, out uint cookie) {
             cookie = eventSinks.Add(sink);
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.Close"]/*' />
         public virtual void Close(uint dwSaveOption) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.DoVerb"]/*' />
         public virtual int DoVerb(int iVerb, MSG[] msg, IOleClientSite site, int index, IntPtr hwndParent, RECT[] posRect) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.EnumAdvise"]/*' />
         public virtual void EnumAdvise(out IEnumSTATDATA ppEnumAdvise) {
             ppEnumAdvise = null;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.EnumVerbs"]/*' />
         public virtual int EnumVerbs(out IEnumOLEVERB ppEnumVerbs) {
             ppEnumVerbs = null;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetClientSite"]/*' />
         public virtual void GetClientSite(out IOleClientSite site) {
             site = this.pClientSite;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetClipboardData"]/*' />
         public virtual void GetClipboardData(uint reserved, out Microsoft.VisualStudio.OLE.Interop.IDataObject obj) {
             obj = null;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetExtent"]/*' />
         public virtual void GetExtent(uint dwDrawAspect, SIZEL[] size) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetMiscStatus"]/*' />
         public virtual int GetMiscStatus(uint dwAspect, out uint status) {
             status = 0;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetMoniker"]/*' />
         public virtual void GetMoniker(uint iAssign, uint whichMoniker, out IMoniker moniker) {
             object key = (object)whichMoniker;
 
             moniker = (IMoniker)monikers[key];
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetUserClassID"]/*' />
         public virtual void GetUserClassID(out Guid pClsid) {
             pClsid = this.GetType().GUID;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetUserType"]/*' />
         public virtual int GetUserType(uint formOfType, IntPtr userType) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.InitFromData"]/*' />
         public virtual int InitFromData(Microsoft.VisualStudio.OLE.Interop.IDataObject data, int fCreation, uint reserved) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.IsUpToDate"]/*' />
         public virtual int IsUpToDate() {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.SetClientSite"]/*' />
         public virtual void SetClientSite(IOleClientSite site) {
             this.pClientSite = site;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.SetColorScheme"]/*' />
         public virtual void SetColorScheme(LOGPALETTE[] logicalPalette) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.SetExtent"]/*' />
         public virtual void SetExtent(uint drawAspect, SIZEL[] size) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.SetHostNames"]/*' />
         public virtual void SetHostNames(string containerApp, string containerObj) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.SetMoniker"]/*' />
         public virtual void SetMoniker(uint whichMoniker, IMoniker moniker) {
             object key = (object)whichMoniker;
 
@@ -400,68 +342,52 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
             monikers.Add(key, moniker);
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.Unadvise"]/*' />
         public virtual void Unadvise(uint dwCookie) {
             eventSinks.RemoveAt(dwCookie);
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.Update"]/*' />
         public virtual int Update() {
             return NativeMethods.S_OK;
         }
     
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.EnableModeless"]/*' />
         public virtual void EnableModeless(int fEnable) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.OnDocWindowActivate"]/*' />
         public virtual void OnDocWindowActivate(int fActivate) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.OnFrameWindowActivate"]/*' />
         public virtual void OnFrameWindowActivate(int fActivate) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.ResizeBorder"]/*' />
         public virtual void ResizeBorder(RECT[] border, ref Guid iid, IOleInPlaceUIWindow window, int fFrameWindow) {
         }
 
 
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.ContextSensitiveHelp"]/*' />
         public virtual void ContextSensitiveHelp(int fEnterHelp) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetWindow"]/*' />
         public virtual void GetWindow(out IntPtr hwnd) {
             hwnd = IntPtr.Zero;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.InPlaceDeactivate"]/*' />
         public virtual void InPlaceDeactivate() {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.ReactivateAndUndo"]/*' />
         public virtual void ReactivateAndUndo() {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.SetObjectRects"]/*' />
         public virtual void SetObjectRects(RECT[] posRect, RECT[] clipRect) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.UIDeactivate"]/*' />
         public virtual void UIDeactivate() {
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.FQueryClose"]/*' />
         public virtual int FQueryClose(int fPromptUser) {
             return 0;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetCntrContextMenu"]/*' />
         public virtual int GetCntrContextMenu(uint dwRoleActiveObject, ref Guid clsidActiveObject, int nMenuIdActiveObject, POINTS[] pos, out Guid clsidCntr, OLEMENUID[] menuid, out uint pgrf) {
             clsidCntr = Guid.Empty;
             pgrf = 0;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetCntrHelp"]/*' />
         public virtual int GetCntrHelp(ref uint pdwRole, ref Guid pclsid, POINT posMouse, uint dwHelpCmd, string pszHelpFileIn, out string pwsHelpFileOut, uint dwDataIn, out uint dwDataOut) {
             pwsHelpFileOut = pszHelpFileIn;
             dwDataOut = dwDataIn;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.GetCntrMessage"]/*' />
         public virtual int GetCntrMessage(ref uint pdwRolw, ref Guid clsid, string titleIn, string textIn, string helpFileIn, out string titleOut, out string textOut, out string helpFileOut, ref uint dwHelpContextId, OLEMSGBUTTON[] msgbutton, OLEMSGDEFBUTTON[] msgdefbutton, OLEMSGICON[] msgicon, ref int sysAlert) {
             titleOut = titleIn;
             textOut = textIn;
@@ -471,15 +397,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         void IOleInPlaceComponent.OnEnterState(uint dwStateId, int fEnter) {
             ((IOleComponent)this).OnEnterState(dwStateId, fEnter);
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.OnWindowActivate"]/*' />
         public virtual int OnWindowActivate(uint windowType, int fActivate) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.TranslateCntrAccelerator"]/*' />
         public virtual int TranslateCntrAccelerator(MSG[] msg) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.UseComponentUIManager"]/*' />
         public virtual int UseComponentUIManager(uint dwCompRole, out uint pgrfCompFlags, IOleComponentUIManager pCompUIMgr, IOleInPlaceComponentSite pIPCompSite) {
             pgrfCompFlags = 0;
             this.pCompUIMgr = pCompUIMgr;
@@ -488,7 +411,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
     }
 #endif
-    /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl"]/*' />
     /// <summary>
     /// This class wraps a managed WinForm control and uses that as the editor window.
     /// </summary>
@@ -497,19 +419,16 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
     public class EditorControl : SimpleEditorView {
         Control control;
         
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.EditorControl"]/*' />
         internal EditorControl(IServiceProvider site, IVsTextLines buffer, Control ctrl) : base(buffer) {
             this.control = ctrl;
             this.Site = site;
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.Control;"]/*' />
         protected Control Control {
             get { return this.control; }
             set { this.control = value; }
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.ClosePane"]/*' />
         public override int ClosePane() {
             if (control != null) {
                 control.Dispose();
@@ -518,7 +437,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
             return base.ClosePane();
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.CreatePaneWindow"]/*' />
         public override int CreatePaneWindow(IntPtr hwndParent, int x, int y, int cx, int cy, out IntPtr hwnd) {
             control.SuspendLayout();
             control.Left = x;
@@ -539,26 +457,20 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             hwnd = control.Handle;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.CommitPendingEdit"]/*' />
         public override int CommitPendingEdit(out int fCommitFailed) {
             fCommitFailed = 0;
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.FDoIdle"]/*' />
         public override int FDoIdle(uint grfidlef) {
             return 0;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.OnAppActivate"]/*' />
         public override void OnAppActivate(int fActive, uint dwOtherThreadID) {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.FQueryTerminate"]/*' />
         public override int FQueryTerminate(int fPromptUser) {
             return 1;
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.OnLoseActivation"]/*' />
         public override void OnLoseActivation() {
         }
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl.HwndGetWindow"]/*' />
         public override IntPtr HwndGetWindow(uint dwWhich, uint dwReserved) {
             return control.Handle;
         }

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditorView.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/EditorView.cs
@@ -71,7 +71,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.buffer = buffer;
         }
 
-        #region IOleCommandTarget methods
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.QueryCommandStatus"]/*' />
         /// <summary>
         /// Override this method to provide custom command status, 
@@ -157,10 +156,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
             return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
         }
-        #endregion
 
-
-        #region IVsWindowPane methods
 
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.ClosePane"]/*' />
         public virtual int ClosePane() {
@@ -222,9 +218,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         public virtual int TranslateAccelerator(MSG[] msg) {
             return (int)NativeMethods.S_FALSE;
         }
-        #endregion 
 
-        #region IVsToolboxUser methods
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.IsSupported"]/*' />
         public virtual int IsSupported(Microsoft.VisualStudio.OLE.Interop.IDataObject data) {
             return (int)NativeMethods.S_FALSE;
@@ -233,24 +227,18 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         public virtual int ItemPicked(Microsoft.VisualStudio.OLE.Interop.IDataObject data) {
             return NativeMethods.S_OK;
         }
-        #endregion
 
-        #region IVsStatusbarUser methods
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.SetInfo"]/*' />
         public virtual int SetInfo() {
             return NativeMethods.S_OK;
         }
-        #endregion
 
-            #region IVsWindowPaneCommit methods
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.CommitPendingEdit"]/*' />
         public virtual int CommitPendingEdit(out int fCommitFailed) {
             fCommitFailed = 0;
             return NativeMethods.S_OK;
         }
-            #endregion
 
-            #region IOleComponent Methods
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.FDoIdle"]/*' />
         public virtual int FDoIdle(uint grfidlef) {
             return 0;
@@ -290,7 +278,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         public virtual int FReserved1(uint reserved, uint message, IntPtr wParam, IntPtr lParam) {
             return 1;
         }
-            #endregion 
     }
 
 #if CUT
@@ -334,7 +321,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         protected OleEditorView(IVsTextLines buffer) : base(buffer) {
         }
     
-        #region IOleObject methods
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.Advise"]/*' />
         public virtual void Advise(IAdviseSink sink, out uint cookie) {
             cookie = eventSinks.Add(sink);
@@ -422,10 +408,8 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         public virtual int Update() {
             return NativeMethods.S_OK;
         }
-        #endregion 
     
 
-        #region IOleInPlaceActiveObject
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.EnableModeless"]/*' />
         public virtual void EnableModeless(int fEnable) {
         }
@@ -438,11 +422,9 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.ResizeBorder"]/*' />
         public virtual void ResizeBorder(RECT[] border, ref Guid iid, IOleInPlaceUIWindow window, int fFrameWindow) {
         }
-        #endregion 
 
 
 
-        #region IOleInPlaceObject methods
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.ContextSensitiveHelp"]/*' />
         public virtual void ContextSensitiveHelp(int fEnterHelp) {
         }
@@ -462,10 +444,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.UIDeactivate"]/*' />
         public virtual void UIDeactivate() {
         }
-        #endregion 
-
-        #region IOleInPlaceComponent methods
-
 
         /// <include file='doc\EditorView.uex' path='docs/doc[@for="OleEditorView.FQueryClose"]/*' />
         public virtual int FQueryClose(int fPromptUser) {
@@ -508,7 +486,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.pIPCompSite = pIPCompSite;
             return NativeMethods.S_OK;
         }
-        #endregion
     }
 #endif
     /// <include file='doc\EditorView.uex' path='docs/doc[@for="EditorControl"]/*' />

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ExpansionProvider.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ExpansionProvider.cs
@@ -504,8 +504,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return value != null;
         }
 
-        #region IVsExpansionClient Members
-
         /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.EndExpansion"]/*' />
         public int EndExpansion() {
             this.expansionActive = false;
@@ -630,9 +628,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             func = GetExpansionFunction(doc.DocumentElement, fieldName);
             return NativeMethods.S_OK;
         }
-
-        #endregion
-
     }
 
 
@@ -781,8 +776,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return result;
         }
 
-        #region IVsExpansionFunction Members
-
         /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.FieldChanged"]/*' />
         public virtual int FieldChanged(string bstrField, out int fRequeryValue) {
             // Returns true if we care about this field changing.
@@ -862,8 +855,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.provider = null;
             return NativeMethods.S_OK;
         }
-
-        #endregion
     }
 
     // todo: for some reason VsExpansionManager is wrong.

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ExpansionProvider.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ExpansionProvider.cs
@@ -20,29 +20,24 @@ using Microsoft.VisualStudio.FSharp.LanguageService.Resources;
 
 namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
-    /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="DefaultFieldValue"]/*' />
     internal class DefaultFieldValue {
         private string field;
         private string value;
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="DefaultFieldValue.DefaultFieldValue"]/*' />
         internal DefaultFieldValue(string field, string value) {
             this.field = field;
             this.value = value;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="DefaultFieldValue.Field"]/*' />
         internal string Field {
             get { return this.field; }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="DefaultFieldValue.Value"]/*' />
         internal string Value {
             get { return this.value; }
         }
     }
 
-    /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider"]/*' />
     [CLSCompliant(false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public class ExpansionProvider : IDisposable, IVsExpansionClient {
@@ -57,7 +52,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         string titleToInsert;
         string pathToInsert;
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.ExpansionProvider"]/*' />
         internal ExpansionProvider(ISource src) {
             if (src == null){
                 throw new ArgumentNullException("src");
@@ -77,14 +71,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.Finalize"]/*' />
         ~ExpansionProvider() {
 #if LANGTRACE
             Trace.WriteLine("~ExpansionProvider");
 #endif
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.Dispose"]/*' />
         public virtual void Dispose() {
             EndTemplateEditing(true);
             this.source = null;
@@ -93,41 +85,34 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             GC.SuppressFinalize(this);
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.Source"]/*' />
         internal ISource Source {
             get { return this.source; }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.TextView"]/*' />
         internal IVsTextView TextView {
             get { return this.view; }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.Expansion"]/*' />
         internal IVsExpansion Expansion {
             get { return this.vsExpansion; }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.ExpansionSession"]/*' />
         internal IVsExpansionSession ExpansionSession {
             get { return this.expansionSession; }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.HandleQueryStatus"]/*' />
         internal virtual bool HandleQueryStatus(ref Guid guidCmdGroup, uint nCmdId, out int hr) {
             // in case there's something to conditinally support later on...
             hr = 0;
             return false;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.InTemplateEditingMode"]/*' />
         internal virtual bool InTemplateEditingMode {
             get {
                 return this.expansionActive;
             }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.InTemplateEditingMode"]/*' />
         internal virtual TextSpan GetExpansionSpan() {
             if (this.expansionSession == null){
                 throw new System.InvalidOperationException(SR.GetString(SR.NoExpansionSession));
@@ -141,7 +126,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.HandlePreExec"]/*' />
         internal virtual bool HandlePreExec(ref Guid guidCmdGroup, uint nCmdId, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) {
             if (!this.expansionActive || this.expansionSession == null) {
 				return false;
@@ -201,7 +185,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.HandlePostExec"]/*' />
         internal virtual bool HandlePostExec(ref Guid guidCmdGroup, uint nCmdId, uint nCmdexecopt, bool commit, IntPtr pvaIn, IntPtr pvaOut) {
             if (guidCmdGroup == typeof(VsCommands2K).GUID) {
                 VsCommands2K cmd = (VsCommands2K)nCmdId;
@@ -222,7 +205,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.DisplayExpansionBrowser"]/*' />
         internal virtual bool DisplayExpansionBrowser(IVsTextView view, string prompt, string[] types, bool includeNullType, string[] kinds, bool includeNullKind) {
             if (this.expansionActive) this.EndTemplateEditing(true);
 
@@ -258,7 +240,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.InsertSpecificExpansion"]/*' />
         internal virtual bool InsertSpecificExpansion(IVsTextView view, XmlElement snippet, TextSpan pos, string relativePath) {
             if (this.expansionActive) this.EndTemplateEditing(true);
 
@@ -295,7 +276,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.InsertNamedExpansion"]/*' />
         internal virtual bool InsertNamedExpansion(IVsTextView view, string title, string path, TextSpan pos, bool showDisambiguationUI) {
 
             if (this.source.IsCompletorActive) {
@@ -319,7 +299,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.FindExpansionByShortcut"]/*' />
         /// <summary>Returns S_OK if match found, S_FALSE if expansion UI is shown, and error otherwise</summary>
         internal virtual int FindExpansionByShortcut(IVsTextView view, string shortcut, TextSpan span, bool showDisambiguationUI, out string title, out string path) {
             if (this.expansionActive) this.EndTemplateEditing(true);
@@ -337,7 +316,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return hr;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.GetExpansionFunction1"]/*' />
         public virtual IVsExpansionFunction GetExpansionFunction(XmlElement xmlFunctionNode, string fieldName) {
             string functionName = null;
             ArrayList rgFuncParams = new ArrayList();
@@ -413,7 +391,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return null;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.PrepareTemplate"]/*' />
         internal virtual void PrepareTemplate(string title, string path) {            
             if (title == null)
                 throw new System.ArgumentNullException("title");
@@ -436,7 +413,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.fieldDefaults.Add(new DefaultFieldValue(field, value));
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.BeginTemplateEditing"]/*' />
         internal virtual void BeginTemplateEditing(int line, int col) {
             if (!this.expansionPrepared) {
                 throw new System.InvalidOperationException(SR.GetString(SR.TemplateNotPrepared));
@@ -463,7 +439,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.titleToInsert = null;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.EndTemplateEditing"]/*' />
         internal virtual void EndTemplateEditing(bool leaveCaret) {
             if (!this.expansionActive || this.expansionSession == null) {
                 this.expansionActive = false;
@@ -475,7 +450,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.expansionActive = false;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.GetFieldSpan"]/*' />
         internal virtual bool GetFieldSpan(string field, out TextSpan pts) {
             if (this.expansionSession == null) {
                 throw new System.InvalidOperationException(SR.GetString(SR.NoExpansionSession));
@@ -491,7 +465,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.GetFieldValue"]/*' />
         internal virtual bool GetFieldValue(string field, out string value) {
             if (this.expansionSession == null) {
                 throw new System.InvalidOperationException(SR.GetString(SR.NoExpansionSession));
@@ -504,14 +477,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return value != null;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.EndExpansion"]/*' />
         public int EndExpansion() {
             this.expansionActive = false;
             this.expansionSession = null;
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.FormatSpan"]/*' />
         public virtual int FormatSpan(IVsTextLines buffer, TextSpan[] ts) {
             if (this.source.GetTextLines() != buffer) {
                 throw new System.ArgumentException(SR.GetString(SR.UnknownBuffer), "buffer");
@@ -534,7 +505,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return rc;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.IsValidKind"]/*' />
         public virtual int IsValidKind(IVsTextLines buffer, TextSpan[] ts, string bstrKind, out int /*BOOL*/ fIsValid)
         {
             fIsValid = 0;
@@ -547,7 +517,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.IsValidType"]/*' />
         public virtual int IsValidType(IVsTextLines buffer, TextSpan[] ts, string[] rgTypes, int iCountTypes, out int /*BOOL*/ fIsValid)
         {
             fIsValid = 0;
@@ -559,7 +528,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.OnItemChosen"]/*' />
         public virtual int OnItemChosen(string pszTitle, string pszPath) {
             TextSpan ts;
             view.GetCaretPos(out ts.iStartLine, out ts.iStartIndex);
@@ -585,18 +553,15 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return hr;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.PositionCaretForEditing"]/*' />
         public virtual int PositionCaretForEditing(IVsTextLines pBuffer, TextSpan[] ts) {
             // NOP
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.OnAfterInsertion"]/*' />
         public virtual int OnAfterInsertion(IVsExpansionSession session) {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.OnBeforeInsertion"]/*' />
         public virtual int OnBeforeInsertion(IVsExpansionSession session) {
             if (session == null)
                 return NativeMethods.E_UNEXPECTED;
@@ -620,7 +585,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionProvider.GetExpansionFunction"]/*' />
         public virtual int GetExpansionFunction(MSXML.IXMLDOMNode xmlFunctionNode, string fieldName, out IVsExpansionFunction func) {
 
             XmlDocument doc = new XmlDocument();
@@ -631,7 +595,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
     }
 
 
-    /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction"]/*' />
     [CLSCompliant(false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public abstract class ExpansionFunction : IVsExpansionFunction {
@@ -640,50 +603,41 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         string[] args;
         string[] list;
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.ExpansionFunction"]/*' />
         /// <summary>You must construct this object with an ExpansionProvider</summary>
         private ExpansionFunction() {
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.ExpansionFunction2"]/*' />
         internal ExpansionFunction(ExpansionProvider provider) {
             this.provider = provider;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.ExpansionProvider"]/*' />
         public ExpansionProvider ExpansionProvider {
             get { return this.provider; }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.Arguments"]/*' />
         public string[] Arguments {
             get { return this.args; }
             set { this.args = value; }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.FieldName"]/*' />
         public string FieldName {
             get { return this.fieldName; }
             set { this.fieldName = value; }
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetCurrentValue"]/*' />
         public abstract string GetCurrentValue();
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetDefaultValue"]/*' />
         public virtual string GetDefaultValue() {
             // This must call GetCurrentValue sincs during initialization of the snippet
             // VS will call GetDefaultValue and not GetCurrentValue.
             return GetCurrentValue();
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetIntellisenseList"]/*' />
         /// <summary>Override this method if you want intellisense drop support on a list of possible values.</summary>
         public virtual string[] GetIntellisenseList() {
             return null;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetArgument"]/*' />
         /// <summary>
         /// Gets the value of the specified argument, resolving any fields referenced in the argument.
         /// In the substitution, "$$" is replaced with "$" and any floating '$' signs are left unchanged,
@@ -755,7 +709,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return arg;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetFieldValue"]/*' />
         public bool GetFieldValue(string name, out string value) {
             value = null;
             if (this.provider != null && this.provider.ExpansionSession != null) {
@@ -765,7 +718,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="DefaultFieldValue.GetSelection"]/*' />
         public TextSpan GetSelection() {
             TextSpan result = new TextSpan();
             ExpansionProvider provider = this.ExpansionProvider;
@@ -776,7 +728,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return result;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.FieldChanged"]/*' />
         public virtual int FieldChanged(string bstrField, out int fRequeryValue) {
             // Returns true if we care about this field changing.
             // We care if the field changes if one of the arguments refers to it.
@@ -793,7 +744,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetCurrentValue1"]/*' />
         public int GetCurrentValue(out string bstrValue, out int hasDefaultValue) {
             try {
                 bstrValue = this.GetCurrentValue();
@@ -804,7 +754,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetDefaultValue1"]/*' />
         public int GetDefaultValue(out string bstrValue, out int hasCurrentValue) {
             try {
                 bstrValue = this.GetDefaultValue();
@@ -815,7 +764,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetFunctionType"]/*' />
         public virtual int GetFunctionType(out uint pFuncType) {
             if (this.list == null) {
                 this.list = this.GetIntellisenseList();
@@ -824,7 +772,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetListCount"]/*' />
         public virtual int GetListCount(out int iListCount) {
             if (this.list == null) {
                 this.list = this.GetIntellisenseList();
@@ -837,7 +784,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.GetListText"]/*' />
         public virtual int GetListText(int iIndex, out string ppszText) {
             if (this.list == null) {
                 this.list = this.GetIntellisenseList();
@@ -850,7 +796,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ExpansionFunction.ReleaseFunction"]/*' />
         public virtual int ReleaseFunction() {
             this.provider = null;
             return NativeMethods.S_OK;

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/LanguageService.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/LanguageService.cs
@@ -164,7 +164,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return this.GetType().GUID;
         }
 
-        #region IVsProvideColorableItems
         public virtual int GetItemCount(out int count)
         {
             count = 0;
@@ -176,9 +175,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             item = null;
             return NativeMethods.E_NOTIMPL;
         }
-        #endregion
 
-        #region IVsLanguageContextProvider
         int IVsLanguageContextProvider.UpdateLanguageContext(uint dwHint, IVsTextLines buffer, TextSpan[] ptsSelection, object ptr)
         {
             if (ptr != null && ptr is IVsUserContext && buffer is IVsTextBuffer)
@@ -211,8 +208,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
                 }
             }
         }
-
-        #endregion
 
         internal virtual int UpdateLanguageContext(LanguageContextHint hint, IVsTextLines buffer, TextSpan[] ptsSelection, IVsUserContext context)
         {
@@ -566,7 +561,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return new ExpansionProvider(src);
         }
 
-        #region IVsLanguageInfo methods
         // GetCodeWindowManager -- this gives us the VsCodeWindow which is what we need to
         // add adornments and so forth.
         public int GetCodeWindowManager(IVsCodeWindow codeWindow, out IVsCodeWindowManager mgr)
@@ -616,9 +610,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return NativeMethods.S_OK;
         }
 
-        #endregion
-
-        #region IVsLanguageDebugInfo methods
         public abstract int GetLanguageID(IVsTextBuffer buffer, int line, int col, out Guid langId);
 
         public virtual int GetLocationOfName(string name, out string pbstrMkDoc, TextSpan[] spans)
@@ -698,7 +689,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
 
         public abstract int ValidateBreakpointLocation(IVsTextBuffer buffer, int line, int col, TextSpan[] pCodeSpan);
-        #endregion
 
         /// <include file='doc\Package.uex' path='docs/doc[@for="LanguageService.GetService"]' />
         internal object GetService(Type serviceType)
@@ -710,7 +700,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return null;
         }
 
-        #region Microsoft.VisualStudio.OLE.Interop.IServiceProvider methods
         public virtual int QueryService(ref Guid guidService, ref Guid iid, out IntPtr obj)
         {
             obj = IntPtr.Zero;
@@ -723,7 +712,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             }
             return (int)NativeMethods.E_UNEXPECTED;
         }
-        #endregion
 
         // Override this method if you want to insert your own view filter
         // into the command chain.  
@@ -1009,7 +997,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
 
 
-        #region IObjectWithSite
         public void GetSite(ref Guid iid, out IntPtr ptr)
         {
             IntPtr pUnk = Marshal.GetIUnknownForObject(this.site);
@@ -1037,7 +1024,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             Microsoft.VisualStudio.Shell.Package pkg = (Microsoft.VisualStudio.Shell.Package)this.site.GetService(typeof(Microsoft.VisualStudio.Shell.Package));
             this.lcid = pkg.GetProviderLocale();
         }
-        #endregion
 
 #if IVsOutliningCapableLanguage                 
         public virtual void CollapseToDefinitions(IVsTextLines buffer, IVsOutliningSession session) {
@@ -1047,16 +1033,11 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 #endif
 
 
-        #region IVsDebuggerEvents Members
-
         public virtual int OnModeChange(DBGMODE dbgmodeNew)
         {
             this.dbgMode = dbgmodeNew;
             return NativeMethods.S_OK;
         }
-
-        #endregion
-
 
         /// Return true if the given encoding information is invalid for your language service
         /// Default always returns false.  If you return true, then also return an error
@@ -1115,7 +1096,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return -1;
         }
 
-        #region IVsFormatFilterProvider Members
         int IVsFormatFilterProvider.QueryInvalidEncoding(uint format, out string pbstrMessage)
         {
             if (QueryInvalidEncoding((__VSTFF)format, out pbstrMessage))
@@ -1161,10 +1141,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return NativeMethods.S_OK;
         }
 
-        #endregion
-
-        #region ILanguageServiceTestHelper
-
         /// <summary>
         /// Version number will increment to indicate a change in the semantics of preexisting methods. 
         /// </summary>
@@ -1173,7 +1149,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return 3;
         }
 
-        #endregion
     } // end class LanguageService
 
     internal class BackgroundRequestAsyncResult

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/LanguageService.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/LanguageService.cs
@@ -690,7 +690,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 
         public abstract int ValidateBreakpointLocation(IVsTextBuffer buffer, int line, int col, TextSpan[] pCodeSpan);
 
-        /// <include file='doc\Package.uex' path='docs/doc[@for="LanguageService.GetService"]' />
         internal object GetService(Type serviceType)
         {
             if (this.site != null)

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/NativeMethods.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/NativeMethods.cs
@@ -14,38 +14,25 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
     using System.Text;
     using System.Globalization;
 
-    /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods"]/*' />
     // This class is shared between assemblies
     [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
     internal static class NativeMethods {
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.InvalidIntPtr"]/*' />
         public static IntPtr InvalidIntPtr = ((IntPtr)((int)(-1)));
 
         // IIDS
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.IID_IServiceProvider"]/*' />
         public static readonly Guid IID_IServiceProvider = typeof(Microsoft.VisualStudio.OLE.Interop.IServiceProvider).GUID;
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.IID_IObjectWithSite"]/*' />
         public static readonly Guid IID_IObjectWithSite = typeof(IObjectWithSite).GUID;
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.IID_IUnknown"]/*' />
         public static readonly Guid IID_IUnknown = new Guid("{00000000-0000-0000-C000-000000000046}");                    
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GUID_PropertyBrowserToolWindow"]/*' />
         public static readonly Guid GUID_PropertyBrowserToolWindow = new Guid(unchecked((int)0xeefa5220), unchecked((short)0xe298), (short)0x11d0, new byte[]{ 0x8f, 0x78, 0x0, 0xa0, 0xc9, 0x11, 0x0, 0x57 });
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GUID_VSStandardCommandSet97"]/*' />
         public static readonly Guid GUID_VSStandardCommandSet97 = new Guid("{5efc7975-14bc-11cf-9b2b-00aa00573819}");
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.CLSID_HtmDocData"]/*' />
         public static readonly Guid CLSID_HtmDocData = new Guid(unchecked((int)0x62C81794), unchecked((short)0xA9EC), (short)0x11D0, new byte[] {0x81, 0x98, 0x0, 0xa0, 0xc9, 0x1b, 0xbe, 0xe3});
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.CLSID_HtmedPackage"]/*' />
         public static readonly Guid CLSID_HtmedPackage = new Guid(unchecked((int)0x1B437D20), unchecked((short)0xF8FE), (short)0x11D2, new byte[] {0xA6, 0xAE, 0x00, 0x10, 0x4B, 0xCC, 0x72, 0x69});
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.CLSID_HtmlLanguageService"]/*' />
         public static readonly Guid CLSID_HtmlLanguageService = new Guid(unchecked((int)0x58E975A0), unchecked((short)0xF8FE), (short)0x11D2, new byte[] {0xA6, 0xAE, 0x00, 0x10, 0x4B, 0xCC, 0x72, 0x69});
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GUID_HtmlEditorFactory"]/*' />
         public static readonly Guid GUID_HtmlEditorFactory = new Guid("{C76D83F8-A489-11D0-8195-00A0C91BBEE3}");
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GUID_TextEditorFactory"]/*' />
         public static readonly Guid GUID_TextEditorFactory = new Guid("{8B382828-6202-11d1-8870-0000F87579D2}");
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GUID_HTMEDAllowExistingDocData"]/*' />
         public static readonly Guid GUID_HTMEDAllowExistingDocData = new Guid(unchecked((int)0x5742d216), unchecked((short)0x8071), (short)0x4779, new byte[] {0xbf, 0x5f, 0xa2, 0x4d, 0x5f, 0x31, 0x42, 0xba});
         
         /// <summary>GUID for the environment package.</summary>
@@ -80,11 +67,8 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         /// <summary>GUID of the general output pane inside the output window.</summary>
         public static readonly Guid GUID_OutWindowGeneralPane = new Guid("{3c24d581-5591-4884-a571-9fe89915cd64}");
         // Guids for GetOutputPane.
-        /// <include file='doc\Package.uex' path='docs/doc[@for="Package.BuildOrder"]/*' />
         public static readonly Guid BuildOrder = new Guid("2032b126-7c8d-48ad-8026-0e0348004fc0");
-        /// <include file='doc\Package.uex' path='docs/doc[@for="Package.BuildOutput"]/*' />
         public static readonly Guid BuildOutput = new Guid("1BD8A850-02D1-11d1-BEE7-00A0C913D1F8");
-        /// <include file='doc\Package.uex' path='docs/doc[@for="Package.DebugOutput"]/*' />
         public static readonly Guid DebugOutput = new Guid("FC076020-078A-11D1-A7DF-00A0C9110051");
         
         //--------------------------------------------------------------------
@@ -171,23 +155,19 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         /// <summary></summary>
         public static readonly Guid GUID_SolutionPage   = new Guid("{9A341D97-5A64-11d3-BFF9-00C04F990235}");
  
-       /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OleComponentUIManager"]/*' />
         [ComImport,System.Runtime.InteropServices.Guid("5EFC7974-14BC-11CF-9B2B-00AA00573819")]
         public class OleComponentUIManager {
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="VsTextBuffer"]/*' />
         [ComImport,System.Runtime.InteropServices.Guid("8E7B96A8-E33D-11D0-A6D5-00C04FB67F6A")]
         public class VsTextBuffer {
         }
 
         // HRESULTS
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.Succeeded"]/*' />
         public static bool Succeeded(int hr) {
             return(hr >= 0);
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.Failed"]/*' />
         public static bool Failed(int hr) {
             return(hr < 0);
         }
@@ -211,21 +191,17 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
         // packing
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.SignedHIWORD"]/*' />
         public static int SignedHIWORD(int n) {
             return (int)(short)((n >> 16) & 0xffff);
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.SignedLOWORD"]/*' />
         public static int SignedLOWORD(int n) {
             return (int)(short)(n & 0xFFFF);
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.CLSCTX_INPROC_SERVER"]/*' />
         public const int
         CLSCTX_INPROC_SERVER  = 0x1;
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.S_FALSE"]/*' />
         public const int
         S_FALSE =   0x00000001,
         S_OK =      0x00000000,
@@ -263,7 +239,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         E_ACCESSDENIED = unchecked((int)0x80070005),
         E_PENDING = unchecked((int)0x8000000A); 
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.VS_E_UNSUPPORTEDFORMAT"]/*' />
         public const int
         VS_E_UNSUPPORTEDFORMAT = unchecked((int)0x80041FEB),
         VS_E_INCOMPATIBLEDOCDATA = unchecked((int)0x80041FEA),
@@ -293,13 +268,11 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             BMP_USER = -5
         };
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.OLECLOSE_SAVEIFDIRTY"]/*' />
         public const int
         OLECLOSE_SAVEIFDIRTY = 0,
         OLECLOSE_NOSAVE = 1,
         OLECLOSE_PROMPTSAVE = 2;
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.OLEIVERB_PRIMARY"]/*' />
         public const int
         OLEIVERB_PRIMARY = 0,
         OLEIVERB_SHOW = -1,
@@ -310,7 +283,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         OLEIVERB_DISCARDUNDOSTATE = -6,
         OLEIVERB_PROPERTIES = -7;                
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.OleErrors"]/*' />
         public const int 
         OLE_E_OLEVERB = unchecked((int)0x80040000),
         OLE_E_ADVF = unchecked((int)0x80040001),
@@ -332,7 +304,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         OLE_E_CANTCONVERT = unchecked((int)0x80040011),
         OLE_E_NOSTORAGE = unchecked((int)0x80040012);
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.OleDispatchErrors"]/*' />
         public const int 
         DISP_E_UNKNOWNINTERFACE = unchecked((int)0x80020001),
         DISP_E_MEMBERNOTFOUND = unchecked((int)0x80020003),
@@ -382,7 +353,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 OFN_DONTADDTORECENT =      unchecked((int)0x02000000),
                 OFN_FORCESHOWHIDDEN =      unchecked((int)0x10000000);
 
-                /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.VSITEMID_NIL"]/*' />
         public const uint
         VSITEMID_NIL               = unchecked((uint)-1),
         VSITEMID_ROOT              = unchecked((uint)-2), 
@@ -391,13 +361,11 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         public const uint VSCOOKIE_NIL               = 0;
 
         // for ISelectionContainer flags
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.ALL"]/*' />
         public const uint
         ALL = 0x1,
         SELECTED = 0x2;
 
         // for IVsSelectionEvents flags
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.UndoManager"]/*' />
         public const uint
         UndoManager = 0x0,
         WindowFrame = 0x1,
@@ -407,29 +375,20 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         UserContext = 0x5;
 
         // for READONLYSTATUS
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.ROSTATUS_NotReadOnly"]/*' />
         public const int
         ROSTATUS_NotReadOnly = 0x0,
         ROSTATUS_ReadOnly = 0x1,
         ROSTATUS_Unknown = unchecked((int)0xFFFFFFFF);
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.IEI_DoNotLoadDocData"]/*' />
         public const int
         IEI_DoNotLoadDocData = 0x10000000;
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.LOGVIEWID_Any"]/*' />
         public static readonly Guid LOGVIEWID_Any             = new Guid(0xffffffff, 0xffff, 0xffff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff );
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.LOGVIEWID_Primary"]/*' />
         public static readonly Guid LOGVIEWID_Primary         = Guid.Empty;
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.LOGVIEWID_Debugging"]/*' />
         public static readonly Guid LOGVIEWID_Debugging       = new Guid("{7651a700-06e5-11d1-8ebd-00a0c90f26ea}");
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.LOGVIEWID_Code"]/*' />
         public static readonly Guid LOGVIEWID_Code            = new Guid("{7651a701-06e5-11d1-8ebd-00a0c90f26ea}");
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.LOGVIEWID_Designer"]/*' />
         public static readonly Guid LOGVIEWID_Designer        = new Guid("{7651a702-06e5-11d1-8ebd-00a0c90f26ea}");
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.LOGVIEWID_TextView"]/*' />
         public static readonly Guid LOGVIEWID_TextView        = new Guid("{7651a703-06e5-11d1-8ebd-00a0c90f26ea}");
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.LOGVIEWID_UserChooseView"]/*' />
         public static readonly Guid LOGVIEWID_UserChooseView  = new Guid("{7651a704-06e5-11d1-8ebd-00a0c90f26ea}");
 
         /// <summary>Command Group GUID for commands that only apply to the UIHierarchyWindow.</summary>
@@ -477,7 +436,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             SEID_LastWindowFrame    = 7
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.CB_SETDROPPEDWIDTH"]/*' />
                 public const int
                 CB_SETDROPPEDWIDTH = 0x0160,
 
@@ -753,20 +711,17 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 PSNRET_INVALID = 1,
                 PSNRET_INVALID_NOCHANGEPAGE = 2;
 
-                /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.PSN_APPLY"]/*' />
         public const int 
         PSN_APPLY = ((0-200)-2),
         PSN_KILLACTIVE = ((0-200)-1),
         PSN_RESET = ((0-200)-3),
         PSN_SETACTIVE = ((0-200)-0);
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GMEM_MOVEABLE"]/*' />
         public const int 
         GMEM_MOVEABLE = 0x0002,
         GMEM_ZEROINIT = 0x0040,
         GMEM_DDESHARE = 0x2000;
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.SWP_NOACTIVATE"]/*' />
         public const int
         SWP_NOACTIVATE = 0x0010,
         SWP_NOZORDER = 0x0004,
@@ -774,23 +729,19 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         SWP_NOMOVE = 0x0002,
         SWP_FRAMECHANGED = 0x0020;
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.TVM_SETINSERTMARK"]/*' />
         public const int
         TVM_SETINSERTMARK = (0x1100 + 26),
         TVM_GETEDITCONTROL = (0x1100 + 15);
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.FILE_ATTRIBUTE_READONLY"]/*' />
         public const int
         FILE_ATTRIBUTE_READONLY = 0x00000001;
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.CEF_CLONEFILE"]/*' />
         public const uint
         CEF_CLONEFILE   = 0x00000001,   // Mutually exclusive w/_OPENFILE
         CEF_OPENFILE    = 0x00000002,   // Mutually exclusive w/_CLONEFILE
         CEF_SILENT      = 0x00000004,   // Editor factory should create editor silently
         CEF_OPENASNEW   = 0x00000008;   // Editor factory should perform necessary fixups
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.cmdidToolsOptions"]/*' />
         public const int cmdidToolsOptions    = 264;
 
         public const int 
@@ -848,65 +799,40 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             OPAQUE = 2,
             FW_BOLD = 700;
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT"]/*' />
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
         public class LOGFONT {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfHeight;"]/*' />
             public int lfHeight;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfWidth;"]/*' />
             public int lfWidth;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfEscapement;"]/*' />
             public int lfEscapement;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfOrientation;"]/*' />
             public int lfOrientation;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfWeight;"]/*' />
             public int lfWeight;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfItalic;"]/*' />
             public byte lfItalic;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfUnderline;"]/*' />
             public byte lfUnderline;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfStrikeOut;"]/*' />
             public byte lfStrikeOut;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfCharSet;"]/*' />
             public byte lfCharSet;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfOutPrecision;"]/*' />
             public byte lfOutPrecision;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfClipPrecision;"]/*' />
             public byte lfClipPrecision;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfQuality;"]/*' />
             public byte lfQuality;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfPitchAndFamily;"]/*' />
             public byte lfPitchAndFamily;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="LOGFONT.lfFaceName;"]/*' />
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst=32)]
             public string   lfFaceName;
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NMHDR"]/*' />
         [StructLayout(LayoutKind.Sequential)]
         public struct NMHDR
         {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NMHDR.hwndFrom;"]/*' />
             public IntPtr hwndFrom;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NMHDR.idFrom;"]/*' />
             public int idFrom;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NMHDR.code;"]/*' />
             public int code;
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="RECT"]/*' />
         [StructLayout(LayoutKind.Sequential)]
         public struct RECT {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="RECT.left;"]/*' />
             public int left;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="RECT.top;"]/*' />
             public int top;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="RECT.right;"]/*' />
             public int right;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="RECT.bottom;"]/*' />
             public int bottom;
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="RECT.RECT"]/*' />
             public RECT(int left, int top, int right, int bottom) {
                 this.left = left;
                 this.top = top;
@@ -914,7 +840,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 this.bottom = bottom;
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="RECT.RECT1"]/*' />
             public RECT(System.Drawing.Rectangle r)
             {
                 this.left = r.Left;
@@ -924,26 +849,20 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="POINT"]/*' />
         [StructLayout(LayoutKind.Sequential)]
         public class POINT {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="POINT.x;"]/*' />
             public int x;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="POINT.y;"]/*' />
             public int y;
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="POINT.POINT"]/*' />
             public POINT() {
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="POINT.POINT1"]/*' />
             public POINT(int x, int y) {
                 this.x = x;
                 this.y = y;
             }
         }
         
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXT"]/*' />
         /// <devdoc>
         /// Helper class for setting the text parameters to OLECMDTEXT structures.
         /// </devdoc>
@@ -952,24 +871,19 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             // Private constructor to avoid creation of objects from this class.
             private OLECMDTEXT() {}
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXTF"]/*' />
             /// <summary>
             /// Flags for the OLE command text
             /// </summary>
             public enum OLECMDTEXTF
             {
-                /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXTF.OLECMDTEXTF_NONE"]/*' />
                 /// <summary>No flag</summary>
                 OLECMDTEXTF_NONE        = 0,
-                /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXTF.OLECMDTEXTF_NAME"]/*' />
                 /// <summary>The name of the command is required.</summary>
                 OLECMDTEXTF_NAME = 1,
-                /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXTF.OLECMDTEXTF_STATUS"]/*' />
                 /// <summary>A description of the status is required.</summary>
                 OLECMDTEXTF_STATUS = 2
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXTF.GetFlags"]/*' />
             /// <summary>
             /// Gets the flags of the OLECMDTEXT structure
             /// </summary>
@@ -988,7 +902,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 return OLECMDTEXTF.OLECMDTEXTF_NONE;
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXTF.GetText"]/*' />
             /// <devdoc>
             /// Accessing the text of this structure is very cumbersome.  Instead, you may
             /// use this method to access an integer pointer of the structure.
@@ -1017,7 +930,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 return s.ToString();
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXTF.SetText"]/*' />
             /// <devdoc>
             /// Accessing the text of this structure is very cumbersome.  Instead, you may
             /// use this method to access an integer pointer of the structure.
@@ -1054,57 +966,36 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="tagOLECMDF"]/*' />
         /// <devdoc>
         /// OLECMDF enums for IOleCommandTarget
         /// </devdoc>
         public enum tagOLECMDF {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="tagOLECMDF.OLECMDF_SUPPORTED"]/*' />
             OLECMDF_SUPPORTED    = 1, 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="tagOLECMDF.OLECMDF_ENABLED"]/*' />
             OLECMDF_ENABLED      = 2, 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="tagOLECMDF.OLECMDF_LATCHED"]/*' />
             OLECMDF_LATCHED      = 4, 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="tagOLECMDF.OLECMDF_NINCHED"]/*' />
             OLECMDF_NINCHED      = 8,
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="tagOLECMDF.OLECMDF_INVISIBLE"]/*' />
             OLECMDF_INVISIBLE    = 16
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts"]/*' />
         /// <devdoc>
         /// Constants for stream usage.
         /// </devdoc>
         public sealed class StreamConsts {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.LOCK_WRITE"]/*' />
             public const   int LOCK_WRITE = 0x1;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.LOCK_EXCLUSIVE"]/*' />
             public const   int LOCK_EXCLUSIVE = 0x2;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.LOCK_ONLYONCE"]/*' />
             public const   int LOCK_ONLYONCE = 0x4;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STATFLAG_DEFAULT"]/*' />
             public const   int STATFLAG_DEFAULT = 0x0;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STATFLAG_NONAME"]/*' />
             public const   int STATFLAG_NONAME = 0x1;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STATFLAG_NOOPEN"]/*' />
             public const   int STATFLAG_NOOPEN = 0x2;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STGC_DEFAULT"]/*' />
             public const   int STGC_DEFAULT = 0x0;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STGC_OVERWRITE"]/*' />
             public const   int STGC_OVERWRITE = 0x1;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STGC_ONLYIFCURRENT"]/*' />
             public const   int STGC_ONLYIFCURRENT = 0x2;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STGC_DANGEROUSLYCOMMITMERELYTODISKCACHE"]/*' />
             public const   int STGC_DANGEROUSLYCOMMITMERELYTODISKCACHE = 0x4;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STREAM_SEEK_SET"]/*' />
             public const   int STREAM_SEEK_SET = 0x0;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STREAM_SEEK_CUR"]/*' />
             public const   int STREAM_SEEK_CUR = 0x1;
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="StreamConsts.STREAM_SEEK_END"]/*' />
             public const   int STREAM_SEEK_END = 0x2;
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream"]/*' />
         /// <devdoc>
         /// This class implements a managed Stream object on top
         /// of a COM IStream
@@ -1117,7 +1008,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             private string creatingStack;
             #endif
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.DataStreamFromComStream"]/*' />
             public DataStreamFromComStream(Microsoft.VisualStudio.OLE.Interop.IStream comStream) : base() {
                 this.comStream = comStream;
 
@@ -1126,7 +1016,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 #endif
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.Position"]/*' />
             public override long Position {
                 get {
                     return Seek(0, SeekOrigin.Current);
@@ -1137,28 +1026,24 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.CanWrite"]/*' />
             public override bool CanWrite {
                 get {
                     return true;
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.CanSeek"]/*' />
             public override bool CanSeek {
                 get {
                     return true;
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.CanRead"]/*' />
             public override bool CanRead {
                 get {
                     return true;
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.Length"]/*' />
             public override long Length {
                 get {
                     long curPos = this.Position;
@@ -1188,7 +1073,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.Flush"]/*' />
             public override void Flush() {
                 if (comStream != null) {
                     try {
@@ -1199,7 +1083,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.Read"]/*' />
             public override int Read(byte[] buffer, int index, int count) {
                 uint bytesRead;
                 byte[] b = buffer;
@@ -1218,14 +1101,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 return (int)bytesRead;
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.SetLength"]/*' />
             public override void SetLength(long value) {
                 ULARGE_INTEGER ul = new ULARGE_INTEGER();
                 ul.QuadPart = (ulong)value;
                 comStream.SetSize(ul);
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.Seek"]/*' />
             public override long Seek(long offset, SeekOrigin origin) {
                 LARGE_INTEGER l = new LARGE_INTEGER();
                 ULARGE_INTEGER[] ul = new ULARGE_INTEGER[1];
@@ -1235,7 +1116,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 return (long)ul[0].QuadPart;
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="DataStreamFromComStream.Write"]/*' />
             public override void Write(byte[] buffer, int index, int count) {
                 uint bytesWritten;
 
@@ -1259,7 +1139,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.Finalize"]/*' />
             ~DataStreamFromComStream() {
                 #if DEBUG
                 if (comStream != null) {
@@ -1271,7 +1150,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="ConnectionPointCookie"]/*' />
         /// <devdoc>
         /// Class that encapsulates a connection point cookie for COM event handling.
         /// </devdoc>
@@ -1284,7 +1162,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             private Type   eventInterface;
             #endif
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="ConnectionPointCookie.ConnectionPointCookie"]/*' />
             /// <devdoc>
             /// Creates a connection point to of the given interface type.
             /// which will call on a managed code sink that implements that interface.
@@ -1292,7 +1169,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             public ConnectionPointCookie(object source, object sink, Type eventInterface) : this(source, sink, eventInterface, true){
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.Finalize1"]/*' />
             ~ConnectionPointCookie(){
                 #if DEBUG
                 System.Diagnostics.Debug.Assert(connectionPoint == null || cookie == 0, "We should never finalize an active connection point. (Interface = " + eventInterface.FullName + "), allocating code (see stack) is responsible for unhooking the ConnectionPoint by calling Disconnect.  Hookup Stack =\r\n" +  callStack);
@@ -1326,7 +1202,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 }
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="ConnectionPointCookie.ConnectionPointCookie1"]/*' />
             /// <devdoc>
             /// Creates a connection point to of the given interface type.
             /// which will call on a managed code sink that implements that interface.
@@ -1382,7 +1257,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GetAbsolutePath"]/*' />
         /// <devdoc>
         /// This method takes a file URL and converts it to an absolute path.  The trick here is that
         /// if there is a '#' in the path, everything after this is treated as a fragment.  So
@@ -1395,7 +1269,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return uri.LocalPath + uri.Fragment;
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GetLocalPath"]/*' />
         /// <devdoc>
         /// This method takes a file URL and converts it to a local path.  The trick here is that
         /// if there is a '#' in the path, everything after this is treated as a fragment.  So
@@ -1423,7 +1296,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.IsSamePath"]/*' />
         /// <devdoc>
         /// Please use this "approved" method to compare file names.
         /// </devdoc>
@@ -1439,86 +1311,64 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return file1 == file2;
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IEventHandler"]/*' />
         [ComImport(),Guid("9BDA66AE-CA28-4e22-AA27-8A7218A0E3FA"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
         public interface IEventHandler {
 
             // converts the underlying codefunction into an event handler for the given event
             // if the given event is NULL, then the function will handle no events
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IEventHandler.AddHandler"]/*' />
             [PreserveSig]
             int AddHandler(string bstrEventName); 
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IEventHandler.RemoveHandler"]/*' />
             [PreserveSig]
             int RemoveHandler(string bstrEventName);
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IEventHandler.GetHandledEvents"]/*' />
 
             IVsEnumBSTR GetHandledEvents();
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IEventHandler.HandlesEvent"]/*' />
 
             bool HandlesEvent(string bstrEventName);
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IParameterKind"]/*' />
         [ComImport(),Guid("A55CCBCC-7031-432d-B30A-A68DE7BDAD75"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
         public interface IParameterKind {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IParameterKind.SetParameterPassingMode"]/*' />
 
             void SetParameterPassingMode(PARAMETER_PASSING_MODE ParamPassingMode);
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IParameterKind.SetParameterArrayDimensions"]/*' />
             void SetParameterArrayDimensions(int uDimensions);
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IParameterKind.GetParameterArrayCount"]/*' />
             int GetParameterArrayCount();
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IParameterKind.GetParameterArrayDimensions"]/*' />
             int GetParameterArrayDimensions(int uIndex);
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IParameterKind.GetParameterPassingMode"]/*' />
             int GetParameterPassingMode();
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="PARAMETER_PASSING_MODE"]/*' />
         public enum PARAMETER_PASSING_MODE
         {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="PARAMETER_PASSING_MODE.cmParameterTypeIn"]/*' />
             cmParameterTypeIn = 1,
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="PARAMETER_PASSING_MODE.cmParameterTypeOut"]/*' />
             cmParameterTypeOut = 2,
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="PARAMETER_PASSING_MODE.cmParameterTypeInOut"]/*' />
             cmParameterTypeInOut = 3
         } 
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IMethodXML"]/*' />
         [
         ComImport, Guid("3E596484-D2E4-461a-A876-254C4F097EBB"),
         InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)
         ]
         public interface IMethodXML
         {
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IMethodXML.GetXML"]/*' />
             // Generate XML describing the contents of this function's body.
             void GetXML (ref string pbstrXML);
             
             // Parse the incoming XML with respect to the CodeModel XML schema and
             // use the result to regenerate the body of the function.
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IMethodXML.SetXML"]/*' />
             [PreserveSig]
             int SetXML (string pszXML);
             
             // This is really a textpoint
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IMethodXML.GetBodyPoint"]/*' />
             [PreserveSig]
             int GetBodyPoint([MarshalAs(UnmanagedType.Interface)]out object bodyPoint);
         }
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IVBFileCodeModelEvents"]/*' />
         [ComImport(),Guid("EA1A87AD-7BC5-4349-B3BE-CADC301F17A3"), InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
         public interface IVBFileCodeModelEvents {
             
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IVBFileCodeModelEvents.StartEdit"]/*' />
             [PreserveSig]
             int StartEdit(); 
             
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IVBFileCodeModelEvents.EndEdit"]/*' />
             [PreserveSig]
             int EndEdit();
         }
@@ -1556,14 +1406,11 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         [DllImport("User32", CharSet=CharSet.Auto)]
         public static extern bool PostMessage(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam);
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GetNativeWndProc"]/*' />
         public static IntPtr GetNativeWndProc(System.Windows.Forms.Control control) {
             IntPtr handle = control.Handle;
             return GetWindowLong(new HandleRef(control, handle), GWL_WNDPROC);
         }
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GWL_WNDPROC"]/*' />
         public const int GWL_WNDPROC = (-4);
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GetWindowLong"]/*' />
         //GetWindowLong won't work correctly for 64-bit: we should use GetWindowLongPtr instead.  On
         //32-bit, GetWindowLongPtr is just #defined as GetWindowLong.  GetWindowLong really should 
         //take/return int instead of IntPtr/HandleRef, but since we're running this only for 32-bit
@@ -1584,11 +1431,9 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         [SuppressMessage("Microsoft.Interoperability", "CA1400:PInvokeEntryPointsShouldExist")]
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto, EntryPoint = "GetWindowLongPtr")]
         public static extern IntPtr GetWindowLongPtr64(HandleRef hWnd, int nIndex);
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.SetWindowLong"]/*' />
         [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "SetWindowLong")]
         public static extern int SetWindowLong(IntPtr hWnd, short nIndex, int value);
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.SetParent"]/*' />
         /// <summary>
         /// Changes the parent window of the specified child window.
         /// </summary>
@@ -1737,22 +1582,16 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         [DllImport("Kernel32", ExactSpelling=true, CharSet=CharSet.Unicode)]
         public static extern int WideCharToMultiByte(int codePage, int flags, [MarshalAs(UnmanagedType.LPWStr)]string wideStr, int chars, [In,Out]byte[] pOutBytes, int bufferBytes, IntPtr defaultChar, IntPtr pDefaultUsed);
 
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.IsDialogMessageA"]/*' />
         [DllImport("user32.dll", EntryPoint = "IsDialogMessageA", SetLastError = true, CharSet = CharSet.Ansi, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
         public static extern bool IsDialogMessageA(IntPtr hDlg, ref MSG msg);
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.SetFocus"]/*' />
         [DllImport("user32.dll")]
         public static extern void SetFocus(IntPtr hwnd);
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GetFocus"]/*' />
         [DllImport("user32.dll")]
         public static extern IntPtr GetFocus();
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.InvalidateRect"]/*' />
         [DllImport("user32.dll")]
         public static extern bool InvalidateRect(IntPtr hwnd, IntPtr rect, bool erase);
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.GetClientRect"]/*' />
         [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "GetClientRect")]
         public static extern int GetClientRect(IntPtr hWnd, ref RECT rect);
-        /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="NativeMethods.SendMessage"]/*' />
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public extern static IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Preferences.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Preferences.cs
@@ -20,17 +20,12 @@ using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 using IServiceProvider = System.IServiceProvider;
 
 namespace Microsoft.VisualStudio.FSharp.LanguageService {
-    /// <include file='doc\Utilities.uex' path='docs/doc[@for="IndentingStyle"]/*' />
     internal enum IndentingStyle {
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="IndentingStyle.None"]/*' />
         None,
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="IndentingStyle.Block"]/*' />
         Block,
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="IndentingStyle.Smart"]/*' />
         Smart
     }
 
-    /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences"]/*' />
     /// <summary>
     /// LanguagePreferences encapsulates the standard General and Tab settings for a language service
     /// and provides a way of getting and setting the values.  It is expected that you
@@ -74,7 +69,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         _HighlightMatchingBraceFlags braceFlags;
         string name;
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.LanguagePreferences"]/*' />
         /// <summary>
         /// Gets the language preferences.
         /// </summary>
@@ -84,16 +78,13 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.name = name;
         }
 
-        /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.LanguagePreferences1"]/*' />
         internal LanguagePreferences() { }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.LanguageName;"]/*' />
         protected string LanguageName {
             get { return this.name; }
             set { this.name = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.Site;"]/*' />
         /// <summary>
         /// This property is not public for a reason. If it were public it would
         /// get called during LoadSettingsFromStorage which will break it.  
@@ -104,20 +95,17 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             set { this.site = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.Site;"]/*' />
         public IServiceProvider GetSite() {
             return this.site;
         }
 
         // Our base language service perferences (from Babel originally)
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableCodeSense;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableCodeSense {
             get { return this.enableCodeSense; }
             set { this.enableCodeSense = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableMatchBraces;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableMatchBraces {
             get {
@@ -126,77 +114,66 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             set { this.enableMatchBraces = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableQuickInfo;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableQuickInfo {
             get { return this.enableQuickInfo; }
             set { this.enableQuickInfo = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableShowMatchingBrace;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableShowMatchingBrace {
             get { return this.enableShowMatchingBrace; }
             set { this.enableShowMatchingBrace = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableMatchBracesAtCaret;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableMatchBracesAtCaret {
             get { return this.enableMatchBracesAtCaret; }
             set { this.enableMatchBracesAtCaret = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.MaxErrorMessages;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int MaxErrorMessages {
             get { return this.maxErrorMessages; }
             set { this.maxErrorMessages = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.CodeSenseDelay;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int CodeSenseDelay {
             get { return this.codeSenseDelay; }
             set { this.codeSenseDelay = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableAsyncCompletion;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableAsyncCompletion {
             get { return this.enableAsyncCompletion; }
             set { this.enableAsyncCompletion = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableFormatSelection;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableFormatSelection {
             get { return this.enableFormatSelection; }
             set { this.enableFormatSelection = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableCommenting;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableCommenting {
             get { return this.enableCommenting; }
             set { this.enableCommenting = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.MaxRegionTime;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int MaxRegionTime {
             get { return this.maxRegionTime; }
             set { this.maxRegionTime = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.HighlightMatchingBraceFlags;"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public _HighlightMatchingBraceFlags HighlightMatchingBraceFlags {
             get { return this.braceFlags; }
             set { this.braceFlags = value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.Init"]/*' />
         public virtual void Init() {
             ILocalRegistry3 localRegistry = site.GetService(typeof(SLocalRegistry)) as ILocalRegistry3;
             string root = null;
@@ -219,18 +196,15 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             localRegistry = null;
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.InitUserPreferences"]/*' />
         public virtual void InitUserPreferences(RegistryKey key, string name) {
             this.GetLanguagePreferences();
         }
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.GetIntegerValue"]/*' />
         public int GetIntegerValue(RegistryKey key, string name, int def) {
             object o = key.GetValue(name);
             if (o is int) return (int)o;
             if (o is string) return int.Parse((string)o, CultureInfo.InvariantCulture);
             return def;
         }
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.GetBooleanValue"]/*' />
         public bool GetBooleanValue(RegistryKey key, string name, bool def) {
             object o = key.GetValue(name);
             if (o is int) return ((int)o != 0);
@@ -238,7 +212,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return def;
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.InitMachinePreferences"]/*' />
         public virtual void InitMachinePreferences(RegistryKey key, string name) {
             using (RegistryKey keyLanguage = key.OpenSubKey("languages\\language services\\" + name, false)) {
                 if (keyLanguage != null) {
@@ -259,70 +232,60 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.Dispose"]/*' />
         public virtual void Dispose() {
             Disconnect();
             site = null;
         }
 
         // General tab
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.AutoListMembers"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool AutoListMembers {
             get { return prefs.fAutoListMembers != 0; }
             set { prefs.fAutoListMembers = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.HideAdvancedMembers"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool HideAdvancedMembers {
             get { return prefs.fHideAdvancedAutoListMembers != 0; }
             set { prefs.fHideAdvancedAutoListMembers = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.ParameterInformation"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ParameterInformation {
             get { return prefs.fAutoListParams != 0; }
             set { prefs.fAutoListParams = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.VirtualSpace"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool VirtualSpace {
             get { return prefs.fVirtualSpace != 0; }
             set { prefs.fVirtualSpace = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.WordWrap"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool WordWrap {
             get { return prefs.fWordWrap != 0; }
             set { prefs.fWordWrap = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.WordWrapGlyphs"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool WordWrapGlyphs {
             get { return (int)prefs.fWordWrapGlyphs != 0; }
             set { prefs.fWordWrapGlyphs = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.CutCopyBlankLines"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool CutCopyBlankLines {
             get { return (int)prefs.fCutCopyBlanks != 0; }
             set { prefs.fCutCopyBlanks = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.LineNumbers"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool LineNumbers {
             get { return prefs.fLineNumbers != 0; }
             set { prefs.fLineNumbers = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableLeftClickForURLs"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool EnableLeftClickForURLs {
             get { return prefs.fHotURLs != 0; }
@@ -330,48 +293,41 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
         // Tabs tab
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.Indenting"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal IndentingStyle IndentStyle {
             get { return (IndentingStyle)prefs.IndentStyle; }
             set { prefs.IndentStyle = (vsIndentStyle)value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.TabSize"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int TabSize {
             get { return (int)prefs.uTabSize; }
             set { prefs.uTabSize = (uint)value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.IndentSize"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int IndentSize {
             get { return (int)prefs.uIndentSize; }
             set { prefs.uIndentSize = (uint)value; }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.InsertSpaces"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool InsertTabs {
             get { return prefs.fInsertTabs != 0; }
             set { prefs.fInsertTabs = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.ShowNavigationBar"]/*' />
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool ShowNavigationBar {
             get { return (int)prefs.fDropdownBar != 0; }
             set { prefs.fDropdownBar = (uint)(value ? 1 : 0); }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.EnableAutoOutlining"]/*' />
         public bool AutoOutlining {
             get { return this.autoOutlining; }
             set { this.autoOutlining = value; }
         }
 
-        /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.GetLanguagePrefs"]/*' />
         public virtual void GetLanguagePreferences() {
             IVsTextManager textMgr = site.GetService(typeof(SVsTextManager)) as IVsTextManager;
             if (textMgr != null) {
@@ -389,7 +345,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\PropertySheet.uex' path='docs/doc[@for="LanguagePreferences.Apply"]/*' />
         public virtual void Apply() {
             IVsTextManager2 textMgr2 = site.GetService(typeof(SVsTextManager)) as IVsTextManager2;
             if (textMgr2 != null) {
@@ -418,28 +373,22 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.OnRegisterMarkerType"]/*' />
         public virtual int OnRegisterMarkerType(int iMarkerType) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.OnRegisterView"]/*' />
         public virtual int OnRegisterView(IVsTextView view) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.OnUnregisterView"]/*' />
         public virtual int OnUnregisterView(IVsTextView view) {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.OnReplaceAllInFilesBegin"]/*' />
         public virtual int OnReplaceAllInFilesBegin() {
             return NativeMethods.S_OK;
         }
-        /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.OnReplaceAllInFilesEnd"]/*' />
         public virtual int OnReplaceAllInFilesEnd() {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.OnUserPreferencesChanged2"]/*' />
         public virtual int OnUserPreferencesChanged2(VIEWPREFERENCES2[] viewPrefs, FRAMEPREFERENCES2[] framePrefs, LANGPREFERENCES2[] langPrefs, FONTCOLORPREFERENCES2[] fontColorPrefs) {
             if (langPrefs != null && langPrefs.Length > 0 && langPrefs[0].guidLang == this.langSvc) {
                 this.prefs = langPrefs[0];

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Preferences.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Preferences.cs
@@ -418,8 +418,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        #region IVsTextManagerEvents2 Members
-
         /// <include file='doc\Preferences.uex' path='docs/doc[@for="LanguagePreferences.OnRegisterMarkerType"]/*' />
         public virtual int OnRegisterMarkerType(int iMarkerType) {
             return NativeMethods.S_OK;
@@ -448,7 +446,5 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
             return NativeMethods.S_OK;
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Source.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Source.cs
@@ -622,8 +622,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         public abstract string OriginalFilename { get; }
 #endif
 
-        #region Reformatting
-
         /// <summary>
         /// This method formats the given span using the given EditArray. The default behavior does nothing.  
         /// So you need to override this method if you want formatting to work.  
@@ -633,10 +631,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         public void ReformatSpan(EditArray mgr, TextSpan span)
         {
         }
-
-        #endregion
-
-        #region Commenting
 
         // Implemented in Source.fs
         /// <summary>Implement this method to provide different comment delimiters.</summary>
@@ -774,10 +768,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return result;
         }
 
-
-        #endregion
-
-        #region IVsTextLinesEvents
         public void OnChangeLineText(TextLineChange[] lineChange, int last)
         {
             TextSpan span = new TextSpan();
@@ -794,7 +784,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         public void OnChangeLineAttributes(int firstLine, int lastLine)
         {
         }
-        #endregion
 
 
         //===================================================================================
@@ -1974,7 +1963,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             }
         }
 
-        #region IVsHiddenTextClient
         public void OnHiddenRegionChange(IVsHiddenRegion region, HIDDEN_REGION_EVENT evt, int fBufferModifiable)
         {
         }
@@ -2012,14 +2000,8 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         public void OnBeforeSessionEnd()
         {
         }
-        #endregion
-
-        #region IVsUserDataEvents Members
 
         public abstract void OnUserDataChange(ref Guid riidKey, object vtNewValue);
-
-        #endregion
-
     }
 
     /// <summary>
@@ -2267,7 +2249,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return '\0';
         }
 
-        #region IVsCompletionSet
         //--------------------------------------------------------------------------
         //IVsCompletionSet methods
         //--------------------------------------------------------------------------
@@ -2451,9 +2432,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             this.displayed = false;
             this.Close();
         }
-        #endregion
-
-        #region IVsCompletionSetEx Members
 
         public int CompareItems(string bstrSoFar, string bstrOther, int lCharactersToCompare, out int plResult)
         {
@@ -2496,8 +2474,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             }
             return NativeMethods.S_OK;
         }
-
-        #endregion
     }
 
     //-------------------------------------------------------------------------------------

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Utilities.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/Utilities.cs
@@ -29,31 +29,26 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
     }
 
-    /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper"]/*' />
     internal sealed class TextSpanHelper
     {
 
         private TextSpanHelper() { }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.StartsAfterStartOf"]/*' />
         /// <devdoc>Returns true if the first span starts after the start of the second span.</devdoc>
         internal static bool StartsAfterStartOf(TextSpan span1, TextSpan span2)
         {
             return (span1.iStartLine > span2.iStartLine || (span1.iStartLine == span2.iStartLine && span1.iStartIndex >= span2.iStartIndex));
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.StartsAfterEndOf"]/*' />
         /// <devdoc>Returns true if the first span starts after the end of the second span.</devdoc>
         internal static bool StartsAfterEndOf(TextSpan span1, TextSpan span2)
         {
             return (span1.iStartLine > span2.iEndLine || (span1.iStartLine == span2.iEndLine && span1.iStartIndex >= span2.iEndIndex));
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.StartsBeforeStartOf"]/*' />
         /// <devdoc>Returns true if the first span starts before the start of the second span.</devdoc>
         internal static bool StartsBeforeStartOf(TextSpan span1, TextSpan span2)
         {
             return !StartsAfterStartOf(span1, span2);
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.StartsBeforeEndOf"]/*' />
         /// <devdoc>Returns true if the first span starts before the end of the second span.</devdoc>
         internal static bool StartsBeforeEndOf(TextSpan span1, TextSpan span2)
         {
@@ -61,33 +56,28 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
                 (span1.iStartLine == span2.iEndLine && span1.iStartIndex < span2.iEndIndex));
         }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.EndsBeforeStartOf"]/*' />
         /// <devdoc>Returns true if the first span ends before the start of the second span.</devdoc>
         internal static bool EndsBeforeStartOf(TextSpan span1, TextSpan span2)
         {
             return (span1.iEndLine < span2.iStartLine || (span1.iEndLine == span2.iStartLine && span1.iEndIndex <= span2.iStartIndex));
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.EndsBeforeEndOf"]/*' />
         /// <devdoc>Returns true if the first span starts before the end of the second span.</devdoc>
         internal static bool EndsBeforeEndOf(TextSpan span1, TextSpan span2)
         {
             return (span1.iEndLine < span2.iEndLine || (span1.iEndLine == span2.iEndLine && span1.iEndIndex <= span2.iEndIndex));
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.EndsAfterStartOf"]/*' />
         /// <devdoc>Returns true if the first span ends after the start of the second span.</devdoc>
         internal static bool EndsAfterStartOf(TextSpan span1, TextSpan span2)
         {
             return (span1.iEndLine > span2.iStartLine ||
                 (span1.iEndLine == span2.iStartLine && span1.iEndIndex > span2.iStartIndex));
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.EndsBeforeEndOf"]/*' />
         /// <devdoc>Returns true if the first span starts after the end of the second span.</devdoc>
         internal static bool EndsAfterEndOf(TextSpan span1, TextSpan span2)
         {
             return !EndsBeforeEndOf(span1, span2);
         }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.Merge"]/*' />
         internal static TextSpan Merge(TextSpan span1, TextSpan span2)
         {
             TextSpan span = new TextSpan();
@@ -116,23 +106,19 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 
             return span;
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.IsPositive"]/*' />
         internal static bool IsPositive(TextSpan span)
         {
             return (span.iStartLine < span.iEndLine || (span.iStartLine == span.iEndLine && span.iStartIndex <= span.iEndIndex));
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.ClearTextSpan"]/*' />
         internal static void Clear(ref TextSpan span)
         {
             span.iStartLine = span.iEndLine = 0;
             span.iStartIndex = span.iEndIndex = 0;
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.IsEmpty"]/*' />
         internal static bool IsEmpty(TextSpan span)
         {
             return (span.iStartLine == span.iEndLine) && (span.iStartIndex == span.iEndIndex);
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.MakePositive"]/*' />
         internal static void MakePositive(ref TextSpan span)
         {
             if (!IsPositive(span))
@@ -150,7 +136,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 
             return;
         }
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.TextSpanNormalize"]/*' />
         /// <devdoc>Pins the text span to valid line bounds returned from IVsTextLines.</devdoc>
         internal static void Normalize(ref  TextSpan span, IVsTextLines textLines)
         {
@@ -177,14 +162,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             span.iEndIndex = Math.Min(span.iEndIndex, lineLength);
         }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.IsSameSpan"]/*' />
         internal static bool IsSameSpan(TextSpan span1, TextSpan span2)
         {
             return span1.iStartLine == span2.iStartLine && span1.iStartIndex == span2.iStartIndex && span1.iEndLine == span2.iEndLine && span1.iEndIndex == span2.iEndIndex;
         }
 
         // Returns true if the given position is to left of textspan.
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.IsBeforeStartOf"]/*' />
         internal static bool IsBeforeStartOf(TextSpan span, int line, int col)
         {
             if (line < span.iStartLine || (line == span.iStartLine && col < span.iStartIndex))
@@ -195,7 +178,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
 
         // Returns true if the given position is to right of textspan.
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.IsAfterEndOf"]/*' />
         internal static bool IsAfterEndOf(TextSpan span, int line, int col)
         {
             if (line > span.iEndLine || (line == span.iEndLine && col > span.iEndIndex))
@@ -206,7 +188,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
 
         // Returns true if the given position is at the edge or inside the span.
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.ContainsInclusive"]/*' />
         internal static bool ContainsInclusive(TextSpan span, int line, int col)
         {
             if (line > span.iStartLine && line < span.iEndLine)
@@ -225,7 +206,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
 
         // Returns true if the given position is purely inside the span.
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.ContainsExclusive"]/*' />
         internal static bool ContainsExclusive(TextSpan span, int line, int col)
         {
             if (line > span.iStartLine && line < span.iEndLine)
@@ -244,7 +224,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
 
         //returns true is span1 is Embedded in span2
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.IsEmbedded"]/*' />
         internal static bool IsEmbedded(TextSpan span1, TextSpan span2)
         {
             return (!TextSpanHelper.IsSameSpan(span1, span2) &&
@@ -252,7 +231,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
                     TextSpanHelper.EndsBeforeEndOf(span1, span2));
         }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.Intersects"]/*' />
         internal static bool Intersects(TextSpan span1, TextSpan span2)
         {
             return TextSpanHelper.StartsBeforeEndOf(span1, span2) &&
@@ -261,7 +239,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 
         // This method simulates what VS does in debug mode so that we can catch the
         // errors in managed code before they go to the native debug assert.
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.ValidSpan"]/*' />
         internal static bool ValidSpan(ISource src, TextSpan span)
         {
             if (!ValidCoord(src, span.iStartLine, span.iStartIndex))
@@ -277,7 +254,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return true;
         }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="TextSpanHelper.ValidCoord"]/*' />
         internal static bool ValidCoord(ISource src, int line, int pos)
         {
             // validate line
@@ -315,112 +291,62 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         }
     }
 
-    /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant"]/*' />
     internal struct Variant
     {
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType"]/*' />
         internal enum VariantType
         {
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_EMPTY"]/*' />
             VT_EMPTY = 0,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_NULL"]/*' />
             VT_NULL = 1,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_I2"]/*' />
             VT_I2 = 2,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_I4"]/*' />
             VT_I4 = 3,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_R4"]/*' />
             VT_R4 = 4,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_R8"]/*' />
             VT_R8 = 5,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_CY"]/*' />
             VT_CY = 6,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_DATE"]/*' />
             VT_DATE = 7,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_BSTR"]/*' />
             VT_BSTR = 8,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_DISPATCH"]/*' />
             VT_DISPATCH = 9,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_ERROR"]/*' />
             VT_ERROR = 10,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_BOOL"]/*' />
             VT_BOOL = 11,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_VARIANT"]/*' />
             VT_VARIANT = 12,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_UNKNOWN"]/*' />
             VT_UNKNOWN = 13,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_DECIMAL"]/*' />
             VT_DECIMAL = 14,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_I1"]/*' />
             VT_I1 = 16,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_UI1"]/*' />
             VT_UI1 = 17,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_UI2"]/*' />
             VT_UI2 = 18,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_UI4"]/*' />
             VT_UI4 = 19,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_I8"]/*' />
             VT_I8 = 20,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_UI8"]/*' />
             VT_UI8 = 21,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_INT"]/*' />
             VT_INT = 22,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_UINT"]/*' />
             VT_UINT = 23,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_VOID"]/*' />
             VT_VOID = 24,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_HRESULT"]/*' />
             VT_HRESULT = 25,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_PTR"]/*' />
             VT_PTR = 26,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_SAFEARRAY"]/*' />
             VT_SAFEARRAY = 27,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_CARRAY"]/*' />
             VT_CARRAY = 28,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_USERDEFINED"]/*' />
             VT_USERDEFINED = 29,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_LPSTR"]/*' />
             VT_LPSTR = 30,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_LPWSTR"]/*' />
             VT_LPWSTR = 31,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_FILETIME"]/*' />
             VT_FILETIME = 64,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_BLOB"]/*' />
             VT_BLOB = 65,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_STREAM"]/*' />
             VT_STREAM = 66,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_STORAGE"]/*' />
             VT_STORAGE = 67,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_STREAMED_OBJECT"]/*' />
             VT_STREAMED_OBJECT = 68,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_STORED_OBJECT"]/*' />
             VT_STORED_OBJECT = 69,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_BLOB_OBJECT"]/*' />
             VT_BLOB_OBJECT = 70,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_CF"]/*' />
             VT_CF = 71,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_CLSID"]/*' />
             VT_CLSID = 72,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_VECTOR"]/*' />
             VT_VECTOR = 0x1000,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_ARRAY"]/*' />
             VT_ARRAY = 0x2000,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_BYREF"]/*' />
             VT_BYREF = 0x4000,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_RESERVED"]/*' />
             VT_RESERVED = 0x8000,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_ILLEGAL"]/*' />
             VT_ILLEGAL = 0xffff,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_ILLEGALMASKED"]/*' />
             VT_ILLEGALMASKED = 0xfff,
-            /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.VariantType.VT_TYPEMASK"]/*' />
             VT_TYPEMASK = 0xfff
         };
 
         private ushort vt;
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.Vt"]/*' />
         internal VariantType Vt
         {
             get
@@ -435,7 +361,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 
         private long value;
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.Value"]/*' />
         internal long Value
         {
             get
@@ -448,7 +373,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             }
         }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.ToVariant"]/*' />
         internal static Variant ToVariant(IntPtr ptr)
         {
             // Marshal.GetObjectForNativeVariant is doing way too much work.
@@ -471,7 +395,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return new Variant();
         }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="Variant.ToChar"]/*' />
         internal char ToChar()
         {
             if (this.Vt == VariantType.VT_UI2)
@@ -484,10 +407,8 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 
     }
 
-    /// <include file='doc\Utilities.uex' path='docs/doc[@for="FilePathUtilities"]/*' />
     internal sealed class FilePathUtilities
     {
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="FilePathUtilities.GetFilePath"]/*' />
         /// <summary>
         /// Get path for text buffer.
         /// </summary>
@@ -503,7 +424,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return GetFilePathInternal(textLines);
         }
 
-        /// <include file='doc\Utilities.uex' path='docs/doc[@for="FilePathUtilities.GetFilePath"]/*' />
         /// <summary>
         /// Get file path for an object that is implementing IVsUserData.
         /// </summary>
@@ -555,7 +475,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
             return fname;
         }
 
-        /// <include file='doc\HierarchyItem.uex' path='docs/doc[@for="VsShell.GetFilePath"]/*' />
         /// <summary>This method returns the file extension in lower case, including the "."
         /// and trims any blanks or null characters from the string.  Null's can creep in via
         /// interop if we get a badly formed BSTR</summary>

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
@@ -20,7 +20,6 @@ using Microsoft.VisualStudio.FSharp.LanguageService.Resources;
 using Microsoft.VisualStudio.FSharp.LanguageService; 
 
 namespace Microsoft.VisualStudio.FSharp.LanguageService {
-    /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter"]/*' />
     /// <summary>
     /// ViewFilter provides a default implementation of IVsTextViewFilter providing a
     /// handling of the following VS commands:
@@ -66,7 +65,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         private bool snippetBound;
         private VsCommands gotoCmd; 
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.SnippetBound"]/*' />
         protected bool SnippetBound {
             get { return snippetBound; }
             set { snippetBound = value; }
@@ -90,7 +88,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return this.projectSystemPackage;
         }
 #endif
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.ViewFilter"]/*' />
         internal ViewFilter(CodeWindowManager mgr, IVsTextView view) {
             this.pvaChar = IntPtr.Zero;
             this.mgr = mgr;
@@ -111,7 +108,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.Finalize"]/*' />
         ~ViewFilter() {
             Dispose();
 #if LANGTRACE
@@ -119,7 +115,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 #endif
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.Dispose"]/*' />
         public virtual void Dispose() {
             this.textView = null;
             this.service = null;
@@ -133,7 +128,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             GC.SuppressFinalize(this); // REVIEW: Why this?
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.Close"]/*' />
         public virtual void Close() {
 #if LANGTRACE
             Trace.WriteLine("ViewFilter::Close");
@@ -160,30 +154,25 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
         const int SizeOfVariant = 16;
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnAfterSnippetsKeyBindingChange"]/*' />
         public virtual int OnAfterSnippetsKeyBindingChange(uint dwCmdGuid, uint dwCmdId, int fBound) {
             this.snippetBound = fBound == 0 ? false : true;
             return VSConstants.S_OK;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnAfterSnippetsUpdate"]/*' />
         public virtual int OnAfterSnippetsUpdate() {
             return VSConstants.S_OK;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.CodeWindowManager;"]/*' />
         /// <summary>Returnt the CodeWindowManager that created this view filter.</summary>
         public CodeWindowManager CodeWindowManager {
             get { return this.mgr; }
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.Source;"]/*' />
         /// <summary>Return the Source object encapsulating the text buffer.</summary>
         internal ISource Source {
             get { return this.source; }
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.TextTipData;"]/*' />
         /// <summary>Get or set the TextTipData object used for displaying tool tips.</summary>
         public TextTipData TextTipData {
             get {
@@ -195,13 +184,11 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             set { this.textTipData = value; }
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.TextView;"]/*' />
         /// <summary>Return the IVsTextView associated with this filter.</summary>
         public IVsTextView TextView {
             get { return this.textView; }
         }
 
-		/// <include file='doc\ExpansionProvider.uex' path='docs/doc[@for="ViewFilter.IsExpansionUIActive"]/*' />
 		public virtual bool IsExpansionUIActive {
 			get {
 				IVsTextViewEx tve = this.textView as IVsTextViewEx;
@@ -212,7 +199,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 			}
 		}
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.GetWordExtent"]/*' />
         /// <summary>Returns the result of Source.GetWordExtent.</summary>
         public virtual int GetWordExtent(int line, int index, uint flags, TextSpan[] span) {
             Debug.Assert(line >= 0 && index >= 0);
@@ -235,7 +221,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.GetDataTipText"]/*' />
         /// <summary>
         /// If Preferences.EnableQuickInfo is true then this method kicks of a parse with the 
         /// reason BackgroundRequestReason.QuickInfo to find information about the current token.  If the
@@ -291,7 +276,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.GetPairExtents"]/*' />
         public virtual int GetPairExtents(int line, int index, TextSpan[] span) {
             Debug.Assert(line >= 0 && index >= 0);
             // This call from VS does not support returning E_PENDING.
@@ -302,32 +286,26 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnChangeCaretLine"]/*' />
         public virtual void OnChangeCaretLine(IVsTextView view, int line, int col) {
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnChangeScrollInfo"]/*' />
         public virtual void OnChangeScrollInfo(IVsTextView view, int iBar, int iMinUnit, int iMaxUnits, int iVisibleUnits, int iFirstVisibleUnit) {
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnKillFocus"]/*' />
         public virtual void OnKillFocus(IVsTextView view) {
             this.service.OnActiveViewLostFocus(view);
             this.mgr.OnKillFocus(view);
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnSetBuffer"]/*' />
         public virtual void OnSetBuffer(IVsTextView view, IVsTextLines buffer) {
             Debug.Assert(buffer == this.mgr.Source.GetTextLines());
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnSetFocus"]/*' />
         public virtual void OnSetFocus(IVsTextView view) {
             this.service.OnActiveViewChanged(view);
             if (this.mgr != null) this.mgr.OnSetFocus(view); // is null during shutdown.
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.QueryCommandStatus"]/*' />
         /// <summary>
         /// Override this method to intercept the IOleCommandTarget::QueryStatus call.
         /// </summary>
@@ -430,7 +408,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return (int)NativeMethods.E_FAIL; // delegate to next command target.
         }
 
-        /// <include file='doc\EditorView.uex' path='docs/doc[@for="SimpleEditorView.QueryParameterList"]/*' />
         /// <summary>
         /// The parameter list of a command is queried by calling Exec with the LOWORD
         /// of nCmdexecopt set to OLECMDEXECOPT_SHOWHELP (instead of the more usual
@@ -458,7 +435,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.HandlePreExec"]/*' />
         public virtual bool HandlePreExec(ref Guid guidCmdGroup, uint nCmdId, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) {
             
             this.wasCompletionActive = this.Source.IsCompletorActive;
@@ -561,7 +537,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.HanelPostExec"]/*' />
         /// <summary>This method hooks up HandleSmartIndent and Source.OnCommand.  </summary>
         public virtual void HandlePostExec(ref Guid guidCmdGroup, uint nCmdId, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut, bool bufferWasChanged) {
 
@@ -639,7 +614,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         [DllImport("oleaut32", PreserveSig = false)]
         static extern void VariantClear(IntPtr pObject);
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.ExecCommand"]/*' />
         /// <summary>
         /// Override this method to intercept the IOleCommandTarget::Exec call.
         /// </summary>
@@ -704,7 +678,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return this.nextTarget.Exec(ref guidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut);
         }
 
-        /// <include file='doc\Source.uex' path='docs/doc[@for="ViewFilter.OnAutoComplete"]/*' />
         public virtual void OnAutoComplete() {
             this.autoCompletedNothing = false;
             this.autoCompleteTypeChar = false;
@@ -726,7 +699,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.autoCompleted = true;
         }
 
-        /// <include file='doc\Source.uex' path='docs/doc[@for="ViewFilter.TypeChar"]/*' />
         // Executes a VsCommands2K.TYPECHAR command on the current command chain.
         public int TypeChar(char ch) {
 
@@ -748,7 +720,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return rc;
         }
 
-        /// <include file='doc\Source.uex' path='docs/doc[@for="ViewFilter.HandleSmartIndent"]/*' />
         /// Override this method if you want to support smart indenting.
         /// This will only be called if Preferences.Indenting == IndentingStyle.Smart which is
         /// only available if you set your language service registry key ShowSmartIndent to 1.
@@ -756,7 +727,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.IOleCommandTarget.QueryStatus"]/*' />
         /// <internalonly/>
         int IOleCommandTarget.QueryStatus(ref Guid guidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText) {
             for (uint i = 0; i < cCmds; i++) {
@@ -780,7 +750,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.IOleCommandTarget.Exec"]/*' />
         /// <internalonly/>
         int IOleCommandTarget.Exec(ref Guid guidCmdGroup, uint nCmdId, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) {
 
@@ -818,7 +787,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.HandleQuickInfo"]/*' />
         /// <summary>This method is called to handle the VsCommands2K.QUICKINFO command.</summary>
         public virtual void HandleQuickInfo(int line, int col) {
             // Get the tip text at that location. 
@@ -870,7 +838,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             textTipData.Update(fullText, iPos, iLength, this.textView);
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.GetFullDataTipText"]/*' />
         /// <summary>This method checks to see if the IVsDebugger is running, and if so, 
         /// calls it to get additional information about the current token and returns a combined result.
         /// You can return an HRESULT here like TipSuccesses2.TIP_S_NODEFAULTTIP.</summary>
@@ -930,7 +897,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.GetTextTipData"]/*' />
         /// <summary>Creates the TextTipData object and returns it</summary>
         public virtual TextTipData CreateTextTipData() {
             // create it 
@@ -938,7 +904,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.HandleGoto"]/*' />
         /// <summary>Handles VsCommands.GotoDefn, VsCommands.GotoDecl and VsCommands.GotoRef by
         /// calling OnSyncGoto on the Source object and opening the text editor on the resulting
         /// URL, then scrolling to the resulting span.</summary>
@@ -1021,12 +986,10 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             NativeMethods.ThrowOnFailure(hr);
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.GetExpansionProvider"]/*' />
         public virtual ExpansionProvider GetExpansionProvider() {
             return this.source.GetExpansionProvider();
         }
 
-        /// <include file='doc\LanguageService.uex' path='docs/doc[@for="ViewFilter.ShowContextMenu"]/*' />
         public virtual void ShowContextMenu(int menuId, Guid groupGuid, IOleCommandTarget target) {
             IVsUIShell uiShell = this.service.GetService(typeof(SVsUIShell)) as IVsUIShell;
             if (uiShell != null && !this.service.IsMacroRecordingOn()) { // disable context menu while recording macros.
@@ -1043,7 +1006,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
         // Special View filter command handling.
-        /// <include file='doc\Source.uex' path='docs/doc[@for="ViewFilter.CommentSelection"]/*' />
         public virtual void CommentSelection() {
             if (this.service == null) return;
 
@@ -1053,7 +1015,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             NativeMethods.ThrowOnFailure(this.textView.SetSelection(span.iStartLine, span.iStartIndex, span.iEndLine, span.iEndIndex));
         }
 
-        /// <include file='doc\Source.uex' path='docs/doc[@for="ViewFilter.GetSelection"]/*' />
         /// <summary>Returns the current selection, adjusted to become a positive text span</summary>
         public TextSpan GetSelection() {
             //get text range
@@ -1065,7 +1026,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return aspan[0];
         }
 
-        /// <include file='doc\Source.uex' path='docs/doc[@for="ViewFilter.UncommentSelection"]/*' />
         public virtual void UncommentSelection() {
             //get text range
             TextSpan span = GetSelection();
@@ -1076,7 +1036,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.ReformatDocument;"]/*' />
         public virtual void ReformatDocument() {
             if (this.CanReformat()) {
                 Debug.Assert(this.source != null);
@@ -1090,7 +1049,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.ReformatSelection;"]/*' />
         public virtual void ReformatSelection() {
             if (this.CanReformat()) {
                 Debug.Assert(this.source != null);
@@ -1110,7 +1068,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\LanguageService.uex' path='docs/doc[@for="ViewFilter.CanReformat"]/*' />
         /// <summary>This method returns true if the FormatDocument and FormatSelection commands
         /// are to be enabled.  Default returns false if debugging, otherwise it returns
         /// the result for Preferences.EnableFormatSelection.</summary>
@@ -1121,7 +1078,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
     }
 
-    /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData"]/*' />
     /// <summary>This class provides a default implementation of IVsTextTipData for
     /// use in the IVsTextTipWindow for displaying tool tips.</summary>
     [CLSCompliant(false)]
@@ -1133,7 +1089,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         string text;
         bool isWindowUp;
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.TextTipData"]/*' />
         internal TextTipData(IServiceProvider site) {
             if (site == null)
                 throw new System.ArgumentNullException("site");
@@ -1155,7 +1110,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 NativeMethods.ThrowOnFailure(textTipWindow.SetTextTipData(this));
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.Close"]/*' />
         public void Close(IVsTextView textView) {
             if (this.textTipWindow != null) {
                 if (this.isWindowUp)
@@ -1165,10 +1119,8 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.IsActive"]/*' />
         public bool IsActive() { return this.isWindowUp; }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.Update"]/*' />
         public void Update(string textValue, int pos, int len, IVsTextView textView) {
             if (textView == null) return;
 
@@ -1183,7 +1135,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.isWindowUp = true;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.CheckCaretPosition"]/*' />
         public void CheckCaretPosition(IVsTextView textView)
         {
             if (textView == null) return;
@@ -1202,7 +1153,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
         ////////////////////////////////////////////////////////////////////////////////
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.GetTipText"]/*' />
         public virtual int GetTipText(string[] pbstrText, out int pfFontData) {
             pfFontData = 0; // TODO: Do whatever formatting we might want...
             if (pbstrText == null || pbstrText.Length == 0)
@@ -1213,24 +1163,20 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.GetTipFontInfo"]/*' />
         public virtual int GetTipFontInfo(int iChars, uint[] pdwFontInfo) {
             return NativeMethods.E_NOTIMPL;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.GetContextStream"]/*' />
         public virtual int GetContextStream(out int piPos, out int piLen) {
             piPos = this.pos;
             piLen = this.len;
             return NativeMethods.S_OK;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.OnDismiss"]/*' />
         public virtual void OnDismiss() {
             this.isWindowUp = false;
         }
 
-        /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.UpdateView"]/*' />
         public virtual void UpdateView() {
         }
     }

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
@@ -160,8 +160,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
         const int SizeOfVariant = 16;
 
-        #region IVsExpansionEvents Members
-
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnAfterSnippetsKeyBindingChange"]/*' />
         public virtual int OnAfterSnippetsKeyBindingChange(uint dwCmdGuid, uint dwCmdId, int fBound) {
             this.snippetBound = fBound == 0 ? false : true;
@@ -173,7 +171,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return VSConstants.S_OK;
         }
 
-        #endregion
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.CodeWindowManager;"]/*' />
         /// <summary>Returnt the CodeWindowManager that created this view filter.</summary>
         public CodeWindowManager CodeWindowManager {
@@ -215,7 +212,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
 			}
 		}
 
-        #region IVsTextViewFilter methods
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.GetWordExtent"]/*' />
         /// <summary>Returns the result of Source.GetWordExtent.</summary>
         public virtual int GetWordExtent(int line, int index, uint flags, TextSpan[] span) {
@@ -305,9 +301,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             TextSpanHelper.MakePositive(ref span[0]);
             return NativeMethods.S_OK;
         }
-        #endregion
 
-        #region IVsTextViewEvents methods
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.OnChangeCaretLine"]/*' />
         public virtual void OnChangeCaretLine(IVsTextView view, int line, int col) {
         }
@@ -332,7 +326,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             this.service.OnActiveViewChanged(view);
             if (this.mgr != null) this.mgr.OnSetFocus(view); // is null during shutdown.
         }
-        #endregion
 
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.QueryCommandStatus"]/*' />
         /// <summary>
@@ -763,7 +756,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             return false;
         }
 
-        #region IOleCommandTarget methods
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.IOleCommandTarget.QueryStatus"]/*' />
         /// <internalonly/>
         int IOleCommandTarget.QueryStatus(ref Guid guidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText) {
@@ -825,7 +817,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             }
             return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
         }
-        #endregion
 
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.HandleQuickInfo"]/*' />
         /// <summary>This method is called to handle the VsCommands2K.QUICKINFO command.</summary>
@@ -1051,8 +1042,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             uiShell = null;
         }
 
-        #region CommentSelection
-
         // Special View filter command handling.
         /// <include file='doc\Source.uex' path='docs/doc[@for="ViewFilter.CommentSelection"]/*' />
         public virtual void CommentSelection() {
@@ -1086,10 +1075,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             NativeMethods.ThrowOnFailure(textView.SetSelection(span.iStartLine, span.iStartIndex, span.iEndLine, span.iEndIndex));
 
         }
-        #endregion
-
-
-        #region Reformat
 
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="ViewFilter.ReformatDocument;"]/*' />
         public virtual void ReformatDocument() {
@@ -1134,9 +1119,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             if (this.service.IsDebugging) return false;
             return this.service.Preferences.EnableFormatSelection;
         }
-
-        #endregion
-
     }
 
     /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData"]/*' />
@@ -1220,7 +1202,6 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         }
 
         ////////////////////////////////////////////////////////////////////////////////
-        #region IVsTextTipData
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.GetTipText"]/*' />
         public virtual int GetTipText(string[] pbstrText, out int pfFontData) {
             pfFontData = 0; // TODO: Do whatever formatting we might want...
@@ -1252,6 +1233,5 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
         /// <include file='doc\ViewFilter.uex' path='docs/doc[@for="TextTipData.UpdateView"]/*' />
         public virtual void UpdateView() {
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/AssemblyReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/AssemblyReferenceNode.cs
@@ -48,16 +48,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             public bool? WantSpecificVersion;  // null -> nothing in .fsproj, true/false mean serialize that value to .fsproj
         }
 
-        #region fields
         private string myAssemblyPath = String.Empty;
         private FileChangeManager myFileChangeListener;
         private bool myIsDisposed = false;
         private AssemblyResolvedInfo resolvedInfo;
         private AssemblyMSBuildProjectionInfo msbuildProjectionInfo;
         private bool fsprojIncludeHasFilename = false;
-        #endregion
 
-        #region properties
         /// <summary>
         /// The name of the assembly this reference represents.
         /// </summary>
@@ -131,9 +128,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return assemblyRef;
             }
         }
-        #endregion
-
-        #region ctors
 
         internal static AssemblyReferenceNode CreateFromProjectFile(ProjectNode root, ProjectElement element, BuildResult buildResult)
         { return new AssemblyReferenceNode(root, element, buildResult); }
@@ -201,9 +195,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             this.InitializeFileChangeEvents();
         }
-        #endregion
-
-        #region methods
 
         internal static bool IsFSharpCoreReference(ReferenceNode node)
         {
@@ -707,6 +698,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         }
 #endif
 
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/AssemblyReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/AssemblyReferenceNode.cs
@@ -274,10 +274,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        /// <summary>
-        /// Closes the node.
-        /// </summary>
-        /// <returns></returns>
+
         public override int Close()
         {
             try
@@ -374,10 +371,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             // LBXML_KEY_REFERENCE_EXTENSION       "ExecutableExtension"
         }
 
-        /// <summary>
-        /// Disposes the node
-        /// </summary>
-        /// <param name="disposing"></param>
         protected override void Dispose(bool disposing)
         {
             if (this.myIsDisposed)

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Attributes.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Attributes.cs
@@ -24,18 +24,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field)]
     internal sealed class PropertyPageTypeConverterAttribute : Attribute
     {
-        #region fields
         Type converterType;
-        #endregion
 
-        #region ctors
         public PropertyPageTypeConverterAttribute(Type type)
         {
             this.converterType = type;
         } 
-        #endregion
 
-        #region properties
         public Type ConverterType
         {
             get
@@ -43,24 +38,18 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.converterType;
             }
         } 
-        #endregion
     }
 
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
     internal sealed class LocDisplayNameAttribute : DisplayNameAttribute
     {
-        #region fields
         string name;
-        #endregion
 
-        #region ctors
         public LocDisplayNameAttribute(string name)
         {
             this.name = name;
         } 
-        #endregion
 
-        #region properties
         public override string DisplayName
         {
             get
@@ -74,6 +63,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return result;
             }
         } 
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAFileItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAFileItem.cs
@@ -303,9 +303,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             });
         }
 
-        /// <summary>
-        /// Gets the ProjectItems for the object.
-        /// </summary>
         public override ProjectItems ProjectItems
         {
             get

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAFileItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAFileItem.cs
@@ -26,15 +26,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAFileItem : OAProjectItem<FileNode>
     {
-        #region ctors
         internal OAFileItem(OAProject project, FileNode node)
             : base(project, node)
         {
         }
 
-        #endregion
-
-        #region overridden methods
         /// <summary>
         /// Returns the dirty state of the document.
         /// </summary>
@@ -324,10 +320,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
         }
 
-
-        #endregion
-
-        #region helpers
         /// <summary>
         /// Saves or Save As the  file
         /// </summary>
@@ -432,7 +424,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 }
             });
         }
-        #endregion
 
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAFolderItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAFolderItem.cs
@@ -24,15 +24,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAFolderItem : OAProjectItem<FolderNode>
     {
-        #region ctors
         internal OAFolderItem(OAProject project, FolderNode node)
             : base(project, node)
         {
         }
 
-        #endregion
-
-        #region overridden methods
         public override ProjectItems Collection
         {
             get
@@ -51,6 +47,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return this.Collection;
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OANavigableProjectItems.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OANavigableProjectItems.cs
@@ -97,9 +97,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
         }
 
-        /// <summary>
-        /// Gets the immediate parent object of a ProjectItems collection.
-        /// </summary>
         public virtual object Parent
         {
             get
@@ -224,10 +221,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             return null;
         }
 
-        /// <summary>
-        /// Returns an enumeration for items in a collection. 
-        /// </summary>
-        /// <returns>An IEnumerator for this object.</returns>
         public virtual IEnumerator GetEnumerator()
         {
             if (this.items == null)

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OANavigableProjectItems.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OANavigableProjectItems.cs
@@ -24,13 +24,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OANavigableProjectItems : EnvDTE.ProjectItems
     {
-        #region fields
         private OAProject project;
         private IList<EnvDTE.ProjectItem> items;
         private HierarchyNode nodeWithItems;
-        #endregion
 
-        #region properties
         /// <summary>
         /// Defines an /*internal, but public for FSharp.Project.dll*/ public list of project items
         /// </summary>
@@ -63,9 +60,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return this.nodeWithItems;
             }
         }
-        #endregion
 
-        #region ctor
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -90,9 +85,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             this.project = project;
             this.nodeWithItems = nodeWithItems;
         }
-        #endregion
-
-        #region EnvDTE.ProjectItems
 
         /// <summary>
         /// Gets a value indicating the number of objects in the collection.
@@ -251,9 +243,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
         }
 
-        #endregion
-
-        #region virtual methods
         /// <summary>
         /// Retrives a list of items associated with the current node.
         /// </summary>
@@ -277,6 +266,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return list;
             });
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OANestedProjectItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OANestedProjectItem.cs
@@ -21,11 +21,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OANestedProjectItem : OAProjectItem<NestedProjectNode>
     {
-        #region fields
         EnvDTE.Project nestedProject = null;
-        #endregion
 
-        #region ctors
         internal OANestedProjectItem(OAProject project, NestedProjectNode node)
             : base(project, node)
         {
@@ -36,9 +33,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
         }
 
-        #endregion
-
-        #region overridden methods
         /// <summary>
         /// Returns the collection of project items defined in the nested project
         /// </summary>
@@ -64,7 +58,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return this.nestedProject;
             }
         }
-        #endregion
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OANullProperty.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OANullProperty.cs
@@ -21,19 +21,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [CLSCompliant(false), ComVisible(true)]
     public class OANullProperty : EnvDTE.Property
     {
-        #region fields
         private OAProperties parent;
-        #endregion
-
-        #region ctors
 
         internal OANullProperty(OAProperties parent)
         {
             this.parent = parent;
         }
-        #endregion
-
-        #region EnvDTE.Property
 
         public object Application
         {
@@ -97,6 +90,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             get { return String.Empty; }
             set { }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProject.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProject.cs
@@ -22,22 +22,17 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAProject : EnvDTE.Project, EnvDTE.ISupportVSProperties
     {
-        #region fields
         private ProjectNode project;
 #if UNUSED_NESTED_PROJECTS
         Automation.OASolutionFolder<ProjectContainerNode> solutionFolder;
 #endif
         EnvDTE.ConfigurationManager configurationManager;
-        #endregion
 
-        #region properties
         public ProjectNode Project
         {
             get { return this.project; }
         }
-        #endregion
 
-        #region ctor
         internal OAProject(ProjectNode project)
         {
             this.project = project;
@@ -49,9 +44,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
 #endif
         }
-        #endregion
 
-        #region EnvDTE.Project
         /// <summary>
         /// Gets or sets the name of the object. 
         /// </summary>
@@ -449,18 +442,14 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 }
             });
         }
-        #endregion
 
-        #region ISupportVSProperties methods
         /// <summary>
         /// For use by F# tooling only. 
         /// </summary>
         public virtual void NotifyPropertiesDelete()
         {
         }
-        #endregion
 
-        #region private methods
         /// <summary>
         /// Saves or Save Asthe project.
         /// </summary>
@@ -588,6 +577,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 }
             });
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProject.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProject.cs
@@ -45,9 +45,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 #endif
         }
 
-        /// <summary>
-        /// Gets or sets the name of the object. 
-        /// </summary>
         public virtual string Name
         {
             get

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProjectItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProjectItem.cs
@@ -22,12 +22,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
          where T : HierarchyNode
     {
 
-        #region fields
         private T node;
         private OAProject project;
-        #endregion
 
-        #region properties
         public /*protected, but public for FSharp.Project.dll*/ T Node
         {
             get
@@ -46,17 +43,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return this.project;
             }
         }
-        #endregion
 
-        #region ctors
         internal OAProjectItem(OAProject project, T node)
         {
             this.node = node;
             this.project = project;
         }
-        #endregion
-
-        #region EnvDTE.ProjectItem
 
         /// <summary>
         /// Gets the requested Extender if it is available for this object
@@ -489,7 +481,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         {
             throw new NotImplementedException();
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProjectItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProjectItem.cs
@@ -290,9 +290,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
         }
 
-        /// <summary>
-        /// Gets or sets the name of the object.
-        /// </summary>
         public virtual string Name
         {
             get

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProjectItems.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProjectItems.cs
@@ -28,14 +28,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAProjectItems : OANavigableProjectItems
     {
-        #region ctor
         internal OAProjectItems(OAProject project, HierarchyNode nodeWithItems)
             : base(project, nodeWithItems)
         {
         }
-        #endregion
 
-        #region EnvDTE.ProjectItems
         /// <summary>
         /// Creates a new project item from an existing item template file and adds it to the project. 
         /// </summary>
@@ -192,9 +189,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             return this.AddItem(fileName, VSADDITEMOPERATION.VSADDITEMOP_OPENFILE);
         }
 
-        #endregion
-
-        #region helper methods
         /// <summary>
         /// Adds an item to the project.
         /// </summary>
@@ -313,7 +307,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 
             return Path.Combine(components);
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProperties.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProperties.cs
@@ -163,9 +163,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 
             throw new ArgumentException(SR.GetString(SR.InvalidParameter, CultureInfo.CurrentUICulture), "index");
         }
-        /// <summary>
-        /// Gets the immediate parent object of a Properties collection.
-        /// </summary>
+
         public virtual object Parent
         {
             get { return null; }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProperties.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProperties.cs
@@ -25,12 +25,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [CLSCompliant(false), ComVisible(true)]
     public class OAProperties : EnvDTE.Properties
     {
-        #region fields
         private NodeProperties target;
         private Dictionary<string, EnvDTE.Property> properties = new Dictionary<string, EnvDTE.Property>(StringComparer.OrdinalIgnoreCase);
-        #endregion
 
-        #region properties
         /// <summary>
         /// Defines the NodeProperties object that contains the defines the properties.
         /// </summary>
@@ -63,9 +60,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return this.properties;
             }
         }
-        #endregion
 
-        #region ctor
         internal OAProperties(NodeProperties target)
         {
             System.Diagnostics.Debug.Assert(target != null);
@@ -73,9 +68,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             this.target = target;
             this.AddPropertiesFromType(target.GetType());
         }
-        #endregion
 
-        #region EnvDTE.Properties
         /// <summary>
         /// For use by F# tooling only.
         /// </summary>
@@ -177,9 +170,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         {
             get { return null; }
         }
-        #endregion
 
-        #region methods
         /// <summary>
         /// Add properties to the collection of properties filtering only those properties which are com-visible and AutomationBrowsable
         /// </summary>
@@ -202,9 +193,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 }
             }
         }
-        #endregion
 
-        #region virtual methods
         /// <summary>
         /// Creates a new OAProperty object and adds it to the current list of properties
         /// </summary>
@@ -213,9 +202,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         {
             this.properties.Add(propertyInfo.Name, new OAProperty(this, propertyInfo));
         }
-        #endregion
-
-        #region helper methods
 
         private bool IsInMap(PropertyInfo propertyInfo)
         {
@@ -263,6 +249,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
             return true;
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProperty.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProperty.cs
@@ -19,21 +19,15 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [CLSCompliant(false), ComVisible(true)]
     public class OAProperty : EnvDTE.Property
     {
-        #region fields
         private OAProperties parent;
         private PropertyInfo pi;
-        #endregion
-
-        #region ctors
 
         internal OAProperty(OAProperties parent, PropertyInfo pi)
         {
             this.parent = parent;
             this.pi = pi;
         }
-        #endregion
 
-        #region EnvDTE.Property
         /// <summary>
         /// For use by F# tooling only.
         /// </summary>
@@ -202,6 +196,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 }
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAReferenceFolderItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAReferenceFolderItem.cs
@@ -23,15 +23,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAReferenceFolderItem : OAProjectItem<ReferenceContainerNode>
     {
-        #region ctors
         internal OAReferenceFolderItem(OAProject project, ReferenceContainerNode node)
             : base(project, node)
         {
         }
 
-        #endregion
-
-        #region overridden methods
         /// <summary>
         /// Returns the project items collection of all the references defined for this project.
         /// </summary>
@@ -43,10 +39,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
         }
 
-
-        #endregion
-
-        #region Helper methods
         private List<EnvDTE.ProjectItem> GetListOfProjectItems()
         {
             List<EnvDTE.ProjectItem> list = new List<EnvDTE.ProjectItem>();
@@ -60,6 +52,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 
             return list;
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAReferenceItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAReferenceItem.cs
@@ -47,9 +47,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             throw new InvalidOperationException();
         }
 
-        /// <summary>
-        /// Gets or sets the name of the object.
-        /// </summary>
         public override string Name
         {
             get

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAReferenceItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAReferenceItem.cs
@@ -23,15 +23,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAReferenceItem : OAProjectItem<ReferenceNode>
     {
-        #region ctors
         internal OAReferenceItem(OAProject project, ReferenceNode node)
             : base(project, node)
         {
         }
 
-        #endregion
-
-        #region overridden methods
         /// <summary>
         /// Not implemented. If called throws invalid operation exception.
         /// </summary>    
@@ -87,6 +83,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return null;
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OASolutionFolder.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OASolutionFolder.cs
@@ -41,8 +41,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         }
 
 
-        #region SolutionFolder Members
-
         public virtual EnvDTE.Project AddFromFile(string fileName)
         {
             ProjectContainerNode projectContainer = (ProjectContainerNode)this.node.ProjectMgr;
@@ -124,8 +122,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return (EnvDTE.DTE)this.node.ProjectMgr.Site.GetService(typeof(EnvDTE.DTE));
             }
         }
-
-        #endregion
     }
 
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAAssemblyReference.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAAssemblyReference.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         {
         }
 
-        #region Reference override
         public override int BuildNumber
         {
             get
@@ -155,6 +154,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return BaseReferenceNode.ResolvedAssembly.Version.ToString();
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OABuildManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OABuildManager.cs
@@ -24,8 +24,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         }
 
 
-        #region BuildManager Members
-
         public string BuildDesignTimeOutput(string bstrOutputMoniker)
         {
             throw new NotImplementedException();
@@ -53,15 +51,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             get { throw new NotImplementedException(); }
         }
 
-        #endregion
-
-        #region _dispBuildManagerEvents_Event Members
-
         public event _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler DesignTimeOutputDeleted;
 
         public event _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler DesignTimeOutputDirty;
-
-        #endregion
 
         private void OnDesignTimeOutputDeleted(object sender, EventArgs args)
         {
@@ -97,8 +89,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             return moniker;
         }
 
-        #region IEventSource<_dispBuildManagerEvents> Members
-
         void IEventSource<_dispBuildManagerEvents>.OnSinkAdded(_dispBuildManagerEvents sink)
         {
             DesignTimeOutputDeleted += new _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler(sink.DesignTimeOutputDeleted);
@@ -110,7 +100,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             DesignTimeOutputDeleted -= new _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler(sink.DesignTimeOutputDeleted);
             DesignTimeOutputDirty -= new _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler(sink.DesignTimeOutputDirty);
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAComReference.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAComReference.cs
@@ -19,7 +19,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         {
         }
 
-        #region Reference override
         public override string Culture
         {
             get
@@ -68,6 +67,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return version.ToString();
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAProjectReference.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAProjectReference.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         {
         }
 
-        #region Reference override
         public override string Culture
         {
             get { return string.Empty; }
@@ -82,6 +81,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         {
             get { return string.Empty; }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAReferenceBase.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAReferenceBase.cs
@@ -19,25 +19,18 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     public class OAReferenceBase<RefType> : Reference
         where RefType : ReferenceNode
     {
-        #region fields
         private RefType referenceNode;
-        #endregion
 
-        #region ctors
         internal OAReferenceBase(RefType referenceNode)
         {
             this.referenceNode = referenceNode;
         }
-        #endregion
 
-        #region properties
         public /*protected, but public for FSharp.Project.dll*/ RefType BaseReferenceNode
         {
             get { return referenceNode; }
         }
-        #endregion
 
-        #region Reference Members
         public virtual int BuildNumber
         {
             get { return 0; }
@@ -200,6 +193,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return ((ReferenceNodeProperties)referenceNode.NodeProperties).Extender(ExtenderName);
             });
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAReferences.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAReferences.cs
@@ -34,7 +34,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             container.OnChildRemoved += new EventHandler<HierarchyNodeEventArgs>(OnReferenceRemoved);
         }
 
-        #region Private Members
         private Reference AddFromSelectorData(VSCOMPONENTSELECTORDATA selector)
         {
             ReferenceNode refNode = container.AddReferenceFromSelectorData(selector);
@@ -57,9 +56,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
             return null;
         }
-        #endregion
-
-        #region References Members
 
         public Reference Add(string bstrPath)
         {
@@ -258,15 +254,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             }
         }
 
-        #endregion
-
-        #region _dispReferencesEvents_Event Members
         public event _dispReferencesEvents_ReferenceAddedEventHandler ReferenceAdded;
         public event _dispReferencesEvents_ReferenceChangedEventHandler ReferenceChanged;
         public event _dispReferencesEvents_ReferenceRemovedEventHandler ReferenceRemoved;
-        #endregion
 
-        #region Callbacks for the HierarchyNode events
         private void OnReferenceAdded(object sender, HierarchyNodeEventArgs args)
         {
             // Validate the parameters.
@@ -336,9 +327,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 ReferenceRemoved(reference);
             }
         }
-        #endregion
 
-        #region IEventSource<_dispReferencesEvents> Members
         void IEventSource<_dispReferencesEvents>.OnSinkAdded(_dispReferencesEvents sink)
         {
             ReferenceAdded += new _dispReferencesEvents_ReferenceAddedEventHandler(sink.ReferenceAdded);
@@ -352,6 +341,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
             ReferenceChanged -= new _dispReferencesEvents_ReferenceChangedEventHandler(sink.ReferenceChanged);
             ReferenceRemoved -= new _dispReferencesEvents_ReferenceRemovedEventHandler(sink.ReferenceRemoved);
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAVSProject.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAVSProject.cs
@@ -24,19 +24,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAVSProject : VSProject
     {
-        #region fields
         private ProjectNode project;
         private OAVSProjectEvents events;
-        #endregion
 
-        #region ctors
         internal OAVSProject(ProjectNode project)
         {
             this.project = project;
         }
-        #endregion
-
-        #region VSProject Members
 
         public ProjectItem AddWebReference(string bstrUrl)
         {
@@ -168,8 +162,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 throw new NotImplementedException();
             }
         }
-
-        #endregion
     }
 
     /// <summary>
@@ -179,18 +171,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAVSProjectEvents : VSProjectEvents
     {
-        #region fields
         private OAVSProject vsProject;
-        #endregion
 
-        #region ctors
         internal OAVSProjectEvents(OAVSProject vsProject)
         {
             this.vsProject = vsProject;
         }
-        #endregion
-
-        #region VSProjectEvents Members
 
         public BuildManagerEvents BuildManagerEvents
         {
@@ -216,8 +202,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 return vsProject.References as ReferencesEvents;
             }
         }
-
-        #endregion
     }
 
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAVSProjectItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAVSProjectItem.cs
@@ -25,18 +25,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
     [ComVisible(true), CLSCompliant(false)]
     public class OAVSProjectItem : VSProjectItem
     {
-        #region fields
         private FileNode fileNode;
-        #endregion
 
-        #region ctors
         internal OAVSProjectItem(FileNode fileNode)
         {
             this.FileNode = fileNode;
         }
-        #endregion
-
-        #region VSProjectItem Members
 
         public virtual Project ContainingProject
         {
@@ -60,9 +54,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 #endif
         }
 
-        #endregion
-
-        #region public properties
         /// <summary>
         /// File Node property
         /// </summary>
@@ -77,7 +68,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
                 fileNode = value;
             }
         }
-        #endregion
-
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAVSProjectItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/VSProject/OAVSProjectItem.cs
@@ -54,9 +54,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 #endif
         }
 
-        /// <summary>
-        /// File Node property
-        /// </summary>
         public FileNode FileNode
         {
             get

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/BuildDependency.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/BuildDependency.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.projectMgr = projectMgr;
         }
 
-        #region IVsBuildDependency methods
         public int get_CanonicalName(out string canonicalName)
         {
             canonicalName = null;
@@ -73,9 +72,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return (unknownProject == null) ? VSConstants.S_FALSE : VSConstants.S_OK;
         }
 
-        #endregion
-
-        #region helper methods
         private IVsHierarchy GetReferencedHierarchy()
         {
             IVsHierarchy hierarchy = null;
@@ -88,8 +84,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VsShellUtilities.GetHierarchy(this.projectMgr.Site, this.referencedProjectGuid);
 
         }
-
-        #endregion
 
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ComReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ComReferenceNode.cs
@@ -113,9 +113,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        /// <summary>
-        /// Constructor for the ComReferenceNode. 
-        /// </summary>
         internal ComReferenceNode(ProjectNode root, ProjectElement element)
             : base(root, element)
         {

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ComReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ComReferenceNode.cs
@@ -35,7 +35,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         [ DllImport( "oleaut32.dll", CharSet = CharSet.Unicode, PreserveSig = false )]
         private static extern void LoadTypeLibEx(string strTypeLibName, RegKind regKind, [ MarshalAs( UnmanagedType.Interface )] out object typeLib );
 
-        #region fields
         private string typeName;
         private Guid typeGuid;
         private string projectRelativeFilePath;
@@ -43,9 +42,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         private string minorVersionNumber;
         private string majorVersionNumber;
         private readonly int lcid;
-        #endregion
 
-        #region properties
         public override string Caption
         {
             get { return this.typeName; }
@@ -115,9 +112,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return comReference;
             }
         }
-        #endregion
 
-        #region ctors
         /// <summary>
         /// Constructor for the ComReferenceNode. 
         /// </summary>
@@ -213,9 +208,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #endregion
-
-        #region methods
         /// <summary>
         /// Links a reference node to the project and hierarchy.
         /// </summary>
@@ -380,7 +372,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ConfigProvider.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ConfigProvider.cs
@@ -30,14 +30,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [ComVisible(true)]
     public class ConfigProvider : IVsCfgProvider2, IVsProjectCfgProvider, IVsExtensibleObject
     {
-        #region fields
         private ProjectNode project;
         private EventSinkCollection cfgEventSinks = new EventSinkCollection();
         private List<KeyValuePair<KeyValuePair<string, string>, string>> newCfgProps = new List<KeyValuePair<KeyValuePair<string, string>, string>>();
         private Dictionary<ConfigCanonicalName, ProjectConfig> configurationsList = new Dictionary<ConfigCanonicalName, ProjectConfig>();
-        #endregion
 
-        #region Properties
         /// <summary>
         /// The associated project.
         /// </summary>
@@ -65,16 +62,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #endregion
-
-        #region ctors
         internal ConfigProvider(ProjectNode manager)
         {
             this.project = manager;
         }
-        #endregion
 
-        #region methods
         /// <summary>
         /// Creates new Project Configuartion objects based on the configuration name.
         /// </summary>
@@ -99,9 +91,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return new ProjectConfig(this.project, canonicalName);
         }
 
-        #endregion
-
-        #region IVsProjectCfgProvider methods
         /// <summary>
         /// Provides access to the IVsProjectCfg interface implemented on a project's configuration object. 
         /// </summary>
@@ -162,11 +151,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             usesIndependentConfigurations = 1;
             return VSConstants.S_OK;
         }
-        #endregion
 
 
-
-        #region IVsCfgProvider2 methods
         /// <summary>
         /// Copies an existing configuration name or creates a new one. 
         /// </summary>
@@ -690,9 +676,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             cookie = this.cfgEventSinks.Add(sink);
             return VSConstants.S_OK;
         }
-        #endregion
-
-#region IVsExtensibleObject Members
 
         /// <summary>
         /// Proved access to an IDispatchable object being a list of configuration properties
@@ -717,9 +700,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.S_OK;
 
         }
-        #endregion
 
-#region helper methods
         /// <summary>
         /// Called when a new configuration name was added.
         /// </summary>
@@ -880,7 +861,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-        #endregion
 
         /// <summary>
         /// Get all the configurations in the project.

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ConfigurationProperties.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ConfigurationProperties.cs
@@ -24,18 +24,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     public class ProjectConfigProperties : 
          VSLangProj.ProjectConfigurationProperties
     {
-        #region fields
         private ProjectConfig projectConfig;
-        #endregion
 
-        #region ctors
         internal ProjectConfigProperties(ProjectConfig projectConfig)
         {
             this.projectConfig = projectConfig;
         }
-        #endregion
-
-        #region IProjectConfigProperties Members
 
         public virtual string OutputPath
         {
@@ -49,8 +43,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #endregion
-        #region VSLangProj.ProjectConfigurationProperties
         public string __id
         {
             get { return UIThread.DoOnUIThread(() => projectConfig.ConfigName); }
@@ -336,7 +328,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             get { return UIThread.DoOnUIThread(() => projectConfig.RemoteDebugMachine); }
             set { UIThread.DoOnUIThread(() => { projectConfig.RemoteDebugMachine = value; }); }
         }
-        #endregion
 
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/DataObject.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/DataObject.cs
@@ -34,7 +34,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
         internal sealed class DataCacheEntry : IDisposable
         {
-                #region fields
                 /// <summary>
                 /// Defines an object that will be a mutex for this object for synchronizing thread calls.
                 /// </summary>
@@ -47,9 +46,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 private DATADIR dataDir;
 
                 private bool isDisposed;
-                #endregion
 
-                #region properties
                 /*internal, but public for FSharp.Project.dll*/ public FORMATETC Format
                 {
                         get
@@ -75,8 +72,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                         }
                 }
 
-                #endregion
-
                 /// <summary>
                 /// The IntPtr is data allocated that should be removed. It is allocated by the ProcessSelectionData method.
                 /// </summary>
@@ -87,7 +82,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                         this.dataDir = dir;
                 }
 
-                #region Dispose
                 ~DataCacheEntry()
                 {
                         Dispose(false);
@@ -128,7 +122,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                                 }
                         }
                 }
-                #endregion
         }
 
         /// <summary>
@@ -137,7 +130,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// </summary>
         internal sealed class DataObject : IDataObject
         {
-                #region fields
                 /*internal, but public for FSharp.Project.dll*/ public const int DATA_S_SAMEFORMATETC = 0x00040130;
 
                 /*internal, but public for FSharp.Project.dll*/ public static readonly int DATA_E_FORMATETC = ForceCast(0x80040064);
@@ -145,7 +137,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 EventSinkCollection map;
 
                 ArrayList entries;
-                #endregion
 
                 /*internal, but public for FSharp.Project.dll*/ public DataObject()
                 {
@@ -158,7 +149,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                         this.entries.Add(new DataCacheEntry(format, data, DATADIR.DATADIR_SET));
                 }
 
-                #region IDataObject methods
                 int IDataObject.DAdvise(FORMATETC[] e, uint adv, IAdviseSink sink, out uint cookie)
                 {
                         STATDATA sdata = new STATDATA();
@@ -237,9 +227,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 void IDataObject.SetData(FORMATETC[] fmt, STGMEDIUM[] m, int fRelease)
                 {
                 }
-                #endregion
 
-                #region static methods
                 /*internal, but public for FSharp.Project.dll*/ public static int ForceCast(uint i)
                 {
                         unchecked { return (int)i; }
@@ -249,8 +237,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 {
                         unchecked { return (uint)i; }
                 }
-
-                #endregion
         }
 
         [SecurityPermissionAttribute(SecurityAction.Demand, Flags = SecurityPermissionFlag.UnmanagedCode)]

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/DataObject.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/DataObject.cs
@@ -515,7 +515,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 int IEnumSTATDATA.Next(uint celt, STATDATA[] d, out uint fetched)
                 {
                         uint rc = 0;
-                        //uint size = (fetched != null) ? fetched[0] : 0;
                         for (uint i = 0; i < celt; i++)
                         {
                                 if (e.MoveNext())
@@ -574,7 +573,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 int IEnumFORMATETC.Next(uint celt, FORMATETC[] d, uint[] fetched)
                 {
                         uint rc = 0;
-                        //uint size = (fetched != null) ? fetched[0] : 0;
                         for (uint i = 0; i < celt; i++)
                         {
                                 if (e.MoveNext())

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/DependentFileNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/DependentFileNode.cs
@@ -30,21 +30,15 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [ComVisible(true)]
     public class DependentFileNode : FileNode
     {
-        #region fields
         /// <summary>
         /// Defines if the node has a name relation to its parent node
         /// e.g. Form1.ext and Form1.resx are name related (until first occurence of extention separator)
         /// </summary>
-        #endregion
-
-        #region Properties
         public override int ImageIndex
         {
             get { return (this.CanShowDefaultIcon() ? (int)ProjectNode.ImageName.DependentFile : (int) ProjectNode.ImageName.MissingFile); }
         }
-        #endregion
 
-        #region ctor
         /// <summary>
         /// Constructor for the DependentFileNode
         /// </summary>
@@ -57,9 +51,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         }
 
 
-        #endregion
-
-        #region overridden methods
         /// <summary>
         /// Disable rename
         /// </summary>
@@ -143,8 +134,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 this.Parent.ReDraw(UIHierarchyElement.SccState);
             }
         }
-        #endregion
-
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/DocumentManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/DocumentManager.cs
@@ -27,11 +27,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal abstract class DocumentManager
     {
-        #region fields
         private HierarchyNode node = null;
-        #endregion
 
-        #region properties
         public /*protected, but public for FSharp.Project.dll*/ HierarchyNode Node
         {
             get
@@ -39,16 +36,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.node;
             }
         }
-        #endregion
         
-        #region ctors
         public /*protected, but public for FSharp.Project.dll*/ DocumentManager(HierarchyNode node)
         {
             this.node = node;
         }
-        #endregion
-
-        #region virtual methods
 
         /// <summary>
         /// Open a document using the standard editor. This method has no implementation since a document is abstract in this context
@@ -139,9 +131,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #endregion
-
-        #region helper methods
         /// <summary>
         /// Get document properties from RDT
         /// </summary>
@@ -224,9 +213,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return fullPath;
         }
 
-        #endregion
-
-        #region static methods
         /// <summary>
         /// Updates the caption for all windows associated to the document.
         /// </summary>
@@ -349,6 +335,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileChangeManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileChangeManager.cs
@@ -81,14 +81,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// </summary>
         private Dictionary<string, ObservedItemInfo> observedItems = new Dictionary<string, ObservedItemInfo>();
 
-        /// <summary>
-        /// Has Disposed already been called?
-        /// </summary>
         private bool disposed;
 
-        /// <summary>
-        /// Overloaded ctor.
-        /// </summary>
         /*internal, but public for FSharp.Project.dll*/ public FileChangeManager(IServiceProvider serviceProvider)
         {
             if (serviceProvider == null)
@@ -105,9 +99,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        /// <summary>
-        /// Disposes resources.
-        /// </summary>
         public void Dispose()
         {
             // Don't dispose more than once

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileChangeManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileChangeManager.cs
@@ -17,7 +17,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal class FileChangeManager : IVsFileChangeEvents
     {
-        #region nested objects
         /// <summary>
         /// Defines a data structure that can link a item moniker to the item and its file change cookie.
         /// </summary>
@@ -65,9 +64,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
 
-        #region Fields
         /// <summary>
         /// Event that is raised when one of the observed file names have changed on disk.
         /// </summary>
@@ -88,20 +85,16 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// Has Disposed already been called?
         /// </summary>
         private bool disposed;
-        #endregion
 
-        #region Constructor
         /// <summary>
         /// Overloaded ctor.
         /// </summary>
         /*internal, but public for FSharp.Project.dll*/ public FileChangeManager(IServiceProvider serviceProvider)
         {
-            #region input validation
             if (serviceProvider == null)
             {
                 throw new ArgumentNullException("serviceProvider");
             }
-            #endregion
 
             this.fileChangeService = (IVsFileChangeEx)serviceProvider.GetService(typeof(SVsFileChangeEx));
 
@@ -111,9 +104,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 throw new InvalidOperationException();
             }
         }
-        #endregion
 
-        #region IDisposable Members
         /// <summary>
         /// Disposes resources.
         /// </summary>
@@ -136,9 +127,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             // Clean the observerItems list
             this.observedItems.Clear();
         }
-        #endregion
 
-        #region IVsFileChangeEvents Members
         /// <summary>
         /// Called when one of the file have changed on disk.
         /// </summary>
@@ -173,9 +162,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return VSConstants.S_OK;
         }
-        #endregion
 
-        #region helpers    
         /// <summary>
         /// Observe when the given file is updated on disk. In this case we do not care about the item id that represents the file in the hierarchy.
         /// </summary>
@@ -192,12 +179,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <param name="id">The item id of the item to observe.</param>
         /*internal, but public for FSharp.Project.dll*/ public void ObserveItem(string fileName, uint id)
         {
-            #region Input validation
             if (String.IsNullOrEmpty(fileName))
             {
                 throw new ArgumentException(SR.GetString(SR.InvalidParameter, CultureInfo.CurrentUICulture), "fileName");
             }
-            #endregion
 
             string fullFileName = Utilities.CanonicalizeFileName(fileName);
             if (!this.observedItems.ContainsKey(fullFileName))
@@ -222,12 +207,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <param name="ignore">Flag indicating whether or not to ignore changes (1 to ignore, 0 to stop ignoring).</param>
         /*internal, but public for FSharp.Project.dll*/ public void IgnoreItemChanges(string fileName, bool ignore)
         {
-            #region Input validation
             if (String.IsNullOrEmpty(fileName))
             {
                 throw new ArgumentException(SR.GetString(SR.InvalidParameter, CultureInfo.CurrentUICulture), "fileName");
             }
-            #endregion
 
             string fullFileName = Utilities.CanonicalizeFileName(fileName);
             if (this.observedItems.ContainsKey(fullFileName))
@@ -243,12 +226,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <param name="fileName">File to stop observing.</param>
         /*internal, but public for FSharp.Project.dll*/ public void StopObservingItem(string fileName)
         {
-            #region Input validation
             if (String.IsNullOrEmpty(fileName))
             {
                 throw new ArgumentException(SR.GetString(SR.InvalidParameter, CultureInfo.CurrentUICulture), "fileName");
             }
-            #endregion
 
             string fullFileName = Utilities.CanonicalizeFileName(fileName);
 
@@ -266,6 +247,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 ErrorHandler.ThrowOnFailure(this.fileChangeService.UnadviseFileChange(itemInfo.FileChangeCookie));
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileDocumentManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileDocumentManager.cs
@@ -27,15 +27,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal class FileDocumentManager : DocumentManager
     {
-        #region ctors
-
         public FileDocumentManager(FileNode node)
             : base(node)
         {
         }
-        #endregion
-
-        #region overriden methods
 
         /// <summary>
         /// Open a file using the standard editor
@@ -71,9 +66,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return this.Open(newFile, openWith, editorFlags, ref editorType, physicalView, ref logicalView, docDataExisting, out windowFrame, windowFrameAction);
         }
 
-        #endregion
-
-        #region public methods
         /// <summary>
         /// Open a file in a document window with a std editor
         /// </summary>
@@ -142,9 +134,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return returnValue;
         }
 
-        #endregion
-
-        #region virtual methods
         /// <summary>
         /// Open a file in a document window
         /// </summary>
@@ -161,10 +150,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             Guid editorType = Guid.Empty;
             return this.Open(newFile, openWith, 0, ref editorType, null, ref logicalView, docDataExisting, out windowFrame, windowFrameAction);
         }
-
-        #endregion
-
-        #region helper methods
 
         private int Open(bool newFile, bool openWith, uint editorFlags, ref Guid editorType, string physicalView, ref Guid logicalView, IntPtr docDataExisting, out IVsWindowFrame windowFrame, WindowFrameShowAction windowFrameAction)
         {
@@ -270,8 +255,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return returnValue;
         }
-
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileNode.cs
@@ -72,11 +72,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [ComVisible(true)]
     public class FileNode : HierarchyNode
     {
-        #region static fiels
         private static Dictionary<string, int> extensionIcons;
-        #endregion
 
-        #region overriden Properties
         /// <summary>
         /// overwrites of the generic hierarchyitem.
         /// </summary>
@@ -155,9 +152,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             }
         }
-        #endregion
 
-        #region ctor
         static FileNode()
         {
             // Build the dictionary with the mapping between some well known extensions
@@ -214,10 +209,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 this.HasDesigner = true;
             } 
         } 
-
-        #endregion
-
-        #region overridden methods
 
         public /*protected, but public for FSharp.Project.dll*/ override NodeProperties CreatePropertiesObject()
         {
@@ -706,9 +697,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return true;
         }
 
-        #endregion
-
-#region virtual methods
         public virtual string FileName
         {
             get
@@ -985,9 +973,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #endregion
-
-#region Helper methods
         /// <summary>
         /// Get's called to rename the eventually running document this hierarchyitem points to
         /// </summary>
@@ -1120,9 +1105,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             uiWindow.ExpandItem(this.ProjectMgr.InteropSafeIVsUIHierarchy, this.ID, EXPANDFLAGS.EXPF_SelectItem);
         }
 
-        #endregion
-
-#region SingleFileGenerator Support methods
 #if SINGLE_FILE_GENERATOR
         /// <summary>
         /// Event handler for the Custom tool property changes
@@ -1146,9 +1128,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.RunGenerator();
         }
 #endif
-        #endregion
 
-#region helpers
 #if SINGLE_FILE_GENERATOR
         /// <summary>
         /// Runs a generator.
@@ -1187,6 +1167,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return childNodes;
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FileNode.cs
@@ -532,7 +532,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                         return VSConstants.S_OK;
 
                     case VsCommands.ViewCode:
-                    //case VsCommands.Delete: goto case VsCommands.OpenWith;
                     case VsCommands.Open:
                     case VsCommands.OpenWith:
                         result |= QueryStatusResult.SUPPORTED | QueryStatusResult.ENABLED;

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FolderNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/FolderNode.cs
@@ -25,7 +25,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [ComVisible(true)]
     public class FolderNode : HierarchyNode
     {
-        #region ctors
         /// <summary>
         /// Constructor for the FolderNode
         /// </summary>
@@ -37,9 +36,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             this.VirtualNodeName = relativePath.TrimEnd('\\');
         }
-        #endregion
 
-        #region overridden properties
         /// <summary>
         /// This relates to the SCC glyph
         /// </summary>
@@ -51,9 +48,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return VsStateIcon.STATEICON_NOSTATEICON;
             }
         }
-        #endregion
 
-        #region overridden methods
         public /*protected, but public for FSharp.Project.dll*/ override NodeProperties CreatePropertiesObject()
         {
             return new FolderNodeProperties(this);
@@ -284,9 +279,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return false;
         }
 
-        #endregion
-
-        #region virtual methods
         /// <summary>
         /// Override if your node is not a file system folder so that
         /// it does nothing or it deletes it from your storage location.
@@ -374,9 +366,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 Directory.Move(this.Url, newPath);
             }
         }
-        #endregion
 
-        #region helper methods
         private void RenameFolder(string newName)
         {
             // Do the rename (note that we only do the physical rename if the leaf name changed)
@@ -433,7 +423,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 throw new InvalidOperationException(errorMessage);
             }
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/GlobalPropertyHandler.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/GlobalPropertyHandler.cs
@@ -1,2 +1,0 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/HierarchyNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/HierarchyNode.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return string.Format("\"{0}\" ({1})", this.Caption, this.GetType());
         }
-        #region nested types
+
         /// <summary>
         /// DropEffect as defined in oleidl.h
         /// </summary>
@@ -67,9 +67,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             Move = 2,
             Link = 4
         };
-        #endregion
 
-        #region Events
         internal event EventHandler<HierarchyNodeEventArgs> OnChildAdded
         {
             add { onChildAdded += value; }
@@ -80,18 +78,14 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             add { onChildRemoved += value; }
             remove { onChildRemoved -= value; }
         }
-        #endregion
 
-        #region static/const fields
         public static readonly Guid SolutionExplorer = new Guid(EnvDTE.Constants.vsWindowKindSolutionExplorer);
         public const int NoImage = -1;
 #if DEBUG
         /*Available only in debug build for FSharp.Project.dll*/ 
         public static int LastTracedProperty = 0;
 #endif
-        #endregion
 
-        #region fields
         private EventSinkCollection hierarchyEventSinks = new EventSinkCollection();
         private ProjectNode projectMgr;
         private ProjectElement itemNode;
@@ -121,9 +115,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <devremark>We will not specify a property for isDisposed, rather it is expected that the a private flag is defined
         /// on all subclasses. We do not want get in a situation where the base class's dipose is not called because a child sets the flag through the property.</devremark>
         private bool isDisposed;
-        #endregion
 
-        #region abstract properties
         /// <summary>
         /// The URL of the node.
         /// </summary>
@@ -150,9 +142,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get;
         }
-        #endregion
-
-        #region virtual properties
 
         public virtual bool IsNonMemberItem
         {
@@ -266,9 +255,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get { return this; }
         }
-        #endregion
-
-        #region properties
 
         internal OleServiceProvider OleServiceProvider
         {
@@ -490,9 +476,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.itemsDraggedOrCutOrCopied;
             }
         }
-        #endregion
-
-        #region ctors
 
         internal HierarchyNode()
         {
@@ -526,9 +509,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             : this(root, new ProjectElement(root, null, true))
         {
         }
-        #endregion
 
-        #region virtual methods
         /// <summary>
         /// Creates an object derived from NodeProperties that will be used to expose properties
         /// spacific for this object to the property browser.
@@ -1399,7 +1380,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return shell.ShowContextMenu(0, ref menuGroup, menuId, pnts, (Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget)this);
         }
 
-        #region initiation of command execution
         /// <summary>
         /// Handles command execution.
         /// </summary>
@@ -1671,9 +1651,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return returnValue;
         }
 
-        #endregion
-
-        #region query command handling
         /// <summary>
         /// Handles menus originating from IOleCommandTarget.
         /// </summary>
@@ -2025,7 +2002,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return queryResult;
         }
 
-        #endregion
         public /*protected, but public for FSharp.Project.dll*/ virtual bool CanDeleteItem(__VSDELETEITEMOPERATION deleteOperation)
         {
             return this.ProjectMgr.CanProjectDeleteItems;
@@ -2306,9 +2282,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return;
         }
-        #endregion
-
-        #region public methods
 
         public void OnItemAdded(HierarchyNode parent, HierarchyNode child)
         {
@@ -2536,10 +2509,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return this.projectMgr.Site.GetService(type);
         }
 
-
-        #endregion
-
-        #region IDisposable
         /// <summary>
         /// The IDispose interface Dispose method for disposing the object determinastically.
         /// </summary>
@@ -2548,10 +2517,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
-
-        #endregion
-
-        #region IVsHierarchy methods
 
         public virtual int AdviseHierarchyEvents(IVsHierarchyEvents sink, out uint cookie)
         {
@@ -2761,9 +2726,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return VSConstants.E_NOTIMPL;
         }
-        #endregion
-
-        #region IVsUIHierarchy methods
 
         public virtual int ExecCommand(uint itemId, ref Guid guidCmdGroup, uint nCmdId, uint nCmdExecOpt, IntPtr pvain, IntPtr p)
         {
@@ -2774,7 +2736,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return this.QueryStatusSelection(guidCmdGroup, cCmds, cmds, pCmdText, CommandOrigin.UiHierarchy);
         }
-        #endregion
 
         /// <summary>
         /// Determines whether the hierarchy item changed. 
@@ -2935,7 +2896,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return returnCode;
         }
 
-        #region IVsPersistHierarchyItem2 methods
 #if IMPLEMENT_IVSPERSISTHIERARCHYITEM2
         /// <summary>
         /// Flag indicating that changes to a file can be ignored when item is saved or reloaded. 
@@ -2997,12 +2957,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code. </returns>
         public virtual int ReloadItem(uint itemId, uint reserved)
         {
-        #region precondition
             if (this.ProjectMgr == null || this.ProjectMgr.IsClosed)
             {
                 return VSConstants.E_FAIL;
             }
-            #endregion
 
             HierarchyNode n = this.ProjectMgr.NodeFromItemId(itemId);
             if (n != null)
@@ -3015,9 +2973,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 #endif
-        #endregion
 
-        #region IOleCommandTarget methods
         /// <summary>
         /// CommandTarget.Exec is called for most major operations if they are NOT UI based. Otherwise IVSUInode::exec is called first
         /// </summary>
@@ -3034,9 +2990,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return this.QueryStatusSelection(guidCmdGroup, cCmds, prgCmds, pCmdText, CommandOrigin.OleCommandTarget);
         }
-        #endregion
-
-        #region IVsHierarchyDeleteHandler methods
 
         public virtual int DeleteItem(uint delItemOp, uint itemId)
         {
@@ -3091,9 +3044,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-        #endregion
-
-        #region IVsHierarchyDropDataSource2 methods
 
         public virtual int GetDropInfo(out uint pdwOKEffects, out Microsoft.VisualStudio.OLE.Interop.IDataObject ppDataObject, out IDropSource ppDropSource)
         {
@@ -3114,9 +3064,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             fCancelDrop = 0;
             return VSConstants.E_NOTIMPL;
         }
-        #endregion
-
-        #region IVsHierarchyDropDataTarget methods
 
         public virtual int DragEnter(Microsoft.VisualStudio.OLE.Interop.IDataObject pDataObject, uint grfKeyState, uint itemid, ref uint pdwEffect)
         {
@@ -3137,9 +3084,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return VSConstants.E_NOTIMPL;
         }
-        #endregion
 
-        #region helper methods
         /*internal, but public for FSharp.Project.dll*/ public HierarchyNode FindChild(string name)
         {
             if (String.IsNullOrEmpty(name))
@@ -3194,7 +3139,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             this.itemsDraggedOrCutOrCopied = new List<HierarchyNode>();
         }
-        #endregion
 
         // Support for multitargeting.
 
@@ -3380,9 +3324,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.S_OK;
         }
 
-
-        #region IVsProjectResources methods
-
         private int CreateResourceDocDataHelper(FileNode f, uint itemidResource, out IVsPersistDocData persistDocData, out IVsTextLines textLines)
         {
             int hr = VSConstants.E_FAIL;
@@ -3512,7 +3453,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             throw new NotImplementedException();
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/HierarchyNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/HierarchyNode.cs
@@ -109,35 +109,18 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         private List<HierarchyNode> itemsDraggedOrCutOrCopied;
         private bool sourceDraggedOrCutOrCopied;
 
-        /// <summary>
-        /// Has the object been disposed.
-        /// </summary>
-        /// <devremark>We will not specify a property for isDisposed, rather it is expected that the a private flag is defined
-        /// on all subclasses. We do not want get in a situation where the base class's dipose is not called because a child sets the flag through the property.</devremark>
         private bool isDisposed;
 
-        /// <summary>
-        /// The URL of the node.
-        /// </summary>
-        /// <value></value>
         public abstract string Url
         {
             get;
         }
 
-        /// <summary>
-        /// The Caption of the node.
-        /// </summary>
-        /// <value></value>
         public abstract string Caption
         {
             get;
         }
 
-        /// <summary>
-        /// The item type guid associated to a node.
-        /// </summary>
-        /// <value></value>
         public abstract Guid ItemTypeGuid
         {
             get;

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/HierarchyNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/HierarchyNode.cs
@@ -48,7 +48,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         IVsSetTargetFrameworkWorkerCallback,
         IVsProjectResources,
         IDisposable
-    //, IVsBuildStatusCallback 
     {
 
         // for good debugger experience

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/IDEBuildLogger.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/IDEBuildLogger.cs
@@ -90,9 +90,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             set { taskReporter = value; }
         }
 
-		/// <summary>
-		/// Constructor.  Inititialize member data.
-		/// </summary>
 		internal IDEBuildLogger(IVsOutputWindowPane output, TaskProvider taskProvider, IVsHierarchy hierarchy)
 		{
 			if (taskProvider == null)
@@ -109,9 +106,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 			this.serviceProvider = new ServiceProvider(site);
 		}
 
-		/// <summary>
-		/// Overridden from the Logger class.
-		/// </summary>
 		public override void Initialize(IEventSource eventSource)
 		{
 			if (null == eventSource)

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/IDEBuildLogger.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/IDEBuildLogger.cs
@@ -35,9 +35,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         // TODO: Remove these constants when we have a version that supports getting the verbosity using automation.
         private string buildVerbosityRegistryRoot = LoggingConstants.DefaultVSRegistryRoot;
         // TODO: Re-enable this constants when we have a version that suppoerts getting the verbosity using automation.
-        //private const string EnvironmentCategory = "Environment";
-        //private const string ProjectsAndSolutionSubCategory = "ProjectsAndSolution";
-        //private const string BuildAndRunPage = "BuildAndRun";
 
 		private int currentIndent;
 		private IVsOutputWindowPane outputWindowPane;

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/IDEBuildLogger.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/IDEBuildLogger.cs
@@ -32,7 +32,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [ComVisible(true)]
     public sealed class IDEBuildLogger : Logger
     {
-        #region fields
         // TODO: Remove these constants when we have a version that supports getting the verbosity using automation.
         private string buildVerbosityRegistryRoot = LoggingConstants.DefaultVSRegistryRoot;
         // TODO: Re-enable this constants when we have a version that suppoerts getting the verbosity using automation.
@@ -51,9 +50,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         private TaskReporter taskReporter;
         private bool haveCachedRegistry = false;
 
-		#endregion
-
-		#region properties
 		public string WarningString
 		{
 			get { return this.warningString; }
@@ -93,9 +89,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             get { return taskReporter; }
             set { taskReporter = value; }
         }
-		#endregion
 
-		#region ctors
 		/// <summary>
 		/// Constructor.  Inititialize member data.
 		/// </summary>
@@ -114,9 +108,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 			Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(hierarchy.GetSite(out site));
 			this.serviceProvider = new ServiceProvider(site);
 		}
-		#endregion
 
-		#region overridden methods
 		/// <summary>
 		/// Overridden from the Logger class.
 		/// </summary>
@@ -141,9 +133,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             eventSource.WarningRaised += new BuildWarningEventHandler(WarningHandler);
             eventSource.MessageRaised += new BuildMessageEventHandler(MessageHandler);
         }
-		#endregion
 
-		#region event delegates
 		/// <summary>
 		/// This is the delegate for error events.
 		/// </summary>
@@ -652,9 +642,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
 		}
 
-		#endregion
-
-		#region helpers
 		/// <summary>
 		/// This method takes a MessageImportance and returns true if messages
 		/// at importance i should be loggeed.  Otherwise return false.
@@ -810,7 +797,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             //EnvDTE.DTE dte = this.serviceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
             //EnvDTE.Properties properties = dte.get_Properties(EnvironmentCategory, ProjectsAndSolutionSubCategory);
         }
-		#endregion
     }
 
     /// <summary>

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ImageHandler.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ImageHandler.cs
@@ -71,10 +71,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        /// <summary>
-        /// Add an image to the ImageHandler.
-        /// </summary>
-        /// <param name="image">the image object to be added.</param>
         public void AddImage(Image image)
         {
             if (null == image)

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/LocalizableProperties.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/LocalizableProperties.cs
@@ -27,7 +27,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
         }
 
-        #region ICustomTypeDescriptor
         public virtual AttributeCollection GetAttributes() 
         {
             AttributeCollection col = TypeDescriptor.GetAttributes(this, true);
@@ -107,7 +106,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return this.GetType().FullName;
         }
-
-        #endregion ICustomTypeDescriptor
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Misc/AutomationExtenderManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Misc/AutomationExtenderManager.cs
@@ -408,14 +408,12 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
         
     }
     
-    /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="AutomationExtMgr_IFilterProperties"]/*' />
     /// <devdoc>
     ///    <para>[To be supplied.]</para>
     /// </devdoc>
     [ComImport, Guid("aade1f59-6ace-43d1-8fca-42af3a5c4f3c"),InterfaceTypeAttribute(ComInterfaceType.InterfaceIsDual)]
     internal interface  AutomationExtMgr_IFilterProperties {
    
-           /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="AutomationExtMgr_IFilterProperties.IsPropertyHidden"]/*' />
            /// <devdoc>
            ///    <para>[To be supplied.]</para>
            /// </devdoc>
@@ -451,7 +449,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
         }
 
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.CreateExtendedProperties"]/*' />
         /// <devdoc>
         ///     Creates the extended descriptors for an object given a list of extenders
         ///     and property names.
@@ -481,7 +478,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return extenders;
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetAttributes"]/*' />
         /// <devdoc>
         ///     Retrieves an array of member attributes for the given object.
         /// </devdoc>
@@ -489,7 +485,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetAttributes(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetClassName"]/*' />
         /// <devdoc>
         ///     Retrieves the class name for this object.  If null is returned,
         ///     the type name is used.
@@ -498,7 +493,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetClassName(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetComponentName"]/*' />
         /// <devdoc>
         ///     Retrieves the name for this object.  If null is returned,
         ///     the default is used.
@@ -507,7 +501,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetComponentName(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetConverter"]/*' />
         /// <devdoc>
         ///      Retrieves the type converter for this object.
         /// </devdoc>
@@ -515,7 +508,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetConverter(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetDefaultEvent"]/*' />
         /// <devdoc>
         ///     Retrieves the default event.
         /// </devdoc>
@@ -524,7 +516,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
         }
 
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetDefaultProperty"]/*' />
         /// <devdoc>
         ///     Retrieves the default property.
         /// </devdoc>
@@ -532,7 +523,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetDefaultProperty(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetEditor"]/*' />
         /// <devdoc>
         ///      Retrieves the an editor for this object.
         /// </devdoc>
@@ -540,7 +530,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetEditor(baseObject, editorBaseType);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetEvents"]/*' />
         /// <devdoc>
         ///     Retrieves an array of events that the given component instance
         ///     provides.  This may differ from the set of events the class
@@ -551,7 +540,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetEvents(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetEvents1"]/*' />
         /// <devdoc>
         ///     Retrieves an array of events that the given component instance
         ///     provides.  This may differ from the set of events the class
@@ -563,7 +551,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetEvents(baseObject, attributes);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetProperties"]/*' />
         /// <devdoc>
         ///     Retrieves an array of properties that the given component instance
         ///     provides.  This may differ from the set of properties the class
@@ -574,7 +561,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return ((ICustomTypeDescriptor)this).GetProperties(new Attribute[0]);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="ExtendedObjectWrapper.GetProperties1"]/*' />
         /// <devdoc>
         ///     Retrieves an array of properties that the given component instance
         ///     provides.  This may differ from the set of properties the class
@@ -774,7 +760,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             this.filteredProps = new Hashtable();
         }
         
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.FilterProperty"]/*' />
         /// <devdoc>
         ///     Filters the given property with the given member attribute.  We only
         ///     support filtering by adding a single attribute here.
@@ -783,7 +768,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             filteredProps[prop] = attr;
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetAttributes"]/*' />
         /// <devdoc>
         ///     Retrieves an array of member attributes for the given object.
         /// </devdoc>
@@ -791,7 +775,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetAttributes(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetClassName"]/*' />
         /// <devdoc>
         ///     Retrieves the class name for this object.  If null is returned,
         ///     the type name is used.
@@ -800,7 +783,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetClassName(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetComponentName"]/*' />
         /// <devdoc>
         ///     Retrieves the name for this object.  If null is returned,
         ///     the default is used.
@@ -809,7 +791,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetComponentName(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetConverter"]/*' />
         /// <devdoc>
         ///      Retrieves the type converter for this object.
         /// </devdoc>
@@ -817,7 +798,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetConverter(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetDefaultEvent"]/*' />
         /// <devdoc>
         ///     Retrieves the default event.
         /// </devdoc>
@@ -825,7 +805,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return null;
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetDefaultProperty"]/*' />
         /// <devdoc>
         ///     Retrieves the default property.
         /// </devdoc>
@@ -833,7 +812,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetDefaultProperty(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetEditor"]/*' />
         /// <devdoc>
         ///      Retrieves the an editor for this object.
         /// </devdoc>
@@ -841,7 +819,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetEditor(baseObject, editorBaseType);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetEvents"]/*' />
         /// <devdoc>
         ///     Retrieves an array of events that the given component instance
         ///     provides.  This may differ from the set of events the class
@@ -852,7 +829,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetEvents(baseObject);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetEvents1"]/*' />
         /// <devdoc>
         ///     Retrieves an array of events that the given component instance
         ///     provides.  This may differ from the set of events the class
@@ -864,7 +840,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetEvents(baseObject, attributes);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetProperties"]/*' />
         /// <devdoc>
         ///     Retrieves an array of properties that the given component instance
         ///     provides.  This may differ from the set of properties the class
@@ -875,7 +850,6 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return ((ICustomTypeDescriptor)this).GetProperties(new Attribute[0]);
         }
 
-        /// <include file='doc\AutomationExtenderManager.uex' path='docs/doc[@for="FilteredObjectWrapper.GetProperties1"]/*' />
         /// <devdoc>
         ///     Retrieves an array of properties that the given component instance
         ///     provides.  This may differ from the set of properties the class

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Misc/AutomationExtenderManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Misc/AutomationExtenderManager.cs
@@ -408,15 +408,9 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
         
     }
     
-    /// <devdoc>
-    ///    <para>[To be supplied.]</para>
-    /// </devdoc>
     [ComImport, Guid("aade1f59-6ace-43d1-8fca-42af3a5c4f3c"),InterfaceTypeAttribute(ComInterfaceType.InterfaceIsDual)]
     internal interface  AutomationExtMgr_IFilterProperties {
    
-           /// <devdoc>
-           ///    <para>[To be supplied.]</para>
-           /// </devdoc>
            [return: System.Runtime.InteropServices.MarshalAs(UnmanagedType.I4)]
            [PreserveSig]                             
            int IsPropertyHidden(string name, [Out]out vsFilterProperties propertyHidden);
@@ -501,31 +495,19 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetComponentName(baseObject);
         }
 
-        /// <devdoc>
-        ///      Retrieves the type converter for this object.
-        /// </devdoc>
         TypeConverter ICustomTypeDescriptor.GetConverter() {
             return TypeDescriptor.GetConverter(baseObject);
         }
 
-        /// <devdoc>
-        ///     Retrieves the default event.
-        /// </devdoc>
         EventDescriptor ICustomTypeDescriptor.GetDefaultEvent() {
             return null;
         }
 
 
-        /// <devdoc>
-        ///     Retrieves the default property.
-        /// </devdoc>
         PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty() {
             return TypeDescriptor.GetDefaultProperty(baseObject);
         }
 
-        /// <devdoc>
-        ///      Retrieves the an editor for this object.
-        /// </devdoc>
         object ICustomTypeDescriptor.GetEditor(Type editorBaseType) {
             return TypeDescriptor.GetEditor(baseObject, editorBaseType);
         }
@@ -791,30 +773,18 @@ namespace Microsoft.VisualStudio.Editors.PropertyPages
             return TypeDescriptor.GetComponentName(baseObject);
         }
 
-        /// <devdoc>
-        ///      Retrieves the type converter for this object.
-        /// </devdoc>
         TypeConverter ICustomTypeDescriptor.GetConverter() {
             return TypeDescriptor.GetConverter(baseObject);
         }
 
-        /// <devdoc>
-        ///     Retrieves the default event.
-        /// </devdoc>
         EventDescriptor ICustomTypeDescriptor.GetDefaultEvent() {
             return null;
         }
 
-        /// <devdoc>
-        ///     Retrieves the default property.
-        /// </devdoc>
         PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty() {
             return TypeDescriptor.GetDefaultProperty(baseObject);
         }
 
-        /// <devdoc>
-        ///      Retrieves the an editor for this object.
-        /// </devdoc>
         object ICustomTypeDescriptor.GetEditor(Type editorBaseType) {
             return TypeDescriptor.GetEditor(baseObject, editorBaseType);
         }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Misc/ConnectionPointContainer.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Misc/ConnectionPointContainer.cs
@@ -43,7 +43,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             connectionPoints.Add(typeof(SinkType).GUID, new ConnectionPoint<SinkType>(this, source));
         }
 
-        #region IConnectionPointContainer Members
         void IConnectionPointContainer.EnumConnectionPoints(out IEnumConnectionPoints ppEnum)
         {
             throw new NotImplementedException();
@@ -52,7 +51,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             ppCP = connectionPoints[riid];
         }
-        #endregion
     }
 
     internal class ConnectionPoint<SinkType> : IConnectionPoint
@@ -77,7 +75,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             sinks = new Dictionary<uint, SinkType>();
             nextCookie = 1;
         }
-        #region IConnectionPoint Members
+
         public void Advise(object pUnkSink, out uint pdwCookie)
         {
             SinkType sink = pUnkSink as SinkType;
@@ -113,6 +111,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             sinks.Remove(dwCookie);
             source.OnSinkRemoved(sink);
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Misc/NativeMethods.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Misc/NativeMethods.cs
@@ -581,7 +581,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem {
                 return s.ToString();
             }
 
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="OLECMDTEXTF.SetText"]/*' />
             /// <devdoc>
             /// Accessing the text of this structure is very cumbersome.  Instead, you may
             /// use this method to access an integer pointer of the structure.
@@ -752,7 +751,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem {
             
             // Parse the incoming XML with respect to the CodeModel XML schema and
             // use the result to regenerate the body of the function.
-            /// <include file='doc\NativeMethods.uex' path='docs/doc[@for="IMethodXML.SetXML"]/*' />
             [PreserveSig]
             int SetXML (string pszXML);
             

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/NestedProjectBuildDependency.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/NestedProjectBuildDependency.cs
@@ -20,15 +20,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     {
         IVsHierarchy dependentHierarchy = null;
 
-        #region ctors
         [CLSCompliant(false)]
         public NestedProjectBuildDependency(IVsHierarchy dependentHierarchy)
         {
             this.dependentHierarchy = dependentHierarchy;
         }
-        #endregion
 
-        #region IVsBuildDependency methods
         public int get_CanonicalName(out string canonicalName)
         {
             canonicalName = null;
@@ -76,7 +73,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return (unknownProject == null) ? VSConstants.E_FAIL : VSConstants.S_OK;
         }
-        #endregion
 
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/NestedProjectNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/NestedProjectNode.cs
@@ -85,9 +85,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        /// <summary>
-        /// The Caption of the nested project.
-        /// </summary>
         public override string Caption
         {
             get

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/NestedProjectNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/NestedProjectNode.cs
@@ -35,7 +35,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     public class NestedProjectNode : HierarchyNode, IPropertyNotifySink
     {
 
-        #region fields
         private IVsHierarchy nestedHierarchy;
 
         Guid projectInstanceGuid = Guid.Empty;
@@ -58,9 +57,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
         // A cooike retrieved when advising on property chnanged events.
         private uint projectPropertyNotifySinkCookie;
-        #endregion
 
-        #region properties
         /*internal, but public for FSharp.Project.dll*/ public IVsHierarchy NestedHierarchy
         {
             get
@@ -68,9 +65,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.nestedHierarchy;
             }
         }
-        #endregion
 
-        #region virtual properties
         /// <summary>
         /// Returns the __VSADDVPFLAGS that will be passed in when calling AddVirtualProjectEx
         /// </summary>
@@ -78,9 +73,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get { return 0; }
         }
-        #endregion
 
-        #region overridden properties
         /// <summary>
         /// The path of the nested project.
         /// </summary>
@@ -136,10 +129,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
 
 
-        #endregion
-
-        #region ctor
-
         public /*protected, but public for FSharp.Project.dll*/ NestedProjectNode()
         {
         }
@@ -149,9 +138,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             this.IsExpanded = true;
         }
-        #endregion
 
-        #region IPropertyNotifySink Members
         /// <summary>
         /// Notifies a sink that the [bindable] property specified by dispID has changed. 
         /// If dispID is DISPID_UNKNOWN, then multiple properties have changed together. 
@@ -186,13 +173,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
 
         }
-
-        #endregion
-
-        #region public methods
-        #endregion
-
-        #region overridden methods
 
         /// <summary>
         /// Get the automation object for the NestedProjectNode
@@ -428,14 +408,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <param name="reserved">Reserved parameter defined at the IVsPersistHierarchyItem2::ReloadItem parameter.</param>
         public /*protected, but public for FSharp.Project.dll*/ override void ReloadItem(uint reserved)
         {
-            #region precondition
             if (this.isDisposed || this.ProjectMgr == null || this.ProjectMgr.IsClosed)
             {
                 throw new InvalidOperationException();
             }
 
             Debug.Assert(this.nestedHierarchy != null, "The nested hierarchy object must be created before calling this method");
-            #endregion
 
             IVsPersistHierarchyItem2 persistHierachyItem = this.nestedHierarchy as IVsPersistHierarchyItem2;
 
@@ -455,14 +433,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <param name="ignoreFlag">Flag indicating whether or not to ignore changes (1 to ignore, 0 to stop ignoring).</param>
         public /*protected, but public for FSharp.Project.dll*/ override void IgnoreItemFileChanges(bool ignoreFlag)
         {
-            #region precondition
             if (this.isDisposed || this.ProjectMgr == null || this.ProjectMgr.IsClosed)
             {
                 throw new InvalidOperationException();
             }
 
             Debug.Assert(this.nestedHierarchy != null, "The nested hierarchy object must be created before calling this method");
-            #endregion
 
             this.IgnoreNestedProjectFile(ignoreFlag);
 
@@ -564,9 +540,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return queryRemoveFileFlags;
         }
-        #endregion
 
-        #region virtual methods
         /// <summary>
         /// Initialize the nested hierarhy node.
         /// </summary>
@@ -659,12 +633,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             // This is the second step in creating and adding a nested project. The inner hierarchy must have been
             // already initialized at this point. 
-            #region precondition
             if (this.nestedHierarchy == null)
             {
                 throw new InvalidOperationException();
             }
-            #endregion
+
             // get the IVsSolution interface from the global service provider
             IVsSolution solution = this.GetService(typeof(IVsSolution)) as IVsSolution;
             Debug.Assert(solution != null, "Could not get the IVsSolution object from the services exposed by this project");
@@ -878,9 +851,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             string newRelativePath = Path.Combine(existingRelativePath, newFileName);
             this.ItemNode.Rename(newRelativePath);
         }
-        #endregion    
 
-        #region helper methods
         /// <summary>
         /// Closes a nested project and releases the nested hierrachy pointer.
         /// </summary>
@@ -1132,7 +1103,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return connectionPoint;
         }
-        #endregion       
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/NodeProperties.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/NodeProperties.cs
@@ -119,11 +119,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         IVsBrowseObject,
         IVsBuildMacroInfo
     {
-        #region fields
         private HierarchyNode node;
-        #endregion
 
-        #region properties
         [Browsable(false)]
         [AutomationBrowsable(false)]
         public HierarchyNode Node
@@ -141,9 +138,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             get { return this.node.Caption; }
         }
 
-        #endregion
-
-        #region ctors
         internal NodeProperties(HierarchyNode node)
         {
             if (node == null)
@@ -152,9 +146,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             this.node = node;
         }
-        #endregion
 
-        #region ISpecifyPropertyPages methods
         public virtual void GetPages(CAUUID[] pages)
         {
             // We do not check whether the supportsProjectDesigner is set to false on the ProjectNode.
@@ -173,9 +165,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             pages[0] = new CAUUID();
             pages[0].cElems = 0;
         }
-        #endregion
-
-        #region IVsBuildMacroInfo methods
 
         /// <summary>
         /// We support this interface so the build event command dialog can display a list
@@ -227,9 +216,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return NativeMethods.S_OK;
         }
 
-        #endregion
-
-        #region IVsSpecifyProjectDesignerPages
         /// <summary>
         /// Implementation of the IVsSpecifyProjectDesignerPages. It will retun the pages that are configuration independent.
         /// </summary>
@@ -240,17 +226,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.GetCommonPropertyPages(pages);
             return VSConstants.S_OK;
         }
-        #endregion
 
-        #region IVsGetCfgProvider methods
         public virtual int GetCfgProvider(out IVsCfgProvider p)
         {
             p = null;
             return VSConstants.E_NOTIMPL;
         }
-        #endregion
 
-        #region IVsBrowseObject methods
         /// <summary>
         /// Maps back to the hierarchy or project item object corresponding to the browse object.
         /// </summary>
@@ -267,9 +249,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             itemid = this.node.ID;
             return VSConstants.S_OK;
         }
-        #endregion
 
-        #region overridden methods
         /// <summary>
         /// Get the Caption of the Hierarchy Node instance. If Caption is null or empty we delegate to base
         /// </summary>
@@ -286,9 +266,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return caption;
             }
         }
-        #endregion
 
-        #region helper methods
         public /*protected, but public for FSharp.Project.dll*/ string GetProperty(string name, string def)
         {
             string a = this.Node.ItemNode.GetMetadata(name);
@@ -347,9 +325,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 pages[0].cElems = 0;
             }
         }
-        #endregion
-
-        #region IInternalExtenderProvider Members
 
         bool EnvDTE80.IInternalExtenderProvider.CanExtend(string extenderCATID, string extenderName, object extendeeObject)
         {
@@ -381,9 +356,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return null;
         }
 
-        #endregion
-
-        #region ExtenderSupport
         [Browsable(false)]
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "CATID")]
         public virtual string ExtenderCATID
@@ -421,8 +393,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return extenderService.GetExtender(this.ExtenderCATID, extenderName, this);
         }
-
-        #endregion
     }
 
     internal sealed class BuildActionPropertyDescriptor : DesignPropertyDescriptor
@@ -652,8 +622,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [CLSCompliant(false), ComVisible(true)]
     public class FileNodeProperties : BuildableNodeProperties
     {
-        #region properties
-
         [SRCategoryAttribute(SR.Advanced)]
         [LocDisplayName(SR.CopyToOutputDirectory)]
         [SRDescriptionAttribute(SR.CopyToOutputDirectoryDescription)]
@@ -703,7 +671,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #region non-browsable properties - used for automation only
         [Browsable(false)]
         public string Extension
         {
@@ -712,31 +679,21 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return Path.GetExtension(this.Node.Caption);
             }
         }
-        #endregion
 
-
-        #endregion
-
-        #region ctors
         internal FileNodeProperties(HierarchyNode node)
             : base(node)
         {
         }
-        #endregion
 
-        #region overridden methods
         public override string GetClassName()
         {
             return SR.GetString(SR.FileProperties, CultureInfo.CurrentUICulture);
         }
-        #endregion
     }
 
     [CLSCompliant(false), ComVisible(true)]
     public class DependentFileNodeProperties : BuildableNodeProperties
     {
-        #region properties
-
         [SRCategoryAttribute(SR.Misc)]
         [LocDisplayName(SR.FileName)]
         [SRDescriptionAttribute(SR.FileNameDescription)]
@@ -758,36 +715,27 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.Node.Url;
             }
         }
-        #endregion
 
-        #region ctors
         internal DependentFileNodeProperties(HierarchyNode node)
             : base(node)
         {
         }
 
-        #endregion
-
-        #region overridden methods
         public override string GetClassName()
         {
             return SR.GetString(SR.FileProperties, CultureInfo.CurrentUICulture);
         }
-        #endregion
     }
 
 #if SINGLE_FILE_GENERATOR
     [CLSCompliant(false), ComVisible(true)]
     public class SingleFileGeneratorNodeProperties : FileNodeProperties
     {
-    #region fields
         private EventHandler<HierarchyNodeEventArgs> onCustomToolChanged;
         private EventHandler<HierarchyNodeEventArgs> onCustomToolNameSpaceChanged;
         public /*protected, but public for FSharp.Project.dll*/ string _customTool = "";
         public /*protected, but public for FSharp.Project.dll*/ string _customToolNamespace = "";
-        #endregion
 
-    #region custom tool events
         /*internal, but public for FSharp.Project.dll*/ public event EventHandler<HierarchyNodeEventArgs> OnCustomToolChanged
         {
             add { onCustomToolChanged += value; }
@@ -800,9 +748,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             remove { onCustomToolNameSpaceChanged -= value; }
         }
 
-        #endregion
-
-    #region properties
         [SRCategoryAttribute(SR.Advanced)]
         [LocDisplayName(SR.CustomTool)]
         [SRDescriptionAttribute(SR.CustomToolDescription)]
@@ -852,14 +797,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
 
-    #region ctors
         internal SingleFileGeneratorNodeProperties(HierarchyNode node)
             : base(node)
         {
         }
-        #endregion
     }
 #endif
 
@@ -867,7 +809,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     public class ProjectNodeProperties : NodeProperties
         , VSLangProj.ProjectProperties
     {
-        #region properties
         [SRCategoryAttribute(SR.Misc)]
         [LocDisplayName(SR.ProjectFolder)]
         [SRDescriptionAttribute(SR.ProjectFolderDescription)]
@@ -896,7 +837,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #region non-browsable properties - used for automation only
         [Browsable(false)]
         public string FileName
         {
@@ -939,18 +879,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
 
-        #endregion
-
-        #region ctors
         internal ProjectNodeProperties(ProjectNode node)
             : base(node)
         {
         }
-        #endregion
 
-        #region overridden methods
         public override string GetClassName()
         {
             return SR.GetString(SR.ProjectProperties, CultureInfo.CurrentUICulture);
@@ -987,9 +921,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return base.GetCfgProvider(out p);
         }
-
-        #endregion
-        #region VsLangProj.ProjectProperties
 
         string VSLangProj.ProjectProperties.__id
         {
@@ -1336,14 +1267,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return assemblyName + extension;
             }
         }
-
-        #endregion
     }
 
     [CLSCompliant(false), ComVisible(true)]
     public class FolderNodeProperties : NodeProperties
     {
-        #region properties
         [SRCategoryAttribute(SR.Misc)]
         [LocDisplayName(SR.FolderName)]
         [SRDescriptionAttribute(SR.FolderNameDescription)]
@@ -1361,7 +1289,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #region properties - used for automation only
         [Browsable(false)]
         [AutomationBrowsable(true)]
         public string FileName
@@ -1393,23 +1320,16 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
 
-        #endregion
-
-        #region ctors
         internal FolderNodeProperties(HierarchyNode node)
             : base(node)
         {
         }
-        #endregion
 
-        #region overridden methods
         public override string GetClassName()
         {
             return SR.GetString(SR.FolderProperties, CultureInfo.CurrentUICulture);
         }
-        #endregion
     }
 
     [CLSCompliant(false), ComVisible(true)]
@@ -1417,7 +1337,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     {
         bool copyLocalDefault;
 
-        #region properties
         [SRCategoryAttribute(SR.Misc)]
         [LocDisplayName(SR.RefName)]
         [SRDescriptionAttribute(SR.RefNameDescription)]
@@ -1459,9 +1378,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.Node.Url;
             }
         }
-        #endregion
 
-        #region ctors
         internal ReferenceNodeProperties(HierarchyNode node)
             : this(node, false)
         {
@@ -1472,14 +1389,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             this.copyLocalDefault = copyLocalDefault;
         }
-        #endregion
 
-        #region overridden methods
         public override string GetClassName()
         {
             return SR.GetString(SR.ReferenceProperties, CultureInfo.CurrentUICulture);
         }
-        #endregion
     }
 
     class FSharpCoreVersionConverter : StringConverter
@@ -1596,14 +1510,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [ComVisible(true)]
     public class ProjectReferencesProperties : ReferenceNodeProperties
     {
-        #region ctors
         internal ProjectReferencesProperties(ProjectReferenceNode node)
             : base(node, true)
         {
         }
-        #endregion
 
-        #region overriden methods
         public override string FullPath
         {
             get
@@ -1611,6 +1522,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return ((ProjectReferenceNode)Node).ReferencedProjectOutputPath;
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/OleServiceProvider.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/OleServiceProvider.cs
@@ -24,11 +24,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
     internal class OleServiceProvider : IOleServiceProvider, IDisposable
     {
-        #region Public Types
         public delegate object ServiceCreatorCallback(Type serviceType);
-        #endregion
 
-        #region Private Types
         private class ServiceData : IDisposable
         {
             private Type serviceType;
@@ -82,9 +79,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 creator = null;
             }
         }
-        #endregion
-
-        #region fields
 
         private Dictionary<Guid, ServiceData> services = new Dictionary<Guid, ServiceData>();
         private bool isDisposed;
@@ -92,15 +86,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// Defines an object that will be a mutex for this object for synchronizing thread calls.
         /// </summary>
         private static volatile object Mutex = new object();
-        #endregion
 
-        #region ctors
         public OleServiceProvider()
         {
         }
-        #endregion
-
-        #region IOleServiceProvider Members
 
         public int QueryService(ref Guid guidService, ref Guid riid, out IntPtr ppvObject)
         {
@@ -148,9 +137,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return hr;
         }
 
-        #endregion
-
-        #region Dispose        
 
         /// <summary>
         /// The IDispose interface Dispose method for disposing the object determinastically.
@@ -160,8 +146,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-
-        #endregion
 
         /// <summary>
         /// Adds the given service to the service container.
@@ -222,7 +206,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #region helper methods
         /// <summary>
         /// The method that does the cleanup.
         /// </summary>
@@ -256,7 +239,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
 
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Output.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Output.cs
@@ -55,8 +55,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return ErrorHandler.Succeeded(get_Property(name, out value)) ? value as string : null;
         }
 
-        #region IVsOutput2 Members
-
         public int get_CanonicalName(out string pbstrCanonicalName)
         {
             pbstrCanonicalName = MSBuildItem.GetEvaluatedInclude(output);
@@ -134,7 +132,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             pguidType = Guid.Empty;
             throw new NotImplementedException();
         }
-
-        #endregion
 }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/OutputGroup.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/OutputGroup.cs
@@ -22,7 +22,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [CLSCompliant(false), ComVisible(true)]
     public class OutputGroup : IVsOutputGroup2
     {
-        #region fields
         private ProjectConfig projectCfg;
         private ProjectNode project;
 
@@ -30,9 +29,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         private Output keyOutput = null;
         private string name;
         private string targetName;
-        #endregion
 
-        #region properties
         /// <summary>
         /// Get the project configuration object associated with this output group
         /// </summary>
@@ -84,10 +81,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
  
-        #endregion
-
-        #region ctors
-
         /// <summary>
         /// Constructor for IVSOutputGroup2 implementation
         /// </summary>
@@ -111,9 +104,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             project = projectManager;
             projectCfg = configuration;
         }
-        #endregion
 
-        #region virtual methods
         public /*protected, but public for FSharp.Project.dll*/ virtual void Refresh()
         {
             // Let MSBuild know which configuration we are working with
@@ -163,18 +154,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             keyOutput = null;
         }
-        #endregion
 
-        #region event handlers
         private void OnProjectPropertyChanged(object sender, ProjectPropertyChangedArgs args)
         {
             // In theory here we should decide if we have to invalidate the group according with the kind of property
             // that is changed.
             InvalidateGroup();
         }
-        #endregion
-
-        #region IVsOutputGroup2 Members
 
         public virtual int get_CanonicalName(out string pbstrCanonicalName)
         {
@@ -284,7 +270,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             pvar = project.GetProjectProperty(pszProperty);
             return VSConstants.S_OK;
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
@@ -183,18 +183,14 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         IVsSpecifyProjectDesignerPages,
         IVsCfgBrowseObject
     {
-        #region constants
         /*internal, but public for FSharp.Project.dll*/ public const string Debug = "Debug";
         /*internal, but public for FSharp.Project.dll*/ public const string Release = "Release";
         /*internal, but public for FSharp.Project.dll*/ public const string AnyCPU = "AnyCPU";
         /*internal, but public for FSharp.Project.dll*/ public const string AnyCPU32BitPreferred = "AnyCPU32BitPreferred";
         public const string Any_CPU = "Any CPU";
 
-        #endregion
 
 
-
-        #region fields
         private ProjectNode project;
         private ConfigCanonicalName configCanonicalName;
         private DateTime lastCache;
@@ -206,7 +202,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         private IVsProjectFlavorCfg flavoredCfg = null;
         private BuildableProjectConfig buildableCfg = null;
         private readonly ProjectConfigProperties projectConfigurationProperties ;
-        #endregion
 
         private string GetProjectAssemblyName()
         {
@@ -218,7 +213,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return this.projectAssemblyNameCache;
         }
 
-        #region properties
         public ProjectNode ProjectMgr
         {
             get
@@ -642,9 +636,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.outputGroups;
             }
         }
-        #endregion
 
-        #region ctors
         internal ProjectConfig(ProjectNode project, ConfigCanonicalName configName)
         {
             this.project = project;
@@ -662,9 +654,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 this.project.LoadXmlFragment(persistXML, this.DisplayName);
             }
         }
-        #endregion
 
-        #region methods
         public /*protected, but public for FSharp.Project.dll*/ virtual OutputGroup CreateOutputGroup(ProjectNode project, KeyValuePair<string, string> group)
         {
             OutputGroup outputGroup = new OutputGroup(group.Key, group.Value, project, this);
@@ -815,9 +805,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return hr;
         }
-        #endregion
 
-#region IVsSpecifyPropertyPages
         public void GetPages(CAUUID[] pages)
         {
             // We do not check whether the supportsProjectDesigner is set to false on the ProjectNode.
@@ -835,9 +823,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             pages[0] = new CAUUID();
             pages[0].cElems = 0;
         }
-        #endregion
 
-#region IVsSpecifyProjectDesignerPages
         /// <summary>
         /// Implementation of the IVsSpecifyProjectDesignerPages. It will retun the pages that are configuration dependent.
         /// </summary>
@@ -848,9 +834,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.GetCfgPropertyPages(pages);
             return VSConstants.S_OK;
         }
-        #endregion
 
-#region IVsCfg methods
         /// <summary>
         /// The display name is a two part item
         /// first part is the config name, 2nd part is the platform name
@@ -887,9 +871,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return VSConstants.S_OK;
         }
-        #endregion
 
-#region IVsProjectCfg methods
         public virtual int EnumOutputs(out IVsEnumOutputs eo)
         {
             CCITracing.TraceCall();
@@ -974,7 +956,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             output = null;
             return VSConstants.E_NOTIMPL;
         }
-        #endregion
 
         private VsDebugTargetInfo GetDebugTargetInfo(uint grfLaunch, bool forLaunch)
         {
@@ -1088,7 +1069,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return info;
         }
-#region IVsDebuggableProjectCfg methods
+
         /// <summary>
         /// Called by the vs shell to start debugging (managed or unmanaged).
         /// Override this method to support other debug engines.
@@ -1143,9 +1124,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             fCanLaunch = this.fCanLaunchCache;
             return VSConstants.S_OK;
         }
-        #endregion
 
-        #region IVsQueryDebuggableProjectCfg
         public virtual int QueryDebugTargets(uint grfLaunch, uint cTargets, VsDebugTargetInfo2[] debugTargetInfo, uint[] actualTargets)
         {
             if (debugTargetInfo == null) // caller only queries for number of targets
@@ -1190,9 +1169,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 actualTargets[0] = 1;
             return VSConstants.S_OK;
         }
-        #endregion
-
-        #region IVsProjectCfg2 Members
 
         public virtual int OpenOutputGroup(string szCanonicalName, out IVsOutputGroup ppIVsOutputGroup)
         {
@@ -1286,9 +1262,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.E_NOTIMPL;
         }
 
-        #endregion
-
-#region IVsCfgBrowseObject
         /// <summary>
         /// Maps back to the configuration corresponding to the browse object. 
         /// </summary>
@@ -1314,9 +1287,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return this.project.NodeProperties.GetProjectItem(out hier, out itemid);
         }
-        #endregion
-
-#region helper methods
 
         private void EnsureCache()
         {
@@ -1380,9 +1350,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 pages[0] = PackageUtilities.CreateCAUUIDFromGuidArray(guids);
             }
         }
-        #endregion
 
-#region IVsProjectFlavorCfg Members
         /// <summary>
         /// This is called to let the flavored config let go
         /// of any reference it may still be holding to the base config
@@ -1424,9 +1392,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-
-        #endregion
-
 
         public string Platform { get { return this.configCanonicalName.Platform; } }
 
@@ -1692,16 +1657,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         }
 #endif
 
-        #region fields
         ProjectConfig config = null;
         EventSinkCollection callbacks = new EventSinkCollection();
         string[] filesWeCalledHandsOff = null;
 #if FX_ATLEAST_45
         IVsBuildManagerAccessor buildManagerAccessor = null; 
 #endif
-        #endregion
 
-        #region ctors
         internal BuildableProjectConfig(ProjectConfig config)
         {
             this.config = config;
@@ -1709,11 +1671,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.buildManagerAccessor = this.config.ProjectMgr.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
 #endif
         }
-        #endregion
 
 #if FX_ATLEAST_45
-        #region IVsBuildableProjectCfg2 Members
-
         private const int VSBLDCFGPROPID_SupportsMTBuild = -16000;
 
         public int GetBuildCfgProperty(int propid, out object pvar)
@@ -1734,10 +1693,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return this.StartBuild(pIVsOutputWindowPane, dwOptions);
         }
-        #endregion
 #endif
-
-        #region IVsBuildableProjectCfg methods
 
         public virtual int AdviseBuildStatusCallback(IVsBuildStatusCallback callback, out uint cookie)
         {
@@ -1851,9 +1807,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.E_NOTIMPL;
         }
-        #endregion
 
-        #region helpers
         private bool NotifyBuildBegin()
         {
 
@@ -1979,6 +1933,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 referenceNode.RefreshReference(buildResult);
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectContainerNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectContainerNode.cs
@@ -31,8 +31,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         IVsParentProject,
         IBuildDependencyOnProjectContainer
     {
-        #region fields
-
         /// <summary>
         /// Setting this flag to true will build all nested project when building this project
         /// </summary>
@@ -47,15 +45,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         ///This might need a refactoring when nested projects can be added and removed by demand.
         /// </devremark>
         private FileChangeManager nestedProjectNodeReloader;
-        #endregion
 
-        #region ctors
         internal ProjectContainerNode()
         {
         }
-        #endregion
 
-        #region properties
         /// <summary>
         /// Returns teh object that handles listening to file changes on the nested project files.
         /// </summary>
@@ -72,9 +66,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.nestedProjectNodeReloader;
             }
         }
-        #endregion
 
-        #region overridden properties
         /// <summary>
         /// This is the object that will be returned by EnvDTE.Project.Object for this project
         /// </summary>
@@ -83,9 +75,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             get { return new Automation.OASolutionFolder<ProjectContainerNode>(this); }
         }
 
-        #endregion
-
-        #region public overridden methods
         /// <summary>
         /// Gets the nested hierarchy.
         /// </summary>
@@ -184,12 +173,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code. </returns>
         public override int ReloadItem(uint itemId, uint reserved)
         {
-            #region precondition
             if (this.IsClosed)
             {
                 return VSConstants.E_FAIL;
             }
-            #endregion
 
             NestedProjectNode node = this.NodeFromItemId(itemId) as NestedProjectNode;
 
@@ -220,9 +207,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             base.Reload();
             this.CreateNestedProjectNodes();
         }
-        #endregion
 
-        #region IVsParentProject
         public virtual int OpenChildren()
         {
             IVsSolution solution = this.GetService(typeof(IVsSolution)) as IVsSolution;
@@ -317,9 +302,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return returnValue;
         }
-        #endregion
 
-        #region IBuildDependencyOnProjectContainerNode
         /// <summary>
         /// Defines whether nested projects should be build with the parent project
         /// </summary>
@@ -348,9 +331,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return nestedProjectList.ToArray();
         }
-        #endregion
-
-        #region helper methods
 
         /*internal, but public for FSharp.Project.dll*/ protected void RemoveNestedProjectNodes()
         {
@@ -769,7 +749,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <param name="e">Event args containing the file name that was updated.</param>
         private void OnNestedProjectFileChangedOnDisk(object sender, FileChangedOnDiskEventArgs e)
         {
-            #region Pre-condition validation
             Debug.Assert(e != null, "No event args specified for the FileChangedOnDisk event");
 
             // We care only about time change for reload.
@@ -782,7 +761,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             string moniker;
             this.GetMkDocument(e.ItemID, out moniker);
             Debug.Assert(NativeMethods.IsSamePath(moniker, e.FileName), " The file + " + e.FileName + " has changed but we could not retrieve the path for the item id associated to the path.");
-            #endregion
 
             bool reload = true;
             if (!Utilities.IsInAutomationFunction(this.Site))
@@ -803,7 +781,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 this.ReloadItem(e.ItemID, 0);
             }
         }
-        #endregion
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectDesignerDocumentManager.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectDesignerDocumentManager.cs
@@ -24,14 +24,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
     internal class ProjectDesignerDocumentManager : DocumentManager
     {
-        #region ctors
         public ProjectDesignerDocumentManager(ProjectNode node)
             : base(node)
         {
         }
-        #endregion
-
-        #region overriden methods
 
         public override int Open(ref Guid logicalView, IntPtr docDataExisting, out IVsWindowFrame windowFrame, WindowFrameShowAction windowFrameAction)
         {
@@ -75,7 +71,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-        #endregion
 
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectElement.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectElement.cs
@@ -49,15 +49,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal sealed class ProjectElement
     {
-        #region fields
         private Microsoft.Build.Evaluation.ProjectItem item;
         private ProjectNode itemProject;
         private bool deleted = false;
         private bool isVirtual = false;
         private Dictionary<string, string> virtualProperties;
-        #endregion
 
-        #region properties
         public string ItemName
         {
             get
@@ -102,9 +99,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.isVirtual;
             }
         }
-        #endregion
 
-        #region ctors
         /// <summary>
         /// Constructor to create a new MSBuild.BuildItem and add it to the project
         /// Only have /*internal, but public for FSharp.Project.dll*/ public constructors as the only one who should be creating
@@ -195,9 +190,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             if (this.isVirtual)
                 this.virtualProperties = new Dictionary<string, string>();
         }
-        #endregion
 
-        #region public methods
         /// <summary>
         /// Calling this method remove this item from the project file.
         /// Once the item is delete, you should not longer be using it.
@@ -392,9 +385,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return path;
         }
 
-        #endregion
-
-#region helper methods
         /// <summary>
         /// Has the item been deleted
         /// </summary>
@@ -402,9 +392,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return (this.deleted || this.item == null);
         }
-        #endregion
 
-#region overridden from System.Object
         public static bool operator ==(ProjectElement element1, ProjectElement element2)
         {
             // Do they reference the same element?
@@ -465,9 +453,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             // TODO, this is not in sync with Equals, so don't put these objects in a dictionary
             return base.GetHashCode();
         }
-        #endregion
-
-
 
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectFactory.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectFactory.cs
@@ -24,15 +24,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     , IVsProjectUpgradeViaFactory, IVsProjectUpgradeViaFactory4
 
 	{
-		#region fields
 		private Microsoft.VisualStudio.Shell.Package package;
 		private System.IServiceProvider site;
 
         private Microsoft.Build.Evaluation.ProjectCollection buildEngine;
         private Microsoft.Build.Evaluation.Project buildProject;
-        #endregion
 
-        #region properties
         public /*protected, but public for FSharp.Project.dll*/ Microsoft.VisualStudio.Shell.Package Package
         {
             get
@@ -74,22 +71,16 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 this.buildProject = value;
             }
         }
-        #endregion
 
-        #region ctor
         public /*protected, but public for FSharp.Project.dll*/ ProjectFactory(Microsoft.VisualStudio.Shell.Package package)
         {
             this.package = package;
             this.site = package;
             this.buildEngine = Utilities.InitializeMsBuildEngine(this.buildEngine);
         }
-        #endregion
 
-        #region abstract methods
         protected abstract ProjectNode CreateProject();
-        #endregion
 
-        #region overriden methods
         /// <summary>
         /// Rather than directly creating the project, ask VS to initate the process of
         /// creating an aggregated project in case we are flavored. We will be called
@@ -179,9 +170,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return guids;
         }
-        #endregion
 
-        #region helpers
 #if FX_ATLEAST_45
 
         private class ProjectInspector
@@ -290,9 +279,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return null;
         }
-	#endregion
 
-        #region IVsProjectUpgradeViaFactory
         private string m_lastUpgradedProjectFile;
         private const string SCC_PROJECT_NAME = "SccProjectName";
         private string m_sccProjectName;
@@ -823,8 +810,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 i++;
             }
         }
-
-        #endregion
-
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectFileConstants.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectFileConstants.cs
@@ -1,14 +1,9 @@
 // Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#region Using directives
-
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics.CodeAnalysis;
-
-#endregion
-
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.CopyPaste.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.CopyPaste.cs
@@ -24,12 +24,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// <remarks>This is a partial class.</remarks>
     public partial class ProjectNode : IVsUIHierWinClipboardHelperEvents
     {
-        #region fields
         private uint copyPasteCookie;
         private DropDataType dropDataType;
-        #endregion
 
-        #region override of IVsHierarchyDropDataTarget methods
         /// <summary>
         /// Called as soon as the mouse drags an item over a new hierarchy or hierarchy window
         /// </summary>
@@ -166,9 +163,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return returnValue;
         }
-        #endregion
 
-        #region override of IVsHierarchyDropDataSource2 methods
         /// <summary>
         /// Returns information about one or more of the items being dragged
         /// </summary>
@@ -304,9 +299,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.S_OK;
         }
 
-        #endregion
-
-        #region IVsUIHierWinClipboardHelperEvents Members
         /// <summary>
         /// Called after your cut/copied items has been pasted
         /// </summary>
@@ -349,9 +341,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.SourceDraggedOrCutOrCopied = false;
             return VSConstants.S_OK;
         }
-        #endregion
 
-        #region virtual methods
         /// <summary>
         /// Determines if a node can accept drop opertaion.
         /// </summary>
@@ -600,9 +590,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return newNode;
         }    
-        #endregion
 
-        #region non-virtual methods
         /// <summary>
         /// Handle the Cut operation to the clipboard
         /// </summary>
@@ -1105,9 +1093,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
 
 
-        #endregion
-
-        #region private helper methods
         /// <summary>
         /// Empties all the data structures added to the clipboard and flushes the clipboard.
         /// </summary>
@@ -1185,7 +1170,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return ptr;
         }
-
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.Events.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.Events.cs
@@ -8,19 +8,14 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
     public partial class ProjectNode
     {
-        #region fields
         private EventHandler<ProjectPropertyChangedArgs> projectPropertiesListeners;
-        #endregion
 
-        #region events
         internal event EventHandler<ProjectPropertyChangedArgs> OnProjectPropertyChanged
         {
             add { projectPropertiesListeners += value; }
             remove { projectPropertiesListeners -= value; }
         }
-        #endregion
 
-        #region methods
         internal void RaiseProjectPropertyChanged(string propertyName, string oldValue, string newValue)
         {
             if (null != projectPropertiesListeners)
@@ -28,7 +23,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 projectPropertiesListeners(this, new ProjectPropertyChangedArgs(propertyName, oldValue, newValue));
             }
         }
-        #endregion
     }
 
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
@@ -682,7 +682,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 		/// </summary>
 		private ProjectPackage package;
 
-        // Has the object been disposed.
         private bool isDisposed;
 
         /// <summary>
@@ -1649,10 +1648,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return Path.Combine(this.BaseURI.AbsoluteUrl, this.filename);
         }
 
-        /// <summary>
-        /// Disposes the project node object.
-        /// </summary>
-        /// <param name="disposing">Flag determining ehether it was deterministic or non deterministic clean up.</param>
         protected override void Dispose(bool disposing)
         {
             if (this.isDisposed)

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
@@ -562,7 +562,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         private Microsoft.Build.Evaluation.Project buildProject;
 
         // TODO cache an instance for perf; but be sure not to be stale (correctness)
-        //private ProjectInstance projectInstance;
         private BuildActionConverter buildActionConverter = new BuildActionConverter();
 
         private ConfigProvider configProvider;

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
@@ -382,8 +382,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         , IVsDesignTimeAssemblyResolution
         , IVsProjectUpgrade
     {
-        #region nested types
-
         /// <summary>
         /// This class stores mapping from ids -> objects. Uses as a replacement of EventSinkCollection (ESC)
         /// Operations:
@@ -515,16 +513,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             DoNotTriggerTrackerEvents = 2
         }
 
-        #endregion
-
-        #region constants
         /// <summary>
         /// The user file extension.
         /// </summary>
         /*internal, but public for FSharp.Project.dll*/ public const string PerUserFileExtension = ".user";
-        #endregion
 
-        #region fields
         /// <summary>
         /// List of output groups names and their associated target
         /// </summary>
@@ -691,9 +684,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
         // Has the object been disposed.
         private bool isDisposed;
-        #endregion
 
-        #region abstract properties
         /// <summary>
         /// This Guid must match the Guid you registered under
         /// HKLM\Software\Microsoft\VisualStudio\%version%\Projects.
@@ -735,9 +726,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        #endregion
-
-        #region virtual properties
         /// <summary>
         /// This is the project instance guid that is peristed in the project file
         /// </summary>
@@ -761,9 +749,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
-
-        #region properties
 
         /// <summary>
         /// Denotes if FSharp.Core reference is relying on TargetFSharpCore property
@@ -778,7 +763,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             get { return MSBuildProject.GetStaticAndVisibleItemsInOrder(this.buildProject); }
         }
 
-        #region overridden properties
         public override int MenuCommandId
         {
             get
@@ -843,10 +827,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-
-        #endregion
-
-        #region virtual properties
 
         public virtual string ErrorString
         {
@@ -957,8 +937,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 this.showProjectInSolutionPage = value;
             }
         }
-
-        #endregion
 
         public bool IsInBatchUpdate
         {
@@ -1365,9 +1343,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 				this.package = value;
 			}
 		}
-		#endregion
-
-        #region ctor
 
         protected ProjectNode()
         {
@@ -1375,9 +1350,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             myExtensibilityEventsHelper = new ExtensibilityEventsHelper(this);
             this.Initialize();
         }
-        #endregion
 
-        #region overridden methods
         public /*protected, but public for FSharp.Project.dll*/ override NodeProperties CreatePropertiesObject()
         {
             return new ProjectNodeProperties(this);
@@ -1951,8 +1924,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return null;
         }
 
-        #endregion
-
         public void UpdateValueOfCanUseTargetFSharpCoreReferencePropertyIfNecessary(ReferenceNode node)
         {
             // property is already set, not need to make one more check
@@ -1965,8 +1936,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 ProjectMgr.CanUseTargetFSharpCoreReference = true;
             }
         }
-
-        #region virtual methods
 
         /// <summary>
         /// Executes a wizard.
@@ -4360,8 +4329,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             MSBuildProject.SetGlobalProperty(this.buildProject, GlobalProperty.Platform.ToString(), configCanonicalName.MSBuildPlatform);
         }
 
-        #endregion
-
         public void BeginBatchUpdate()
         {
             // refresh current state
@@ -4444,7 +4411,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return String.Empty;
         }
 
-#region non-virtual methods
         private void TellMSBuildCurrentSolutionConfiguration()
         {
             var canonicalCfgNameOpt = FetchCurrentConfigurationName();
@@ -4985,9 +4951,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-#endregion
-
-#region IVsGetCfgProvider Members
         //=================================================================================
 
         public virtual int GetCfgProvider(out IVsCfgProvider p)
@@ -4997,18 +4960,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             p = this.ConfigProvider;
             return (p == null ? VSConstants.E_NOTIMPL : VSConstants.S_OK);
         }
-#endregion
-
-#region IPersist Members
 
         public int GetClassID(out Guid clsid)
         {
             clsid = this.ProjectGuid;
             return VSConstants.S_OK;
         }
-#endregion
-
-#region IPersistFileFormat Members
 
         int IPersistFileFormat.GetClassID(out Guid clsid)
         {
@@ -5158,9 +5115,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             // TODO: turn file watcher back on.
             return VSConstants.S_OK;
         }
-#endregion
-
-#region IVsProject3 Members
 
         /// <summary>
         /// Callback from the additem dialog. Deals with adding new and existing items
@@ -5874,9 +5828,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return hr;
         }
 
-#endregion
-
-#region IVsProjectBuidSystem Members
         public virtual int SetHostObject(string targetName, string taskName, object hostObject)
         {
             Debug.Assert(targetName != null && taskName != null && this.buildProject != null && this.buildProject.Targets != null);
@@ -5934,10 +5885,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.S_OK;
         }
 
-#endregion
-
-#region IVsComponentUser methods
-
         /// <summary>
         /// Add Components to the Project.
         /// Used by the environment to add components specified by the user in the Component Selector dialog 
@@ -5974,9 +5921,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return VSConstants.S_OK;
         }
-#endregion
 
-#region IVsDependencyProvider Members
         public int EnumDependencies(out IVsEnumDependencies enumDependencies)
         {
             enumDependencies = new EnumDependencies(this.buildDependencyList);
@@ -5989,9 +5934,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.S_OK;
         }
 
-#endregion
-
-#region IVsSccProject2 Members
         /// <summary>
         /// This method is called to determine which files should be placed under source control for a given VSITEMID within this hierarchy.
         /// </summary>
@@ -6159,10 +6101,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-#endregion
-
-#region IVsProjectSpecialFiles Members
-
 
         /// <summary>
         /// Allows you to query the project for special files and optionally create them. 
@@ -6223,10 +6161,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.E_NOTIMPL;
         }
 
-#endregion
-
-#region IAggregatedHierarchy Members
-
         /// <summary>
         /// Get the inner object of an aggregated hierarchy
         /// </summary>
@@ -6235,10 +6169,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return this;
         }
-
-#endregion
-
-#region IBuildDependencyUpdate Members
 
         public virtual IVsBuildDependency[] BuildDependencies
         {
@@ -6274,9 +6204,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-#endregion
-
-#region IReferenceDataProvider Members
         /// <summary>
         /// Returns the reference container node.
         /// </summary>
@@ -6286,17 +6213,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return this.FindChild(ReferenceContainerNode.ReferencesNodeVirtualName) as IReferenceContainer;
         }
 
-#endregion
-
-#region IProjectEventsListener Members
         public bool IsProjectEventsListener
         {
             get { return this.isProjectEventsListener; }
             set { this.isProjectEventsListener = value; }
         }
-#endregion
-
-#region IProjectEventsProvider Members
 
         /// <summary>
         /// Defines the provider for the project events
@@ -6320,10 +6241,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-
-#endregion
-
-#region IVsAggregatableProject Members
 
         /// <summary>
         /// Retrieve the list of project GUIDs that are aggregated together to make this project.
@@ -6405,10 +6322,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.E_NOTIMPL;
         }
 
-#endregion
-
-#region IVsProjectFlavorCfgProvider Members
-
         int IVsProjectFlavorCfgProvider.CreateProjectFlavorCfg(IVsCfg pBaseProjectCfg, out IVsProjectFlavorCfg ppFlavorCfg)
         {
             // Our config object is also our IVsProjectFlavorCfg object
@@ -6416,10 +6329,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-
-#endregion
-
-#region IVsBuildPropertyStorage Members
 
         /// <summary>
         /// Get the property of an item
@@ -6527,9 +6436,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.S_OK;
         }
 
-#endregion
-
-        #region IVsProjectUpgrade
         public int UpgradeProject(uint grfUpgradeFlags)
         {
             var hasTargetFramework = IsTargetFrameworkInstalled();
@@ -6540,9 +6446,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             // VSConstants.OLE_E_PROMPTSAVECANCELLED causes the shell to leave project unloaded
             return hasTargetFramework ? VSConstants.S_OK : VSConstants.OLE_E_PROMPTSAVECANCELLED;
         }
-        #endregion
-
-        #region private helper methods
 
         /// <summary>
         /// Initialize projectNode
@@ -6844,8 +6747,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             element[id] = xmlText;
         }
-
-#endregion
 
         public bool IsProjectOpened { get { return this.projectOpened;  } }
         internal ExtensibilityEventsHelper ExtensibilityEventsHelper 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectPackage.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectPackage.cs
@@ -22,14 +22,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [CLSCompliant(false)]
     public abstract class ProjectPackage : Microsoft.VisualStudio.Shell.Package
     {
-        #region fields
         /// <summary>
         /// This is the place to register all the solution listeners.
         /// </summary>
         private List<SolutionListener> solutionListeners = new List<SolutionListener>();
-        #endregion
 
-        #region properties
         /// <summary>
         /// Add your listener to this list. They should be added in the overridden Initialize befaore calling the base.
         /// </summary>
@@ -40,9 +37,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.solutionListeners;
             }
         }
-        #endregion
 
-        #region methods
         protected override void Initialize()
         {
             base.Initialize();
@@ -80,6 +75,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 base.Dispose(disposing);
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectReferenceNode.cs
@@ -24,8 +24,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [CLSCompliant(false), ComVisible(true)]
     public class ProjectReferenceNode : ReferenceNode
     {
-        #region fieds
-
         /// <summary>
         /// Containes either null if project reference is OK or instance of Task with error message if project reference is invalid
         /// i.e. project A references project B when target framework version for B is higher that for A
@@ -66,10 +64,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
         private bool enableCaching;
         private string cachedReferencedProjectOutputPath;
-
-        #endregion
-
-        #region properties
 
         internal bool EnableCaching
         {
@@ -505,9 +499,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return projectReference;
             }
         }
-        #endregion
 
-        #region ctors
         /// <summary>
         /// Constructor for the ReferenceNode. It is called when the project is reloaded, when the project element representing the refernce exists. 
         /// </summary>
@@ -603,9 +595,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.buildDependency = new BuildDependency(this.ProjectMgr, this.referencedProjectGuid);
 
         }
-        #endregion
 
-        #region methods
         public /*protected, but public for FSharp.Project.dll*/ override NodeProperties CreatePropertiesObject()
         {
             return new ProjectReferencesProperties(this);
@@ -901,8 +891,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return string.Format(CultureInfo.CurrentCulture, SR.GetString(SR.ProjectReferencesDifferentFramework, CultureInfo.CurrentUICulture), referencedProjectName, currentFrameworkName.Identifier, otherFrameworkName.Identifier);
         }
-
-        #endregion
 
         enum FrameworkCompatibility
         {

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectReferenceNode.cs
@@ -536,9 +536,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
-        /// <summary>
-        /// constructor for the ProjectReferenceNode
-        /// </summary>
         internal ProjectReferenceNode(ProjectNode root, string referencedProjectName, string projectPath, string projectReference)
             : base(root)
         {

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectSystem.Base.csproj
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectSystem.Base.csproj
@@ -137,7 +137,6 @@
     <Compile Include="FileNode.cs" />
     <Compile Include="DependentFileNode.cs" />
     <Compile Include="FolderNode.cs" />
-    <Compile Include="GlobalPropertyHandler.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="HierarchyNode.cs" />
     <Compile Include="ImageHandler.cs" />

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/PropertiesEditorLauncher.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/PropertiesEditorLauncher.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     {
         private ServiceProvider serviceProvider;
 
-        #region ctor
         public PropertiesEditorLauncher(ServiceProvider serviceProvider)
         {
             if (serviceProvider == null)
@@ -31,8 +30,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             this.serviceProvider = serviceProvider;
         }
-        #endregion
-        #region overridden methods
+
         /// <summary>
         /// Launch the Project Properties Editor (properties pages)
         /// </summary>
@@ -52,7 +50,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return false;
         }
-        #endregion
 
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ReferenceContainerNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ReferenceContainerNode.cs
@@ -32,20 +32,15 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [CLSCompliant(false), ComVisible(true)]
     public class ReferenceContainerNode : HierarchyNode, IReferenceContainer
     {
-        #region fields
         /*internal, but public for FSharp.Project.dll*/ public const string ReferencesNodeVirtualName = "References";
         private List<ProjectReferenceNode> projectReferencesWithEnabledCaching = new List<ProjectReferenceNode>();
-        #endregion
         
-        #region ctor
         internal ReferenceContainerNode(ProjectNode root) : base(root)
         {
             this.VirtualNodeName = ReferencesNodeVirtualName;
             this.ExcludeNodeFromScc = true;
         }
-        #endregion
 
-        #region Properties
         private static string[] supportedReferenceTypes = new string[] {
             ProjectFileConstants.ProjectReference,
             ProjectFileConstants.Reference,
@@ -55,9 +50,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get { return supportedReferenceTypes; }
         }
-        #endregion
 
-        #region overridden properties
         public override int SortPriority
         {
             get 
@@ -104,10 +97,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return references;
             }
         }
-
-        #endregion
-
-        #region overridden methods
 
         public override void AddChild(HierarchyNode node)
         {
@@ -255,8 +244,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return false;
         }
 
-        #endregion
-
         public void BeginBatchUpdate()
         {
             foreach (var r in EnumReferences())
@@ -274,7 +261,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             projectReferencesWithEnabledCaching.Clear();
         }
 
-        #region IReferenceContainer
         public IList<ReferenceNode> EnumReferences()
         {
             List<ReferenceNode> refs = new List<ReferenceNode>();
@@ -478,7 +464,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return node;
         }
-        #endregion
 
         private void EnableCachingForProjectReferencesInBatchUpdate(HierarchyNode node)
         {
@@ -490,7 +475,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             projectReferencesWithEnabledCaching.Add(projectReference);
         }
 
-        #region virtual methods
         internal virtual ReferenceNode CreateReferenceNode(string referenceType, ProjectElement element, BuildResult buildResult)
         {
             ReferenceNode node = null;
@@ -533,9 +517,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return node;
         }
-        #endregion
 
-        #region Helper functions to add references
         /// <summary>
         /// Creates a project reference node given an existing project element.
         /// </summary>
@@ -699,7 +681,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             ComReferenceNode node = new ComReferenceNode(this.ProjectMgr, selectorData);
             return node;
         }
-        #endregion
-
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ReferenceNode.cs
@@ -27,18 +27,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     {
         public /*protected, but public for FSharp.Project.dll*/ delegate void CannotAddReferenceErrorMessage();
 
-        /// <summary>
-        /// constructor for the ReferenceNode
-        /// </summary>
         internal ReferenceNode(ProjectNode root, ProjectElement element)
             : base(root, element)
         {
             this.ExcludeNodeFromScc = true;
         }
 
-        /// <summary>
-        /// constructor for the ReferenceNode
-        /// </summary>
         internal ReferenceNode(ProjectNode root)
             : base(root)
         {

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ReferenceNode.cs
@@ -27,7 +27,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     {
         public /*protected, but public for FSharp.Project.dll*/ delegate void CannotAddReferenceErrorMessage();
 
-        #region ctors
         /// <summary>
         /// constructor for the ReferenceNode
         /// </summary>
@@ -46,9 +45,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.ExcludeNodeFromScc = true;
         }
 
-        #endregion
-
-        #region overridden properties
         public override int MenuCommandId
         {
             get { return VsMenus.IDM_VS_CTXT_REFERENCE; }
@@ -74,9 +70,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return String.Empty;
             }
         }
-        #endregion
 
-        #region overridden methods
         public /*protected, but public for FSharp.Project.dll*/ override NodeProperties CreatePropertiesObject()
         {
             return new ReferenceNodeProperties(this);
@@ -204,10 +198,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return base.ExecCommandOnNode(cmdGroup, cmd, nCmdexecopt, pvaIn, pvaOut);
 
         }
-
-        #endregion
-
-        #region  methods
 
         /// <summary>
         /// If this is a managed assembly that has been resolved, its simple name.  Else if this is project reference, the filename (sans path/extension).  Else string.Empty.
@@ -381,9 +371,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         }
 
         public /*protected, but public for FSharp.Project.dll*/ abstract void BindReferenceData();
-
-        #endregion
-
     }
 
     internal class AddReferenceCheckResult

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SelectionListener.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SelectionListener.cs
@@ -87,9 +87,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.E_NOTIMPL;
         }
 
-        /// <summary>
-        /// The IDispose interface Dispose method for disposing the object determinastically.
-        /// </summary>
         public void Dispose()
         {
             this.Dispose(true);

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SelectionListener.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SelectionListener.cs
@@ -25,7 +25,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
     internal abstract class SelectionListener : IVsSelectionEvents, IDisposable
     {
-        #region fields
         private uint eventsCookie = (uint)ShellConstants.VSCOOKIE_NIL;
         private IVsMonitorSelection monSel = null;
         private ServiceProvider serviceProvider = null;
@@ -34,9 +33,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// Defines an object that will be a mutex for this object for synchronizing thread calls.
         /// </summary>
         private static volatile object Mutex = new object();
-        #endregion
 
-        #region ctors
         public /*protected, but public for FSharp.Project.dll*/ SelectionListener(ServiceProvider serviceProvider)
         {
 
@@ -50,9 +47,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 throw new InvalidOperationException();
             }
         }
-        #endregion
 
-        #region properties
         public /*protected, but public for FSharp.Project.dll*/ uint EventsCookie
         {
             get
@@ -76,9 +71,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.serviceProvider;
             }
         }
-        #endregion
-
-        #region IVsSelectionEvents Members
 
         public virtual int OnCmdUIContextChanged(uint dwCmdUICookie, int fActive)
         {
@@ -95,9 +87,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.E_NOTIMPL;
         }
 
-        #endregion
-
-        #region IDisposable Members
         /// <summary>
         /// The IDispose interface Dispose method for disposing the object determinastically.
         /// </summary>
@@ -106,9 +95,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
-        #endregion
 
-        #region methods
         public void Init()
         {
             if (this.SelectionMonitor != null)
@@ -142,7 +129,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
-
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SingleFileGenerator.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SingleFileGenerator.cs
@@ -22,14 +22,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     internal class SingleFileGenerator : ISingleFileGenerator, IVsGeneratorProgress
     {
 
-        #region fields
         private bool gettingCheckoutStatus;
         private bool runningGenerator;
         private bool hasRunGenerator = false;
         private ProjectNode projectMgr;
-        #endregion
 
-        #region ctors
         /// <summary>
         /// Overloadde ctor.
         /// </summary>
@@ -38,9 +35,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             this.projectMgr = projectMgr;
         }
-        #endregion
-
-        #region IVsGeneratorProgress Members
 
         public virtual int GeneratorError(int warning, uint level, string err, uint line, uint col)
         {
@@ -52,9 +46,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.E_NOTIMPL;
         }
 
-        #endregion
-
-        #region ISingleFileGenerator
         /// <summary>
         /// Runs the generator on the current project item.
         /// </summary>
@@ -83,9 +74,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
         
-        #region virtual methods
         /// <summary>
         /// Invokes the specified generator
         /// </summary>
@@ -305,9 +294,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return filePath;
         }
-        #endregion
 
-        #region helpers
         /// <summary>
         /// Returns the buffer contents for a moniker.
         /// </summary>
@@ -466,12 +453,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return (ret == 1);
         }
-        #endregion
-        
 
-
-
-        #region QueryEditQuerySave helpers
         /// <summary>
         /// This function asks to the QueryEditQuerySave service if it is possible to
         /// edit the file.
@@ -525,7 +507,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return false;
         }        
-        #endregion
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SingleFileGeneratorFactory.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SingleFileGeneratorFactory.cs
@@ -23,27 +23,21 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal class SingleFileGeneratorFactory : IVsSingleFileGeneratorFactory
     {
-        #region nested types
         private class GeneratorMetaData
         {
-            #region fields
             private Guid generatorClsid = Guid.Empty;
             private int generatesDesignTimeSource = -1;
             private int generatesSharedDesignTimeSource = -1;
             private int useDesignTimeCompilationFlag = -1;
             object generator = null;
-            #endregion
 
-            #region ctor
             /// <summary>
             /// Constructor
             /// </summary>
             public GeneratorMetaData()
             {
             }
-            #endregion
 
-            #region Public Properties
             /// <summary>
             /// Generator instance
             /// </summary>
@@ -118,11 +112,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     generatorClsid = value;
                 }
             }
-            #endregion
         }
-        #endregion
 
-        #region fields
         /// <summary>
         /// Base generator registry key for MPF based project
         /// </summary>
@@ -162,9 +153,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// A service provider
         /// </summary>
         private System.IServiceProvider serviceProvider;
-        #endregion
 
-        #region ctors
         /// <summary>
         /// Constructor for SingleFileGeneratorFactory
         /// </summary>
@@ -175,9 +164,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.projectType = projectType;
             this.serviceProvider = serviceProvider;
         }
-        #endregion
 
-        #region properties
         /// <summary>
         /// Defines the project type guid of the associated project.
         /// </summary>
@@ -195,9 +182,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             get { return this.serviceProvider; }
             set { this.serviceProvider = value; }
         }
-        #endregion
 
-        #region IVsSingleFileGeneratorFactory Helpers
         /// <summary>
         /// Returns the project generator key under [VS-ConfigurationRoot]]\Generators
         /// </summary>
@@ -231,9 +216,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.serviceProvider.GetService(typeof(SLocalRegistry)) as ILocalRegistry;
             }
         }
-        #endregion
 
-        #region IVsSingleFileGeneratorFactory Members
         /// <summary>
         /// Creates an instance of the single file generator requested
         /// </summary>
@@ -353,8 +336,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-        #endregion
-
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SingleFileGeneratorFactory.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SingleFileGeneratorFactory.cs
@@ -31,9 +31,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             private int useDesignTimeCompilationFlag = -1;
             object generator = null;
 
-            /// <summary>
-            /// Constructor
-            /// </summary>
             public GeneratorMetaData()
             {
             }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListener.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListener.cs
@@ -25,8 +25,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
     internal abstract class SolutionListener : IVsSolutionEvents3, IVsSolutionEvents4, IDisposable
     {
-
-        #region fields
         private uint eventsCookie = (uint)ShellConstants.VSCOOKIE_NIL;
         private IVsSolution solution = null;
         private IServiceProvider serviceProvider = null;
@@ -35,9 +33,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// Defines an object that will be a mutex for this object for synchronizing thread calls.
         /// </summary>
         private static volatile object Mutex = new object();
-        #endregion
 
-        #region ctors
         public /*protected, but public for FSharp.Project.dll*/ SolutionListener(IServiceProvider serviceProvider)
         {
 
@@ -51,9 +47,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 throw new InvalidOperationException();
             }
         }
-        #endregion
 
-        #region properties
         public /*protected, but public for FSharp.Project.dll*/ uint EventsCookie
         {
             get
@@ -77,9 +71,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return this.serviceProvider;
             }
         }
-        #endregion
 
-        #region IVsSolutionEvents3, IVsSolutionEvents2, IVsSolutionEvents methods
         public virtual int OnAfterCloseSolution(object reserved)
         {
             return VSConstants.E_NOTIMPL;
@@ -154,9 +146,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return VSConstants.E_NOTIMPL;
         }
-        #endregion
 
-        #region IVsSolutionEvents4 methods
         public virtual int OnAfterAsynchOpenProject(IVsHierarchy hierarchy, int added)
         {
             return VSConstants.E_NOTIMPL;
@@ -179,9 +169,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             return VSConstants.E_NOTIMPL;
         }
-        #endregion
-
-        #region Dispose        
 
         /// <summary>
         /// The IDispose interface Dispose method for disposing the object determinastically.
@@ -192,9 +179,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             GC.SuppressFinalize(this);
         }
 
-        #endregion
-
-        #region methods
         public void Init()
         {
             if (this.solution != null)
@@ -228,6 +212,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListener.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListener.cs
@@ -170,9 +170,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return VSConstants.E_NOTIMPL;
         }
 
-        /// <summary>
-        /// The IDispose interface Dispose method for disposing the object determinastically.
-        /// </summary>
         public void Dispose()
         {
             this.Dispose(true);

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListenerForBuildDependencyUpdate.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListenerForBuildDependencyUpdate.cs
@@ -29,13 +29,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal class SolutionListenerForBuildDependencyUpdate : SolutionListener
     {
-        #region ctors
         public SolutionListenerForBuildDependencyUpdate(IServiceProvider serviceProvider) : base(serviceProvider)
         {
         }
-        #endregion
 
-        #region overridden methods
         /// <summary>
         /// Update build dependency list if solution is fully loaded
         /// </summary>
@@ -77,9 +74,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-        #endregion
 
-        #region Helper methods
         /// <summary>
         /// Update dependency list
         /// </summary>
@@ -173,9 +168,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             NestedProjectBuildDependency dependency = new NestedProjectBuildDependency(nestedProject);
             projectContainer.AddBuildDependency(dependency);
         }
-
-        #endregion
-
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListenerForProjectEvents.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListenerForProjectEvents.cs
@@ -27,7 +27,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal class SolutionListenerForProjectEvents : SolutionListener, IProjectEvents
     {
-        #region events
         /// <summary>
         /// Event raised just after the project file opened.
         /// </summary>
@@ -37,16 +36,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// Event raised before the project file closed.
         /// </summary>
         public event EventHandler<BeforeProjectFileClosedEventArgs> BeforeProjectFileClosed;
-        #endregion
 
-        #region ctor
         /*internal, but public for FSharp.Project.dll*/ public SolutionListenerForProjectEvents(IServiceProvider serviceProvider)
             : base(serviceProvider)
         {
         }
-        #endregion
 
-        #region overridden methods
         public override int OnAfterOpenProject(IVsHierarchy hierarchy, int added)
         {
             IProjectEventsListener projectEventListener = hierarchy as IProjectEventsListener;
@@ -68,9 +63,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return VSConstants.S_OK;
         }
-        #endregion
 
-        #region helpers
         /// <summary>
         /// Raises after project file opened event.
         /// </summary>
@@ -102,5 +95,4 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
     }
-    #endregion
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListenerForProjectReferenceUpdate.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/SolutionListenerForProjectReferenceUpdate.cs
@@ -25,14 +25,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
     internal class SolutionListenerForProjectReferenceUpdate : SolutionListener
     {
-        #region ctor
         public SolutionListenerForProjectReferenceUpdate(IServiceProvider serviceProvider)
             : base(serviceProvider)
         {
         }
-        #endregion
-
-        #region overridden methods
 
         /// <summary>
         /// Notifies listening clients that the project has been opened. 
@@ -188,9 +184,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
         }
 
-        #endregion
-
-        #region helper methods
         private List<ProjectReferenceNode> GetProjectReferencesContainingThisProject(IVsHierarchy inputHierarchy)
         {
             List<ProjectReferenceNode> projectReferences = new List<ProjectReferenceNode>();
@@ -268,6 +261,5 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return null;
 
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/StructuresEnums.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/StructuresEnums.cs
@@ -17,7 +17,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
-    #region structures
     [StructLayoutAttribute(LayoutKind.Sequential)]
     internal struct _DROPFILES
     {
@@ -27,9 +26,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         public Int32 fNC;
         public Int32 fWide;
     }
-    #endregion
 
-    #region enums
     /// <summary>
     /// Defines possible types of output that can produced by a language project
     /// </summary>
@@ -343,15 +340,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         SqmSessionGuid
     }
 
-	#endregion
-
     public class AfterProjectFileOpenedEventArgs : EventArgs
     {
-        #region fields
         private bool added;
-        #endregion
 
-        #region properties
         /// <summary>
         /// True if the project is added to the solution after the solution is opened. false if the project is added to the solution while the solution is being opened.
         /// </summary>
@@ -360,23 +352,17 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get { return this.added; }
         }
-        #endregion
 
-        #region ctor
         /*internal, but public for FSharp.Project.dll*/ public AfterProjectFileOpenedEventArgs(bool added)
         {
             this.added = added;
         }
-        #endregion
     }
 
     public class BeforeProjectFileClosedEventArgs : EventArgs
     {
-        #region fields
         private bool removed;
-        #endregion
 
-        #region properties
         /// <summary>
         /// true if the project was removed from the solution before the solution was closed. false if the project was removed from the solution while the solution was being closed.
         /// </summary>
@@ -385,14 +371,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get { return this.removed; }
         }
-        #endregion
 
-        #region ctor
         /*internal, but public for FSharp.Project.dll*/ public BeforeProjectFileClosedEventArgs(bool removed)
         {
             this.removed = removed;
         }
-        #endregion
     }
 
     /// <summary>
@@ -418,7 +401,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal class FileChangedOnDiskEventArgs : EventArgs
     {
-        #region Private fields
         /// <summary>
         /// File name that was changed on disk.
         /// </summary>
@@ -433,7 +415,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// The reason the file has changed on disk.
         /// </summary>
         private _VSFILECHANGEFLAGS fileChangeFlag;
-        #endregion
 
         /// <summary>
         /// Constructs a new event args.
@@ -489,12 +470,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal class ActiveConfigurationChangedEventArgs : EventArgs
     {
-        #region Private fields
         /// <summary>
         /// The hierarchy whose configuration has changed 
         /// </summary>
         private IVsHierarchy hierarchy;
-        #endregion
 
         /// <summary>
         /// Constructs a new event args.

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/TokenProcessor.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/TokenProcessor.cs
@@ -27,14 +27,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     [CLSCompliant(false)]
     public class TokenProcessor
     {
-        #region fields
         // Internal fields
         private ArrayList tokenlist;
 
-
-        #endregion
-
-        #region Initialization
         /// <summary>
         /// Constructor
         /// </summary>
@@ -81,9 +76,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             tokenlist.Add(new DeleteToken(tokenToDelete));
         }
-        #endregion
 
-        #region TokenProcessing
         /// <summary>
         /// For all known token, replace token with correct value
         /// </summary>
@@ -158,9 +151,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             buffer = System.Text.RegularExpressions.Regex.Replace(buffer, regularExp, rpBetweenToken.TokenReplacement);
         }
 
-        #endregion
-
-        #region Guid generators
         /// <summary>
         /// Generates a string representation of a guid with the following format:
         /// 0x01020304, 0x0506, 0x0708, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10
@@ -250,9 +240,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             return ResultingStr.ToString();
         }
-        #endregion
 
-        #region Helper Methods
         /// <summary>
         /// This function will accept a subset of the characters that can create an
         /// identifier name: there are other unicode char that can be inside the name, but
@@ -370,8 +358,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
             return result.ToString();
         }
-        #endregion
-
     }
 
     /// <summary>

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/TokenProcessor.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/TokenProcessor.cs
@@ -30,9 +30,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         // Internal fields
         private ArrayList tokenlist;
 
-        /// <summary>
-        /// Constructor
-        /// </summary>
         public TokenProcessor()
         {
             tokenlist = new ArrayList();

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/TrackDocumentsHelper.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/TrackDocumentsHelper.cs
@@ -28,22 +28,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
     /// </summary>
     internal class TrackDocumentsHelper
     {
-        #region fields
         private ProjectNode projectMgr;
-        #endregion
 
-        #region properties
-
-        #endregion
-
-        #region ctors
         /*internal, but public for FSharp.Project.dll*/ public TrackDocumentsHelper(ProjectNode project)
         {
             this.projectMgr = project;
         }
-        #endregion
 
-        #region helper methods
         /// <summary>
         /// Gets the IVsTrackProjectDocuments2 object by asking the service provider for it.
         /// </summary>
@@ -175,7 +166,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 ErrorHandler.ThrowOnFailure(this.GetIVsTrackProjectDocuments2().OnAfterRenameFile(projectMgr.InteropSafeIVsProject, strOldName, strNewName, flag));
             }
         }
-        #endregion
     }
 }
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Url.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Url.cs
@@ -296,7 +296,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             get { return this.uri; }
         }
 
-        // <include file='doc\Utilities.uex' path='docs/doc[@for="Url.Segments"]/*' />
         // Unlike the Uri class, this ALWAYS succeeds, even on relative paths, and it
         // strips out the path separator characters
         

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Utilities.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Utilities.cs
@@ -127,7 +127,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return active != 0;
         }
 
-        /// <include file='doc\VsShellUtilities.uex' path='docs/doc[@for="Utilities.IsInAutomationFunction"]/*' />
         /// <devdoc>
         /// Is an extensibility object executing an automation function.
         /// </devdoc>

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/VSMDCodeDomProvider.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/VSMDCodeDomProvider.cs
@@ -22,11 +22,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             this.provider = provider;
         }
 
-        #region IVSMDCodeDomProvider Members
         object IVSMDCodeDomProvider.CodeDomProvider
         {
             get { return provider; }
         }
-        #endregion
     }
 }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/RegistrationAttributes/WebSiteProjectAttribute.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/RegistrationAttributes/WebSiteProjectAttribute.cs
@@ -32,18 +32,13 @@ namespace Microsoft.VisualStudio.Shell
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public sealed class WebSiteProjectAttribute : RegistrationAttribute
     {
-        #region Constants
         private const string webSiteProjectGuid = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
         private const string websitePackageGuid = "{39c9c826-8ef8-4079-8c95-428f5b1c323f}";
-        #endregion
 
-        #region Fields
         private Type packageType;
         private string languageID;
         private string languageName;
-        #endregion
 
-        #region Constructors
         /// <summary>
         /// Creates a new WebSiteProjectAttribute attribute to register a 
         /// language with the web site project 
@@ -65,9 +60,7 @@ namespace Microsoft.VisualStudio.Shell
             this.languageName = languageName;
 
         }
-        #endregion
 
-        #region Properties
         /// <summary>
         /// Gets the Language ID which is being referenced from the vstemplate
         /// </summary>
@@ -123,9 +116,7 @@ namespace Microsoft.VisualStudio.Shell
             key.Close();
             return vsInstallDir;
         }
-        #endregion
 
-        #region Methods
         /// <summary>
         /// Called to register this attribute with the given context.  The context
         /// contains the location where the registration information should be placed.
@@ -174,7 +165,6 @@ namespace Microsoft.VisualStudio.Shell
                 context.RemoveKey(string.Format(CultureInfo.InvariantCulture, "{0}\\{1}", ProjectTemplatesDir, languageID));
             }
         }
-        #endregion
     }
 }
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/RegistrationAttributes/WebSiteProjectRelatedFilesAttribute.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/RegistrationAttributes/WebSiteProjectRelatedFilesAttribute.cs
@@ -28,18 +28,12 @@ namespace Microsoft.VisualStudio.Shell
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public sealed class WebSiteProjectRelatedFilesAttribute : RegistrationAttribute
     {
-        #region Constants
         private const string webSiteProjectGuid = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
-        #endregion
 
-        #region Fields
         //private Type packageType;
         private string primaryFileExtension;
         private string relatedFileExtension;
-        #endregion
         
-        #region Constructors
-
         /// <summary>
         /// Creates a new WebSiteProjectAttribute attribute to register a 
         /// language with the web site project 
@@ -69,9 +63,7 @@ namespace Microsoft.VisualStudio.Shell
             this.relatedFileExtension = relatedFileExtension;
 
         }
-        #endregion
 
-        #region Properties
         /// <summary>
         /// Gets the primary file extension which will nest files
         /// </summary>
@@ -100,9 +92,6 @@ namespace Microsoft.VisualStudio.Shell
             }
         }
 
-        #endregion
-
-        #region Methods
         /// <summary>
         /// Called to register this attribute with the given context.  The context
         /// contains the location where the registration information should be placed.
@@ -134,7 +123,6 @@ namespace Microsoft.VisualStudio.Shell
             }
 
         }
-        #endregion
     }
 }
 #endif

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/RegistrationAttributes/WebSiteProjectRelatedFilesAttribute.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/RegistrationAttributes/WebSiteProjectRelatedFilesAttribute.cs
@@ -30,7 +30,6 @@ namespace Microsoft.VisualStudio.Shell
     {
         private const string webSiteProjectGuid = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
 
-        //private Type packageType;
         private string primaryFileExtension;
         private string relatedFileExtension;
         

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/AppConfigHelper.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/AppConfigHelper.fs
@@ -180,7 +180,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             Debug.Assert(document <> null, "Null XmlDocument?")
             document
             
-        // #region IDisposable
         interface IDisposable with
             member x.Dispose() =
                 if rdtCookie <> 0u && rdtFlags <> _VSRDTFLAGS.RDT_NoLock then
@@ -188,7 +187,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     rdt.UnlockDocument((uint32 rdtFlags) ||| (uint32 _VSRDTFLAGS.RDT_Unlock_SaveIfDirty), rdtCookie) |> ignore
                     rdtCookie <- 0u
         
-        // #endregion
 
     // This type provides a wrapper around the app.config file and provides methods to update
     // the config file with framework moniker information.

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
@@ -720,8 +720,6 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
 #if DESIGNER                
                 this.AddCATIDMapping(typeof<OAFSharpFileItem>, typeof<OAFSharpFileItem>.GUID)
 #endif
-                // The following are not specific to F# and as such we need a separate GUID (we simply used guidgen.exe to create new guids)
-
                 // This one we use the same as F# file nodes since both refer to files
                 this.AddCATIDMapping(typeof<FileNodeProperties>, typeof<FSharpFileNodeProperties>.GUID)
                 this.AddCATIDMapping(typeof<ProjectConfigProperties>, typeof<ProjectConfigProperties>.GUID)

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
@@ -354,9 +354,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 kvp.Value.Invoke()
         member this.Advise(callbackOwnerKey, callback) =
             notificationsDict.[callbackOwnerKey] <- callback
-// REVIEW: This is not currently used. Leaving it commented out in case we want to revive it.          
-//        member this.Unadvise(callbackOwnerKey) =  
-//            notificationsDict.Remove(callbackOwnerKey) |> ignore
 
     // Used to get us sorted appropriately with the other MSFT products in the splash screen and about box
     [<Guid("591E80E4-5F44-11d3-8BDC-00C04F8EC28C")>]
@@ -724,7 +721,6 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
                 this.AddCATIDMapping(typeof<OAFSharpFileItem>, typeof<OAFSharpFileItem>.GUID)
 #endif
                 // The following are not specific to F# and as such we need a separate GUID (we simply used guidgen.exe to create new guids)
-//                this.AddCATIDMapping(typeof<FolderNodeProperties>, new Guid("C5A0C252-8688-415D-9B1A-4334775CA4B3"))
 
                 // This one we use the same as F# file nodes since both refer to files
                 this.AddCATIDMapping(typeof<FileNodeProperties>, typeof<FSharpFileNodeProperties>.GUID)
@@ -1062,61 +1058,7 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
                     | _ -> String.Compare(node2.Caption, node1.Caption, true, CultureInfo.CurrentCulture)
                 else
                     node2.SortPriority - node1.SortPriority
-(*
-            /// <summary>
-            /// AddChild - add a node, sorted in the right location.
-            /// </summary>
-            /// <param name="node">The node to add.</param>
-            override fshProjNode.AddChild(node : HierarchyNode) =
-                // REVIEW: fix so files added to bottom, not sorted alpha
-                let this = fshProjNode
-                if node = null then
-                    raise <| new ArgumentNullException("node")
 
-                let map = this.ProjectMgr.ItemIdMap
-
-                // make sure the node is in the map.
-                let nodeWithSameID = this.ProjectMgr.ItemIdMap.[node.ID]
-                if not (Object.ReferenceEquals(node, nodeWithSameID)) then
-                    if (nodeWithSameID = null) && (int(node.ID) <= this.ProjectMgr.ItemIdMap.Count) then
-                        // reuse our hierarchy id if possible.
-                        this.ProjectMgr.ItemIdMap.SetAt(node.ID, this)
-                    else
-                        raise <| new InvalidOperationException()
-
-                let mutable previous = null : HierarchyNode
-                let mutable n = this.FirstChild
-                while n <> null && not (this.ProjectMgr.CompareNodes(node, n) > 0) do
-                    previous <- n
-                    n <- n.NextSibling
-                // insert "node" after "previous".
-                if previous <> null then
-                    node.NextSibling <- previous.NextSibling
-                    previous.NextSibling <- node
-                    if previous = this.LastChild then
-                        this.LastChild <- node
-                else
-                    if this.LastChild = null then
-                        this.LastChild <- node
-                    node.NextSibling <- this.FirstChild
-                    this.FirstChild <- node
-                node.Parent <- this
-                this.OnItemAdded(this, node)
-                ()
-*)
-(*
-            override x.IsItemTypeFileType(typ:string) =
-                if not (base.IsItemTypeFileType(typ)) then 
-                    if (String.Compare(typ, "Page", StringComparison.OrdinalIgnoreCase) = 0
-                     || String.Compare(typ, "ApplicationDefinition", StringComparison.OrdinalIgnoreCase) = 0
-                     || String.Compare(typ, "Resource", StringComparison.OrdinalIgnoreCase) = 0) then 
-                        true
-                    else
-                        false
-                else
-                    //This is a well known item node type, so return true.
-                    true
-*)
             override x.CreatePropertiesObject() : NodeProperties = 
                 (new FSharpProjectNodeProperties(this) :> NodeProperties)
 
@@ -2041,7 +1983,6 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
                     guidEditorType <- GuidList.guidEditorFactory
                     VSConstants.S_OK
 
-            // #region IVsProjectSpecificEditorMap2 Members
             interface IVsProjectSpecificEditorMap2 with 
                 member x.GetSpecificEditorProperty(_mkDocument:string, _propid:int, result: byref<obj>) =
                     // initialize output params
@@ -2320,17 +2261,6 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
             with get() = this.Node.ProjectMgr.GetProjectProperty(ProjectFileConstants.RootNamespace)
             and set(value) = this.Node.ProjectMgr.SetProjectProperty(ProjectFileConstants.RootNamespace, value)
 
-//  REVIEW Temporarily dispabling these until further work can be done.    
-//        [<Browsable(false)>]
-//        member this.ApplicationIcon
-//            with get() = this.Node.ProjectMgr.GetProjectProperty(ProjectFileConstants.ApplicationIcon)
-//            and set(value) = this.Node.ProjectMgr.SetProjectProperty(ProjectFileConstants.ApplicationIcon, value)
-//            
-//        [<Browsable(false)>]
-//        member this.ApplicationManifest 
-//            with get() = this.Node.ProjectMgr.GetProjectProperty(ProjectFileConstants.ApplicationManifest)
-//            and set(value) = this.Node.ProjectMgr.SetProjectProperty(ProjectFileConstants.ApplicationManifest, value)
-//            
         [<Browsable(false)>]
         member this.Win32ResourceFile
             with get() = this.Node.ProjectMgr.GetProjectProperty(ProjectFileConstants.Win32Resource)

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/ProjectPrelude.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/ProjectPrelude.fs
@@ -387,7 +387,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 #endif
 
     module internal Attributes = 
-        //[<assembly: System.Security.SecurityTransparent>]
 #if NO_ASSEM_ATTRS_YET    
         //
         // General Information about an assembly is controlled through the following 

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
@@ -32,7 +32,6 @@ open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.TextManager.Interop
 
 module internal AssemblyAttributes = 
-    //[<assembly: System.Security.SecurityTransparent>]
     [<assembly:ComVisible(true)>]
     do()
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiLanguageService.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiLanguageService.fs
@@ -62,7 +62,6 @@ type internal FsiDeclarations(items : (string*string*string*int)[] ) =
 // Methods
 type internal FsiMethods() =
     inherit Methods()
-    // let items = [|"Alpha";"Beta";"Gamma";"Saturn";"Zune"|] // For testing.
     let items = [| |]
     override this.GetCount() = items.Length
     override this.GetDescription(i) = items.[i]
@@ -167,8 +166,6 @@ module internal Helpers =
     let FsiKeyword =
         { new IVsColorableItem with 
             member x.GetDefaultColors(piForeground, piBackground) =
-                //Check.ArrayArgumentNotNullOrEmpty piForeground "piForeground"
-                //Check.ArrayArgumentNotNullOrEmpty piBackground "piBackground"
                 piForeground.[0] <- COLORINDEX.CI_BLUE
                 piBackground.[0] <- COLORINDEX.CI_USERTEXT_BK
                 VSConstants.S_OK
@@ -197,7 +194,6 @@ type internal FsiLanguageService() =
     member this.Sessions with set x = sessions <- Some x
     
     override this.GetLanguagePreferences() =
-        //System.Windows.Forms.MessageBox.Show("GetLanguagePrefs") |> ignore
         if preferences = null then
             preferences <- new LanguagePreferences(this.Site,
                                                    typeof<FsiLanguageService>.GUID,
@@ -207,13 +203,11 @@ type internal FsiLanguageService() =
         preferences
         
     override this.GetScanner(buffer:IVsTextLines) =
-        //System.Windows.Forms.MessageBox.Show("GetScanner") |> ignore
         if scanner = null then
             scanner <- (new FsiScanner(buffer) :> IScanner)
         scanner
         
     override this.ParseSource(req:ParseRequest) =
-        //System.Windows.Forms.MessageBox.Show("ParseSource") |> ignore
         (new FsiAuthoringScope(sessions,readOnlySpan) :> AuthoringScope)
                 
     override this.Name = "FSharpInteractive" // LINK: see ProvidePackage attribute on the package.

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
@@ -29,12 +29,6 @@ module internal Hooks =
 
     // This should be called from the Package ctor, to do unsited initialisation.
     let fsiConsoleWindowPackageCtorUnsited (this:Package) =        
-(*      // "Proffer the service"
-        let serviceContainer = this :> IServiceContainer
-        let langService = new FsiLanguageService()
-        langService.SetSite(this)        
-        serviceContainer.AddService(typeof<FsiLanguageService>,langService,true)
-*)
 
         // This seems an alternative to the boiler plate proffering above. Gives delayed creation?
         let callback  = fsiServiceCreatorCallback(this)

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -105,7 +105,6 @@ type internal FsiToolWindow() as this =
 
     // Remove: after next submit (passing through SD)       
     // vsTextManager did not seem to yield current selection...
-    // let vsTextManager  = Util.CreateObjectT<VsTextManagerClass,VsTextManager> provider
 
     // The IP sample called GetService() to obtain the LanguageService.
     let fsiLangService = provider.GetService(typeof<FsiLanguageService>) |> unbox : FsiLanguageService
@@ -477,20 +476,6 @@ type internal FsiToolWindow() as this =
 
     let onMLSend (sender:obj) (e:EventArgs) =       
         sendSelectionToFSI(false)
-(*
-        // Remove: after next submit (passing through SD)       
-        // The below did not work, so move to use Automatic API via DTE above...        
-        let vsTextManager  = Util.CreateObjectT<VsTextManagerClass,VsTextManager> provider
-        let res,view = vsTextManager.GetActiveView(0(*<--fMustHaveFocus=0/1*),null) // 
-        if res = VSConstants.S_OK then
-            let span = Array.zeroCreate<TextSpan> 1
-            view.GetSelectionSpan(span) |> throwOnFailure0
-            let span = span.[0]
-            let text = view.GetTextStream(span.iStartLine,span.iStartIndex,span.iEndLine,span.iEndIndex) |> throwOnFailure1
-            Windows.Forms.MessageBox.Show("EXEC:\n" + text) |> ignore
-        else        
-            Windows.Forms.MessageBox.Show("Could not find the 'active text view', error code = " + sprintf "0x%x" res) |> ignore
-*)
         
     /// Handle UP and DOWN. Cycle history.    
     let onHistory (sender:obj) (e:EventArgs) =

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/quickparse.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/quickparse.fs
@@ -38,7 +38,6 @@ module internal QuickParse =
             let hoverChar = line.[index]
             if not (IsLongIdentifierPartCharacter hoverChar) then 
                 // The character is not an identifier character. Return nothing
-                //JAMES: dprintf "GetIdentifierIsland returning None because hoverChar '%c' was not an identifier character: line=%s, index=%d\n" hoverChar line index
                 None
             else
                 let mutable left = index
@@ -47,10 +46,8 @@ module internal QuickParse =
                 while left>=0 && IsLongIdentifierPartCharacter line.[left] do left<-left-1
                 while right<len && IsIdentifierPartCharacter line.[right] do right<-right+1
                 let result = line.Substring(left+1,right-left-1)
-                //JAMES: dprintf "GetIdentifierIsland line=%s, index=%d, result=%s\n" line index result
                 Some(result)
         else
-            //JAMES: dprintf "GetIdentifierIsland returning None because index was out of range: line=%s, index=%d\n" line index
             None
     /// Get the partial long name of the identifier to the left of index.
     let GetPartialLongName(line:string,index) =

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/sessions.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/sessions.fs
@@ -272,9 +272,8 @@ let fsiProcess (procInfo:ProcessStartInfo) =
     // Fix 982: Force input to be written in UTF8 regardless of the apparent encoding.
     let inputWriter = new System.IO.StreamWriter(cmdProcess.StandardInput.BaseStream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier=false))
     inputWriter.AutoFlush <- false;
-    //System.Windows.Forms.MessageBox.Show (sprintf "sending in encoding %O=%d/%d, code page = %d\n" inputWriter.Encoding inputWriter.Encoding.CodePage  inputWriter.Encoding.WindowsCodePage   cmdProcess.StandardInput.Encoding.CodePage) |> ignore
+
     let send str = 
-        //System.Windows.Forms.MessageBox.Show (sprintf "sending '%s'" str) |> ignore
         inputWriter.WriteLine(str:string); 
         inputWriter.Flush()
     inE.Add(send);


### PR DESCRIPTION
This remove code regions.

there are lot of regions by access or type (like `#region field` or `#region ctor`) with few code inside.
The regions for implementation of interface are not really useful, visual studio helps
Regions also hide the code and problems, easier without

Others:

- removed include of not existing doc in comments (noise)
- redundant comments (``/// this is a constructor`` )
- commented code
- an empty file