### PR TITLE
Enable breakpoints in 'with' augmentations for class types

### DIFF
--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -219,8 +219,10 @@ type internal UntypedParseInfo(parsed:UntypedParseResults) =
                   | SynExpr.Tuple (es,_,_) -> 
                       yield! walkExprs es
 
-                  | SynExpr.Record (_,_,fs,_) -> 
-                    
+                  | SynExpr.Record (_,os,fs,_) ->
+                      match os with
+                      | Some (e,_) -> yield! walkExpr true e
+                      | None -> ()
                       yield! walkExprs (List.map (fun (_, v, _) -> v) fs |> List.choose id)
 
                   | SynExpr.ObjExpr (_,_,bs,is,_,_) -> 


### PR DESCRIPTION
Close #551

I could successfully validate my fix with @dsyme minimal repro code once my F# SDK has been clobbered :v:

It seems the doc is wrong:
- version is not 5099 but 9055
- I'm not sure about it, but I think that most msbuild commands to test in VS in release are already included in appveyor script. So I guess the procedure might be simplified.