### PR TITLE
[WIP] Add "Do not show this message again" to type provider security dialog

### DIFF
--- a/src/fsharp/est.fsi
+++ b/src/fsharp/est.fsi
@@ -20,6 +20,12 @@ module internal ExtensionTyping =
         val mutable displayLSTypeProviderSecurityDialogBlockingUI : (string->unit) option
         val mutable theMostRecentFileNameWeChecked : string option
 
+    module internal ApprovalsChecking =
+
+        val isAlwaysTrust : unit -> bool
+
+        val setAlwaysTrust : bool -> unit
+
     module internal ApprovalIO =
 
         val partiallyCanonicalizeFileName : string -> string

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSLangSvcStrings.resx
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSLangSvcStrings.resx
@@ -160,6 +160,10 @@
     <value>Project using type provider:</value>
     <comment>dialog label - project causing dialog</comment>
   </data>
+  <data name="TPSEC_DoNotShowAgain" xml:space="preserve">
+    <value>Always Enable and do not show this message again</value>
+    <comment>dialog label - do not show again checkbox text</comment>
+  </data>
   <data name="TPSEC_PublisherInfo" xml:space="preserve">
     <value>Publisher information:</value>
     <comment>dialog label - publisher info of type provider assembly</comment>

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/Security.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/Security.fs
@@ -123,6 +123,15 @@ type internal TypeProviderSecurityDialog =
         buttonPanel.Children.Add(disableButton) |> ignore
         sp.Children.Add(buttonPanel) |> ignore
 
+        let doNotShowAgain = ref false
+        let doNotShowAgainCheckbox = new CheckBox(Content="Do not show this message again")
+        doNotShowAgainCheckbox.Click.Add(fun ea ->
+            let checkbox = ea.Source :?> CheckBox
+            doNotShowAgain := checkbox.IsChecked.HasValue && checkbox.IsChecked.Value)
+        let doNotShowAgainPanel = new StackPanel(Orientation = Orientation.Horizontal, HorizontalAlignment=System.Windows.HorizontalAlignment.Left)
+        doNotShowAgainPanel.Children.Add(doNotShowAgainCheckbox) |> ignore
+        sp.Children.Add(doNotShowAgainPanel) |> ignore
+
         let separator = new System.Windows.Controls.Separator()
         separator.Margin <- new System.Windows.Thickness(0.0, 8.0, 0.0, 0.0)
         sp.Children.Add(separator) |> ignore
@@ -163,13 +172,16 @@ type internal TypeProviderSecurityDialog =
         di.WindowStartupLocation <- System.Windows.WindowStartupLocation.CenterOwner
         di.Loaded.Add (fun _ -> System.Windows.Input.Keyboard.Focus(disableButton) |> ignore)
         di.ShowModal() |> ignore
-        let approval =
-            if !enabled then
-                Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalIO.TypeProviderApprovalStatus.Trusted(assem)
-            else
-                Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalIO.TypeProviderApprovalStatus.NotTrusted(assem)
-        Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalIO.ReplaceApprovalStatus None approval
-        // invalidate any language service caching
-        TypeProviderSecurityGlobals.invalidationCallback()
+        if !doNotShowAgain
+        then Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalsChecking.setAlwaysTrust true
+        else
+            let approval =
+                if !enabled then
+                    Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalIO.TypeProviderApprovalStatus.Trusted(assem)
+                else
+                    Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalIO.TypeProviderApprovalStatus.NotTrusted(assem)
+            Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalIO.ReplaceApprovalStatus None approval
+            // invalidate any language service caching
+            TypeProviderSecurityGlobals.invalidationCallback()
                 
         

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/Security.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/Security.fs
@@ -124,7 +124,7 @@ type internal TypeProviderSecurityDialog =
         sp.Children.Add(buttonPanel) |> ignore
 
         let doNotShowAgain = ref false
-        let doNotShowAgainCheckbox = new CheckBox(Content="Do not show this message again")
+        let doNotShowAgainCheckbox = new CheckBox(Content=Strings.GetString "TPSEC_DoNotShowAgain")
         doNotShowAgainCheckbox.Click.Add(fun ea ->
             let checkbox = ea.Source :?> CheckBox
             doNotShowAgain := checkbox.IsChecked.HasValue && checkbox.IsChecked.Value)

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
@@ -2061,7 +2061,11 @@ type FSharpPackage() as self =
                 // the 'displayLSTypeProviderSecurityDialogBlockingUI' callback is run async to the background typecheck, so after the user has interacted with the dialog, request a re-typecheck
                 TypeProviderSecurityGlobals.invalidationCallback() 
 
