### PR TITLE
Fix 362 - Depickling assertion followed by nullref internal errors in units-of-measure case

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1341,3 +1341,4 @@ estApplyStaticArgumentsForMethodNotImplemented,"A type provider implemented GetS
 3183,ppparsUnexpectedToken,"Unexpected token '%s' in preprocessor expression"
 3184,ppparsIncompleteExpression,"Incomplete preprocessor expression"
 3185,ppparsMissingToken,"Missing token '%s' in preprocessor expression"
+3186,pickleMissingDefinition,"An error occurred while reading the F# metadata node at position %d in table '%s' of assembly '%s'. The node had no matching declaration. Please report this warning. You may need to recompile the F# assembly you are using."

--- a/src/fsharp/pickle.fs
+++ b/src/fsharp/pickle.fs
@@ -728,7 +728,8 @@ let check (ilscope:ILScopeRef) (inMap : NodeInTable<_,_>) =
     for i = 0 to inMap.Count - 1 do
       let n = inMap.Get i
       if not (inMap.IsLinked n) then 
-        System.Diagnostics.Debug.Assert(false, sprintf "*** unpickle: osgn %d in table %s with IL scope %s had no matching declaration (was not fixed up)\nPlease report this warning. (Note for compiler developers: to get information about which item this index relates to, enable the conditional in Pickle.p_osgn_ref to refer to the given index number and recompile an identical copy of the source for the DLL containing the data being unpickled.  A message will then be printed indicating the name of the item.\n" i inMap.Name ilscope.QualifiedName)
+        warning(Error(FSComp.SR.pickleMissingDefinition i inMap.Name ilscope.QualifiedName, range0))
+        // Note for compiler developers: to get information about which item this index relates to, enable the conditional in Pickle.p_osgn_ref to refer to the given index number and recompile an identical copy of the source for the DLL containing the data being unpickled.  A message will then be printed indicating the name of the item.\n" 
 #endif
 
 let unpickleObjWithDanglingCcus file ilscope (iILModule:ILModuleDef) u (phase2bytes:byte[]) =

--- a/src/fsharp/pickle.fs
+++ b/src/fsharp/pickle.fs
@@ -728,7 +728,7 @@ let check (ilscope:ILScopeRef) (inMap : NodeInTable<_,_>) =
     for i = 0 to inMap.Count - 1 do
       let n = inMap.Get i
       if not (inMap.IsLinked n) then 
-        warning(Error(FSComp.SR.pickleMissingDefinition i inMap.Name ilscope.QualifiedName, range0))
+        warning(Error(FSComp.SR.pickleMissingDefinition (i, inMap.Name, ilscope.QualifiedName), range0))
         // Note for compiler developers: to get information about which item this index relates to, enable the conditional in Pickle.p_osgn_ref to refer to the given index number and recompile an identical copy of the source for the DLL containing the data being unpickled.  A message will then be printed indicating the name of the item.\n" 
 #endif
 

--- a/src/fsharp/pickle.fs
+++ b/src/fsharp/pickle.fs
@@ -723,14 +723,12 @@ let pickleObjWithDanglingCcus file g scope p x =
   
 #endif
     
-#if DEBUG
 let check (ilscope:ILScopeRef) (inMap : NodeInTable<_,_>) =
     for i = 0 to inMap.Count - 1 do
       let n = inMap.Get i
       if not (inMap.IsLinked n) then 
         warning(Error(FSComp.SR.pickleMissingDefinition (i, inMap.Name, ilscope.QualifiedName), range0))
         // Note for compiler developers: to get information about which item this index relates to, enable the conditional in Pickle.p_osgn_ref to refer to the given index number and recompile an identical copy of the source for the DLL containing the data being unpickled.  A message will then be printed indicating the name of the item.\n" 
-#endif
 
 let unpickleObjWithDanglingCcus file ilscope (iILModule:ILModuleDef) u (phase2bytes:byte[]) =
     let st2 = 
@@ -777,13 +775,11 @@ let unpickleObjWithDanglingCcus file ilscope (iILModule:ILModuleDef) u (phase2by
              ifile=file 
              iILModule = iILModule }
         let res = u st1
-#if DEBUG
 #if LAZY_UNPICKLE
 #else
         check ilscope st1.itycons;
         check ilscope st1.ivals;
         check ilscope st1.itypars;
-#endif
 #endif
         res
 


### PR DESCRIPTION
This converts a debug-only message for #362 into a check, a warning and advice.  The warning is not attributed to a specific line number, rather we use "range0".

I don't know if it's worth adding a test case for this. When using it manually on #362 we now get this:

``
unknown(1,1): warning FS3186: An error occurred while reading the F# metadata no
de at position 10 in table 'itypars' of assembly 'a, Version=0.0.0.0, Culture=ne
utral, PublicKeyToken=null'. The node had no matching declaration. Please report
 this warning. You may need to recompile the F# assembly you are using.
``

which is of some help, though it is followed by the errors as before.  (I'm loathe to raise a hard "error" condition here on import as in many cases the assembly will still be usable.)


