### PR TITLE
Fix for #368 - changes to effects and try/catch optimization

### DIFF
--- a/src/fsharp/opt.fs
+++ b/src/fsharp/opt.fs
@@ -288,8 +288,6 @@ type OptimizationSettings =
     member x.InlineLambdas () = x.localOpt ()  
     /// eliminate unused bindings with no effect 
     member x.EliminateUnusedBindings () = x.localOpt () 
-    /// eliminate try around expr with no effect 
-    member x.EliminateTryCatchAndTryFinally () = x.localOpt () 
     /// eliminate first part of seq if no effect 
     member x.EliminateSequential () = x.localOpt () 
     /// determine branches in pattern matching
@@ -2139,17 +2137,8 @@ and OptimizeTryFinally cenv env (spTry,spFinally,e1,e2,m,ty) =
           HasEffect = e1info.HasEffect || e2info.HasEffect;
           MightMakeCriticalTailcall = false; // no tailcalls from inside in try/finally
           Info = UnknownValue } 
-    (* try-finally, so no effect means no exception can be raised, so just sequence the finally *)
-    if cenv.settings.EliminateTryCatchAndTryFinally () && not e1info.HasEffect then 
-        let sp = 
-            match spTry with 
-            | SequencePointAtTry _ -> SequencePointsAtSeq 
-            | SequencePointInBodyOfTry -> SequencePointsAtSeq 
-            | NoSequencePointAtTry -> SuppressSequencePointOnExprOfSequential
-        Expr.Sequential(e1',e2',ThenDoSeq,sp,m),info 
-    else
-        mkTryFinally cenv.g (e1',e2',m,ty,spTry,spFinally), 
-        info
+    mkTryFinally cenv.g (e1',e2',m,ty,spTry,spFinally), 
+    info
 
 //-------------------------------------------------------------------------
 // Optimize/analyze a try/catch construct.
@@ -2158,21 +2147,17 @@ and OptimizeTryFinally cenv env (spTry,spFinally,e1,e2,m,ty) =
 and OptimizeTryCatch cenv env (e1,vf,ef,vh,eh,m,ty,spTry,spWith) =
     if verboseOptimizations then dprintf "OptimizeTryCatch\n";
     let e1',e1info = OptimizeExpr cenv env e1    
