### PR TITLE
Fix 316 - null array-valued attribute causes the compiler internal error

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -4388,6 +4388,8 @@ and encodeCustomAttrValue ilg ty c =
     match ty, c with 
     | ILType.Boxed tspec, _ when tspec.Name = tname_Object ->  
        [| yield! encodeCustomAttrElemTypeForObject c; yield! encodeCustomAttrPrimValue ilg c |]
+    | ILType.Array (shape, _), ILAttribElem.Null when shape = ILArrayShape.SingleDimensional ->  
+       [| yield! i32AsBytes 0xFFFFFFFF |]
     | ILType.Array (shape, elemType), ILAttribElem.Array (_,elems) when shape = ILArrayShape.SingleDimensional ->  
        [| yield! i32AsBytes elems.Length; for elem in elems do yield! encodeCustomAttrValue ilg elemType elem |]
     | _ -> 
@@ -4755,6 +4757,7 @@ let decodeILAttribData ilg (ca: ILAttribute) scope =
               parseVal ty sigptr 
       | ILType.Array(shape,elemTy) when shape = ILArrayShape.SingleDimensional ->  
           let n,sigptr = sigptr_get_i32 bytes sigptr
+          if n = 0xFFFFFFFF then ILAttribElem.Null,sigptr else
           let rec parseElems acc n sigptr = 
             if n = 0 then List.rev acc else
             let v,sigptr = parseVal elemTy sigptr

--- a/src/fsharp/ilxgen.fs
+++ b/src/fsharp/ilxgen.fs
@@ -5690,7 +5690,11 @@ and GenAttribArg amap g eenv x (ilArgTy:ILType) =
 
     match x,ilArgTy with 
 
-    (* Detect standard constants *)
+    // Detect 'null' used for an array argument
+    | Expr.Const(Const.Zero,_,_),ILType.Array  _ -> 
+        ILAttribElem.Null
+
+    // Detect standard constants 
     | Expr.Const(c,m,_),_ -> 
         let tynm = ilArgTy.TypeSpec.Name
         let isobj = (tynm = "System.Object")

--- a/tests/fsharp/core/attributes/test.fsx
+++ b/tests/fsharp/core/attributes/test.fsx
@@ -1299,6 +1299,28 @@ module AttributeTestsOnExtensionProperties =
     check "vwlnwer-0wreknj4" (test3()) "Equals: [||], GetHashCode: [||], GetType: [||], Object.get_ExtensionMethod: [|Inline|], Object.get_Item: [|Inline|], Object.set_Item: [|Inline|], ToString: [||]"
 
 
+module ParamArrayNullAttribute = 
+    open System
+
+    type Attr([<ParamArray>] pms: obj[]) =
+      inherit Attribute()
+      override x.ToString() = sprintf "Attr(%A)" pms
+
+    [<Attr(null)>]
+    let f () = ()
+
+    let test3() = 
+        match <@ f() @> with
+        | Quotations.Patterns.Call(_, m, _) ->
+            m.GetCustomAttributes(typeof<Attr>, false)
+            |> Seq.map (fun x -> x.ToString())
+            |> String.concat ", "
+        | _ -> failwith "unreachable 3"
+
+    check "vwcewecioj9" (test3()) "Attr(<null>)"
+ 
+
+
 (*-------------------------------------------------------------------------
 !* Test passed?
  *------------------------------------------------------------------------- *)


### PR DESCRIPTION
Fix #316 
We were missing the 0xFFFFFFFF case indicating a "null" value for arrays