### PR TITLE
Removing internal interface usage, and tail calls in "dict"

### DIFF
--- a/src/fsharp/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/fsharp/FSharp.Core/fslib-extra-pervasives.fs
@@ -31,24 +31,25 @@ module ExtraTopLevelOperators =
     [<CompiledName("CreateSet")>]
     let set l = Collections.Set.ofSeq l
 
+    let inline ICollection_Contains<'collection,'item when 'collection :> ICollection<'item>> (collection:'collection) (item:'item) =
+        collection.Contains item
+
     let inline dictImpl (comparer:IEqualityComparer<'SafeKey>) (makeSafeKey:'Key->'SafeKey) (getKey:'SafeKey->'Key) (l:seq<'Key*'T>) = 
         let t = Dictionary comparer
         for (k,v) in l do 
             t.[makeSafeKey k] <- v
-        let d = (t :> IDictionary<_,_>)
-        let c = (t :> ICollection<_>)
         // Give a read-only view of the dictionary
         { new IDictionary<'Key, 'T> with 
                 member s.Item 
-                    with get x = d.[makeSafeKey x]
+                    with get x = t.[makeSafeKey x]
                     and  set x v = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)))
                 member s.Keys = 
-                    let keys = d.Keys
+                    let keys = t.Keys
                     { new ICollection<'Key> with 
                           member s.Add(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
                           member s.Clear() = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
                           member s.Remove(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
-                          member s.Contains(x) = keys.Contains(makeSafeKey x)
+                          member s.Contains(x) = t.ContainsKey (makeSafeKey x)
                           member s.CopyTo(arr,i) = 
                               let mutable n = 0 
                               for k in keys do 
@@ -61,31 +62,31 @@ module ExtraTopLevelOperators =
                       interface System.Collections.IEnumerable with
                             member s.GetEnumerator() = ((keys |> Seq.map getKey) :> System.Collections.IEnumerable).GetEnumerator() }
                     
-                member s.Values = d.Values
+                member s.Values = upcast t.Values
                 member s.Add(k,v) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)))
-                member s.ContainsKey(k) = d.ContainsKey(makeSafeKey k)
+                member s.ContainsKey(k) = t.ContainsKey(makeSafeKey k)
                 member s.TryGetValue(k,r) = 
                     let safeKey = makeSafeKey k
-                    if d.ContainsKey(safeKey) then (r <- d.[safeKey]; true) else false
+                    if t.ContainsKey(safeKey) then (r <- t.[safeKey]; true) else false
                 member s.Remove(k : 'Key) = (raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated))) : bool) 
           interface ICollection<KeyValuePair<'Key, 'T>> with 
                 member s.Add(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
                 member s.Clear() = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
                 member s.Remove(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
-                member s.Contains(KeyValue(k,v)) = c.Contains(KeyValuePair<_,_>(makeSafeKey k,v))
+                member s.Contains(KeyValue(k,v)) = ICollection_Contains t (KeyValuePair<_,_>(makeSafeKey k,v))
                 member s.CopyTo(arr,i) = 
                     let mutable n = 0 
-                    for (KeyValue(k,v)) in c do 
+                    for (KeyValue(k,v)) in t do 
                         arr.[i+n] <- KeyValuePair<_,_>(getKey k,v)
                         n <- n + 1
                 member s.IsReadOnly = true
-                member s.Count = c.Count
+                member s.Count = t.Count
           interface IEnumerable<KeyValuePair<'Key, 'T>> with
                 member s.GetEnumerator() = 
-                    (c |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(getKey k,v))).GetEnumerator()
+                    (t |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(getKey k,v))).GetEnumerator()
           interface System.Collections.IEnumerable with
                 member s.GetEnumerator() = 
-                    ((c |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(getKey k,v))) :> System.Collections.IEnumerable).GetEnumerator() }
+                    ((t |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(getKey k,v))) :> System.Collections.IEnumerable).GetEnumerator() }
 
     // We avoid wrapping a StructBox, because under 64 JIT we get some "hard" tailcalls which affect performance
     let dictValueType (l:seq<'Key*'T>) = dictImpl HashIdentity.Structural<'Key> id id l


### PR DESCRIPTION
Compliments #549 and #513.

The performance test from https://github.com/Microsoft/visualfsharp/pull/513#issuecomment-122249135 shows the improvement of this pull request.

Almost at performance parity with using Dictionary directly which is great. The only real area that is remaining is related to https://github.com/Microsoft/visualfsharp/issues/574 (which is only really a concern for generic objects; but it would be nice to be able to use a generic value based key, so I think that should still be discussed. I will create a more directed example over there)