### PR TITLE
Fix 34 - check for duplicate extension members

### DIFF
--- a/src/fsharp/check.fs
+++ b/src/fsharp/check.fs
@@ -1070,7 +1070,6 @@ let CheckTopBinding cenv env (TBind(v,e,_) as bind) =
                 | _ -> true (* not hiddenRepr *)
 
             let kind = (if v.IsMember then "member" else "value")
-
             let check skipValCheck nm = 
                 if not skipValCheck && 
                    v.IsModuleBinding && 
@@ -1078,7 +1077,6 @@ let CheckTopBinding cenv env (TBind(v,e,_) as bind) =
                    not (valEq tcref.ModuleOrNamespaceType.AllValsByLogicalName.[nm] v) then
                     
                     error(Duplicate(kind,v.DisplayName,v.Range));
-
 
 #if CASES_IN_NESTED_CLASS
                 if tcref.IsUnionTycon && nm = "Cases" then 

--- a/src/fsharp/check.fs
+++ b/src/fsharp/check.fs
@@ -1205,7 +1205,7 @@ let CheckEntityDefn cenv env (tycon:Entity) =
 
         let getHash (hash:Dictionary<string,_>) nm = 
              if hash.ContainsKey(nm) then hash.[nm] else []
-         
+        
         // precompute methods grouped by MethInfo.LogicalName
         let hashOfImmediateMeths = 
                 let h = new Dictionary<string, _>()

--- a/src/fsharp/check.fs
+++ b/src/fsharp/check.fs
@@ -1073,7 +1073,7 @@ let CheckTopBinding cenv env (TBind(v,e,_) as bind) =
 
             let check skipValCheck nm = 
                 if not skipValCheck && 
-                   v.IsModuleBinding &&
+                   v.IsModuleBinding && 
                    tcref.ModuleOrNamespaceType.AllValsByLogicalName.ContainsKey(nm) && 
                    not (valEq tcref.ModuleOrNamespaceType.AllValsByLogicalName.[nm] v) then
                     
@@ -1205,9 +1205,9 @@ let CheckEntityDefn cenv env (tycon:Entity) =
 
         let immediateProps = GetImmediateIntrinsicPropInfosOfType (None,AccessibleFromSomewhere) cenv.g cenv.amap m typ
 
-        let getHash (hash:Dictionary<string,_>) nm =
+        let getHash (hash:Dictionary<string,_>) nm = 
              if hash.ContainsKey(nm) then hash.[nm] else []
-
+         
         // precompute methods grouped by MethInfo.LogicalName
         let hashOfImmediateMeths = 
                 let h = new Dictionary<string, _>()

--- a/tests/fsharp/typecheck/sigs/neg23.bsl
+++ b/tests/fsharp/typecheck/sigs/neg23.bsl
@@ -38,3 +38,11 @@ neg23.fs(92,18,92,21): typecheck error FS0439: The method 'X04' has curried argu
 neg23.fs(110,21,110,22): typecheck error FS0439: The method 'F' has curried arguments but has the same name as another method in this type. Methods with curried arguments cannot be overloaded. Consider using a method taking tupled arguments.
 
 neg23.fs(113,21,113,22): typecheck error FS0439: The method 'F' has curried arguments but has the same name as another method in this type. Methods with curried arguments cannot be overloaded. Consider using a method taking tupled arguments.
+
+neg23.fs(164,18,164,29): typecheck error FS0037: Two members called 'GroupRowsBy' have the same signature
+
+neg23.fs(165,18,165,29): typecheck error FS0037: Two members called 'GroupRowsBy' have the same signature
+
+neg23.fs(168,17,168,20): typecheck error FS0037: Two members called 'Foo' have the same signature
+
+neg23.fs(169,17,169,20): typecheck error FS0037: Two members called 'Foo' have the same signature

--- a/tests/fsharp/typecheck/sigs/neg23.fs
+++ b/tests/fsharp/typecheck/sigs/neg23.fs
@@ -155,3 +155,15 @@ module PositiveTests =
         let y2 : int -> int = c.M2 (3,4)
         let y3 : int * int -> int -> int = c.M2
 
+
+type Frame = 
+  class 
+  end
+module X =
+  type Frame with
+    member frame.GroupRowsBy(key) = ()
+    member frame.GroupRowsBy(key) = ()
+    
+    // Up to erasure
+    member this.Foo (x:int->int) = printfn "method 1"
+    member this.Foo (x:FSharpFunc<int,int>) = printfn "method 2"


### PR DESCRIPTION
This adds a check for duplicate extension members, fixing long-standing bug #34 