### PR TITLE
Run AppVeyor build using VS 2015 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Windows Server 2012 R2
+os: Visual Studio 2015
 
 init: 
 build_script: 


### PR DESCRIPTION
AppVeyor has started supporting VS 2015 on Pro environment recently http://www.appveyor.com/blog/2015/08/02/visual-studio-2015-rtm