### PR TITLE
Remove StructBox for Value Types

### DIFF
--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -177,9 +177,9 @@ namespace Microsoft.FSharp.Collections
 
             // Build the groupings
             for v in array do
-                let key = projection v
+                let safeKey = projection v
                 let mutable prev = Unchecked.defaultof<_>
-                if dict.TryGetValue(key, &prev) then dict.[key] <- prev + 1 else dict.[key] <- 1
+                if dict.TryGetValue(safeKey, &prev) then dict.[safeKey] <- prev + 1 else dict.[safeKey] <- 1
 
             let res = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked dict.Count
             let mutable i = 0
@@ -435,13 +435,13 @@ namespace Microsoft.FSharp.Collections
             // Build the groupings
             for i = 0 to (array.Length - 1) do
                 let v = array.[i]
-                let key = keyf v
+                let safeKey = keyf v
                 let mutable prev = Unchecked.defaultof<_>
-                if dict.TryGetValue(key, &prev) then
+                if dict.TryGetValue(safeKey, &prev) then
                     prev.Add v
                 else 
                     let prev = ResizeArray initialBucketSize
-                    dict.[key] <- prev
+                    dict.[safeKey] <- prev
                     prev.Add v
                      
             // Return the array-of-arrays.

--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -172,7 +172,7 @@ namespace Microsoft.FSharp.Collections
 
             Microsoft.FSharp.Primitives.Basics.Array.subUnchecked 0 count array
 
-        let countByImpl (comparer:IEqualityComparer<'SafeKey>) (projection:'T->'SafeKey) (getKey:'SafeKey->'Key) (array:'T[]) =
+        let inline countByImpl (comparer:IEqualityComparer<'SafeKey>) (projection:'T->'SafeKey) (getKey:'SafeKey->'Key) (array:'T[]) =
             let dict = Dictionary comparer
 
             // Build the groupings
@@ -423,7 +423,7 @@ namespace Microsoft.FSharp.Collections
             let rec loop i = i >= len1 || (f.Invoke(array1.[i], array2.[i]) && loop (i+1))
             loop 0
 
