### PR TITLE
Fix #492 - use ConvILTypeRefUnadjusted not ConvILTypeRef

### DIFF
--- a/src/fsharp/creflect.fs
+++ b/src/fsharp/creflect.fs
@@ -967,7 +967,7 @@ and ConvTyconRef cenv (tcref:TyconRef) m =
     | TProvidedTypeExtensionPoint info when not cenv.g.isInteractive && not info.IsErased -> 
         // Note, generated types are (currently) non-generic
         let tref = ExtensionTyping.GetILTypeRefOfProvidedType (info.ProvidedType, m)
-        ConvILTypeRef cenv tref
+        ConvILTypeRefUnadjusted cenv m tref
     | _ -> 
 #endif
     let repr = tcref.CompiledRepresentation


### PR DESCRIPTION
- **Bug number** #492 
- **Customer scenario** Runtime crash in user code (dynamic assembly load failure) due to bad codegen. This is a regression. Occurs when downtargeting to F# 3.1 and using any query expression against the SQL Entity type provider (or other type providers that use static linking in a similar way).

- **Fix description**

Use correct API when encoding quoted assembly references.  `ConvILTypeRefUnadjusted` properly handles the case where the reference is statically linked. `ConvILTypeRef` does not.

These two used to be a single API.  They were split in [`640db00`](https://github.com/Microsoft/visualfsharp/commit/640db001bf4c91a31c45115355842205e9631e16#diff-58f43f706f29780d884d23a41f710571R963) and it was a simple oversight that the wrong one was wired up here.

- **Testing done**
We have private tests which cover these type providers, they were simply never run in a cross-version configuration.  That's frustrating, as cross-version testing was automated recently with #446.  Running those tests, the bug would have been found a month ago.  With the fix, they all pass.