### PR TITLE
fix #580 Optimize checkbox in project configuration page

### DIFF
--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
@@ -323,7 +323,17 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             
         private bool getBool(string projectFileConstant)
         {
-            return "true" == GetConfigurationProperty(projectFileConstant, false);
+            return getNullableBool(projectFileConstant) ?? false;
+        }
+
+        private bool? getNullableBool(string projectFileConstant)
+        {
+            var p = GetConfigurationProperty(projectFileConstant, false);
+
+            if (p == null)
+                return null;
+
+            return p == "true";
         }
 
         private void setBool(string projectFileConstant, bool p)
@@ -397,7 +407,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get
             {
-                return getBool(ProjectFileConstants.Optimize);
+                return getNullableBool(ProjectFileConstants.Optimize) ?? true;
             }
             set
             {

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectConfig.cs
@@ -330,7 +330,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             var p = GetConfigurationProperty(projectFileConstant, false);
 
-            if (p == null)
+            if (string.IsNullOrWhiteSpace(p))
                 return null;
 
             return p == "true";
@@ -419,7 +419,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get
             {
-                return getBool(ProjectFileConstants.Tailcalls);
+                return getNullableBool(ProjectFileConstants.Tailcalls) ?? true;
             }
             set
             {


### PR DESCRIPTION
if Optimize msbuild property does not exists, default is true so should be checked in config page