-    // try-catch, so no effect means no exception can be raised, so discard the catch 
-    if cenv.settings.EliminateTryCatchAndTryFinally () && not e1info.HasEffect then 
-        e1',e1info 
-    else
-        let envinner = BindInternalValToUnknown cenv vf (BindInternalValToUnknown cenv vh env)
-        let ef',efinfo = OptimizeExpr cenv envinner ef 
-        let eh',ehinfo = OptimizeExpr cenv envinner eh 
-        let info = 
-            { TotalSize = e1info.TotalSize + efinfo.TotalSize+ ehinfo.TotalSize  + tryCatchSize;
-              FunctionSize = e1info.FunctionSize + efinfo.FunctionSize+ ehinfo.FunctionSize  + tryCatchSize;
-              HasEffect = e1info.HasEffect || efinfo.HasEffect || ehinfo.HasEffect;
-              MightMakeCriticalTailcall = false;
-              Info = UnknownValue } 
-        mkTryWith cenv.g (e1',vf,ef',vh,eh',m,ty,spTry,spWith), 
-        info
+    let envinner = BindInternalValToUnknown cenv vf (BindInternalValToUnknown cenv vh env)
+    let ef',efinfo = OptimizeExpr cenv envinner ef 
+    let eh',ehinfo = OptimizeExpr cenv envinner eh 
+    let info = 
+        { TotalSize = e1info.TotalSize + efinfo.TotalSize+ ehinfo.TotalSize  + tryCatchSize;
+          FunctionSize = e1info.FunctionSize + efinfo.FunctionSize+ ehinfo.FunctionSize  + tryCatchSize;
+          HasEffect = e1info.HasEffect || efinfo.HasEffect || ehinfo.HasEffect;
+          MightMakeCriticalTailcall = false;
+          Info = UnknownValue } 
+    mkTryWith cenv.g (e1',vf,ef',vh,eh',m,ty,spTry,spWith), 
+    info
 
 //-------------------------------------------------------------------------
 // Optimize/analyze a while loop

--- a/src/fsharp/opt.fs
+++ b/src/fsharp/opt.fs
@@ -1298,7 +1298,7 @@ and OpHasEffect g op =
     | TOp.TupleFieldGet(_) -> false
     | TOp.ExnFieldGet(ecref,n) -> isExnFieldMutable ecref n 
     | TOp.RefAddrGet -> false
-    | TOp.ValFieldGet rfref  -> rfref.RecdField.IsMutable
+    | TOp.ValFieldGet rfref  -> rfref.RecdField.IsMutable || HasFSharpAttribute g g.attrib_AllowNullLiteralAttribute rfref.Tycon.Attribs
     | TOp.ValFieldGetAddr _rfref  -> true (* check *)
     | TOp.LValueOp (LGetAddr,lv) -> lv.IsMutable
     | TOp.UnionCaseFieldSet _

--- a/tests/fsharp/optimize/analyses/effects.HasEffect.output.test.bsl
+++ b/tests/fsharp/optimize/analyses/effects.HasEffect.output.test.bsl
@@ -48,3 +48,11 @@ function simpleLibraryUse19 at line 66 causes side effects or may not terminate
 function complexDataAnalysisFunction at line 73 causes no side effects
 function complexDataConstructionFunction at line 81 causes side effects or may not terminate
 function veryComplexDataConstructionFunction at line 90 causes side effects or may not terminate
+function ( .ctor ) at line 118 causes side effects or may not terminate
+function X at line 119 causes no side effects
+function ( .ctor ) at line 122 causes side effects or may not terminate
+function X at line 123 causes side effects or may not terminate
+function ( .ctor ) at line 125 causes side effects or may not terminate
+function Y at line 127 causes no side effects
+function ( .ctor ) at line 130 causes side effects or may not terminate
+function Y at line 132 causes side effects or may not terminate

--- a/tests/fsharp/optimize/analyses/effects.HasEffect.output.test.bsl
+++ b/tests/fsharp/optimize/analyses/effects.HasEffect.output.test.bsl
@@ -50,9 +50,22 @@ function complexDataConstructionFunction at line 81 causes side effects or may n
 function veryComplexDataConstructionFunction at line 90 causes side effects or may not terminate
 function ( .ctor ) at line 118 causes side effects or may not terminate
 function X at line 119 causes no side effects
-function ( .ctor ) at line 122 causes side effects or may not terminate
-function X at line 123 causes side effects or may not terminate
-function ( .ctor ) at line 125 causes side effects or may not terminate
-function Y at line 127 causes no side effects
+function A at line 121 causes no side effects
+function ( .ctor ) at line 124 causes side effects or may not terminate
+function X at line 125 causes no side effects
+function A at line 127 causes no side effects
 function ( .ctor ) at line 130 causes side effects or may not terminate
-function Y at line 132 causes side effects or may not terminate
+function X at line 131 causes side effects or may not terminate
+function A at line 133 causes side effects or may not terminate
+function ( .ctor ) at line 135 causes side effects or may not terminate
+function Y at line 137 causes no side effects
+function Z at line 138 causes side effects or may not terminate
+function A at line 139 causes no side effects
+function ( .ctor ) at line 142 causes side effects or may not terminate
+function Y at line 144 causes no side effects
+function Z at line 145 causes side effects or may not terminate
+function A at line 146 causes no side effects
+function ( .ctor ) at line 149 causes side effects or may not terminate
+function Y at line 151 causes side effects or may not terminate
+function Z at line 152 causes side effects or may not terminate
+function A at line 153 causes side effects or may not terminate

--- a/tests/fsharp/optimize/analyses/effects.fs
+++ b/tests/fsharp/optimize/analyses/effects.fs
@@ -114,5 +114,21 @@ module BasicAnalysisTests =
                         complexDataConstructionFunction t1l t1k (complexDataConstructionFunction t1r k t2)
                 | _ -> failwith "veryComplexDataConstructionFunction"
             else complexDataConstructionFunction t1 k t2
+            
+    type NullNotPossible(i:int) =
+        member __.X = i   // no side effects, non-nullable
+
+    [<AllowNullLiteral>]
+    type NullPossible(i:int) =
+        member __.X = i   // yes side effects, nullable
+        
+    type DerivedFromNullPossible(i:int) =
+        inherit NullPossible(i)
+        member __.Y = i   // no side effects, non-nullable
+        
+    [<AllowNullLiteral>]
+    type DerivedFromNullPossibleAlsoNullPossible(i:int) =
+        inherit NullPossible(i)
+        member __.Y = i   // yes side effects, nullable
 
 printfn "Test run"

--- a/tests/fsharp/optimize/analyses/effects.fs
+++ b/tests/fsharp/optimize/analyses/effects.fs
@@ -116,19 +116,40 @@ module BasicAnalysisTests =
             else complexDataConstructionFunction t1 k t2
             
     type NullNotPossible(i:int) =
-        member __.X = i   // no side effects, non-nullable
+        member __.X = i   // no effects
+        abstract member A : int
+        default __.A = i  // no effects
+
+    [<AllowNullLiteral(false)>]
+    type NullNotPossibleAttr(i:int) =
+        member __.X = i   // no effects
+        abstract member A : int
+        default __.A = i  // no effects
 
     [<AllowNullLiteral>]
     type NullPossible(i:int) =
-        member __.X = i   // yes side effects, nullable
+        member __.X = i   // yes effects
+        abstract member A : int
+        default __.A = i  // yes effects
         
     type DerivedFromNullPossible(i:int) =
         inherit NullPossible(i)
-        member __.Y = i   // no side effects, non-nullable
-        
+        member __.Y = i   // no effects
+        member __.Z = base.X   // yes effects
+        override __.A = i  // no effects
+      
+    [<AllowNullLiteral(false)>]
+    type DerivedFromNullPossibleAttrFalse(i:int) =
+        inherit NullPossible(i)
+        member __.Y = i   // no effects
+        member __.Z = base.X   // yes effects
+        override __.A = i  // no effects
+
     [<AllowNullLiteral>]
     type DerivedFromNullPossibleAlsoNullPossible(i:int) =
         inherit NullPossible(i)
-        member __.Y = i   // yes side effects, nullable
+        member __.Y = i   // yes effects
+        member __.Z = base.X   // yes effects
+        override __.A = i  // yes effects
 
 printfn "Test run"

--- a/tests/fsharpqa/Source/Conformance/Expressions/ControlFlowExpressions/TryCatch/TryCatch03.fs
+++ b/tests/fsharpqa/Source/Conformance/Expressions/ControlFlowExpressions/TryCatch/TryCatch03.fs
@@ -1,0 +1,26 @@
+type MyRec = { A : int; B : string }
+
+[<AllowNullLiteral>]
+type NullType(i:int) = 
+    member __.X = i
+
+let updateRecd x =
+    try
+       { x with A = 42 }
+    with e ->
+       { A = 0; B = "success" }
+       
+if (updateRecd Unchecked.defaultof<MyRec>).B <> "success" then exit 1
+
+let touchType (x : NullType) =
+    try
+       x.X
+    with e ->
+       -1
+       
+if (touchType null) <> -1 then exit 1
+
+exit 0
+       
+
+

--- a/tests/fsharpqa/Source/Conformance/Expressions/ControlFlowExpressions/TryCatch/env.lst
+++ b/tests/fsharpqa/Source/Conformance/Expressions/ControlFlowExpressions/TryCatch/env.lst
@@ -1,4 +1,5 @@
 	SOURCE=TryCatch01.fs			# TryCatch01.fs
 	SOURCE=TryCatch02.fs			# TryCatch02.fs
+	SOURCE=TryCatch03.fs			# TryCatch03.fs
 
 	SOURCE=E_RethrowOutsideCatch01.fs	# E_RethrowOutsideCatch01.fs


### PR DESCRIPTION
2 changes:
- Eliminate the optimization that removes try/catch blocks around code assumed to be effect-free
- Reading fields is treated as an effect if the implementing type has `[<AllowNullLiteral>]`

The perf overhead introduced by a try/catch block that doesn't throw is extremely tiny.  Some [quick tests](https://gist.github.com/latkin/857be0ec50626d4d3327) indicate that it's in the ballpark of 0.000001ms (650ms over 1B iterations), if measurable at all.

This seems like a very modest gain, at the risk of runtime catastrophe. Given the realities of .NET interop - unexpected nulls, OutOfMemory, ThreadAbort - IMO it doesn't seem justified.