### PR TITLE
reference System.Runtime in scripts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Although the primary focus of this repo is F# for Windows and the Visual Studio 
 ###Get In Touch
 
 Keep up with the Visual F# Team and the development of the Visual F# Tools by following us [@VisualFSharp](https://twitter.com/VisualFSharp) or subscribing to our [team blog](http://blogs.msdn.com/b/fsharpteam/).
+

--- a/src/fsharp/build.fs
+++ b/src/fsharp/build.fs
@@ -1575,9 +1575,12 @@ let DefaultBasicReferencesForOutOfProjectSources =
       // Note: this is not a partiuclarly good technique as it relying on the environment the compiler is executing in
       // to determine the default references. However, System.Core will only fail to load on machines with only .NET 2.0,
       // in which case the compiler will also be running as a .NET 2.0 process.
+      //
+      // NOTE: it seems this can now be removed now that .NET 4.x is minimally assumed when using this toolchain
       if (try System.Reflection.Assembly.Load "System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" |> ignore; true with _ -> false) then 
           yield "System.Core" 
 
+      yield "System.Runtime"
       yield "System.Web"
       yield "System.Web.Services"
       yield "System.Windows.Forms" ]
@@ -1604,6 +1607,7 @@ let SystemAssemblies primaryAssemblyName =
       yield "System.Web.Services"
       yield "System.Windows.Forms"
       yield "System.Core"
+      yield "System.Runtime"
       yield "System.Observable"
       yield "System.Numerics"] 
 


### PR DESCRIPTION
This fixes #381 

When referencing a PCL assembly that has an ExtensionAttribute (or auto-opens namespaces that reveal methods with this attribute), we need to be able to resolve the assembly System.Runtime, which needs to be in the reference set.  If it's not, a serious error happens internally.

Adding System.Runtime to the default assembly references is safe because we assume at least .NET 4.5 when running this toolchain, which has this DLL available.

I'm doing some manual testing on this and will now explore whether we can add an automatable test.