### PR TITLE
Fix #471 - consider QueryStartUpToDateCheck options, harden against sync context issues

### DIFF
--- a/vsintegration/src/unittests/Tests.ProjectSystem.UpToDate.fs
+++ b/vsintegration/src/unittests/Tests.ProjectSystem.UpToDate.fs
@@ -327,6 +327,58 @@ type UpToDate() =
             Assert.IsFalse(config.IsFastUpToDateCheckEnabled())
             ))
 
+    [<Test>]
+    member public this.UTDOptionsFlags () =
+        this.MakeProjectAndDo(["file1.fs"], [], "", (fun project ->
+            let configNameDebugx86 = ConfigCanonicalName("Debug", "x86")
+            let debugConfigx86 = project.ConfigProvider.GetProjectConfiguration(configNameDebugx86)            
+            let buildableConfig = 
+                match debugConfigx86.get_BuildableProjectCfg() with
+                | 0, bc -> bc
+                | _ -> failwith "get_BuildableProjectCfg failed"
+
+            let testFlag flag expected =            
+                let supported = Array.zeroCreate<int> 1
+                let ready = Array.zeroCreate<int> 1
+                buildableConfig.QueryStartUpToDateCheck(flag, supported, ready) |> ignore
+                Assert.IsTrue(supported.[0] = expected)
+                Assert.IsTrue(ready.[0] = expected)
+
+            [ VSConstants.VSUTDCF_DTEEONLY, 1
+              VSConstants.VSUTDCF_PACKAGE, 0
+              VSConstants.VSUTDCF_PRIVATE, 1
+              VSConstants.VSUTDCF_REBUILD, 1 ]
+            |> List.iter (fun (flag, expected) -> testFlag flag expected)
+          ))
+
+    [<Test>]
+    member public this.UTDOptionsFlagsUTDDisabled () =
+        this.MakeProjectAndDo(["file1.fs"], [],  @"
+                <PropertyGroup>
+                    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+                </PropertyGroup>
+            ", (fun project ->
+            let configNameDebugx86 = ConfigCanonicalName("Debug", "x86")
+            let debugConfigx86 = project.ConfigProvider.GetProjectConfiguration(configNameDebugx86)            
+            let buildableConfig = 
+                match debugConfigx86.get_BuildableProjectCfg() with
+                | 0, bc -> bc
+                | _ -> failwith "get_BuildableProjectCfg failed"
+
+            let testFlag flag expected =            
+                let supported = Array.zeroCreate<int> 1
+                let ready = Array.zeroCreate<int> 1
+                buildableConfig.QueryStartUpToDateCheck(flag, supported, ready) |> ignore
+                Assert.AreEqual(supported.[0], expected)
+                Assert.AreEqual(ready.[0], expected)
+
+            [ VSConstants.VSUTDCF_DTEEONLY, 1
+              VSConstants.VSUTDCF_PACKAGE, 0
+              VSConstants.VSUTDCF_PRIVATE, 0
+              VSConstants.VSUTDCF_REBUILD, 0 ]
+            |> List.iter (fun (flag, expected) -> testFlag flag expected)
+          ))
+
 [<TestFixture>]
 type ``UpToDate PreserveNewest`` () = 
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
@@ -4150,7 +4150,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     // REVIEW/TODO: shall we abandon accessing automation here and just look at MSBuild state?
                     EnvDTE.Project automationObject = this.GetAutomationObject() as EnvDTE.Project;
                     ConfigCanonicalName currentConfigName;
-                    if (Utilities.TryGetActiveConfigurationAndPlatform(this.Site, InteropSafeIVsHierarchy, out currentConfigName))
+                    if (Utilities.TryGetActiveConfigurationAndPlatform(this.Site, this.ProjectIDGuid, out currentConfigName))
                     {
                         if (currentConfigName == configCanonicalName) return;
                     }
@@ -4346,7 +4346,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
 
             ConfigCanonicalName configCanonicalName;
