### PR TITLE
Fix 238 - Generic use of member constraint solved to record field causes crash

### DIFF
--- a/src/fsharp/csolve.fs
+++ b/src/fsharp/csolve.fs
@@ -1157,7 +1157,7 @@ and SolveMemberConstraint (csenv:ConstraintSolverEnv) permitWeakResolution ndeep
                                    IsRecdFieldAccessible amap m AccessibleFromEverywhere rfinfo.RecdFieldRef &&
                                    not rfinfo.LiteralValue.IsSome && 
                                    not rfinfo.RecdField.IsCompilerGenerated -> 
-                            Some (TTraitSolvedRecdProp (rfinfo, isSetProp))
+                            Some (TTraitSolvedRecdProp (rfinfo, isSetProp), rfinfo.FieldType)
                         | _ -> None)
                   match props with 
                   | [ prop ] -> Some prop
@@ -1210,9 +1210,9 @@ and SolveMemberConstraint (csenv:ConstraintSolverEnv) permitWeakResolution ndeep
                   CollectThenUndo (fun trace -> ResolveOverloading csenv (WithTrace(trace)) nm ndeep true (0,0) AccessibleFromEverywhere calledMethGroup false (Some rty))  
 
               match recdPropSearch, methOverloadResult with 
-              | Some a, None -> 
-                  // OK, the constraint is solved by a record property
-                  ResultD a
+              | Some (sln, rty2), None -> 
+                  // OK, the constraint is solved by a record property. Assert that the return types match.
+                  SolveTypEqualsTypKeepAbbrevs csenv ndeep m2 trace rty rty2 ++ (fun () -> ResultD sln)
               | None, Some (calledMeth:CalledMeth<_>) -> 
                   // OK, the constraint is solved. 
                   // Re-run without undo to commit the inference equations. Throw errors away 

--- a/src/fsharp/csolve.fs
+++ b/src/fsharp/csolve.fs
@@ -1157,7 +1157,7 @@ and SolveMemberConstraint (csenv:ConstraintSolverEnv) permitWeakResolution ndeep
                                    IsRecdFieldAccessible amap m AccessibleFromEverywhere rfinfo.RecdFieldRef &&
                                    not rfinfo.LiteralValue.IsSome && 
                                    not rfinfo.RecdField.IsCompilerGenerated -> 
-                            Some (TTraitSolvedRecdProp (rfinfo, isSetProp), rfinfo.FieldType)
+                            Some (rfinfo, isSetProp)
                         | _ -> None)
                   match props with 
                   | [ prop ] -> Some prop
@@ -1210,9 +1210,11 @@ and SolveMemberConstraint (csenv:ConstraintSolverEnv) permitWeakResolution ndeep
                   CollectThenUndo (fun trace -> ResolveOverloading csenv (WithTrace(trace)) nm ndeep true (0,0) AccessibleFromEverywhere calledMethGroup false (Some rty))  
 
               match recdPropSearch, methOverloadResult with 
-              | Some (sln, rty2), None -> 
+              | Some (rfinfo, isSetProp), None -> 
                   // OK, the constraint is solved by a record property. Assert that the return types match.
-                  SolveTypEqualsTypKeepAbbrevs csenv ndeep m2 trace rty rty2 ++ (fun () -> ResultD sln)
+                  let rty2 = if isSetProp then  g.unit_ty else rfinfo.FieldType
+                  SolveTypEqualsTypKeepAbbrevs csenv ndeep m2 trace rty rty2 ++ (fun () -> 
+                  ResultD (TTraitSolvedRecdProp(rfinfo, isSetProp)))
               | None, Some (calledMeth:CalledMeth<_>) -> 
                   // OK, the constraint is solved. 
                   // Re-run without undo to commit the inference equations. Throw errors away 

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -1696,6 +1696,16 @@ module RecordPropertyConstraintTests =
     check "ckjwnewk" (f8()) (System.TimeSpan.FromSeconds 2.0) // after mutation
     check "ckjwnewk" (f10()) "Gary"
 
+
+// See https://github.com/Microsoft/visualfsharp/issues/238
+module GenericPropertyConstraintSolvedByRecord = 
+
+    type hober<'a> = { foo : 'a }
+
+    let inline print_foo_memb x = box (^a : (member foo : 'b) x)
+
+    let v = print_foo_memb { foo=1 } 
+
 let aa =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 
 


### PR DESCRIPTION
Fix #238

We were missing a constraint assertion (to force the return type of a record solution to be equal to the return type in the static member constraint being solved)

