### PR TITLE
Fix #199 - Explicitly set custom F# editor settings if they are missing

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.fsproj
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/FSharp.LanguageService.fsproj
@@ -71,6 +71,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0.dll" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.dll" />
     <Reference Include="Microsoft.VisualStudio.Shell.Design, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Utilities, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Package.LanguageService.$(VisualStudioVersion)" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
     <Reference Include="Microsoft.VisualStudio.ProjectAggregator" />

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
@@ -2039,6 +2039,9 @@ type FSharpPackage() as self =
     /// We specify our customizations in the General profile for VS, but we have found that in some cases
     /// those customizations are incorrectly ignored.
     member private this.EstablishDefaultSettingsIfMissing() =
+#if VS_VERSION_DEV12
+        ()  // ISettingsManager only implemented for VS 14.0+
+#else
         match this.GetService(typeof<SVsSettingsPersistenceManager>) with
         | :? Microsoft.VisualStudio.Settings.ISettingsManager as settingsManager ->
             for settingName,defaultValue in fsharpSpecificProfileSettings do
@@ -2049,6 +2052,7 @@ type FSharpPackage() as self =
                     settingsManager.SetValueAsync(settingName, defaultValue, false) |> ignore
                 | _ -> ()
         | _ -> ()
+#endif
 
     member self.RegisterForIdleTime() =
         mgr <- (self.GetService(typeof<SOleComponentManager>) :?> IOleComponentManager)

--- a/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs
@@ -2022,12 +2022,14 @@ type FSharpPackage() as self =
     
     let mutable mgr : IOleComponentManager = null
 
+#if !VS_VERSION_DEV12
     let fsharpSpecificProfileSettings =
         [| "TextEditor.F#.Insert Tabs", box false
            "TextEditor.F#.Brace Completion", box true
            "TextEditor.F#.Make URLs Hot", box false
            "TextEditor.F#.Indent Style", box 1u |]
-    
+#endif
+
     override self.Initialize() =
         UIThread.CaptureSynchronizationContext()
         self.EstablishDefaultSettingsIfMissing()


### PR DESCRIPTION
After talking with VS platform people, this is the suggested workaround for cases where VS fails to apply the custom F# settings from the General profile.

F# only specifies ~~3~~ (edit: 4) settings that deviate from the editor defaults, so it's only these 3 that need special care, AFAICT.

I'm still talking with the platform people to make sure this is the correct approach, but figured I'd send the PR to get review early.

ref #199 