### PR TITLE
fix #508 ide test IsUpToDatePreserveNewest

### DIFF
--- a/vsintegration/src/unittests/Tests.ProjectSystem.UpToDate.fs
+++ b/vsintegration/src/unittests/Tests.ProjectSystem.UpToDate.fs
@@ -388,7 +388,7 @@ type ``UpToDate PreserveNewest`` () =
         let test (input, inputTimestamp) (output, outputTimestamp) =
             let logs = ref []
             let outputPanel = VsMocks.vsOutputWindowPane(logs)
-            let logger = OutputWindowLogger.CreateUpToDateCheckLogger(outputPanel)
+            let logger = OutputWindowLogger((fun () -> true), outputPanel)
         
             let tryTimestamp (path: string) (_l: OutputWindowLogger) =
                 let toN = function Some d -> Nullable<_>(d) | None -> Nullable<_>()


### PR DESCRIPTION
OutputWindowLogger.CreateUpToDateCheckLogger now check a registry key and log is disabled by default