### PR TITLE
Server GC mode for compiler

### DIFF
--- a/src/fsharp/Fsc-proto/Fsc-proto.fsproj
+++ b/src/fsharp/Fsc-proto/Fsc-proto.fsproj
@@ -26,6 +26,10 @@
     <Compile Include="..\fscmain.fs">
       <Link>fscmain.fs</Link>
     </Compile>
+    <None Include="fsc-proto.exe.config">
+      <Link>fsc-proto.exe.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/src/fsharp/Fsc-proto/fsc-proto.exe.config
+++ b/src/fsharp/Fsc-proto/fsc-proto.exe.config
@@ -1,17 +1,6 @@
 <configuration>
-
-  <!-- 
-  <startup>       
-    <supportedRuntime version="v2.0" />
-
-    <supportedRuntime version="v2.0.50727" />
-
-    <supportedRuntime version="v4.0.30319" />
-
-  </startup>  
--->
-  
    <runtime>
+      <gcServer enabled="true"/>
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
          <dependentAssembly>
             <assemblyIdentity name="FSharp.Core" publicKeyToken="a19089b1c74d0809" culture="neutral" />
@@ -19,5 +8,4 @@
          </dependentAssembly>
       </assemblyBinding>
    </runtime>
-
 </configuration>

--- a/src/fsharp/Fsc/fsc.exe.config
+++ b/src/fsharp/Fsc/fsc.exe.config
@@ -2,6 +2,7 @@
 <configuration>
   <runtime>
     <legacyUnhandledExceptionPolicy enabled="true" />
+    <gcServer enabled="true"/>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity

--- a/tests/fsharpqa/testenv/src/HostedCompilerServer/App.config
+++ b/tests/fsharpqa/testenv/src/HostedCompilerServer/App.config
@@ -3,4 +3,7 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+    <runtime>
+        <gcServer enabled="true"/>
+    </runtime>
 </configuration>


### PR DESCRIPTION
As mentioned in #404.

I don't think we should change fsi/fsianycpu, as those are sometimes used to drive interactive UIs, which benefit from the increased responsiveness of the default GC.