### PR TITLE
Lighter-weight API for checking if an assembly contains a TP

### DIFF
--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -637,6 +637,9 @@ val ParseOneInputFile : TcConfig * Lexhelp.LexResourceManager * string list * st
 /// Get the initial type checking environment including the loading of mscorlib/System.Core, FSharp.Core
 /// applying the InternalsVisibleTo in referenced assemblies and opening 'Checked' if requested.
 val GetInitialTcEnv : string option * range * TcConfig * TcImports * TcGlobals -> TcEnv
+
+/// opens an IL reader for the specified assembly and checks if there is a TypeProviderAssembly assembly-level attribute
+val CheckOneAssemblyForTypeProviderAttribute : string -> bool
                 
 [<Sealed>]
 /// Represents the incremental type checking state for a set of inputs

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -1228,6 +1228,7 @@ val TryFindAttributeUsageAttribute : TcGlobals -> range -> TyconRef -> bool opti
 
 #if EXTENSIONTYPING
 /// returns Some(assemblyName) for success
+val isTypeProviderAssemblyAttr  : ILAttribute -> bool
 val TryDecodeTypeProviderAssemblyAttr : ILGlobals -> ILAttribute -> string option
 #endif
 val IsSignatureDataVersionAttr  : ILAttribute -> bool

--- a/src/fsharp/fsc.fsi
+++ b/src/fsharp/fsc.fsi
@@ -8,6 +8,9 @@ open Microsoft.FSharp.Compiler.TcGlobals
 open Microsoft.FSharp.Compiler.Tast
 open Microsoft.FSharp.Compiler.TypeChecker
 
+/// F# IDE tools can invoke this to obtain the set of referenced assemblies which contain type provider definitions
+val internal ContainsTypeProvider : string -> bool
+
 #if NO_COMPILER_BACKEND
 #else
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/AssemblyReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/AssemblyReferenceNode.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
     [CLSCompliant(false)]
     [ComVisible(true)]
-    public class AssemblyReferenceNode : ReferenceNode
+    public class AssemblyReferenceNode : TypeProviderContainingReferenceNode
     {
         private struct AssemblyResolvedInfo
         {
@@ -311,6 +311,14 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         private bool IsSpecialFSharpCoreReference
         {
             get { return ProjectMgr.CanUseTargetFSharpCoreReference && IsFSharpCoreReference(this) && ContainsUsagesOfTargetFSharpCoreVersionProperty(this); }
+        }
+
+        public override string AssemblyPath
+        {
+            get
+            {
+                return this.Url;
+            }
         }
 
         public override NodeProperties CreatePropertiesObject()

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectNode.cs
@@ -498,6 +498,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             PFX = 50,
             [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SNK")]
             SNK = 51,
+            TypeProviderAssembly = Audio,
 
             ImageLast = 51
         }

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectReferenceNode.cs
@@ -22,7 +22,7 @@ using Task = Microsoft.VisualStudio.Shell.Task;
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
     [CLSCompliant(false), ComVisible(true)]
-    public class ProjectReferenceNode : ReferenceNode
+    public class ProjectReferenceNode : TypeProviderContainingReferenceNode
     {
         /// <summary>
         /// Containes either null if project reference is OK or instance of Task with error message if project reference is invalid
@@ -497,6 +497,14 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                     projectReference = new Automation.OAProjectReference(this);
                 }
                 return projectReference;
+            }
+        }
+
+        public override string AssemblyPath
+        {
+            get
+            {
+                return this.ReferencedProjectOutputPath;
             }
         }
 

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectSystem.Base.csproj
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/ProjectSystem.Base.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Misc\UnsafeNativeMethods.cs" />
     <Compile Include="Misc\AutomationExtenderManager.cs" />
     <Compile Include="AssemblyReferenceNode.cs" />
+    <Compile Include="TypeProviderContainingReferenceNode.cs" />
     <Compile Include="GroupingReferenceNode.cs" />
     <Compile Include="Attributes.cs" />
     <Compile Include="AssemblyInfo.cs" />

--- a/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/TypeProviderContainingReferenceNode.cs
+++ b/vsintegration/src/vs/FsPkgs/FSharp.Project/Common.Source.CSharp/Project/TypeProviderContainingReferenceNode.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.FSharp.ProjectSystem
+{
+    [CLSCompliant(false), ComVisible(true)]
+    public abstract class TypeProviderContainingReferenceNode : ReferenceNode
+    {
+        private bool containsTypeProvider;
+        
+        internal TypeProviderContainingReferenceNode(ProjectNode root, ProjectElement element)
+            : base(root, element)
+        {
+            this.containsTypeProvider = false;
+        }
+
+        internal TypeProviderContainingReferenceNode(ProjectNode root)
+            : base(root)
+        {
+            this.containsTypeProvider = false;
+        }
+        
+        public bool ContainsTypeProvider
+        {
+            get { return containsTypeProvider; }
+            set
+            {
+                if (containsTypeProvider != value)
+                {
+                    containsTypeProvider = value;
+                    this.ReDraw(UIHierarchyElement.Icon);
+                }
+            }
+        }
+        
+        public abstract string AssemblyPath
+        {
+            get;
+        }
+
+        public override int ImageIndex
+        {
+            get
+            {
+                const int typeProviderAssemblyIcon = (int) ProjectNode.ImageName.TypeProviderAssembly;
+                return ContainsTypeProvider ? typeProviderAssemblyIcon : base.ImageIndex;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Old situation for checking if a project had referenced a type provider:
  - Language service had somewhat unreliable, hard-to-predict way of detecting TPs
    - Raise event when LS compiler hits a TP during background compile (hard to know when that will happen)
    - Rely on global mutable state in compiler to track current source file being processed -> use that to tie back to current project
  - Project system had a deterministic and accurate (but very slow) way of detecting TPs
    - Run through the beginning of the full compile pipeline, but stop after references are imported

New API is fairly lightweight, and targeted at a single reference - no need to launch full compile machinery. It simply opens an IL reader to a specified assembly and checks for `TypeProviderAssemblyAttribute`. This looks to be fast enough for on-demand use in the IDE tools.