### PR TITLE
fix 147 - error FS0073: internal error: Undefined or unsolved type variable: 'a

### DIFF
--- a/src/fsharp/tc.fs
+++ b/src/fsharp/tc.fs
@@ -12743,6 +12743,14 @@ module TyconBindingChecking = begin
         // Post letrec env 
         let envFinal = AddLocalTyconRefs false g cenv.amap scopem tcrefsWithCSharpExtensionMembers envInitial
         let envFinal = AddLocalVals cenv.tcSink scopem prelimRecValues envFinal
+        let envFinal = 
+             let ctorVals = 
+                 [ for (TyconBindingsPassBGroup(_tcref, defnBs)) in defnsBs do
+                      for defnB in defnBs do
+                        match defnB with
+                        | PassBIncrClassCtor (incrClassCtorLhs, _) -> yield incrClassCtorLhs.InstanceCtorVal
+                        | _ -> ()  ]
+             AddLocalVals cenv.tcSink scopem ctorVals envFinal
 
         binds,envFinal,tpenv
 

--- a/tests/fsharp/typecheck/sigs/build.bat
+++ b/tests/fsharp/typecheck/sigs/build.bat
@@ -8,6 +8,9 @@ call %~d0%~p0..\..\..\config.bat
 "%FSC%" --noframework -r:"%FSCOREDLLPATH%" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Core.dll" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Data.dll" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.dll" -r:"%X86_PROGRAMFILES%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Numerics.dll" -a -o:pos21.dll  pos21.fs
 @if ERRORLEVEL 1 goto Error
 
+call ..\..\single-neg-test.bat neg92
+@if ERRORLEVEL 1 goto Error
+
 call ..\..\single-neg-test.bat neg91
 @if ERRORLEVEL 1 goto Error
 

--- a/tests/fsharp/typecheck/sigs/neg92.bsl
+++ b/tests/fsharp/typecheck/sigs/neg92.bsl
@@ -1,0 +1,1 @@
+needs updating

--- a/tests/fsharp/typecheck/sigs/neg92.bsl
+++ b/tests/fsharp/typecheck/sigs/neg92.bsl
@@ -1,1 +1,4 @@
-needs updating
+
+neg92.fs(10,19,10,20): typecheck error FS0064: This construct causes code to be less generic than indicated by the type annotations. The type variable 'T has been constrained to be type ''U'.
+
+neg92.fs(9,9,9,30): typecheck error FS0670: This code is not sufficiently generic. The type variable 'U could not be generalized because it would escape its scope.

--- a/tests/fsharp/typecheck/sigs/neg92.fs
+++ b/tests/fsharp/typecheck/sigs/neg92.fs
@@ -1,0 +1,23 @@
+module Test
+
+
+module Test1 = 
+    type SomeClass(x : 'T) = class end
+        //member this.P = 1
+        //member this.X = x
+
+    let SomeFunc<'U> (x : 'U) =
+        SomeClass(x)
+
+module Test2 = 
+    open System
+
+    type SomeClass(updater : #IComparable->unit) =
+        let onLoaded () = 
+            let adorner : #IComparable = failwith ""
+            updater adorner
+        member this.OnLoaded = onLoaded
+
+    let UpdateAdorner (updater : #IComparable->unit)=
+        let updater = SomeClass (updater)
+        updater.OnLoaded


### PR DESCRIPTION
Fix #147 

This fixes a long-standing type checker bug. We need to push implicit constructors into the type checking environment when determining what type variables can be generalized. 
