### PR TITLE
Enable IsNull test in UnboxAndOptionStuff() tests

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/PrimTypes.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/PrimTypes.fs
@@ -674,7 +674,8 @@ type UnboxAndOptionStuff() =
         Assert.IsTrue( tryUnbox<int> (box 1) = Some 1)
         Assert.IsTrue( tryUnbox<string> (box "") = Some "")
         Assert.IsTrue( tryUnbox<string> (box 1) = None)
-        
+
+    [<Test>]
     member this.IsNull() =
         Assert.IsTrue( isNull (null : string))
         Assert.IsTrue( isNull (null : string[]))


### PR DESCRIPTION
@mexx commented [here](https://visualfsharp.codeplex.com/SourceControl/network/forks/dsyme/cleanup/contribution/7672) that the IsNull test was not enabled, this fixes that (test is now running and passing)