-            Microsoft.FSharp.Compiler.ExtensionTyping.GlobalsTheLanguageServiceCanPoke.displayLSTypeProviderSecurityDialogBlockingUI <- Some showDialog
+            let unlessAlwaysTrustShowDialog path =
+                if not (Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalsChecking.isAlwaysTrust ())
+                then showDialog path
+
+            Microsoft.FSharp.Compiler.ExtensionTyping.GlobalsTheLanguageServiceCanPoke.displayLSTypeProviderSecurityDialogBlockingUI <- Some unlessAlwaysTrustShowDialog
 
             self.RegisterForIdleTime()
             box language

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
@@ -2043,7 +2043,7 @@ type FSharpPackage() as self =
             language.SetSite(self)
             language.Initialize()
             TypeProviderSecurityGlobals.invalidationCallback <- fun () -> language.LanguageServiceState.InteractiveChecker.InvalidateAll()
-            Microsoft.FSharp.Compiler.ExtensionTyping.GlobalsTheLanguageServiceCanPoke.displayLSTypeProviderSecurityDialogBlockingUI <- Some(fun (typeProviderRunTimeAssemblyFileName) ->
+            let showDialog typeProviderRunTimeAssemblyFileName =
                 let pubInfo = GetVerifiedPublisherInfo.GetVerifiedPublisherInfo typeProviderRunTimeAssemblyFileName
                 let filename = 
                     match Microsoft.FSharp.Compiler.ExtensionTyping.GlobalsTheLanguageServiceCanPoke.theMostRecentFileNameWeChecked with
@@ -2060,7 +2060,9 @@ type FSharpPackage() as self =
                     )
                 // the 'displayLSTypeProviderSecurityDialogBlockingUI' callback is run async to the background typecheck, so after the user has interacted with the dialog, request a re-typecheck
                 TypeProviderSecurityGlobals.invalidationCallback() 
-                )
+
+            Microsoft.FSharp.Compiler.ExtensionTyping.GlobalsTheLanguageServiceCanPoke.displayLSTypeProviderSecurityDialogBlockingUI <- Some showDialog
+
             self.RegisterForIdleTime()
             box language
         | _ -> null

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
@@ -309,6 +309,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             System.Windows.Controls.DockPanel.SetDock(doNotShowAgainCheckbox, System.Windows.Controls.Dock.Top)
             doNotShowAgainCheckbox.DataContext <- tptop
             doNotShowAgainCheckbox.SetBinding(CheckBox.IsCheckedProperty, "AlwaysTrust") |> ignore
+            doNotShowAgainCheckbox.Margin <- new Windows.Thickness(0.0, 4.0, 0.0, 6.0)
 
             panel.Children.Add(iconAndTextGrid) |> ignore
             panel.Children.Add(doNotShowAgainCheckbox) |> ignore

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
@@ -99,6 +99,27 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         member this.Assem with get() = assem
         member this.FileName with get() = fileName
 
+    type ViewModelBase() =
+        let propertyChanged = new Event<_, _>()
+ 
+        interface INotifyPropertyChanged with
+            [<CLIEvent>]
+            member x.PropertyChanged = propertyChanged.Publish
+
+        member x.OnPropertyChanged(propertyName) =
+            propertyChanged.Trigger(x, PropertyChangedEventArgs(propertyName))
+
+    type TPTOP() =
+        inherit ViewModelBase()
+
+        let mutable alwaysTrust = false
+
+        member x.AlwaysTrust 
+            with get() = alwaysTrust 
+            and set(b) = 
+                alwaysTrust <- b
+                x.OnPropertyChanged("AlwaysTrust")
+
     [<ComVisible(true)>]
     [<CLSCompliant(false)>]
     [<Guid("4B7954C1-7D80-4FB6-8C18-2567DF5735F9")>]
@@ -161,6 +182,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     dgrow.MoveFocus(new System.Windows.Input.TraversalRequest(System.Windows.Input.FocusNavigationDirection.Next)) |> ignore
                 )
 
