### PR TITLE
Fix 299 - ReflectedDefinition on overloaded extension methods

### DIFF
--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -2684,6 +2684,29 @@ module NestedQuotations =
 
     runAll()
 
+module ExtensionMembersWithSameName = 
+    let check nm a b = if not (a = b) then printfn "%s failed, expected %A, got %A" nm b a
+    open FSharp.Quotations
+    type System.Object with
+        [<ReflectedDefinition>]
+        member this.Add(x) = x
+        [<ReflectedDefinition>]
+        member this.Add(x, y) = x + y
+
+    let runAll () =
+        match  <@ obj().Add(2) @> with
+        | (Patterns.Call(_, m, _)) -> 
+            let text = m |> Expr.TryGetReflectedDefinition |> sprintf "%A"
+            check "clewwenf094" text "Some Lambda (this, Lambda (x, x))"
+        | _ -> ()
+
+        match  <@ obj().Add(2,3) @> with
+        | (Patterns.Call(_, m, _)) -> 
+            let text = m |> Expr.TryGetReflectedDefinition |> sprintf "%A"
+            check "clewwenf095" (m.GetParameters().Length) 3
+        | _ -> ()
+
+    runAll()
 
 let aa =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 

--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -2685,8 +2685,7 @@ module NestedQuotations =
     runAll()
 
 module ExtensionMembersWithSameName = 
-    let check nm a b = if not (a = b) then printfn "%s failed, expected %A, got %A" nm b a
-    open FSharp.Quotations
+
     type System.Object with
         [<ReflectedDefinition>]
         member this.Add(x) = x

--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -2691,19 +2691,35 @@ module ExtensionMembersWithSameName =
         member this.Add(x) = x
         [<ReflectedDefinition>]
         member this.Add(x, y) = x + y
+        [<ReflectedDefinition>]
+        static member SAdd(x) = x
+        [<ReflectedDefinition>]
+        static member SAdd(x, y) = x + y
 
     let runAll () =
         match  <@ obj().Add(2) @> with
         | (Patterns.Call(_, m, _)) -> 
             let text = m |> Expr.TryGetReflectedDefinition |> sprintf "%A"
             check "clewwenf094" text "Some Lambda (this, Lambda (x, x))"
-        | _ -> ()
+        | _ -> failwith "unexpected shape"
 
         match  <@ obj().Add(2,3) @> with
         | (Patterns.Call(_, m, _)) -> 
             let text = m |> Expr.TryGetReflectedDefinition |> sprintf "%A"
             check "clewwenf095" (m.GetParameters().Length) 3
-        | _ -> ()
+        | _ -> failwith "unexpected shape"
+
+        match  <@ obj.SAdd(2) @> with
+        | (Patterns.Call(_, m, _)) -> 
+            let text = m |> Expr.TryGetReflectedDefinition |> sprintf "%A"
+            check "clewwenf096" text "Some Lambda (x, x)"
+        | _ -> failwith "unexpected shape"
+
+        match  <@ obj.SAdd(2,3) @> with
+        | (Patterns.Call(_, m, _)) -> 
+            let text = m |> Expr.TryGetReflectedDefinition |> sprintf "%A"
+            check "clewwenf097" (m.GetParameters().Length) 2
+        | _ -> failwith "unexpected shape"
 
     runAll()
 


### PR DESCRIPTION
Fix #299 

F# extension members with the same compiled name had ambiguous quotations.  Use the "member" encoding available for these in the quotation data format.
