### PR TITLE
Ranges for ObjectModel types should include their augmentation's range

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1445,8 +1445,10 @@ tyconDefn:
          match tcDefRepr with
          | SynTypeDefnRepr.ObjectModel (k,cspec,m) -> SynTypeDefnRepr.ObjectModel (k,memberCtorPattern::cspec,m)
          | _ -> reportParseErrorAt (rhs2 parseState 1 5) (FSComp.SR.parsOnlyClassCanTakeValueArguments()); tcDefRepr
-      
-       TypeDefn($1,tcDefRepr,members, unionRanges (rhs parseState 1) tcDefRepr.Range)  }
+       let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
+       let mWhole = (declRange, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
+       
+       TypeDefn($1,tcDefRepr,members,mWhole) }
 
 
 /* The right-hand-side of a type definition */


### PR DESCRIPTION
fixes https://github.com/Microsoft/visualfsharp/issues/551

Explanation (from [comment](https://github.com/Microsoft/visualfsharp/issues/551#issuecomment-137305314) on issue)

> I think this is a parser bug - the assigned range for an ObjectModel declaration does not currently include it's augmentation's range, so ValidateBreakpointLocation "correctly" decides the requested BP is not within any known ranges.

> This looks like an oversight, as the other `tyconDefn` cases do combine all the ranges together. Relevant code is [here](https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/pars.fsy#L1438-L1449), this case should have a `unionRangeWithListBy` bit like the previous 2 cases.  Adding that fixes the bug in my testing.

Looking into whether there is a sensible way to add tests for this to the IDE unit test suite