### PR TITLE
Fixed prompt message when --pause compiler switch is used

### DIFF
--- a/src/fsharp/fscopts.fs
+++ b/src/fsharp/fscopts.fs
@@ -761,7 +761,7 @@ let ReportTime (tcConfig:TcConfig) descr =
     | None -> ()
     | Some prevDescr ->
         if tcConfig.pause then 
-            dprintf "[done '%s', entering '%s'] press any key... " prevDescr descr;
+            dprintf "[done '%s', entering '%s'] press <enter> to continue... " prevDescr descr;
             System.Console.ReadLine() |> ignore;
         // Intentionally putting this right after the pause so a debugger can be attached.
         match tcConfig.simulateException with


### PR DESCRIPTION
Fix for issue #445 
Preferred to update compiler message over replacing `ReadLine` with `ReadKey`, because in this way fix is unlikely to break anything else.