### PR TITLE
Do not create xmldoc by default in templates

### DIFF
--- a/vsintegration/src/Templates/ConsoleProjectTemplates/ProjectTemplates/ConsoleApplication/ConsoleApplication.fsproj
+++ b/vsintegration/src/Templates/ConsoleProjectTemplates/ProjectTemplates/ConsoleApplication/ConsoleApplication.fsproj
@@ -36,7 +36,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>

--- a/vsintegration/src/Templates/ConsoleProjectTemplates/ProjectTemplates/ConsoleApplication/ConsoleApplication.fsproj
+++ b/vsintegration/src/Templates/ConsoleProjectTemplates/ProjectTemplates/ConsoleApplication/ConsoleApplication.fsproj
@@ -26,7 +26,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/vsintegration/src/Templates/LibraryProjectTemplates/ProjectTemplates/Library/Library.fsproj
+++ b/vsintegration/src/Templates/LibraryProjectTemplates/ProjectTemplates/Library/Library.fsproj
@@ -33,7 +33,6 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib"/>

--- a/vsintegration/src/Templates/LibraryProjectTemplates/ProjectTemplates/Library/Library.fsproj
+++ b/vsintegration/src/Templates/LibraryProjectTemplates/ProjectTemplates/Library/Library.fsproj
@@ -25,7 +25,6 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/vsintegration/src/Templates/NetCore259ProjectTemplates/ProjectTemplates/NETCorePortableLibrary/PortableLibrary.fsproj
+++ b/vsintegration/src/Templates/NetCore259ProjectTemplates/ProjectTemplates/NETCorePortableLibrary/PortableLibrary.fsproj
@@ -31,7 +31,6 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core">

--- a/vsintegration/src/Templates/NetCore259ProjectTemplates/ProjectTemplates/NETCorePortableLibrary/PortableLibrary.fsproj
+++ b/vsintegration/src/Templates/NetCore259ProjectTemplates/ProjectTemplates/NETCorePortableLibrary/PortableLibrary.fsproj
@@ -23,7 +23,6 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/vsintegration/src/Templates/NetCore78ProjectTemplates/ProjectTemplates/NetCorePortableLibrary/PortableLibrary.fsproj
+++ b/vsintegration/src/Templates/NetCore78ProjectTemplates/ProjectTemplates/NetCorePortableLibrary/PortableLibrary.fsproj
@@ -31,7 +31,6 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core">

--- a/vsintegration/src/Templates/NetCore78ProjectTemplates/ProjectTemplates/NetCorePortableLibrary/PortableLibrary.fsproj
+++ b/vsintegration/src/Templates/NetCore78ProjectTemplates/ProjectTemplates/NetCorePortableLibrary/PortableLibrary.fsproj
@@ -23,7 +23,6 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/vsintegration/src/Templates/NetCoreProjectTemplates/ProjectTemplates/NETCorePortableLibrary/PortableLibrary.fsproj
+++ b/vsintegration/src/Templates/NetCoreProjectTemplates/ProjectTemplates/NETCorePortableLibrary/PortableLibrary.fsproj
@@ -31,7 +31,6 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core">

--- a/vsintegration/src/Templates/NetCoreProjectTemplates/ProjectTemplates/NETCorePortableLibrary/PortableLibrary.fsproj
+++ b/vsintegration/src/Templates/NetCoreProjectTemplates/ProjectTemplates/NETCorePortableLibrary/PortableLibrary.fsproj
@@ -23,7 +23,6 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/vsintegration/src/Templates/PortableLibraryProjectTemplates/ProjectTemplates/PortableLibrary/PortableLibrary.fsproj
+++ b/vsintegration/src/Templates/PortableLibraryProjectTemplates/ProjectTemplates/PortableLibrary/PortableLibrary.fsproj
@@ -30,7 +30,6 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core">

--- a/vsintegration/src/Templates/PortableLibraryProjectTemplates/ProjectTemplates/PortableLibrary/PortableLibrary.fsproj
+++ b/vsintegration/src/Templates/PortableLibraryProjectTemplates/ProjectTemplates/PortableLibrary/PortableLibrary.fsproj
@@ -22,7 +22,6 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/vsintegration/src/Templates/SilverlightProjectTemplates/ProjectTemplates/SilverlightLibrary/SilverlightLibrary.fsproj
+++ b/vsintegration/src/Templates/SilverlightProjectTemplates/ProjectTemplates/SilverlightLibrary/SilverlightLibrary.fsproj
@@ -37,7 +37,6 @@
     <DefineConstants>TRACE;SILVERLIGHT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/vsintegration/src/Templates/SilverlightProjectTemplates/ProjectTemplates/SilverlightLibrary/SilverlightLibrary.fsproj
+++ b/vsintegration/src/Templates/SilverlightProjectTemplates/ProjectTemplates/SilverlightLibrary/SilverlightLibrary.fsproj
@@ -29,7 +29,6 @@
     <DefineConstants>DEBUG;TRACE;SILVERLIGHT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\$safeprojectname$.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
xmldoc are generated by default creating a new project (console/library/etc).

no xmldoc is the same default of c# projects (both debug/release)

i splitted in two commits, so if needed we can leave xmldoc enabled by default only for release build

i know there is no issue linked to this pr, but i think is easier to discuss here and merge/reject, the change is minimal
