### PR TITLE
fix app.config uptodate status

### DIFF
--- a/vsintegration/src/unittests/TestLib.Utils.fs
+++ b/vsintegration/src/unittests/TestLib.Utils.fs
@@ -47,6 +47,9 @@ module Asserts =
         | Some(msg) -> Assert.Fail(msg)
         | None -> ()
 
+    let AssertBuildSuccessful (result: Microsoft.VisualStudio.FSharp.ProjectSystem.BuildResult) =
+        Assert.IsTrue(result.IsSuccessful, "Expected build to succeed")
+
 module UIStuff =
     let SetupSynchronizationContext() =
         Microsoft.VisualStudio.FSharp.LanguageService.UIThread.InitUnitTestingMode()

--- a/vsintegration/src/unittests/Tests.ProjectSystem.UpToDate.fs
+++ b/vsintegration/src/unittests/Tests.ProjectSystem.UpToDate.fs
@@ -59,7 +59,7 @@ type UpToDate() =
             File.AppendAllText(embedPath, "some embedded resource")
 
             Assert.IsFalse(config.IsUpToDate(logger, true))
-            project.Build(configNameDebug, output, "Build") |> ignore
+            project.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(config.IsUpToDate(logger, true))
 
             // None items should not affect up-to-date (unless captured by well-known items, e.g. App.config)
@@ -111,7 +111,7 @@ type UpToDate() =
 
             project.SetConfiguration(config.ConfigCanonicalName);
             Assert.IsFalse(config.IsUpToDate(logger, true))
-            project.Build(configNameDebug, output, "Build") |> ignore
+            project.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(config.IsUpToDate(logger, true))
 
             for path in [verPath; keyPath] do
@@ -146,7 +146,7 @@ type UpToDate() =
             File.AppendAllText(absFilePath, "printfn \"hello\"")
 
             Assert.IsFalse(config.IsUpToDate(logger, true))
-            project.Build(configNameDebug, output, "Build") |> ignore
+            project.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(config.IsUpToDate(logger, true))
 
             // touch proj file
@@ -177,7 +177,7 @@ type UpToDate() =
             let config1 = project1.ConfigProvider.GetProjectConfiguration(configNameDebug)
 
             Assert.IsFalse(config1.IsUpToDate(logger, true))
-            project1.Build(configNameDebug, output, "Build") |> ignore
+            project1.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(config1.IsUpToDate(logger, true))
 
             let output1 = Path.Combine(project1.ProjectFolder, "bin\\debug", project1.OutputFileName)
@@ -196,7 +196,7 @@ type UpToDate() =
                 let startTime = DateTime.Now
 
                 Assert.IsFalse(config2.IsUpToDate(logger, true))
-                project2.Build(configNameDebug, output, "Build") |> ignore
+                project2.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
                 Assert.IsTrue(config2.IsUpToDate(logger, true))
 
                 // reference is updated
@@ -234,7 +234,7 @@ type UpToDate() =
             File.AppendAllText(sourcePath, "printfn \"hello\"")
 
             Assert.IsFalse(config.IsUpToDate(logger, true))
-            project.Build(configNameDebug, output, "Build") |> ignore
+            project.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(config.IsUpToDate(logger, true))
 
             let startTime = DateTime.Now
@@ -283,25 +283,25 @@ type UpToDate() =
             Assert.IsFalse(debugConfigAnyCPU.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigAnyCPU.IsUpToDate(logger, true))
 
