### PR TITLE
Don't suppress missing FSI transitive references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ tests/fsharpqa/Source/CodeGen/EmittedIL/ComputationExpressions/ComputationExprLi
 *.chk
 *.bak
 *.orig
+*.mdf
+*.ldf

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -336,11 +336,11 @@ let convTypeRefAux (cenv:cenv) (tref:ILTypeRef) =
             | None ->
                 let asmName    = convAssemblyRef asmref
                 FileSystem.AssemblyLoad(asmName)
-        let typT       = assembly.GetType(qualifiedName)
+        let typT = assembly.GetType(qualifiedName, throwOnError=true)
         typT |> nonNull "convTypeRefAux" 
     | ILScopeRef.Module _ 
     | ILScopeRef.Local _ ->
-        let typT = Type.GetType(qualifiedName,true) 
+        let typT = Type.GetType(qualifiedName, throwOnError=true) 
         typT |> nonNull "convTypeRefAux" 
 
 


### PR DESCRIPTION
Close https://github.com/Microsoft/visualfsharp/issues/509.

Use `throwOnError` option so that missing reference exception is propagated correctly to the top level.