+            let tptop = TPTOP()
+
             pageActivatedEvent.Add(fun () ->
                 let approvals = Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalIO.ReadApprovalsFile None
                 let initialApprovals = [|
@@ -177,8 +200,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 let backingStore = new System.Collections.ObjectModel.ObservableCollection<_>( initialApprovals ) // create backing store for UI
                 grid.ItemsSource <- backingStore
 
+                tptop.AlwaysTrust <- Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalsChecking.isAlwaysTrust ()
+
                 let rec pageCloseLogic = new System.Windows.RoutedEventHandler(fun _ _ ->
                     try
+                        Microsoft.FSharp.Compiler.ExtensionTyping.ApprovalsChecking.setAlwaysTrust (tptop.AlwaysTrust)
+
                         // make lists of tuples for structural equality test
                         let finalVals = backingStore |> Seq.map (fun x -> x.FileName, x.IsTrusted) |> Seq.toList
                         if finalVals <> initVals then
@@ -278,7 +305,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 System.Windows.Controls.DockPanel.SetDock(grid, System.Windows.Controls.Dock.Top)
                 grid
 
+            let doNotShowAgainCheckbox = new CheckBox(Content="Always trust type providers")
+            System.Windows.Controls.DockPanel.SetDock(doNotShowAgainCheckbox, System.Windows.Controls.Dock.Top)
+            doNotShowAgainCheckbox.DataContext <- tptop
+            doNotShowAgainCheckbox.SetBinding(CheckBox.IsCheckedProperty, "AlwaysTrust") |> ignore
+
             panel.Children.Add(iconAndTextGrid) |> ignore
+            panel.Children.Add(doNotShowAgainCheckbox) |> ignore
             panel.Children.Add(grid) |> ignore
             panel.SetResourceReference(System.Windows.Controls.Control.BackgroundProperty, System.Windows.SystemColors.ControlBrushKey)
             this.Child <- panel

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 System.Windows.Controls.DockPanel.SetDock(grid, System.Windows.Controls.Dock.Top)
                 grid
 
-            let doNotShowAgainCheckbox = new CheckBox(Content="Always trust type providers")
+            let doNotShowAgainCheckbox = new CheckBox(Content=FSharpSR.GetString "TPTOP_AlwaysTrust")
             System.Windows.Controls.DockPanel.SetDock(doNotShowAgainCheckbox, System.Windows.Controls.Dock.Top)
             doNotShowAgainCheckbox.DataContext <- tptop
             doNotShowAgainCheckbox.SetBinding(CheckBox.IsCheckedProperty, "AlwaysTrust") |> ignore

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/VSPackage.resx
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/VSPackage.resx
@@ -520,6 +520,10 @@
     <value>Using a Type Provider from a source that is unknown or not trusted can expose your computer to security threats, as it will run under the privileges of the current user.</value>
     <comment>Tools-Options-F# tools-Type Providers: overall description</comment>
   </data>
+  <data name="TPTOP_AlwaysTrust" xml:space="preserve">
+    <value>Always trust type providers</value>
+    <comment>Tools-Options-F# tools-Type Providers: always trust type providers description</comment>
+  </data>
   <data name="TPTOP_Trusted" xml:space="preserve">
     <value>Trusted</value>
     <comment>Tools-Options-F# tools-Type Providers: column header</comment>


### PR DESCRIPTION
fix #378 

added the checkbox to type provider dialog

![image](https://cloud.githubusercontent.com/assets/147243/7523672/64834edc-f4fd-11e4-8a0f-e588ee624720.png)

The preference is stored using a file `%APPLOCALDATA%\Local\Microsoft\VisualStudio\12.0\always-trust-type-providers.lock` (like the type providers list `type-providers.txt`, same directory)
Cannot reenable it after (like T4), but this behaviour can be documented, delete a file is easy. Should i add this check to Tools menu?

i splitted the 233514b to make the diff easier

### TODO

- [x] localization with resorce (today or tomorrow)
- [ ] integration tests (??)
- [x] add to Tools menu?
- [ ] add tests below to developer wiki, something like "Checklist for UI changes"

### Tests

- [X] manual tests :smile:
- [ ] localization
- [x] 200% high DPI
- [x] Check box can be selected/toggled via keyboard
- [x] Windows narrator can read the label text

i need review :eyes: :eyes: :eyes: :eyes: 
