### PR TITLE
Reversing logic for testing whether every field is static

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6307,7 +6307,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                 (match ilTypeDefKind with ILTypeDefKind.ValueType -> true | _ -> false) &&
                 // All structs are sequential by default 
                 // Structs with no instance fields get size 1, pack 0
-                tycon.AllFieldsAsList |> List.exists (fun f -> not f.IsStatic)
+                tycon.AllFieldsAsList |> List.forall (fun f -> f.IsStatic)
 
             isEmptyStruct && cenv.opts.workAroundReflectionEmitBugs && not tycon.TyparsNoRange.IsEmpty
         


### PR DESCRIPTION
Fix #654 

Note that I don't know if similar changes should be made to line [6623](https://github.com/Microsoft/visualfsharp/blob/bf1b709520d05c577739672a1e1a86fe14b17800/src/fsharp/IlxGen.fs#L6623), or if the `workAroundReflectionEmitBugs` stuff is even needed any more.

I also don't know how to test this change, since `workAroundReflectionEmitBugs` is only enabled in F# Interactive.