### PR TITLE
Make Seq.cast's non-generic and generic IEnumerable implementations equivalent

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule.fs
@@ -260,7 +260,19 @@ type SeqModule() =
         let expectedNullSeq = seq [null;null]
         
         VerifySeqsEqual expectedNullSeq NullSeq
+
+        CheckThrowsExn<System.InvalidCastException>(fun () -> 
+            let strings = 
+                integerArray 
+                |> Seq.cast<string>               
+            for o in strings do ()) 
         
+        CheckThrowsExn<System.InvalidCastException>(fun () -> 
+            let strings = 
+                integerArray 
+                |> Seq.cast<string>
+                :> System.Collections.IEnumerable // without this upcast the for loop throws, so it should with this upcast too
+            for o in strings do ()) 
         
         ()
         

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -25,11 +25,11 @@ namespace Microsoft.FSharp.Collections
 
       let cast (e : IEnumerator) : IEnumerator<'T> = 
           { new IEnumerator<'T> with 
-                member x.Current = unbox e.Current
+                member x.Current = unbox<'T> e.Current
             interface IEnumerator with 
-                member x.Current = unbox  e.Current
+                member x.Current = unbox<'T> e.Current :> obj
                 member x.MoveNext() = e.MoveNext()
-                member x.Reset() = noReset();
+                member x.Reset() = noReset()
             interface System.IDisposable with 
                 member x.Dispose() = 
                     match e with 

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6307,7 +6307,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                 (match ilTypeDefKind with ILTypeDefKind.ValueType -> true | _ -> false) &&
                 // All structs are sequential by default 
                 // Structs with no instance fields get size 1, pack 0
-                tycon.AllFieldsAsList |> List.exists (fun f -> not f.IsStatic)
+                tycon.AllFieldsAsList |> List.forall (fun f -> f.IsStatic)
 
             isEmptyStruct && cenv.opts.workAroundReflectionEmitBugs && not tycon.TyparsNoRange.IsEmpty
         


### PR DESCRIPTION
Fix #650 