### PR TITLE
Scope 'move up/down' keybindings to sln explorer only

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/MenusAndCommands.vsct
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/MenusAndCommands.vsct
@@ -174,8 +174,8 @@
     </Bitmaps>
   </Commands>
   <KeyBindings>
-    <KeyBinding guid="FSharpProjectCmdSet" id="MoveUpCmd" editor="guidVSStd97" key1="VK_UP" mod1="Alt" />
-    <KeyBinding guid="FSharpProjectCmdSet" id="MoveDownCmd" editor="guidVSStd97" key1="VK_DOWN" mod1="Alt" />
+    <KeyBinding guid="FSharpProjectCmdSet" id="MoveUpCmd" editor="SlnExplorerGuid" key1="VK_UP" mod1="Alt" />
+    <KeyBinding guid="FSharpProjectCmdSet" id="MoveDownCmd" editor="SlnExplorerGuid" key1="VK_DOWN" mod1="Alt" />
   </KeyBindings>
   <Symbols>
     <GuidSymbol name ="FSharpProjectPackage" value ="{91a04a73-4f2c-4e7c-ad38-c1a68e7da05c}" />
@@ -206,5 +206,6 @@
     <GuidSymbol name="FSharpMoveDownBmp" value="{E249E640-8AD4-4f84-81E7-2EE58E9641AC}" >
       <IDSymbol name="moveDown" value="1" />
     </GuidSymbol>
+    <GuidSymbol name="SlnExplorerGuid" value="{3AE79031-E1BC-11D0-8F78-00A0C9110057}" />
   </Symbols>
 </CommandTable>


### PR DESCRIPTION
Fixes #417

Before, `Alt-Up/Down` hijacked by F# when Find/Replace dialog open:

![updownbefore](https://cloud.githubusercontent.com/assets/5943573/7481348/22d35656-f324-11e4-997e-9eed7fabce7a.gif)

After, Find/Replace gets to handle the key events:

![updownafter](https://cloud.githubusercontent.com/assets/5943573/7481373/4ac48b30-f324-11e4-8f39-f1ccb3d9ca20.gif)