### PR TITLE
Fix #282 - Remove duplicate 'Visual F# Items' node for project items

### DIFF
--- a/vsintegration/src/Templates/ItemTemplates/ItemTemplates.csproj
+++ b/vsintegration/src/Templates/ItemTemplates/ItemTemplates.csproj
@@ -69,51 +69,45 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <!-- work around inconsistencies with escaping the # character -->
-  <Target Name="FixHashEscaping" AfterTargets="ZipItems" >
-    <Copy SourceFiles="@(IntermediateZipItem)"
-          DestinationFiles="@(IntermediateZipItem->'%(FullPath)'->Replace(&quot;%2523&quot;,&quot;#&quot;))"
-          SkipUnchangedFiles="true" />
-   </Target>
   <ItemGroup>
     <VSTemplate Include="ItemTemplates\CodeFile\CodeFile.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\Code</OutputSubPath>
+      <OutputSubPath>Code</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\ScriptFile\ScriptFile.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\Code</OutputSubPath>
+      <OutputSubPath>Code</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\ODataServiceConnection\ODataServiceConnection.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\Data</OutputSubPath>
+      <OutputSubPath>Data</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\SignatureFile\SignatureFile.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\Code</OutputSubPath>
+      <OutputSubPath>Code</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\SqlDataConnection\SqlDataConnection.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\Data</OutputSubPath>
+      <OutputSubPath>Data</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\SqlEntityConnection\SqlEntityConnection.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\Data</OutputSubPath>
+      <OutputSubPath>Data</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\WsdlServiceConnection\WsdlServiceConnection.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\Data</OutputSubPath>
+      <OutputSubPath>Data</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\AppConfig\AppConfig.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\General</OutputSubPath>
+      <OutputSubPath>General</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\TextFile\TextFile.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\General</OutputSubPath>
+      <OutputSubPath>General</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
     <VSTemplate Include="ItemTemplates\XMLFile\XMLFile.vstemplate">
-      <OutputSubPath>Visual F%252523 Items\General</OutputSubPath>
+      <OutputSubPath>General</OutputSubPath>
       <SubType>Designer</SubType>
     </VSTemplate>
   </ItemGroup>


### PR DESCRIPTION
Shiproom template:

- **Bug number** #282 
- **Customer scenario** Tree structure shown for F# items in "Add new item" dialog was wrong, see linked bug for screenshot.
- **Fix description** Revert df66e131c97b78f7. That was originally a fix for the *opposite* problem, where all items appeared directly under the root node: http://visualfsharp.codeplex.com/workitem/118
- **Testing done** Manual verification + Failing IDE automation now passes

At some point another fix to our templates VSIX must have restored the original expected behavior here, thus turning the "fix" from earlier into a new bug where we have *too many* nodes in the "add new item" dialog.