### PR TITLE
fix StartUpToDateCheck with VSUTDCF_DTEEONLY option,

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
@@ -1838,6 +1838,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             int utdSupported = config.IsFastUpToDateCheckEnabled() ? 1 : 0;
 
+            var optionsFlags = (VsUpToDateCheckFlags)options;
+            if ((optionsFlags & (VsUpToDateCheckFlags.VSUTDCF_DTEEONLY)) == VsUpToDateCheckFlags.VSUTDCF_DTEEONLY)
+            {
+                utdSupported = 0;
+            }
+
             if (supported != null && supported.Length > 0)
                 supported[0] = utdSupported;
             if (ready != null && ready.Length > 0)
@@ -1880,6 +1886,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         public virtual int StartUpToDateCheck(IVsOutputWindowPane pane, uint options)
         {
             CCITracing.TraceCall();
+
+            var optionsFlags = (VsUpToDateCheckFlags) options;
+            if ((optionsFlags & (VsUpToDateCheckFlags.VSUTDCF_DTEEONLY)) == VsUpToDateCheckFlags.VSUTDCF_DTEEONLY)
+            {
+                return VSConstants.E_NOTIMPL;
+            }
             
             return config.IsUpToDate(OutputWindowLogger.CreateUpToDateCheckLogger(pane), false) ? VSConstants.S_OK : VSConstants.E_FAIL;
         }


### PR DESCRIPTION
fix #471 

return build not up-to-date if flag VSUTDCF_DTEEONLY is used for StartUpToDateCheck.

