### PR TITLE
Fix 483 project item save filename null

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAFileItem.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAFileItem.cs
@@ -222,10 +222,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         /// </summary>
         /// <param name="fileName">The name with which to save the project or project item.</param>
         /// <exception cref="InvalidOperationException">Is thrown if the save operation failes.</exception>
-        /// <exception cref="ArgumentNullException">Is thrown if fileName is null.</exception>
         public override void Save(string fileName)
         {
-            this.DoSave(false, fileName);
+            this.DoSave(false, fileName ?? string.Empty);
         }
 
         /// <summary>
@@ -233,6 +232,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         /// </summary>
         /// <param name="fileName">The file name with which to save the solution, project, or project item. If the file exists, it is overwritten</param>
         /// <returns>true if the rename was successful. False if Save as failes</returns>
+        /// <exception cref="ArgumentNullException">Is thrown if fileName is null.</exception>
         public override bool SaveAs(string fileName)
         {
             try

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProject.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/Automation/OAProject.cs
@@ -414,10 +414,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
         /// </summary>
         /// <param name="fileName">The file name of the project</param>
         /// <exception cref="InvalidOperationException">Is thrown if the save operation failes.</exception>
-        /// <exception cref="ArgumentNullException">Is thrown if fileName is null.</exception>        
         public virtual void Save(string fileName)
         {
-            this.DoSave(false, fileName);
+            this.DoSave(false, fileName ?? string.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
fix #483 

the filename parameter of both [Envdte.Project.Save](https://msdn.microsoft.com/en-us/library/envdte.project.save.aspx) and [Envdte.ProjectItem.Save](https://msdn.microsoft.com/en-us/library/envdte.projectitem.save.aspx) is optional ( null value or string.empty )

Same behaviour of c# projects 
