### PR TITLE
Add back 'validate-type-providers' compiler option

### DIFF
--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -733,6 +733,7 @@ let testFlag tcConfigB =
 // not shown in fsc.exe help, no warning on use, motiviation is for use from VS
 let vsSpecificFlags (tcConfigB: TcConfigBuilder) = 
   [ CompilerOption("vserrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.VSErrors), None, None);
+    CompilerOption("validate-type-providers", tagNone, OptionUnit (id), None, None);  // preserved for compatibility's sake, no longer has any effect
     CompilerOption("LCID", tagInt, OptionInt (fun n -> tcConfigB.lcid <- Some(n)), None, None);
     CompilerOption("flaterrors", tagNone, OptionUnit (fun () -> tcConfigB.flatErrors <- true), None, None); 
     CompilerOption("sqmsessionguid", tagNone, OptionString (fun s -> tcConfigB.sqmSessionGuid <- try System.Guid(s) |> Some  with e -> None), None, None);

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/dumpAllCommandLineOptions/dummy.fs
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/dumpAllCommandLineOptions/dummy.fs
@@ -76,6 +76,7 @@
 //<Expects status="success">section='NoSection                ' ! option=test                           kind=OptionString</Expects>
 //<Expects status="success">section='NoSection                ' ! option=use-incremental-build          kind=OptionUnit</Expects>
 //<Expects status="success">section='NoSection                ' ! option=vserrors                       kind=OptionUnit</Expects>
+//<Expects status="success">section='NoSection                ' ! option=validate-type-providers        kind=OptionUnit</Expects>
 //<Expects status="success">section='NoSection                ' ! option=LCID                           kind=OptionInt</Expects>
 //<Expects status="success">section='NoSection                ' ! option=flaterrors                     kind=OptionUnit</Expects>
 //<Expects status="success">section='NoSection                ' ! option=jit                            kind=OptionSwitch</Expects>


### PR DESCRIPTION
For compatibility, as mentioned at https://github.com/Microsoft/visualfsharp/pull/448/files#r37509117