### PR TITLE
Fix #392 - restore limited support for 'execute line in interactive'

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.Base/ViewFilter.cs
@@ -436,6 +436,10 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                 {
                     return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED;
                 }
+                else if (nCmdId == (uint)Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteLineInInteractive)
+                {
+                    return (int)OLECMDF.OLECMDF_SUPPORTED | (int)OLECMDF.OLECMDF_ENABLED | (int)OLECMDF.OLECMDF_DEFHIDEONCTXTMENU;
+                }
             }
             else if (guidCmdGroup == guidInteractive)
             {
@@ -570,7 +574,12 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             {
                 if (nCmdId == (uint)Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteSelectionInInteractive)
                 {
-                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), false, null, null);
+                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), Interactive.FsiEditorSendAction.ExecuteSelection, null, null);
+                    return true;
+                }
+                else if (nCmdId == (uint)Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteLineInInteractive)
+                {
+                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), Interactive.FsiEditorSendAction.ExecuteLine, null, null);
                     return true;
                 }
             }
@@ -578,7 +587,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
             {
                 if (nCmdId == cmdIDDebugSelection)
                 {
-                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), true, null, null);
+                    Interactive.Hooks.OnMLSend(GetProjectSystemPackage(), Interactive.FsiEditorSendAction.DebugSelection, null, null);
                     return true;
                 }
             }

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiBasis.fs
@@ -56,6 +56,8 @@ module internal Guids =
     // some commands moved to VS Shell
     let guidInteractiveShell            = Microsoft.VisualStudio.VSConstants.VsStd11 
     let cmdIDSendSelection              = int Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteSelectionInInteractive
+    let cmdIDSendLine                   = int Microsoft.VisualStudio.VSConstants.VSStd11CmdID.ExecuteLineInInteractive
+
     // some commands not in VS Shell
     let guidInteractive                 = Guid("8B9BF77B-AF94-4588-8847-2EB2BFFD29EB")
     let cmdIDDebugSelection             = 0x01

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiCommands.vsct
@@ -223,6 +223,7 @@
          Ideally, we would bind it for F# only editor.
     -->
     <KeyBinding guid ="guidVSStd11" id ="cmdidExecuteSelectionInInteractive" editor="GUID_TextEditorFactory" key1="VK_RETURN" mod1="Alt"  />
+    <KeyBinding guid ="guidVSStd11" id ="cmdidExecuteLineInInteractive" editor="GUID_TextEditorFactory" key1="VK_OEM_7" mod1="Alt"  />
 
     <!-- CRTL-ALT-F for FSI window - following similar bindings for "other windows" -->
     <KeyBinding guid="guidFsiPackageCmdSet" id="cmdidFsiToolWindow"    editor="guidVSStd97" key1="F" mod1="Control Alt"  />
@@ -294,6 +295,7 @@
 
     <GuidSymbol name="guidVSStd11" value="{D63DB1F0-404E-4B21-9648-CA8D99245EC3}" >
       <IDSymbol name="cmdidExecuteSelectionInInteractive" value ="0x018"/>
+      <IDSymbol name="cmdidExecuteLineInInteractive" value ="0x019"/>
       <IDSymbol name="cmdidInteractiveSessionInterrupt" value ="0x01A"/>
       <IDSymbol name="cmdidInteractiveSessionRestart" value ="0x01B"/>
     </GuidSymbol>

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
@@ -72,10 +72,13 @@ module internal Hooks =
     let private withFSIToolWindow (this:Package) f =
         queryFSIToolWindow this f ()
 
-    let OnMLSend (this:Package) (debug : bool) (sender:obj) (e:EventArgs) =
+    let OnMLSend (this:Package) (action : FsiEditorSendAction) (sender:obj) (e:EventArgs) =
         withFSIToolWindow this (fun window ->
-            if debug then window.MLDebug(sender, e)
-            else window.MLSend(sender, e)
+            match action with
+            | FsiEditorSendAction.ExecuteSelection -> window.MLSendSelection(sender, e)
+            | FsiEditorSendAction.ExecuteLine -> window.MLSendLine(sender, e)
+            | FsiEditorSendAction.DebugSelection -> window.MLDebugSelection(sender, e)
+            | _ -> ignore () // appease 'missing match case' warning
         )
 
     let AddReferencesToFSI (this:Package) references =

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/fsiPackageHooks.fs
@@ -75,10 +75,9 @@ module internal Hooks =
     let OnMLSend (this:Package) (action : FsiEditorSendAction) (sender:obj) (e:EventArgs) =
         withFSIToolWindow this (fun window ->
             match action with
-            | FsiEditorSendAction.ExecuteSelection -> window.MLSendSelection(sender, e)
-            | FsiEditorSendAction.ExecuteLine -> window.MLSendLine(sender, e)
-            | FsiEditorSendAction.DebugSelection -> window.MLDebugSelection(sender, e)
-            | _ -> ignore () // appease 'missing match case' warning
+            | ExecuteSelection -> window.MLSendSelection(sender, e)
+            | ExecuteLine -> window.MLSendLine(sender, e)
+            | DebugSelection -> window.MLDebugSelection(sender, e)
         )
 
     let AddReferencesToFSI (this:Package) references =


### PR DESCRIPTION
Fixes #398 - adds back the keyboard shortcut and command handling for 'Execute line in interactive'.

This maintains the decision to remove "execute line" from the UI context menu. It just restores the keyboard shortcut and backend handling so that we don't break anyone's muscle memory.