### PR TITLE
#461: Added tests to reveal problem with source code location for FS0…

### DIFF
--- a/tests/fsharpqa/Source/EntryPoint/W_NoEntryPointInLastModuleInsideMultipleNamespace.fs
+++ b/tests/fsharpqa/Source/EntryPoint/W_NoEntryPointInLastModuleInsideMultipleNamespace.fs
@@ -1,0 +1,22 @@
+// #Regression #NoMT #EntryPoint 
+// Empty program entry point warning
+// Lack of entry point produces warning with correct source location when compiled to *.exe
+// when multiple namespaces with multiple modules declared in source file 
+//<Expects id="FS0988" span="(22,24-22,24)" status="warning">Main module of program is empty\: nothing will happen when it is run</Expects>
+
+#light
+namespace MyNamespace1
+
+module MyModule1 =
+    let irrelevant = 10
+    
+module MyModule2 =
+    let irrelevant = 10
+    
+namespace MyNamespace2
+
+module MyModule3 =
+    let irrelevant = 10
+    
+module MyModule4 =
+    let irrelevant = 10

--- a/tests/fsharpqa/Source/EntryPoint/W_NoEntryPointModuleInNamespace.fs
+++ b/tests/fsharpqa/Source/EntryPoint/W_NoEntryPointModuleInNamespace.fs
@@ -1,0 +1,11 @@
+// #Regression #NoMT #EntryPoint 
+// Empty program entry point warning
+// Lack of entry point produces warning with correct source location when compiled to *.exe
+// when single module declared inside namespace
+//<Expects id="FS0988" span="(11,24-11,24)" status="warning">Main module of program is empty\: nothing will happen when it is run</Expects>
+
+#light
+namespace MyNamespace1
+
+module MyModule1 =
+    let irrelevant = 10

--- a/tests/fsharpqa/Source/EntryPoint/W_NoEntryPointMultipleModules.fs
+++ b/tests/fsharpqa/Source/EntryPoint/W_NoEntryPointMultipleModules.fs
@@ -1,0 +1,13 @@
+// #Regression #NoMT #EntryPoint 
+// Empty program entry point warning
+// Lack of entry point produces warning with correct source location when compiled to *.exe
+// when multiple modules declared without declaring namespace
+//<Expects id="FS0988" span="(13,24-13,24)" status="warning">Main module of program is empty\: nothing will happen when it is run</Expects>
+
+#light
+
+module MyModule1 =
+    let irrelevant = 10
+
+module MyModule2 =
+    let irrelevant = 10

--- a/tests/fsharpqa/Source/EntryPoint/W_NoEntryPointTypeInNamespace.fs
+++ b/tests/fsharpqa/Source/EntryPoint/W_NoEntryPointTypeInNamespace.fs
@@ -1,0 +1,10 @@
+// #Regression #NoMT #EntryPoint 
+// Empty program entry point warning
+// Lack of entry point produces warning with correct source location when compiled to *.exe
+// when source file declares type inside namespace
+//<Expects id="FS0988" span="(10,18-10,18)" status="warning">Main module of program is empty\: nothing will happen when it is run</Expects>
+
+#light
+namespace MyNamespace1
+
+type T = T of int

--- a/tests/fsharpqa/Source/EntryPoint/env.lst
+++ b/tests/fsharpqa/Source/EntryPoint/env.lst
@@ -17,3 +17,7 @@ NoMT	SOURCE=entrypointandFSI02.fsx FSIMODE=EXEC COMPILE_ONLY=1				# entrypointan
 	SOURCE=E_CompilingToALibrary01.fs SCFLAGS="--test:ErrorRanges --target:library"	# E_CompilingToALibrary01.fs
 	SOURCE=E_CompilingToAModule01.fs  SCFLAGS="--test:ErrorRanges --target:module"	# E_CompilingToAModule01.fs
 	SOURCE=EntryPointAndAssemblyCulture.fs								# EntryPointAndAssemblyCulture.fs
+	SOURCE=W_NoEntryPointInLastModuleInsideMultipleNamespace.fs SCFLAGS="--test:ErrorRanges"	# W_NoEntryPointInLastModuleInsideMultipleNamespace.fs
+	SOURCE=W_NoEntryPointModuleInNamespace.fs SCFLAGS="--test:ErrorRanges"	# W_NoEntryPointModuleInNamespace.fs
+	SOURCE=W_NoEntryPointMultipleModules.fs SCFLAGS="--test:ErrorRanges"	# W_NoEntryPointMultipleModules.fs
+	SOURCE=W_NoEntryPointTypeInNamespace.fs SCFLAGS="--test:ErrorRanges"	# W_NoEntryPointTypeInNamespace.fs


### PR DESCRIPTION
Added tests to reveal problem (#461) with source code location for `FS0988` warning.
There are 4 new tests 1 of them is already passed by current implementation.

For now I haven't found the way to fix issue. One of the problems is that I don't understand intension of [QualifiedNameOfFile](https://github.com/Microsoft/visualfsharp/blob/c129badb23e20de07bdb38ea16fa2fa32a31cdb1/src/fsharp/ast.fs#L1432) which range [is used](https://github.com/Microsoft/visualfsharp/blob/c129badb23e20de07bdb38ea16fa2fa32a31cdb1/src/fsharp/ilxgen.fs#L5913) when compiler [emit warning](https://github.com/Microsoft/visualfsharp/blob/c129badb23e20de07bdb38ea16fa2fa32a31cdb1/src/fsharp/ilxgen.fs#L5982).