### PR TITLE
fix invalid already rendered folder error

### DIFF
--- a/vsintegration/src/unittests/Tests.ProjectSystem.RoundTrip.fs
+++ b/vsintegration/src/unittests/Tests.ProjectSystem.RoundTrip.fs
@@ -100,6 +100,17 @@ type RoundTrip() =
                              CompileItem @"A\qux.fs"]
         this.``FsprojRoundtrip.PositiveTest``(MSBuildItems origItems, MSBuildItems expectedItems)
 
+    [<Test>]
+    member public this.``FsprojRoundTrip.Regression.FoldersWithSameName``() =
+        let items = MSBuildItems [CompileItem @"First\Second\bar.fs"
+                                  CompileItem @"Second\qux.fs"]
+        this.``FsprojRoundtrip.PositiveTest``(items, items)
+
+    [<Test>]
+    member public this.``FsprojRoundTrip.Regression.FoldersWithSameName2``() =
+        let items = MSBuildItems [CompileItem @"First\First\bar.fs"]
+        this.``FsprojRoundtrip.PositiveTest``(items, items)
+
     member this.``Fsproj.NegativeTest``(items : MSBuildItems) =
         DoWithTempFile "Test.fsproj" (fun file ->
             File.AppendAllText(file, TheTests.SimpleFsprojText([], [], items.ToString()))

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/MSBuildUtilities.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/MSBuildUtilities.fs
@@ -120,7 +120,7 @@ type internal MSBuildUtilities() =
                 // push folder
                 Inc(curPathParts)
                 curPathParts.Add(pathParts.[curPathParts.Count]) // e.g. transition from A\ to A\D\E\bar.fs
-                if not(alreadyRenderedFolders.Add(curPathParts)) && throwIfCannotRender then
+                if not(alreadyRenderedFolders.Add(new List<string>(curPathParts))) && throwIfCannotRender then
                     raise <| new InvalidOperationException(String.Format(FSharpSR.GetString(FSharpSR.ProjectRenderFolderMultiple), projectNode.ProjectFile, bi.Include))
             Inc(curPathParts)
             if bi.ItemType = ProjectFileConstants.Folder then


### PR DESCRIPTION
fix #246

fix invalid already rendered folder error when a project contains
folders with same name

Take 3: fix the current algorithm, one-liner ftw :smile:

the problem was:

the alreadyRenderedFolders hashset is used to store the folders as list ( "a\b" -> ["a"; "b"] ) but the list added was the local variable curPathParts, **mutated** inside the while, so the alreadyRenderedFolders item was also modified (same instance) -> :boom: 
