### PR TITLE
Array.chunkBySize does not return final chunk in some cases

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
@@ -151,6 +151,8 @@ type ArrayModule() =
         Assert.IsTrue([| [|1..4|]; [|5..8|] |] = Array.chunkBySize 4 [|1..8|])
         Assert.IsTrue([| [|1..4|]; [|5..8|]; [|9..10|] |] = Array.chunkBySize 4 [|1..10|])
         Assert.IsTrue([| [|1|]; [|2|]; [|3|]; [|4|] |] = Array.chunkBySize 1 [|1..4|])
+        Assert.IsTrue([| [|1..3|]; [|4|] |] = Array.chunkBySize 3 [|1..4|])
+        Assert.IsTrue([| [|1..5|]; [|6..10|]; [|11..12|] |] = Array.chunkBySize 5 [|1..12|])
 
         // string Seq
         Assert.IsTrue([| [|"a"; "b"|]; [|"c";"d"|]; [|"e"|] |] = Array.chunkBySize 2 [|"a";"b";"c";"d";"e"|])

--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -584,7 +584,7 @@ namespace Microsoft.FSharp.Collections
                 let res = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked chunkCount : 'T[][]
                 for i = 0 to len / chunkSize - 1 do
                     res.[i] <- Microsoft.FSharp.Primitives.Basics.Array.subUnchecked (i * chunkSize) chunkSize array
-                if len % chunkCount <> 0 then
+                if len % chunkSize <> 0 then
                     res.[chunkCount - 1] <- Microsoft.FSharp.Primitives.Basics.Array.subUnchecked ((chunkCount - 1) * chunkSize) (len % chunkSize) array
                 res
 


### PR DESCRIPTION
An example case is Array.chunkBySize 3 [|1..4|], the code calculates the
number of chunks to be 2, and then does not copy the final (partial) chunk
as 4 mod 2 is 0. Similarly for Array.chunkBySize 5 [|1..12|], number of
chunks is 3 and 12 % 3 = 0

Changing check to len % chunkSize fixes this.

Fixes #501