-            if (!Utilities.TryGetActiveConfigurationAndPlatform(this.Site, InteropSafeIVsHierarchy, out configCanonicalName))
+            if (!Utilities.TryGetActiveConfigurationAndPlatform(this.Site, this.ProjectIDGuid, out configCanonicalName))
             {
                 throw new InvalidOperationException();
             }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Utilities.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Utilities.cs
@@ -940,20 +940,14 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <param name="configuration">The name of the active configuration.</param>
         /// <param name="platform">The name of the platform.</param>
         /// <returns>true if successfull.</returns>
-        /*internal, but public for FSharp.Project.dll*/ public static bool TryGetActiveConfigurationAndPlatform(System.IServiceProvider serviceProvider, IVsHierarchy hierarchy, out ConfigCanonicalName configCanonicalName)
+        /*internal, but public for FSharp.Project.dll*/ public static bool TryGetActiveConfigurationAndPlatform(System.IServiceProvider serviceProvider, Guid projectId, out ConfigCanonicalName configCanonicalName)
         {
             if (serviceProvider == null)
             {
                 throw new ArgumentNullException("serviceProvider");
             }
 
-            if (hierarchy == null)
-            {
-                throw new ArgumentNullException("hierarchy");
-            }
-            
-
-            IVsSolutionBuildManager2 solutionBuildManager = serviceProvider.GetService(typeof(SVsSolutionBuildManager)) as IVsSolutionBuildManager2;
+            IVsSolutionBuildManager5 solutionBuildManager = serviceProvider.GetService(typeof(SVsSolutionBuildManager)) as IVsSolutionBuildManager5;
 
             if (solutionBuildManager == null)
             {
@@ -961,17 +955,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return false;
             }
 
-            IVsProjectCfg[] activeConfigs = new IVsProjectCfg[1];
-            ErrorHandler.ThrowOnFailure(solutionBuildManager.FindActiveProjectCfg(IntPtr.Zero, IntPtr.Zero, hierarchy, activeConfigs));
-
-            IVsProjectCfg activeCfg = activeConfigs[0];
-
-            // Can it be that the activeCfg is null?
-            System.Diagnostics.Debug.Assert(activeCfg != null, "Cannot find the active configuration");
-
             string canonicalName;
-            ErrorHandler.ThrowOnFailure(activeCfg.get_CanonicalName(out canonicalName));
+            ErrorHandler.ThrowOnFailure(solutionBuildManager.FindActiveProjectCfgName(projectId, out canonicalName));
+
             configCanonicalName = new ConfigCanonicalName(canonicalName);
+
             return true;
         }
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/FS/Project.fs
@@ -2137,7 +2137,7 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
                 if GetCaption(pHierProj) = GetCaption(projNode.InteropSafeIVsHierarchy) then
                     // This code matches what ProjectNode.SetConfiguration would do; that method cannot be called during a build, but at this
                     // current moment in time, it is 'safe' to do this update.
-                    let _,currentConfigName = Utilities.TryGetActiveConfigurationAndPlatform(projNode.Site, projNode.InteropSafeIVsHierarchy)
+                    let _,currentConfigName = Utilities.TryGetActiveConfigurationAndPlatform(projNode.Site, projNode.ProjectIDGuid)
                     MSBuildProject.SetGlobalProperty(projNode.BuildProject, ProjectFileConstants.Configuration, currentConfigName.ConfigName)
                     MSBuildProject.SetGlobalProperty(projNode.BuildProject, ProjectFileConstants.Platform, currentConfigName.MSBuildPlatform)
                     projNode.UpdateMSBuildState()


### PR DESCRIPTION
Shiproom template:

- **Bug number** #471 
- **Customer scenario** VS extensions (e.g. TestDriven .NET) invoking F# project system `StartUpToDateCheck` get unexpected `ArgumentException` due to sync context issues.
- **Fix description**
 - Use `IVsSolutionBuildManager5.FindActiveProjectCfgName` instead of `IVsSolutionBuildManager2.FindActiveProjectCfg` in `TryGetActiveConfigurationAndPlatform`, as it is not sensitive to sync context
 - Give proper consideration to the VSUTDCF options flags passed to QueryStartUpToDateCheck
- **Testing done** Manual verification w/ TestDriven.NET + IDE unit tests