-            project.Build(configNameDebugx86, output, "Build") |> ignore
+            project.Build(configNameDebugx86, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(debugConfigx86.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigx86.IsUpToDate(logger, true))
             Assert.IsFalse(debugConfigAnyCPU.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigAnyCPU.IsUpToDate(logger, true))
 
-            project.Build(configNameReleasex86, output, "Build") |> ignore
+            project.Build(configNameReleasex86, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(debugConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(releaseConfigx86.IsUpToDate(logger, true))
             Assert.IsFalse(debugConfigAnyCPU.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigAnyCPU.IsUpToDate(logger, true))
 
-            project.Build(configNameDebugAnyCPU, output, "Build") |> ignore
+            project.Build(configNameDebugAnyCPU, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(debugConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(releaseConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(debugConfigAnyCPU.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigAnyCPU.IsUpToDate(logger, true))
 
-            project.Build(configNameReleaseAnyCPU, output, "Build") |> ignore
+            project.Build(configNameReleaseAnyCPU, output, "Build") |> AssertBuildSuccessful
             Assert.IsTrue(debugConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(releaseConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(debugConfigAnyCPU.IsUpToDate(logger, true))

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
@@ -1197,7 +1197,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         public virtual int OpenOutputGroup(string szCanonicalName, out IVsOutputGroup ppIVsOutputGroup)
         {
             ppIVsOutputGroup = null;
-            // Search through our list of groups to find the one they are looking forgroupName
+            // Search through our list of groups to find the one they are looking for groupName
             foreach (OutputGroup group in OutputGroups)
             {
                 string groupName;
@@ -1458,7 +1458,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return null;
         }
 
-        internal bool GetUTDCheckInputs(ref HashSet<string> inputs)
+        internal bool GetUTDCheckInputs(HashSet<string> inputs)
         {
             // the project file itself
             inputs.Add(Utilities.CanonicalizeFileNameNoThrow(this.project.BuildProject.FullPath));
@@ -1527,8 +1527,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             return true;
         }
 
-        internal bool GetUTDCheckOutputs(ref HashSet<string> outputs, HashSet<string> inputs)
+        internal void GetUTDCheckOutputs(HashSet<string> inputs, HashSet<string> outputs, out List<Tuple<string, string>> preserveNewestOutputs)
         {
+            preserveNewestOutputs = new List<Tuple<string, string>>();
+
             // Output groups give us the paths to the following outputs
             //   result EXE or DLL in "obj" dir
             //   PDB file in "obj" dir (if project is configured to create this)
@@ -1546,15 +1548,29 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             var outputAssembly = this.project.GetOutputAssembly(this.ConfigCanonicalName);
             outputs.Add(Utilities.CanonicalizeFileNameNoThrow(outputAssembly));
 
+            bool isExe = outputAssembly.EndsWith(".exe", StringComparison.OrdinalIgnoreCase);
+
             // final PDB path
             if (this.DebugSymbols &&
-                (outputAssembly.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) || outputAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)))
+                (isExe || outputAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)))
             {
                 var pdbPath = outputAssembly.Remove(outputAssembly.Length - 4) + ".pdb";
                 outputs.Add(Utilities.CanonicalizeFileNameNoThrow(pdbPath));
             }
 
-            return true;
+            if (isExe)
+            {
+                var appConfig = inputs.FirstOrDefault(x => String.Compare(Path.GetFileName(x), "app.config", StringComparison.OrdinalIgnoreCase) == 0);
+                if (appConfig != null)
+                {
+                    // the app.config is not removed from the inputs to maintain 
+                    // the same behavior of a C# project:
+                    // When a app.config is changed, after the build, the project 
+                    // is not up-to-date until a rebuild
+                    var exeConfig = Utilities.CanonicalizeFileNameNoThrow(outputAssembly + ".config");
+                    preserveNewestOutputs.Add(Tuple.Create(appConfig, exeConfig));
+                }
+            }
         }
 
         // there is a well-known property users can specify that signals for UTD check to be disabled
@@ -1584,12 +1600,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
 
             var inputs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (!GetUTDCheckInputs(ref inputs))
+            if (!GetUTDCheckInputs(inputs))
                 return false;
 
             var outputs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (!GetUTDCheckOutputs(ref outputs, inputs))
-                return false;
+            List<Tuple<string, string>> preserveNewestOutputs;
+            GetUTDCheckOutputs(inputs, outputs, out preserveNewestOutputs);
 
             // determine the oldest output timestamp
             DateTime stalestOutputTime = DateTime.MaxValue.ToUniversalTime();
@@ -1625,12 +1641,47 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     freshestInputTime = timeStamp.Value;
             }
 
+            // check 1-1 Preserve Newest mappings
+            foreach (var kv in preserveNewestOutputs)
+            {
+                if (!IsUpToDatePreserveNewest(logger, TryGetLastWriteTimeUtc, kv.Item1, kv.Item2)) 
+                    return false;
+            }
+
             logger.WriteLine("Freshest input: {0}", freshestInputTime.ToLocalTime());
             logger.WriteLine("Stalest output: {0}", stalestOutputTime.ToLocalTime());
             logger.WriteLine("Up to date: {0}", freshestInputTime <= stalestOutputTime);
 
-            // if all outputs are younger than all inuts, we are up to date
+            // if all outputs are younger than all inputs, we are up to date
             return freshestInputTime <= stalestOutputTime;
+        }
+
+        public static bool IsUpToDatePreserveNewest(OutputWindowLogger logger, Func<string, OutputWindowLogger, DateTime?> tryGetLastWriteTimeUtc, string input, string output)
+        {
+            var inputTime = tryGetLastWriteTimeUtc(input, logger);
+            if (!inputTime.HasValue)
+            {
+                logger.WriteLine("Declaring project NOT up to date, can't find expected input {0}", input);
+                return false;
+            }
+
+            var outputTime = tryGetLastWriteTimeUtc(output, logger);
+            if (!outputTime.HasValue)
+            {
+                logger.WriteLine("Declaring project NOT up to date, can't find expected output {0}", output);
+                return false;
+            }
+
+            var inputTimeValue = inputTime.Value;
+            var outputTimeValue = outputTime.Value;
+
+            if (outputTimeValue < inputTimeValue)
+            {
+                logger.WriteLine("Declaring project NOT up to date, ouput {0} is stale", output);
+                return false;
+            }
+
+            return true;
         }
     }
 


### PR DESCRIPTION
fix #11 

fix both Content and app.config uptodate check

app.config is like Content with "Copy if Newer", so a new build doesn't replace a modified .exe.config in output directory