-        let groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (array: 'T[]) =
+        let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (array: 'T[]) =
             let dict = Dictionary<_,ResizeArray<_>> comparer
 
             // Previously this was 1, but I think this is rather stingy, considering that we are alreadying paying

--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -426,12 +426,6 @@ namespace Microsoft.FSharp.Collections
         let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (array: 'T[]) =
             let dict = Dictionary<_,ResizeArray<_>> comparer
 
-            // Previously this was 1, but I think this is rather stingy, considering that we are alreadying paying
-            // for at least a key, the ResizeArray reference, which includes an array reference, an Entry in the
-            // Dictionary, plus any empty space in the Dictionary of unfilled hash buckets. Having it larger means
-            // that we won't be having as many re-allocations. The ResizeArray is destroyed at the end anyway.
-            let initialBucketSize = 4
-
             // Build the groupings
             for i = 0 to (array.Length - 1) do
                 let v = array.[i]
@@ -440,7 +434,7 @@ namespace Microsoft.FSharp.Collections
                 if dict.TryGetValue(safeKey, &prev) then
                     prev.Add v
                 else 
-                    let prev = ResizeArray initialBucketSize
+                    let prev = ResizeArray ()
                     dict.[safeKey] <- prev
                     prev.Add v
                      

--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -172,23 +172,38 @@ namespace Microsoft.FSharp.Collections
 
             Microsoft.FSharp.Primitives.Basics.Array.subUnchecked 0 count array
 
-        [<CompiledName("CountBy")>]
-        let countBy projection (array:'T[]) =
-            checkNonNull "array" array
-            let dict = new Dictionary<Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.StructBox<'Key>,int>(Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.StructBox<'Key>.Comparer)
+        let countByImpl (comparer:IEqualityComparer<'SafeKey>) (projection:'T->'SafeKey) (getKey:'SafeKey->'Key) (array:'T[]) =
+            let dict = Dictionary comparer
 
             // Build the groupings
             for v in array do
-                let key = Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.StructBox (projection v)
+                let key = projection v
                 let mutable prev = Unchecked.defaultof<_>
                 if dict.TryGetValue(key, &prev) then dict.[key] <- prev + 1 else dict.[key] <- 1
 
             let res = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked dict.Count
             let mutable i = 0
             for group in dict do
-                res.[i] <- group.Key.Value, group.Value
+                res.[i] <- getKey group.Key, group.Value
                 i <- i + 1
             res
+
+        // We avoid wrapping a StructBox, because under 64 JIT we get some "hard" tailcalls which affect performance
+        let countByValueType (projection:'T->'Key) (array:'T[]) = countByImpl HashIdentity.Structural<'Key> projection id array
+
+        // Wrap a StructBox around all keys in case the key type is itself a type using null as a representation
+        let countByRefType   (projection:'T->'Key) (array:'T[]) = countByImpl Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.StructBox<'Key>.Comparer (fun t -> Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.StructBox (projection t)) (fun sb -> sb.Value) array
+
+        [<CompiledName("CountBy")>]
+        let countBy (projection:'T->'Key) (array:'T[]) =
+            checkNonNull "array" array
+#if FX_ATLEAST_40
+            if typeof<'Key>.IsValueType
+                then countByValueType projection array
+                else countByRefType   projection array
+#else
+            countByRefType projection array
+#endif
 
         [<CompiledName("Append")>]
         let append (array1:'T[]) (array2:'T[]) = 
@@ -408,31 +423,52 @@ namespace Microsoft.FSharp.Collections
             let rec loop i = i >= len1 || (f.Invoke(array1.[i], array2.[i]) && loop (i+1))
             loop 0
 
-        [<CompiledName("GroupBy")>]
-        let groupBy keyf (array: 'T[]) =
-            checkNonNull "array" array
-            let dict = new Dictionary<RuntimeHelpers.StructBox<'Key>,ResizeArray<'T>>(RuntimeHelpers.StructBox<'Key>.Comparer)
+        let groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (array: 'T[]) =
+            let dict = Dictionary<_,ResizeArray<_>> comparer
+
+            // Previously this was 1, but I think this is rather stingy, considering that we are alreadying paying
+            // for at least a key, the ResizeArray reference, which includes an array reference, an Entry in the
+            // Dictionary, plus any empty space in the Dictionary of unfilled hash buckets. Having it larger means
+            // that we won't be having as many re-allocations. The ResizeArray is destroyed at the end anyway.
+            let initialBucketSize = 4
 
             // Build the groupings
             for i = 0 to (array.Length - 1) do
                 let v = array.[i]
-                let key = RuntimeHelpers.StructBox (keyf v)
-                let ok, prev = dict.TryGetValue(key)
-                if ok then 
-                    prev.Add(v)
+                let key = keyf v
+                let mutable prev = Unchecked.defaultof<_>
+                if dict.TryGetValue(key, &prev) then
+                    prev.Add v
                 else 
-                    let prev = new ResizeArray<'T>(1)
+                    let prev = ResizeArray initialBucketSize
                     dict.[key] <- prev
-                    prev.Add(v)
+                    prev.Add v
                      
             // Return the array-of-arrays.
             let result = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked dict.Count
             let mutable i = 0
             for group in dict do
-                result.[i] <- group.Key.Value, group.Value.ToArray()
+                result.[i] <- getKey group.Key, group.Value.ToArray()
                 i <- i + 1
 
             result
+
+        // We avoid wrapping a StructBox, because under 64 JIT we get some "hard" tailcalls which affect performance
+        let groupByValueType (keyf:'T->'Key) (array:'T[]) = groupByImpl HashIdentity.Structural<'Key> keyf id array
+
+        // Wrap a StructBox around all keys in case the key type is itself a type using null as a representation
+        let groupByRefType   (keyf:'T->'Key) (array:'T[]) = groupByImpl Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.StructBox<'Key>.Comparer (fun t -> Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.StructBox (keyf t)) (fun sb -> sb.Value) array
+
+        [<CompiledName("GroupBy")>]
+        let groupBy (keyf:'T->'Key) (array:'T[]) =
+            checkNonNull "array" array
+#if FX_ATLEAST_40
+            if typeof<'Key>.IsValueType
+                then groupByValueType keyf array
+                else groupByRefType   keyf array
+#else
+            groupByRefType keyf array
+#endif
 
         [<CompiledName("Pick")>]
         let pick f (array: _[]) = 

--- a/src/fsharp/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/fsharp/FSharp.Core/fslib-extra-pervasives.fs
@@ -30,19 +30,16 @@ module ExtraTopLevelOperators =
     [<CompiledName("CreateSet")>]
     let set l = Collections.Set.ofSeq l
 
-    [<CompiledName("CreateDictionary")>]
-    let dict l = 
-        // Use a dictionary (this requires hashing and equality on the key type)
-        // Wrap keys in a StructBox in case they are null (when System.Collections.Generic.Dictionary fails). 
-        let t = new Dictionary<RuntimeHelpers.StructBox<'Key>,_>(RuntimeHelpers.StructBox<'Key>.Comparer)
+    let inline dictImpl (comparer:IEqualityComparer<'SafeKey>) (makeSafeKey:'Key->'SafeKey) (getKey:'SafeKey->'Key) (l:seq<'Key*'T>) = 
+        let t = Dictionary comparer
         for (k,v) in l do 
-            t.[RuntimeHelpers.StructBox(k)] <- v
+            t.[makeSafeKey k] <- v
         let d = (t :> IDictionary<_,_>)
         let c = (t :> ICollection<_>)
         // Give a read-only view of the dictionary
         { new IDictionary<'Key, 'T> with 
                 member s.Item 
-                    with get x = d.[RuntimeHelpers.StructBox(x)]
+                    with get x = d.[makeSafeKey x]
                     and  set x v = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)))
                 member s.Keys = 
                     let keys = d.Keys
@@ -50,45 +47,60 @@ module ExtraTopLevelOperators =
                           member s.Add(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
                           member s.Clear() = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
                           member s.Remove(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
-                          member s.Contains(x) = keys.Contains(RuntimeHelpers.StructBox(x))
+                          member s.Contains(x) = keys.Contains(makeSafeKey x)
                           member s.CopyTo(arr,i) = 
                               let mutable n = 0 
                               for k in keys do 
-                                  arr.[i+n] <- k.Value
+                                  arr.[i+n] <- getKey k
                                   n <- n + 1
                           member s.IsReadOnly = true
                           member s.Count = keys.Count
                       interface IEnumerable<'Key> with
-                            member s.GetEnumerator() = (keys |> Seq.map (fun v -> v.Value)).GetEnumerator()
+                            member s.GetEnumerator() = (keys |> Seq.map getKey).GetEnumerator()
                       interface System.Collections.IEnumerable with
-                            member s.GetEnumerator() = ((keys |> Seq.map (fun v -> v.Value)) :> System.Collections.IEnumerable).GetEnumerator() }
+                            member s.GetEnumerator() = ((keys |> Seq.map getKey) :> System.Collections.IEnumerable).GetEnumerator() }
                     
                 member s.Values = d.Values
                 member s.Add(k,v) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)))
-                member s.ContainsKey(k) = d.ContainsKey(RuntimeHelpers.StructBox(k))
+                member s.ContainsKey(k) = d.ContainsKey(makeSafeKey k)
                 member s.TryGetValue(k,r) = 
-                    let key = RuntimeHelpers.StructBox(k)
+                    let key = makeSafeKey k
                     if d.ContainsKey(key) then (r <- d.[key]; true) else false
                 member s.Remove(k : 'Key) = (raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated))) : bool) 
           interface ICollection<KeyValuePair<'Key, 'T>> with 
                 member s.Add(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
                 member s.Clear() = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
                 member s.Remove(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
-                member s.Contains(KeyValue(k,v)) = c.Contains(KeyValuePair<_,_>(RuntimeHelpers.StructBox(k),v))
+                member s.Contains(KeyValue(k,v)) = c.Contains(KeyValuePair<_,_>(makeSafeKey k,v))
                 member s.CopyTo(arr,i) = 
                     let mutable n = 0 
                     for (KeyValue(k,v)) in c do 
-                        arr.[i+n] <- KeyValuePair<_,_>(k.Value,v)
+                        arr.[i+n] <- KeyValuePair<_,_>(getKey k,v)
                         n <- n + 1
                 member s.IsReadOnly = true
                 member s.Count = c.Count
           interface IEnumerable<KeyValuePair<'Key, 'T>> with
                 member s.GetEnumerator() = 
-                    (c |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(k.Value,v))).GetEnumerator()
+                    (c |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(getKey k,v))).GetEnumerator()
           interface System.Collections.IEnumerable with
                 member s.GetEnumerator() = 
-                    ((c |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(k.Value,v))) :> System.Collections.IEnumerable).GetEnumerator() }
+                    ((c |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(getKey k,v))) :> System.Collections.IEnumerable).GetEnumerator() }
 
+    // We avoid wrapping a StructBox, because under 64 JIT we get some "hard" tailcalls which affect performance
+    let dictValueType (l:seq<'Key*'T>) = dictImpl HashIdentity.Structural<'Key> id id l
+
+    // Wrap a StructBox around all keys in case the key type is itself a type using null as a representation
+    let dictRefType   (l:seq<'Key*'T>) = dictImpl RuntimeHelpers.StructBox<'Key>.Comparer (fun k -> RuntimeHelpers.StructBox k) (fun sb -> sb.Value) l
+
+    [<CompiledName("CreateDictionary")>]
+    let dict (l:seq<'Key*'T>) =
+#if FX_ATLEAST_40
+        if typeof<'Key>.IsValueType
+            then dictValueType l
+            else dictRefType   l
+#else
+        dictRefType l
+#endif
 
     let getArray (vals : seq<'T>) = 
         match vals with

--- a/src/fsharp/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/fsharp/FSharp.Core/fslib-extra-pervasives.fs
@@ -64,8 +64,8 @@ module ExtraTopLevelOperators =
                 member s.Add(k,v) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)))
                 member s.ContainsKey(k) = d.ContainsKey(makeSafeKey k)
                 member s.TryGetValue(k,r) = 
-                    let key = makeSafeKey k
-                    if d.ContainsKey(key) then (r <- d.[key]; true) else false
+                    let safeKey = makeSafeKey k
+                    if d.ContainsKey(safeKey) then (r <- d.[safeKey]; true) else false
                 member s.Remove(k : 'Key) = (raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated))) : bool) 
           interface ICollection<KeyValuePair<'Key, 'T>> with 
                 member s.Add(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -449,7 +449,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Where")>]
         let where f x = Microsoft.FSharp.Primitives.Basics.List.filter f x
 
-        let groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (list: 'T list) =
+        let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (list: 'T list) =
             let dict = Dictionary<_,ResizeArray<_>> comparer
 
             // Previously this was 1, but I think this is rather stingy, considering that we are alreadying paying

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -47,9 +47,9 @@ namespace Microsoft.FSharp.Collections
                 match srcList with
                 | [] -> ()
                 | h::t ->
-                    let key = projection h
+                    let safeKey = projection h
                     let mutable prev = 0
-                    if dict.TryGetValue(key, &prev) then dict.[key] <- prev + 1 else dict.[key] <- 1
+                    if dict.TryGetValue(safeKey, &prev) then dict.[safeKey] <- prev + 1 else dict.[safeKey] <- 1
                     loop t
             loop list
             let mutable result = []
@@ -462,13 +462,13 @@ namespace Microsoft.FSharp.Collections
             let rec loop list =
                 match list with
                 | v :: t -> 
-                    let key = keyf v
+                    let safeKey = keyf v
                     let mutable prev = Unchecked.defaultof<_>
-                    if dict.TryGetValue(key, &prev) then
+                    if dict.TryGetValue(safeKey, &prev) then
                         prev.Add v
                     else 
                         let prev = ResizeArray initialBucketSize
-                        dict.[key] <- prev
+                        dict.[safeKey] <- prev
                         prev.Add v
                     loop t
                 | _ -> ()

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -70,7 +70,7 @@ namespace Microsoft.FSharp.Collections
                 then countByValueType projection list
                 else countByRefType   projection list
 #else
-            countByRefType projection source
+            countByRefType projection list
 #endif
 
         [<CompiledName("Map")>]
@@ -492,7 +492,7 @@ namespace Microsoft.FSharp.Collections
                 then groupByValueType keyf list
                 else groupByRefType   keyf list
 #else
-            groupByRefType keyf source
+            groupByRefType keyf list
 #endif
 
         [<CompiledName("Partition")>]

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -452,12 +452,6 @@ namespace Microsoft.FSharp.Collections
         let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (list: 'T list) =
             let dict = Dictionary<_,ResizeArray<_>> comparer
 
-            // Previously this was 1, but I think this is rather stingy, considering that we are alreadying paying
-            // for at least a key, the ResizeArray reference, which includes an array reference, an Entry in the
-            // Dictionary, plus any empty space in the Dictionary of unfilled hash buckets. Having it larger means
-            // that we won't be having as many re-allocations. The ResizeArray is destroyed at the end anyway.
-            let initialBucketSize = 4
-
             // Build the groupings
             let rec loop list =
                 match list with
@@ -467,7 +461,7 @@ namespace Microsoft.FSharp.Collections
                     if dict.TryGetValue(safeKey, &prev) then
                         prev.Add v
                     else 
-                        let prev = ResizeArray initialBucketSize
+                        let prev = ResizeArray ()
                         dict.[safeKey] <- prev
                         prev.Add v
                     loop t

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1444,32 +1444,45 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "source" source
             mkSeq (fun () -> source.GetEnumerator())
 
+        [<CompiledName("GroupBy")>]
+        let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (seq:seq<'T>) =
+            let dict = Dictionary<_,ResizeArray<_>> comparer
 
+            // Previously this was 1, but I think this is rather stingy, considering that we are alreadying paying
+            // for at least a key, the ResizeArray reference, which includes an array reference, an Entry in the
+            // Dictionary, plus any empty space in the Dictionary of unfilled hash buckets.
+            let minimumBucketSize = 4
+
+            // Build the groupings
+            seq |> iter (fun v -> 
+                let key = keyf v
+                let mutable prev = Unchecked.defaultof<_>
+                match dict.TryGetValue (key, &prev) with
+                | true -> prev.Add v
+                | false ->
+                    let prev = ResizeArray minimumBucketSize
+                    dict.[key] <- prev
+                    prev.Add v)
+
+            // Trim the size of each result group, don't trim very small buckets, as excessive work, and garbage for 
+            // minimal gain 
+            dict |> iter (fun group -> if group.Value.Count > minimumBucketSize then group.Value.TrimExcess())
+                         
+            // Return the sequence-of-sequences. Don't reveal the 
+            // internal collections: just reveal them as sequences
+            dict |> map (fun group -> (getKey group.Key, readonly group.Value))
+
+        // We avoid wrapping a StructBox, because under 64 JIT we get some "hard" tailcalls which affect performance
+        let groupByValueType (keyf:'T->'Key) (seq:seq<'T>) = seq |> groupByImpl HashIdentity.Structural<'Key> keyf id 
+
+        // Wrap a StructBox around all keys in case the key type is itself a type using null as a representation
+        let groupByRefType   (keyf:'T->'Key) (seq:seq<'T>) = seq |> groupByImpl StructBox<'Key>.Comparer (fun t -> StructBox (keyf t)) (fun sb -> sb.Value)
 
         [<CompiledName("GroupBy")>]
-        let groupBy keyf seq =
-
-            mkDelayedSeq (fun () -> 
-                // Wrap a StructBox(_) around all keys in case the key type is itself a type using null as a representation
-                let dict = new Dictionary<StructBox<'Key>,ResizeArray<'T>>(StructBox<'Key>.Comparer)
-
-                // Build the groupings
-                seq |> iter (fun v -> 
-                    let key = StructBox (keyf v)
-                    let ok,prev = dict.TryGetValue(key)
-                    if ok then 
-                        prev.Add(v)
-                    else 
-                        let prev = new ResizeArray<'T>(1)
-                        dict.[key] <- prev
-                        prev.Add(v))
-
-                // Trim the size of each result group.
-                dict |> iter (fun group -> group.Value.TrimExcess())
-                         
-                // Return the sequence-of-sequences. Don't reveal the 
-                // internal collections: just reveal them as sequences
-                dict |> map (fun group -> (group.Key.Value, readonly group.Value)))
+        let groupBy (keyf:'T->'Key) (seq:seq<'T>) =
+            if typeof<'T>.IsValueType
+                then mkDelayedSeq (fun () -> groupByValueType keyf seq)
+                else mkDelayedSeq (fun () -> groupByRefType   keyf seq)
 
         [<CompiledName("Distinct")>]
         let distinct source =

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1445,6 +1445,8 @@ namespace Microsoft.FSharp.Collections
             mkSeq (fun () -> source.GetEnumerator())
 
         let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (seq:seq<'T>) =
+            checkNonNull "seq" seq
+
             let dict = Dictionary<_,ResizeArray<_>> comparer
 
             // Previously this was 1, but I think this is rather stingy, considering that we are alreadying paying
@@ -1479,8 +1481,6 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("GroupBy")>]
         let groupBy (keyf:'T->'Key) (seq:seq<'T>) =
-            checkNonNull "source" seq
-
 #if FX_ATLEAST_40
             if typeof<'Key>.IsValueType
                 then mkDelayedSeq (fun () -> groupByValueType keyf seq)

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1461,7 +1461,7 @@ namespace Microsoft.FSharp.Collections
                 match dict.TryGetValue (safeKey, &prev) with
                 | true -> prev.Add v
                 | false ->
-                    let prev = ResizeArray minimumBucketSize
+                    let prev = ResizeArray ()
                     dict.[safeKey] <- prev
                     prev.Add v)
 

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1456,13 +1456,13 @@ namespace Microsoft.FSharp.Collections
 
             // Build the groupings
             seq |> iter (fun v -> 
-                let key = keyf v
+                let safeKey = keyf v
                 let mutable prev = Unchecked.defaultof<_>
-                match dict.TryGetValue (key, &prev) with
+                match dict.TryGetValue (safeKey, &prev) with
                 | true -> prev.Add v
                 | false ->
                     let prev = ResizeArray minimumBucketSize
-                    dict.[key] <- prev
+                    dict.[safeKey] <- prev
                     prev.Add v)
 
             // Trim the size of each result group, don't trim very small buckets, as excessive work, and garbage for 
@@ -1548,11 +1548,11 @@ namespace Microsoft.FSharp.Collections
 
             // Build the groupings
             source |> iter (fun v -> 
-                let key = keyf v
+                let safeKey = keyf v
                 let mutable prev = Unchecked.defaultof<_>
-                if dict.TryGetValue(key, &prev)
-                    then dict.[key] <- prev + 1
-                    else dict.[key] <- 1)
+                if dict.TryGetValue(safeKey, &prev)
+                    then dict.[safeKey] <- prev + 1
+                    else dict.[safeKey] <- 1)
 
             dict |> map (fun group -> (getKey group.Key, group.Value))
 

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1479,9 +1479,15 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("GroupBy")>]
         let groupBy (keyf:'T->'Key) (seq:seq<'T>) =
-            if typeof<'T>.IsValueType
+            checkNonNull "source" seq
+
+#if FX_ATLEAST_40
+            if typeof<'Key>.IsValueType
                 then mkDelayedSeq (fun () -> groupByValueType keyf seq)
                 else mkDelayedSeq (fun () -> groupByRefType   keyf seq)
+#else
+            mkDelayedSeq (fun () -> groupByRefType keyf seq)
+#endif
 
         [<CompiledName("Distinct")>]
         let distinct source =
@@ -1557,10 +1563,16 @@ namespace Microsoft.FSharp.Collections
         let countByRefType   (keyf:'T->'Key) (seq:seq<'T>) = seq |> countByImpl StructBox<'Key>.Comparer (fun t -> StructBox (keyf t)) (fun sb -> sb.Value)
 
         [<CompiledName("CountBy")>]
-        let countBy (keyf:'T->'Key) (seq:seq<'T>) =
-            if typeof<'T>.IsValueType
-                then mkDelayedSeq (fun () -> countByValueType keyf seq)
-                else mkDelayedSeq (fun () -> countByRefType   keyf seq)
+        let countBy (keyf:'T->'Key) (source:seq<'T>) =
+            checkNonNull "source" source
+
+#if FX_ATLEAST_40
+            if typeof<'Key>.IsValueType
+                then mkDelayedSeq (fun () -> countByValueType keyf source)
+                else mkDelayedSeq (fun () -> countByRefType   keyf source)
+#else
+            mkDelayedSeq (fun () -> countByRefType   keyf source)
+#endif
 
         [<CompiledName("Sum")>]
         let inline sum (source: seq< (^a) >) : ^a = 


### PR DESCRIPTION
The StructBox idiom is used for countBy/groupBy/dict so that reference type's with null values can work.

For Value Types this is just an extra layer of indirection which adds a performance cost without any benefit. This change request adds checks on the keys type, and then calls a customised value or reference type version.

This is related to #513, but can be considered a worthwhile optimization on it's own.