### PR TITLE
Fix typos in FSharp.Core

### DIFF
--- a/src/fsharp/FSharp.Core/Linq.fs
+++ b/src/fsharp/FSharp.Core/Linq.fs
@@ -167,11 +167,11 @@ open ReflectionAdapters
 
 module LeafExpressionConverter =
 
-    // The following is recognized as a LINQ 'member intialization pattern' in a quotation.
+    // The following is recognized as a LINQ 'member initialization pattern' in a quotation.
     let MemberInitializationHelper (_x:'T)  : 'T =  raise (NotSupportedException "This function should not be called directly")
 
 
-    // The following is recognized as a LINQ 'member intialization pattern' in a quotation.
+    // The following is recognized as a LINQ 'member initialization pattern' in a quotation.
     let NewAnonymousObjectHelper (_x:'T)  : 'T =  raise (NotSupportedException "This function should not be called directly")
 
     // This is used to mark expressions inserted to satisfy C#'s design where, inside C#-compiler generated

--- a/src/fsharp/FSharp.Core/array.fsi
+++ b/src/fsharp/FSharp.Core/array.fsi
@@ -716,7 +716,7 @@ namespace Microsoft.FSharp.Collections
         /// <param name="array">The input array.</param>
         /// <exception cref="System.ArgumentNullException">Thrown when the input array is null.</exception>
         /// <exception cref="System.ArgumentException">Thrown when the input array is empty.</exception>
-        /// <returns>The final result of the redcutions.</returns>
+        /// <returns>The final result of the reductions.</returns>
         [<CompiledName("Reduce")>]
         val reduce: reduction:('T -> 'T -> 'T) -> array:'T[] -> 'T
 
@@ -1171,7 +1171,7 @@ namespace Microsoft.FSharp.Collections
             /// <summary>Create an array given the dimension and a generator function to compute the elements.</summary>
             ///
             /// <remarks>Performs the operation in parallel using System.Threading.Parallel.For.
-            /// The order in which the given function is applied to indicies is not specified.</remarks>
+            /// The order in which the given function is applied to indices is not specified.</remarks>
             /// <param name="count"></param>
             /// <param name="initializer"></param>
             /// <returns>'T[]</returns>
@@ -1183,7 +1183,7 @@ namespace Microsoft.FSharp.Collections
             /// respectively </summary>
             ///
             /// <remarks>Performs the operation in parallel using System.Threading.Parallel.For.
-            /// The order in which the given function is applied to indicies is not specified.</remarks>
+            /// The order in which the given function is applied to indices is not specified.</remarks>
             /// <param name="predicate">The function to test the input elements.</param>
             /// <param name="array">The input array.</param>
             /// <returns>'T[] * 'T[]</returns>

--- a/src/fsharp/FSharp.Core/array2.fsi
+++ b/src/fsharp/FSharp.Core/array2.fsi
@@ -39,7 +39,7 @@ namespace Microsoft.FSharp.Collections
 
         /// <summary>Builds a new array whose elements are the same as the input array.</summary>
         ///
-        /// <remarks>For non-zero-based arrays the basing on an input array will be propogated to the output
+        /// <remarks>For non-zero-based arrays the basing on an input array will be propagated to the output
         /// array.</remarks>
         ///
         /// <param name="array">The input array.</param>
@@ -170,7 +170,7 @@ namespace Microsoft.FSharp.Collections
         /// <summary>Builds a new array whose elements are the results of applying the given function
         /// to each of the elements of the array.</summary>
         ///
-        /// <remarks>For non-zero-based arrays the basing on an input array will be propogated to the output
+        /// <remarks>For non-zero-based arrays the basing on an input array will be propagated to the output
         /// array.</remarks>
         ///
         /// <param name="mapping">A function that is applied to transform each item of the input array.</param>

--- a/src/fsharp/FSharp.Core/array3.fsi
+++ b/src/fsharp/FSharp.Core/array3.fsi
@@ -45,7 +45,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Iterate")>]
         val iter: action:('T -> unit) -> array:'T[,,] -> unit
 
-        /// <summary>Applies the given function to each element of the array. The integer indicies passed to the
+        /// <summary>Applies the given function to each element of the array. The integer indices passed to the
         /// function indicates the index of element.</summary>
         /// <param name="action">The function to apply to each element of the array.</param>
         /// <param name="array">The input array.</param>
@@ -73,7 +73,7 @@ namespace Microsoft.FSharp.Collections
         /// <summary>Builds a new array whose elements are the results of applying the given function
         /// to each of the elements of the array.</summary>
         ///
-        /// <remarks>For non-zero-based arrays the basing on an input array will be propogated to the output
+        /// <remarks>For non-zero-based arrays the basing on an input array will be propagated to the output
         /// array.</remarks>
         /// <param name="mapping">The function to transform each element of the array.</param>
         /// <param name="array">The input array.</param>
@@ -85,7 +85,7 @@ namespace Microsoft.FSharp.Collections
         /// to each of the elements of the array. The integer indices passed to the
         /// function indicates the element being transformed.</summary>
         ///
-        /// <remarks>For non-zero-based arrays the basing on an input array will be propogated to the output
+        /// <remarks>For non-zero-based arrays the basing on an input array will be propagated to the output
         /// array.</remarks>
         /// <param name="mapping">The function to transform the elements at each index in the array.</param>
         /// <param name="array">The input array.</param>

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1287,7 +1287,7 @@ namespace Microsoft.FSharp.Control
 
             // The contract: 
             //      a) cancellation signal should always propagate to task
-            //      b) CancellationTokenSource that produced a token must not be disposed until the the task.IsComplete
+            //      b) CancellationTokenSource that produced a token must not be disposed until the task.IsComplete
             // We are:
             //      1) registering for cancellation signal here so that not to miss the signal
             //      2) disposing the registration just before setting result/exception on TaskCompletionSource -
@@ -1769,7 +1769,7 @@ namespace Microsoft.FSharp.Control
                             // Call the cancellation routine
                             match cancelAction with 
                             | None -> 
-                                // Register the result. This may race with a sucessful result, but
+                                // Register the result. This may race with a successful result, but
                                 // ResultCell allows a race and throws away whichever comes last.
                                 once.Do(fun () ->
                                             let canceledResult = Canceled (OperationCanceledException())
@@ -1936,7 +1936,7 @@ namespace Microsoft.FSharp.Control
                             | None -> 
                                 // We've been cancelled without a cancel action. Stop listening to events
                                 event.RemoveHandler(del)
-                                // Register the result. This may race with a sucessful result, but
+                                // Register the result. This may race with a successful result, but
                                 // ResultCell allows a race and throws away whichever comes last.
                                 once.Do(fun () -> resultCell.RegisterResult(Canceled (OperationCanceledException()),reuseThread=true) |> unfake) 
                             | Some cancel -> 
@@ -2360,7 +2360,7 @@ namespace Microsoft.FSharp.Control
                                     // That continuation is a no-op now, but it is still a registered reader for arriving messages.
                                     // Therefore we just abandon it - a brutal way of canceling.
                                     // This ugly non-compositionality is only needed because we only support a single mailbox reader
-                                    // (i.e. the user is not allowed to run several Recieve/TryRecieve/Scan/TryScan in parallel) - otherwise 
+                                    // (i.e. the user is not allowed to run several Receive/TryReceive/Scan/TryScan in parallel) - otherwise 
                                     // we would just have an extra no-op reader in the queue.
                                     savedCont <- None)
 

--- a/src/fsharp/FSharp.Core/control.fsi
+++ b/src/fsharp/FSharp.Core/control.fsi
@@ -375,7 +375,7 @@ namespace Microsoft.FSharp.Control
         static member FromBeginEnd : beginAction:(System.AsyncCallback * obj -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
 
         /// <summary>Creates an asynchronous computation in terms of a Begin/End pair of actions in 
-        /// the style used in CLI APIs. This overlaod should be used if the operation is 
+        /// the style used in CLI APIs. This overload should be used if the operation is 
         /// qualified by one argument. For example, 
         ///     <c>Async.FromBeginEnd(place,ws.BeginGetWeather,ws.EndGetWeather)</c>
         /// When the computation is run, <c>beginFunc</c> is executed, with
@@ -396,7 +396,7 @@ namespace Microsoft.FSharp.Control
         static member FromBeginEnd : arg:'Arg1 * beginAction:('Arg1 * System.AsyncCallback * obj -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
 
         /// <summary>Creates an asynchronous computation in terms of a Begin/End pair of actions in 
-        /// the style used in CLI APIs. This overlaod should be used if the operation is 
+        /// the style used in CLI APIs. This overload should be used if the operation is 
         /// qualified by two arguments. For example, 
         ///     <c>Async.FromBeginEnd(arg1,arg2,ws.BeginGetWeather,ws.EndGetWeather)</c>
         /// When the computation is run, <c>beginFunc</c> is executed, with
@@ -418,7 +418,7 @@ namespace Microsoft.FSharp.Control
         static member FromBeginEnd : arg1:'Arg1 * arg2:'Arg2 * beginAction:('Arg1 * 'Arg2 * System.AsyncCallback * obj -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
 
         /// <summary>Creates an asynchronous computation in terms of a Begin/End pair of actions in 
-        /// the style used in CLI APIs. This overlaod should be used if the operation is 
+        /// the style used in CLI APIs. This overload should be used if the operation is 
         /// qualified by three arguments. For example, 
         ///     <c>Async.FromBeginEnd(arg1,arg2,arg3,ws.BeginGetWeather,ws.EndGetWeather)</c>
         /// When the computation is run, <c>beginFunc</c> is executed, with
@@ -629,7 +629,7 @@ namespace Microsoft.FSharp.Control
         /// <param name="computation">The input computation.</param>
         /// <param name="compensation">The action to be run after <c>computation</c> completes or raises an
         /// exception (including cancellation).</param>
-        /// <returns>An asynchronous computation that executes computation and compensation aftewards or
+        /// <returns>An asynchronous computation that executes computation and compensation afterwards or
         /// when an exception is raised.</returns>
         member TryFinally : computation:Async<'T> * compensation:(unit -> unit) -> Async<'T>
 
@@ -809,7 +809,7 @@ namespace Microsoft.FSharp.Control
         /// the message to be sent.</param>
         /// <param name="timeout">An optional timeout parameter (in milliseconds) to wait for a reply message.
         /// Defaults to -1 which corresponds to <c>System.Threading.Timeout.Infinite</c>.</param>
-        /// <returns>An asychronous computation that will wait for the reply from the agent.</returns>
+        /// <returns>An asynchronous computation that will wait for the reply from the agent.</returns>
         member PostAndAsyncReply : buildMessage:(AsyncReplyChannel<'Reply> -> 'Msg) * ?timeout : int -> Async<'Reply>
 
         /// <summary>Like PostAndReply, but returns None if no reply within the timeout period.</summary>

--- a/src/fsharp/FSharp.Core/fslib-extra-pervasives.fsi
+++ b/src/fsharp/FSharp.Core/fslib-extra-pervasives.fsi
@@ -73,7 +73,7 @@ module ExtraTopLevelOperators =
     [<CompiledName("CreateSet")>]
     val set : elements:seq<'T> -> Set<'T>
 
-    /// <summary>Builds an aysnchronous workflow using computation expression syntax.</summary>
+    /// <summary>Builds an asynchronous workflow using computation expression syntax.</summary>
     [<CompiledName("DefaultAsyncBuilder")>]
     val async : Microsoft.FSharp.Control.AsyncBuilder  
 

--- a/src/fsharp/FSharp.Core/math/z.fsi
+++ b/src/fsharp/FSharp.Core/math/z.fsi
@@ -83,26 +83,26 @@ namespace Microsoft.FSharp.Core
     type bigint = System.Numerics.BigInteger
 
     [<AutoOpen>]
-    /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+    /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
     module NumericLiterals =
 
-        /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+        /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
         module NumericLiteralI = 
             open System.Numerics
 
-            /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+            /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
             val FromZero : value:unit -> 'T
-            /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+            /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
             val FromOne : value:unit -> 'T
-            /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+            /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
             val FromInt32 : value:int32 -> 'T
-            /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+            /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
             val FromInt64 : value:int64 -> 'T
-            /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+            /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
             val FromString : text:string -> 'T
-            /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+            /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
             val FromInt64Dynamic : value:int64 -> obj
-            /// Provides a default implementations of F# numeric literal syntax  for literals fo the form 'dddI' 
+            /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' 
             val FromStringDynamic : text:string -> obj
 
         

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -881,10 +881,10 @@ namespace Microsoft.FSharp.Core
         val inline FastLimitedGenericEqualityComparer<'T> : limit: int -> System.Collections.Generic.IEqualityComparer<'T> when 'T : equality
 
         /// <summary>Make an F# hash/equality object for the given type</summary>
-        [<CompilerMessage("This function is a compiler instrinsic should not be used directly", 1204, IsHidden=true)>]
+        [<CompilerMessage("This function is a compiler intrinsic should not be used directly", 1204, IsHidden=true)>]
         val FastGenericEqualityComparerFromTable<'T> : System.Collections.Generic.IEqualityComparer<'T> when 'T : equality
 
-        [<CompilerMessage("This function is a compiler instrinsic should not be used directly", 1204, IsHidden=true)>]
+        [<CompilerMessage("This function is a compiler intrinsic should not be used directly", 1204, IsHidden=true)>]
         /// <summary>Make an F# comparer object for the given type</summary>
         val FastGenericComparerFromTable<'T>  : System.Collections.Generic.IComparer<'T> when 'T : comparison 
 
@@ -1097,7 +1097,7 @@ namespace Microsoft.FSharp.Core
             val inline GetString : source:string -> index:int -> char
 
             /// <summary>This function implements calls to default constructors
-            /// acccessed by 'new' constraints.</summary>
+            /// accessed by 'new' constraints.</summary>
             [<CompilerMessage("This function is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
             val inline CreateInstance : unit -> 'T when 'T : (new : unit -> 'T)
 
@@ -1564,7 +1564,7 @@ namespace Microsoft.FSharp.Core
 
     [<AbstractClass>]
     [<Sealed>]
-    /// <summary>Helper functions for converting F# first class function values to and from CLI representaions
+    /// <summary>Helper functions for converting F# first class function values to and from CLI representations
     /// of functions using delegates.</summary>
     type FuncConvert = 
         /// <summary>Convert the given Action delegate object to an F# function value</summary>
@@ -2121,7 +2121,7 @@ namespace Microsoft.FSharp.Core
         [<CompiledName("Ignore")>]
         val inline ignore : value:'T -> unit
 
-        /// <summary>Unboxes a strongly typed value.</summary>
+        /// <summary>Unbox a strongly typed value.</summary>
         /// <param name="value">The boxed value.</param>
         /// <returns>The unboxed result.</returns>
         [<CompiledName("Unbox")>]
@@ -3389,7 +3389,7 @@ namespace Microsoft.FSharp.Control
     /// <summary>First class event values for arbitrary delegate types.</summary>
     ///
     /// <remarks>F# gives special status to member properties compatible with type IDelegateEvent and 
-    /// tagged with the CLIEventAttribute. In this case the F# compiler generates approriate 
+    /// tagged with the CLIEventAttribute. In this case the F# compiler generates appropriate 
     /// CLI metadata to make the member appear to other CLI languages as a CLI event.</remarks>
     type IDelegateEvent<'Delegate when 'Delegate :> System.Delegate > =
         /// <summary>Connect a handler delegate object to the event. A handler can

--- a/src/fsharp/FSharp.Core/quotations.fs
+++ b/src/fsharp/FSharp.Core/quotations.fs
@@ -537,7 +537,7 @@ module Patterns =
         if index < 0 || index >= fields.Length then invalidArg "index" (SR.GetString(SR.QinvalidCaseIndex))
         fields.[index]
  
-    /// Returns type of lambda applciation - something like "(fun a -> ..) b"
+    /// Returns type of lambda application - something like "(fun a -> ..) b"
     let rec typeOfAppliedLambda f =
         let fty = ((typeOf f):Type) 
         match fty.GetGenericArguments() with 
@@ -641,7 +641,7 @@ module Patterns =
         if not (assignableFrom declType (typeOf obj)) then invalidArg "obj" (SR.GetString(SR.QincorrectInstanceType))
 
       
-    // Checks lambda application for correctnes
+    // Checks lambda application for correctness
     let checkAppliedLambda (f, v) =
         let fty = typeOf f
         let ftyG = (if fty.IsGenericType then  fty.GetGenericTypeDefinition()  else fty)

--- a/src/fsharp/FSharp.Core/quotations.fsi
+++ b/src/fsharp/FSharp.Core/quotations.fsi
@@ -146,7 +146,7 @@ type Expr =
     /// <returns>The resulting expression.</returns>
     static member FieldSet: obj:Expr * fieldInfo:FieldInfo * value:Expr -> Expr 
 
-    /// <summary>Builds an expression that represents the constrution of an F# function value</summary>
+    /// <summary>Builds an expression that represents the construction of an F# function value</summary>
     /// <param name="parameter">The parameter to the function.</param>
     /// <param name="body">The body of the function.</param>
     /// <returns>The resulting expression.</returns>
@@ -159,7 +159,7 @@ type Expr =
     /// <returns>The resulting expression.</returns>
     static member Let : letVariable:Var * letExpr:Expr * body:Expr -> Expr 
 
-    /// <summary>Builds recursives expressions associated with 'let rec' constructs</summary>
+    /// <summary>Builds recursive expressions associated with 'let rec' constructs</summary>
     /// <param name="bindings">The list of bindings for the let expression.</param>
     /// <param name="body">The sub-expression where the bindings are in scope.</param>
     /// <returns>The resulting expression.</returns>
@@ -402,7 +402,7 @@ type Expr =
     static member RegisterReflectedDefinitions: assembly:Assembly * resource:string * serializedValue:byte[] * referencedTypes:Type[] -> unit
 
     /// <summary>Fetches or creates a new variable with the given name and type from a global pool of shared variables
-    /// indexed by name and type. The type is given by the expicit or inferred type parameter</summary>
+    /// indexed by name and type. The type is given by the explicit or inferred type parameter</summary>
     /// <param name="name">The variable name.</param>
     /// <returns>The created of fetched typed global variable.</returns>
     static member GlobalVar<'T> : name:string -> Expr<'T>
@@ -578,7 +578,7 @@ module Patterns =
     [<CompiledName("QuoteTypedPattern")>]
     val (|QuoteTyped|_|)           : input:Expr -> Expr option 
 
-    /// <summary>An active pattern to recognize expressions that represent sequential exeuction of one expression followed by another</summary>
+    /// <summary>An active pattern to recognize expressions that represent sequential execution of one expression followed by another</summary>
     /// <param name="input">The input expression to match against.</param>
     /// <returns>(Expr * Expr) option</returns>
     [<CompiledName("SequentialPattern")>]
@@ -765,11 +765,11 @@ module DerivedPatterns =
 
     /// <summary>A parameterized active pattern to recognize calls to a specified function or method.
     /// The returned elements are the optional target object (present if the target is an 
-    /// instance method), the generic type instantation (non-empty if the target is a generic
+    /// instance method), the generic type instantiation (non-empty if the target is a generic
     /// instantiation), and the arguments to the function or method.</summary>
     /// <param name="templateParameter">The input template expression to specify the method to call.</param>
     /// <returns>The optional target object (present if the target is an 
-    /// instance method), the generic type instantation (non-empty if the target is a generic
+    /// instance method), the generic type instantiation (non-empty if the target is a generic
     /// instantiation), and the arguments to the function or method.</returns>
     [<CompiledName("SpecificCallPattern")>]
     val (|SpecificCall|_|)  : templateParameter:Expr -> (Expr -> (Expr option * list<Type> * list<Expr>) option)
@@ -792,7 +792,7 @@ module DerivedPatterns =
     [<CompiledName("PropertySetterWithReflectedDefinitionPattern")>]
     val (|PropertySetterWithReflectedDefinition|_|) : propertyInfo:PropertyInfo -> Expr option
 
-/// <summary>Active patterns for traversing, visiting, rebuilding and tranforming expressions in a generic way</summary>
+/// <summary>Active patterns for traversing, visiting, rebuilding and transforming expressions in a generic way</summary>
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module ExprShape =
 

--- a/src/fsharp/FSharp.Core/reflect.fsi
+++ b/src/fsharp/FSharp.Core/reflect.fsi
@@ -161,7 +161,7 @@ type FSharpValue =
     /// <returns>The description of the union case reader.</returns>
     static member PreComputeUnionTagMemberInfo : unionType:Type  * ?bindingFlags:BindingFlags -> MemberInfo
 
-    /// <summary>Precomputes a function for reading all the fields for a particular discriminator case of a union type</summary>
+    /// <summary>Precompute a function for reading all the fields for a particular discriminator case of a union type</summary>
     ///
     /// <remarks>Using the computed function will typically be faster than executing a corresponding call to GetFields</remarks>
     /// <param name="unionCase">The description of the union case to read.</param>
@@ -169,7 +169,7 @@ type FSharpValue =
     /// <returns>A function to for reading the fields of the given union case.</returns>
     static member PreComputeUnionReader       : unionCase:UnionCaseInfo  * ?bindingFlags:BindingFlags -> (obj -> obj[])
 
-    /// <summary>Precomputes a function for constructing a discriminated union value for a particular union case. </summary>
+    /// <summary>Precompute a function for constructing a discriminated union value for a particular union case. </summary>
     /// <param name="unionCase">The description of the union case.</param>
     /// <param name="bindingFlags">Optional binding flags.</param>
     /// <returns>A function for constructing values of the given union case.</returns>
@@ -216,7 +216,7 @@ type FSharpValue =
     /// <returns>An array of the fields from the given tuple.</returns>
     static member GetTupleFields: tuple:obj -> obj []
     
-    /// <summary>Precomputes a function for reading the values of a particular tuple type</summary>
+    /// <summary>Precompute a function for reading the values of a particular tuple type</summary>
     ///
     /// <remarks>Assumes the given type is a TupleType.
     /// If not, ArgumentException is raised during pre-computation.</remarks>
@@ -231,7 +231,7 @@ type FSharpValue =
     /// <returns>The description of the tuple element and an optional type and index if the tuple is big.</returns>
     static member PreComputeTuplePropertyInfo: tupleType:Type * index:int -> PropertyInfo * (Type * int) option
     
-    /// <summary>Precomputes a function for reading the values of a particular tuple type</summary>
+    /// <summary>Precompute a function for reading the values of a particular tuple type</summary>
     ///
     /// <remarks>Assumes the given type is a TupleType.
     /// If not, ArgumentException is raised during pre-computation.</remarks>
@@ -440,7 +440,7 @@ module FSharpReflectionExtensions =
         /// <returns>The description of the union case reader.</returns>
         static member PreComputeUnionTagMemberInfo : unionType:Type * ?allowAccessToPrivateRepresentation : bool -> MemberInfo
 
-        /// <summary>Precomputes a function for reading all the fields for a particular discriminator case of a union type</summary>
+        /// <summary>Precompute a function for reading all the fields for a particular discriminator case of a union type</summary>
         ///
         /// <remarks>Using the computed function will typically be faster than executing a corresponding call to GetFields</remarks>
         /// <param name="unionCase">The description of the union case to read.</param>
@@ -448,7 +448,7 @@ module FSharpReflectionExtensions =
         /// <returns>A function to for reading the fields of the given union case.</returns>
         static member PreComputeUnionReader       : unionCase:UnionCaseInfo * ?allowAccessToPrivateRepresentation : bool -> (obj -> obj[])
 
-        /// <summary>Precomputes a function for constructing a discriminated union value for a particular union case. </summary>
+        /// <summary>Precompute a function for constructing a discriminated union value for a particular union case. </summary>
         /// <param name="unionCase">The description of the union case.</param>
         /// <param name="allowAccessToPrivateRepresentation">Optional flag that denotes accessibility of the private representation.</param>    
         /// <returns>A function for constructing values of the given union case.</returns>

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -416,7 +416,7 @@ namespace Microsoft.FSharp.Collections
         
         // Binding. 
         //
-        // We use a type defintion to apply a local dynamic optimization. 
+        // We use a type definition to apply a local dynamic optimization. 
         // We automatically right-associate binding, i.e. push the continuations to the right.
         // That is, bindG (bindG G1 cont1) cont2 --> bindG G1 (cont1 o cont2)
         // This makes constructs such as the following linear rather than quadratic:
@@ -1450,7 +1450,7 @@ namespace Microsoft.FSharp.Collections
 
             let dict = Dictionary<_,ResizeArray<_>> comparer
 
-            // Previously this was 1, but I think this is rather stingy, considering that we are alreadying paying
+            // Previously this was 1, but I think this is rather stingy, considering that we are already paying
             // for at least a key, the ResizeArray reference, which includes an array reference, an Entry in the
             // Dictionary, plus any empty space in the Dictionary of unfilled hash buckets.
             let minimumBucketSize = 4

--- a/src/fsharp/FSharp.Core/seq.fsi
+++ b/src/fsharp/FSharp.Core/seq.fsi
@@ -263,7 +263,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Empty")>]
         val empty<'T> : seq<'T>
 
-        /// <summary>Returns a new sequence with the distinct elements of the second sequence which do not apear in the first sequence,
+        /// <summary>Returns a new sequence with the distinct elements of the second sequence which do not appear in the first sequence,
         /// using generic hash and equality comparisons to compare values.</summary>
         ///
         /// <remarks>Note that this function returns a sequence that digests the whole of the first input sequence as soon as

--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -295,7 +295,7 @@ namespace Microsoft.FSharp.Collections
             // Perf: tried bruteForce for low heights, but nothing significant 
             match t1,t2 with               
             | SetNode(k1,t11,t12,h1),SetNode(k2,t21,t22,h2) -> // (t11 < k < t12) AND (t21 < k2 < t22) 
-                // Divide and Quonquer:
+                // Divide and Conquer:
                 //   Suppose t1 is largest.
                 //   Split t2 using pivot k1 into lo and hi.
                 //   Union disjoint subproblems and then combine. 

--- a/src/fsharp/FSharp.Core/set.fsi
+++ b/src/fsharp/FSharp.Core/set.fsi
@@ -245,7 +245,7 @@ namespace Microsoft.FSharp.Collections
         val union: set1:Set<'T> -> set2:Set<'T> -> Set<'T>
 
         /// <summary>Computes the union of a sequence of sets.</summary>
-        /// <param name="sets">The sequence of sets to untion.</param>
+        /// <param name="sets">The sequence of sets to union.</param>
         /// <returns>The union of the input sets.</returns>
         [<CompiledName("UnionMany")>]
         val unionMany: sets:seq<Set<'T>> -> Set<'T>


### PR DESCRIPTION
Make this a separate PR since it will change generated XmlDoc shipped with FSharp.Core.dll.