### PR TITLE
reduce ILMethodDef and ILTypeDef memory usage

### DIFF
--- a/TESTGUIDE.md
+++ b/TESTGUIDE.md
@@ -35,17 +35,40 @@ Note: **Don't** run tests from a Visual Studio developer command prompt (see bel
 
 The script `tests\RunTests.cmd` has been provided to make execution of the above suites simple.  You can kick off a full test run of any of the above suites like this:
 
-```
-RunTests.cmd <debug|release> fsharp [tags to run] [tags not to run]
-RunTests.cmd <debug|release> fsharpqa [tags to run] [tags not to run]
-RunTests.cmd <debug|release> compilerunit
-RunTests.cmd <debug|release> coreunit
-RunTests.cmd <debug|release> coreunitportable47
-RunTests.cmd <debug|release> coreunitportable7
-RunTests.cmd <debug|release> coreunitportable78
-RunTests.cmd <debug|release> coreunitportable259
-RunTests.cmd <debug|release> ideunit
-```
+
+    RunTests.cmd <debug|release> fsharp [tags to run] [tags not to run]
+    RunTests.cmd <debug|release> fsharpqa [tags to run] [tags not to run]
+    RunTests.cmd <debug|release> compilerunit
+    RunTests.cmd <debug|release> coreunit
+    RunTests.cmd <debug|release> coreunitportable47
+    RunTests.cmd <debug|release> coreunitportable7
+    RunTests.cmd <debug|release> coreunitportable78
+    RunTests.cmd <debug|release> coreunitportable259
+    RunTests.cmd <debug|release> ideunit
+
+Debug runs look like this:
+
+    RunTests.cmd debug fsharp 
+    RunTests.cmd debug fsharpqa
+    RunTests.cmd debug compilerunit
+    RunTests.cmd debug coreunit
+    RunTests.cmd debug coreunitportable47
+    RunTests.cmd debug coreunitportable7
+    RunTests.cmd debug coreunitportable78
+    RunTests.cmd debug coreunitportable259
+    RunTests.cmd debug ideunit
+
+Release runs look like this:
+
+    RunTests.cmd release fsharp 
+    RunTests.cmd release fsharpqa
+    RunTests.cmd release compilerunit
+    RunTests.cmd release coreunit
+    RunTests.cmd release coreunitportable47
+    RunTests.cmd release coreunitportable7
+    RunTests.cmd release coreunitportable78
+    RunTests.cmd release coreunitportable259
+    RunTests.cmd release ideunit
 
 `RunTests.cmd` sets a handful of environment variables which allow for the tests to work, then puts together and executes the appropriate command line to start the specified test suite.
 

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -4062,7 +4062,7 @@ let mkILDelegateMethods ilg (parms,rtv:ILReturn) =
                    Flags = mdef.Flags.SetHideBySig(true).SetAbstract(false) }
     let ctor = mkILCtor(ILMemberAccess.Public, [ mkILParamNamed("object",ilg.typ_Object); mkILParamNamed("method",ilg.typ_IntPtr) ], MethodBody.None)
     let ctor = { ctor with  
-                   ImplementationFlags= mdef.ImplementationFlags.SetCodeType(MethodImplAttributes.Runtime);
+                   ImplementationFlags= ctor.ImplementationFlags.SetCodeType(MethodImplAttributes.Runtime);
                    Flags = ctor.Flags.SetHideBySig(true) }
     [ ctor;
       one "Invoke" parms rty;

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -1192,7 +1192,6 @@ let mkILLocals xs = (match xs with [] -> emptyILLocals | _ -> ILList.ofList xs)
 type ILMethodBody = 
     { IsZeroInit: bool;
       MaxStack: int32;
-      NoInlining: bool;
       Locals: ILLocals;
       Code:  ILCode;
       SourceMarker: ILSourceMarker option }
@@ -3026,7 +3025,6 @@ type ILFieldSpec with
 let mkILMethodBody (zeroinit,locals,maxstack,code,tag) = 
   { IsZeroInit=zeroinit;
     MaxStack=maxstack;
-    NoInlining=false;
     Locals= locals ;
     Code= code;
     SourceMarker=tag }

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -3188,7 +3188,7 @@ let mkILGenericNonVirtualMethod (nm,access,genparams, actual_args,actual_ret, im
     mdBody= mkMethBodyAux impl;
     ImplementationFlags = MethodImplAttributes.IL ||| MethodImplAttributes.Managed;
     // see Bug343136: missing HideBySig attribute makes it problematic for C# to consume F# method overloads. 
-    Flags = MethodAttributes.Virtual ||| MethodAttributes.HideBySig }
+    Flags = MethodAttributes.HideBySig }
     
 let mkILNonGenericInstanceMethod (nm,access,args,ret,impl) =  
   mkILGenericNonVirtualMethod (nm,access,mkILEmptyGenericParams,args,ret,impl)

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -6,6 +6,7 @@ module internal Microsoft.FSharp.Compiler.AbstractIL.IL
 
 open Internal.Utilities
 open System.Collections.Generic
+open System.Reflection
 
 /// The type used to store relatively small lists in the Abstract IL data structures, i.e. for ILTypes, ILGenericArgs, ILParameters and ILLocals.
 /// See comments in il.fs for why we've isolated this representation and the possible future choices we might use here.
@@ -1143,20 +1144,13 @@ type ILOverridesSpec =
     member MethodRef: ILMethodRef
     member EnclosingType: ILType 
 
-// REVIEW: fold this into ILMethodDef
-type ILMethodVirtualInfo =
-    { IsFinal: bool; 
-      IsNewSlot: bool; 
-      IsCheckAccessOnOverride: bool;
-      IsAbstract: bool; }
-
 [<RequireQualifiedAccess>]
 type MethodKind =
     | Static 
     | Cctor 
     | Ctor 
     | NonVirtual 
-    | Virtual of ILMethodVirtualInfo
+    | Virtual 
 
 // REVIEW: fold this into ILMethodDef
 [<RequireQualifiedAccess>]
@@ -1165,13 +1159,6 @@ type MethodBody =
     | PInvoke of PInvokeMethod       (* platform invoke to native  *)
     | Abstract
     | Native
-
-// REVIEW: fold this into ILMethodDef
-[<RequireQualifiedAccess>]
-type MethodCodeKind =
-    | IL
-    | Native
-    | Runtime
 
 /// Generic parameters.  Formal generic parameter declarations
 /// may include the bounds, if any, on the generic parameter.
@@ -1213,25 +1200,11 @@ type ILMethodDef =
       Return: ILReturn;
       Access: ILMemberAccess;
       mdBody: ILLazyMethodBody;   
-      mdCodeKind: MethodCodeKind;   
-      IsInternalCall: bool;
-      IsManaged: bool;
-      IsForwardRef: bool;
+      ImplementationFlags : MethodImplAttributes
+      Flags : MethodAttributes
       SecurityDecls: ILPermissions;
       /// Note: some methods are marked "HasSecurity" even if there are no permissions attached, e.g. if they use SuppressUnmanagedCodeSecurityAttribute 
-      HasSecurity: bool; 
       IsEntryPoint:bool;
-      IsReqSecObj: bool;
-      IsHideBySig: bool;
-      IsSpecialName: bool;
-      /// The method is exported to unmanaged code using COM interop.
-      IsUnmanagedExport: bool; 
-      IsSynchronized: bool;
-      IsPreserveSig: bool;
-      /// .NET 2.0 feature: SafeHandle finalizer must be run 
-      IsMustRun: bool; 
-      IsNoInline: bool;
-     
       GenericParams: ILGenericParameterDefs;
       CustomAttrs: ILAttributes; }
       
@@ -1253,6 +1226,18 @@ type ILMethodDef =
     /// instance methods that are virtual or abstract or implement an interface slot.  The predicates (IsClassInitializer,IsConstructor,IsStatic,IsNonVirtualInstance,IsVirtual) form a complete, non-overlapping classification of this type
     member IsVirtual: bool
     
+    member IsInternalCall : bool
+    member IsManaged : bool
+    member IsForwardRef : bool
+    member IsHideBySig : bool
+    member IsReqSecObj : bool
+    member IsUnmanagedExport : bool
+    member IsSpecialName : bool
+    member IsSynchronized : bool
+    member IsMustRun : bool
+    member IsPreserveSig : bool
+    member IsNoInline : bool
+    member HasSecurity : bool
     member IsFinal: bool
     member IsNewSlot: bool
     member IsCheckAccessOnOverride : bool

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1195,7 +1195,6 @@ type ILMethodDef =
       CallingConv: ILCallingConv;
       Parameters: ILParameters;
       Return: ILReturn;
-      Access: ILMemberAccess;
       mdBody: ILLazyMethodBody;   
       ImplementationFlags : MethodImplAttributes
       Flags : MethodAttributes
@@ -1205,7 +1204,8 @@ type ILMethodDef =
       GenericParams: ILGenericParameterDefs;
       CustomAttrs: ILAttributes; }
       
-    member ParameterTypes: ILTypes;
+    member Access: ILMemberAccess
+    member ParameterTypes: ILTypes
     member IsIL : bool
     member Code : ILCode option
     member Locals : ILLocals
@@ -1420,7 +1420,6 @@ and [<NoComparison; NoEquality>]
     { tdKind: ILTypeDefKind;
       Name: string;  
       GenericParams: ILGenericParameterDefs;  
-      Access: ILTypeDefAccess;  
       Flags : System.Reflection.TypeAttributes
       Layout: ILTypeDefLayout;
       NestedTypes: ILTypeDefs;
@@ -1434,6 +1433,8 @@ and [<NoComparison; NoEquality>]
       Events: ILEventDefs;
       Properties: ILPropertyDefs;
       CustomAttrs: ILAttributes; }
+
+    member Access: ILTypeDefAccess
     member IsClass: bool
     member IsInterface: bool
     member IsEnum: bool
@@ -1615,6 +1616,8 @@ type TypeAttributes with
     member SetEncoding : ILDefaultPInvokeEncoding -> TypeAttributes
     member SetSpecialName : bool -> TypeAttributes
     member SetInitSemantics : ILTypeInit -> TypeAttributes
+    member SetAccess : ILTypeDefAccess -> TypeAttributes
+    static member None : TypeAttributes
 
 type MethodAttributes with 
     member SetFinal : bool -> MethodAttributes
@@ -1623,6 +1626,8 @@ type MethodAttributes with
     member SetHideBySig : bool -> MethodAttributes
     member SetNewSlot : bool -> MethodAttributes
     member SetHasSecurity : bool -> MethodAttributes
+    member SetAccess : ILMemberAccess -> MethodAttributes
+    static member None : MethodAttributes
 
 type MethodImplAttributes with 
     member SetPreserveSig : bool -> MethodImplAttributes

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1147,8 +1147,7 @@ type MethodKind =
     | Static 
     | Cctor 
     | Ctor 
-    | NonVirtual 
-    | Virtual 
+    | Instance
 
 // REVIEW: fold this into ILMethodDef
 [<RequireQualifiedAccess>]

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -981,9 +981,7 @@ type ILLocals = ILList<ILLocal>
 [<NoComparison; NoEquality>]
 type ILMethodBody = 
     { IsZeroInit: bool;
-      /// strictly speakin should be a uint16 
       MaxStack: int32; 
-      NoInlining: bool;
       Locals: ILLocals;
       Code: ILCode;
       SourceMarker: ILSourceMarker option }

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1142,13 +1142,6 @@ type ILOverridesSpec =
     member MethodRef: ILMethodRef
     member EnclosingType: ILType 
 
-[<RequireQualifiedAccess>]
-type MethodKind =
-    | Static 
-    | Cctor 
-    | Ctor 
-    | Instance
-
 // REVIEW: fold this into ILMethodDef
 [<RequireQualifiedAccess>]
 type MethodBody =
@@ -1191,7 +1184,6 @@ type ILLazyMethodBody =
 [<NoComparison; NoEquality>]
 type ILMethodDef = 
     { Name: string;
-      mdKind: MethodKind;
       CallingConv: ILCallingConv;
       Parameters: ILParameters;
       Return: ILReturn;
@@ -1230,6 +1222,7 @@ type ILMethodDef =
     member IsReqSecObj : bool
     member IsUnmanagedExport : bool
     member IsSpecialName : bool
+    member IsRTSpecialName : bool
     member IsSynchronized : bool
     member IsMustRun : bool
     member IsPreserveSig : bool
@@ -1625,8 +1618,10 @@ type MethodAttributes with
     member SetCheckAccessOnOverride : bool -> MethodAttributes
     member SetHideBySig : bool -> MethodAttributes
     member SetNewSlot : bool -> MethodAttributes
+    member SetSpecialName : bool -> MethodAttributes
     member SetHasSecurity : bool -> MethodAttributes
     member SetAccess : ILMemberAccess -> MethodAttributes
+    member SetStatic : bool -> MethodAttributes
     static member None : MethodAttributes
 
 type MethodImplAttributes with 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1154,7 +1154,7 @@ type MethodKind =
 type MethodBody =
     | IL of ILMethodBody
     | PInvoke of PInvokeMethod       (* platform invoke to native  *)
-    | Abstract
+    | None
     | Native
 
 /// Generic parameters.  Formal generic parameter declarations

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1421,32 +1421,34 @@ and [<NoComparison; NoEquality>]
       Name: string;  
       GenericParams: ILGenericParameterDefs;  
       Access: ILTypeDefAccess;  
-      IsAbstract: bool;
-      IsSealed: bool; 
-      IsSerializable: bool; 
-      /// Class or interface generated for COM interop 
-      IsComInterop: bool; 
+      Flags : System.Reflection.TypeAttributes
       Layout: ILTypeDefLayout;
-      IsSpecialName: bool;
-      Encoding: ILDefaultPInvokeEncoding;
       NestedTypes: ILTypeDefs;
       Implements: ILTypes;  
       Extends: ILType option; 
       Methods: ILMethodDefs;
       SecurityDecls: ILPermissions;
     /// Note: some classes are marked "HasSecurity" even if there are no permissions attached, e.g. if they use SuppressUnmanagedCodeSecurityAttribute 
-      HasSecurity: bool; 
       Fields: ILFieldDefs;
       MethodImpls: ILMethodImplDefs;
-      InitSemantics: ILTypeInit;
       Events: ILEventDefs;
       Properties: ILPropertyDefs;
       CustomAttrs: ILAttributes; }
-    member IsClass: bool;
-    member IsInterface: bool;
-    member IsEnum: bool;
-    member IsDelegate: bool;
+    member IsClass: bool
+    member IsInterface: bool
+    member IsEnum: bool
+    member IsDelegate: bool
     member IsStructOrEnum : bool
+
+    member IsAbstract: bool
+    member IsSealed: bool
+    member IsSerializable: bool
+      /// Class or interface generated for COM interop 
+    member IsComInterop: bool
+    member IsSpecialName: bool
+    member HasSecurity: bool
+    member Encoding: ILDefaultPInvokeEncoding
+    member InitSemantics: ILTypeInit
 
 [<NoEquality; NoComparison>]
 [<Sealed>]
@@ -1603,6 +1605,30 @@ type ILModuleDef =
 /// or event. This is useful especially if your code is not using the Ilbind 
 /// API to bind references. 
 val resolveILMethodRef: ILTypeDef -> ILMethodRef -> ILMethodDef
+
+type TypeAttributes with 
+    member SetSerializable : bool -> TypeAttributes
+    member SetComInterop : bool -> TypeAttributes
+    member SetSealed : bool -> TypeAttributes
+    member SetAbstract : bool -> TypeAttributes
+    member SetHasSecurity : bool -> TypeAttributes
+    member SetEncoding : ILDefaultPInvokeEncoding -> TypeAttributes
+    member SetSpecialName : bool -> TypeAttributes
+    member SetInitSemantics : ILTypeInit -> TypeAttributes
+
+type MethodAttributes with 
+    member SetFinal : bool -> MethodAttributes
+    member SetAbstract : bool -> MethodAttributes
+    member SetCheckAccessOnOverride : bool -> MethodAttributes
+    member SetHideBySig : bool -> MethodAttributes
+    member SetNewSlot : bool -> MethodAttributes
+    member SetHasSecurity : bool -> MethodAttributes
+
+type MethodImplAttributes with 
+    member SetPreserveSig : bool -> MethodImplAttributes
+    member SetSynchronized : bool -> MethodImplAttributes
+    member SetNoInlining : bool -> MethodImplAttributes
+
 
 // ------------------------------------------------------------------ 
 // Type Names

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -6,6 +6,7 @@ module internal Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 
 open System
 open System.Collections
+open System.Reflection
 open System.Collections.Generic
 open Internal.Utilities
 open Internal.Utilities.Collections

--- a/src/absil/ilprint.fs
+++ b/src/absil/ilprint.fs
@@ -920,11 +920,9 @@ let goutput_mdef env os (md: ILMethodDef) =
       (if md.IsCheckAccessOnOverride then " strict " else "")^
       (if md.IsAbstract then " abstract " else "")^
       (if md.IsStatic then " static " else "")^
-      (match md.mdKind with 
-       | MethodKind.Ctor -> "rtspecialname" 
-       | MethodKind.Cctor -> "specialname rtspecialname static" 
-       | _ -> "")^
-        
+      (if md.IsRTSpecialName then " rtspecialname " else "")^
+      (if md.IsSpecialName then " specialname " else "")^
+       
       (match md.mdBody.Contents with 
         | MethodBody.PInvoke (attr) -> 
         "pinvokeimpl(\""^ attr.Where.Name^"\" as \""^ attr.Name ^"\""^

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -1625,16 +1625,6 @@ and seekReadClassLayout ctxt idx =
     | Some (pack,size) -> { Size = Some size; 
                            Pack = Some pack; }
 
-and memberAccessOfFlags flags =
-    let f = (flags &&& 0x00000007)
-    if f = 0x00000001 then  ILMemberAccess.Private 
-    elif f = 0x00000006 then  ILMemberAccess.Public 
-    elif f = 0x00000004 then  ILMemberAccess.Family 
-    elif f = 0x00000002 then  ILMemberAccess.FamilyAndAssembly 
-    elif f = 0x00000005 then  ILMemberAccess.FamilyOrAssembly 
-    elif f = 0x00000003 then  ILMemberAccess.Assembly 
-    else ILMemberAccess.CompilerControlled
-
 and typeAccessOfFlags flags =
     let f = (flags &&& 0x00000007)
     if f = 0x00000001 then ILTypeDefAccess.Public 
@@ -1645,6 +1635,16 @@ and typeAccessOfFlags flags =
     elif f = 0x00000007 then ILTypeDefAccess.Nested ILMemberAccess.FamilyOrAssembly 
     elif f = 0x00000005 then ILTypeDefAccess.Nested ILMemberAccess.Assembly 
     else ILTypeDefAccess.Private
+
+and memberAccessOfFlags flags =
+    let f = (flags &&& 0x00000007)
+    if f = 0x00000001 then  ILMemberAccess.Private 
+    elif f = 0x00000006 then  ILMemberAccess.Public 
+    elif f = 0x00000004 then  ILMemberAccess.Family 
+    elif f = 0x00000002 then  ILMemberAccess.FamilyAndAssembly 
+    elif f = 0x00000005 then  ILMemberAccess.FamilyOrAssembly 
+    elif f = 0x00000003 then  ILMemberAccess.Assembly 
+    else ILMemberAccess.CompilerControlled
 
 and typeLayoutOfFlags ctxt flags tidx = 
     let f = (flags &&& 0x00000018)
@@ -1667,8 +1667,8 @@ and typeKindOfFlags nm (super:ILType option) flags =
 
 
 and isTopTypeDef flags =
-    (typeAccessOfFlags flags =  ILTypeDefAccess.Private) ||
-     typeAccessOfFlags flags =  ILTypeDefAccess.Public
+    let f = (flags &&& 0x00000007)
+    (f = 0x00000000 || f = 0x00000001)
        
 and seekIsTopTypeDefOfIdx ctxt idx =
     let (flags,_,_, _, _,_) = seekReadTypeDefRow ctxt idx
@@ -1733,7 +1733,6 @@ and seekReadTypeDef ctxt toponly (idx:int) =
            { tdKind= kind
              Name=nm
              GenericParams=typars 
-             Access= typeAccessOfFlags flags
              Flags = enum<TypeAttributes> flags
              Layout = layout
              NestedTypes= nested
@@ -2291,7 +2290,6 @@ and seekReadMethod ctxt numtypars (idx:int) =
             elif ctor then MethodKind.Ctor 
             elif isStatic then MethodKind.Static 
             else MethodKind.Instance);
-       Access = memberAccessOfFlags flags;
        SecurityDecls=seekReadSecurityDecls ctxt (TaggedIndex(hds_MethodDef,idx));
        ImplementationFlags=enum implflags
        Flags=enum flags

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2264,14 +2264,11 @@ and seekReadFieldDefAsFieldSpecUncached ctxtH idx =
 and seekReadMethod ctxt numtypars (idx:int) =
      let (codeRVA, implflags, flags, nameIdx, typeIdx, paramIdx) = seekReadMethodRow ctxt idx
      let nm = readStringHeap ctxt nameIdx
-     let isStatic = (flags &&& 0x0010) <> 0x0
      let abstr = (flags &&& 0x0400) <> 0x0
      let pinvoke = (flags &&& 0x2000) <> 0x0
      let codetype = implflags &&& 0x0003
      let unmanaged = (implflags &&& 0x0004) <> 0x0
      let internalcall = (implflags &&& 0x1000) <> 0x0
-     let cctor = (nm = ".cctor")
-     let ctor = (nm = ".ctor")
      let _generic,_genarity,cc,retty,argtys,varargs = readBlobHeapAsMethodSig ctxt numtypars typeIdx
      if varargs <> None then dprintf "ignoring sentinel and varargs in ILMethodDef signature";
      
@@ -2285,11 +2282,6 @@ and seekReadMethod ctxt numtypars (idx:int) =
      let ret,ilParams = seekReadParams ctxt (retty,argtys) paramIdx endParamIdx
 
      { Name=nm;
-       mdKind = 
-           (if cctor then MethodKind.Cctor 
-            elif ctor then MethodKind.Ctor 
-            elif isStatic then MethodKind.Static 
-            else MethodKind.Instance);
        SecurityDecls=seekReadSecurityDecls ctxt (TaggedIndex(hds_MethodDef,idx));
        ImplementationFlags=enum implflags
        Flags=enum flags

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2280,10 +2280,8 @@ and seekReadMethod ctxt numtypars (idx:int) =
      let (codeRVA, implflags, flags, nameIdx, typeIdx, paramIdx) = seekReadMethodRow ctxt idx
      let nm = readStringHeap ctxt nameIdx
      let isStatic = (flags &&& 0x0010) <> 0x0
-     let virt = (flags &&& 0x0040) <> 0x0
      let abstr = (flags &&& 0x0400) <> 0x0
      let pinvoke = (flags &&& 0x2000) <> 0x0
-     let _rtspecialname = (flags &&& 0x1000) <> 0x0
      let codetype = implflags &&& 0x0003
      let unmanaged = (implflags &&& 0x0004) <> 0x0
      let internalcall = (implflags &&& 0x1000) <> 0x0
@@ -2306,8 +2304,7 @@ and seekReadMethod ctxt numtypars (idx:int) =
            (if cctor then MethodKind.Cctor 
             elif ctor then MethodKind.Ctor 
             elif isStatic then MethodKind.Static 
-            elif virt then MethodKind.Virtual 
-            else MethodKind.NonVirtual);
+            else MethodKind.Instance);
        Access = memberAccessOfFlags flags;
        SecurityDecls=seekReadSecurityDecls ctxt (TaggedIndex(hds_MethodDef,idx));
        ImplementationFlags=enum implflags
@@ -2327,7 +2324,7 @@ and seekReadMethod ctxt numtypars (idx:int) =
            if codeRVA <> 0x0 then dprintn "non-IL or abstract method with non-zero RVA";
            mkMethBodyLazyAux (notlazy MethodBody.Abstract)  
          else 
-           seekReadMethodRVA ctxt (idx,nm,internalcall,numtypars) codeRVA;   
+           seekReadMethodRVA ctxt (idx,nm,numtypars) codeRVA;   
      }
      
      
@@ -2851,9 +2848,9 @@ and seekReadTopCode ctxt numtypars (sz:int) start seqpoints =
    instrs,rawToLabel, lab2pc, raw2nextLab
 
 #if NO_PDB_READER
-and seekReadMethodRVA ctxt (_idx,nm,_internalcall,numtypars) rva = 
+and seekReadMethodRVA ctxt (_idx,nm,numtypars) rva = 
 #else
-and seekReadMethodRVA ctxt (idx,nm,_internalcall,numtypars) rva = 
+and seekReadMethodRVA ctxt (idx,nm,numtypars) rva = 
 #endif
   mkMethBodyLazyAux 
    (lazy

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -1625,6 +1625,16 @@ and seekReadClassLayout ctxt idx =
     | Some (pack,size) -> { Size = Some size; 
                            Pack = Some pack; }
 
+and memberAccessOfFlags flags =
+    let f = (flags &&& 0x00000007)
+    if f = 0x00000001 then  ILMemberAccess.Private 
+    elif f = 0x00000006 then  ILMemberAccess.Public 
+    elif f = 0x00000004 then  ILMemberAccess.Family 
+    elif f = 0x00000002 then  ILMemberAccess.FamilyAndAssembly 
+    elif f = 0x00000005 then  ILMemberAccess.FamilyOrAssembly 
+    elif f = 0x00000003 then  ILMemberAccess.Assembly 
+    else ILMemberAccess.CompilerControlled
+
 and typeAccessOfFlags flags =
     let f = (flags &&& 0x00000007)
     if f = 0x00000001 then ILTypeDefAccess.Public 
@@ -1635,16 +1645,6 @@ and typeAccessOfFlags flags =
     elif f = 0x00000007 then ILTypeDefAccess.Nested ILMemberAccess.FamilyOrAssembly 
     elif f = 0x00000005 then ILTypeDefAccess.Nested ILMemberAccess.Assembly 
     else ILTypeDefAccess.Private
-
-and memberAccessOfFlags flags =
-    let f = (flags &&& 0x00000007)
-    if f = 0x00000001 then  ILMemberAccess.Private 
-    elif f = 0x00000006 then  ILMemberAccess.Public 
-    elif f = 0x00000004 then  ILMemberAccess.Family 
-    elif f = 0x00000002 then  ILMemberAccess.FamilyAndAssembly 
-    elif f = 0x00000005 then  ILMemberAccess.FamilyOrAssembly 
-    elif f = 0x00000003 then  ILMemberAccess.Assembly 
-    else ILMemberAccess.CompilerControlled
 
 and typeLayoutOfFlags ctxt flags tidx = 
     let f = (flags &&& 0x00000018)
@@ -2306,7 +2306,7 @@ and seekReadMethod ctxt numtypars (idx:int) =
            seekReadImplMap ctxt nm  idx
          elif internalcall || abstr || unmanaged || (codetype <> 0x00) then 
            if codeRVA <> 0x0 then dprintn "non-IL or abstract method with non-zero RVA";
-           mkMethBodyLazyAux (notlazy MethodBody.Abstract)  
+           mkMethBodyLazyAux (notlazy MethodBody.None)  
          else 
            seekReadMethodRVA ctxt (idx,nm,numtypars) codeRVA;   
      }
@@ -3049,7 +3049,7 @@ and seekReadMethodRVA ctxt (idx,nm,numtypars) rva =
                SourceMarker=methRangePdbInfo}
        else 
            if logging then failwith "unknown format";
-           MethodBody.Abstract
+           MethodBody.None
      end)
 
 and int32AsILVariantType ctxt (n:int32) = 

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2280,26 +2280,14 @@ and seekReadMethod ctxt numtypars (idx:int) =
      let (codeRVA, implflags, flags, nameIdx, typeIdx, paramIdx) = seekReadMethodRow ctxt idx
      let nm = readStringHeap ctxt nameIdx
      let isStatic = (flags &&& 0x0010) <> 0x0
-     let final = (flags &&& 0x0020) <> 0x0
      let virt = (flags &&& 0x0040) <> 0x0
-     let strict = (flags &&& 0x0200) <> 0x0
-     let hidebysig = (flags &&& 0x0080) <> 0x0
-     let newslot = (flags &&& 0x0100) <> 0x0
      let abstr = (flags &&& 0x0400) <> 0x0
-     let specialname = (flags &&& 0x0800) <> 0x0
      let pinvoke = (flags &&& 0x2000) <> 0x0
-     let export = (flags &&& 0x0008) <> 0x0
      let _rtspecialname = (flags &&& 0x1000) <> 0x0
-     let reqsecobj = (flags &&& 0x8000) <> 0x0
-     let hassec = (flags &&& 0x4000) <> 0x0
      let codetype = implflags &&& 0x0003
      let unmanaged = (implflags &&& 0x0004) <> 0x0
-     let forwardref = (implflags &&& 0x0010) <> 0x0
-     let preservesig = (implflags &&& 0x0080) <> 0x0
      let internalcall = (implflags &&& 0x1000) <> 0x0
-     let synchronized = (implflags &&& 0x0020) <> 0x0
      let noinline = (implflags &&& 0x0008) <> 0x0
-     let mustrun = (implflags &&& 0x0040) <> 0x0
      let cctor = (nm = ".cctor")
      let ctor = (nm = ".ctor")
      let _generic,_genarity,cc,retty,argtys,varargs = readBlobHeapAsMethodSig ctxt numtypars typeIdx
@@ -2319,28 +2307,13 @@ and seekReadMethod ctxt numtypars (idx:int) =
            (if cctor then MethodKind.Cctor 
             elif ctor then MethodKind.Ctor 
             elif isStatic then MethodKind.Static 
-            elif virt then 
-             MethodKind.Virtual 
-               { IsFinal=final; 
-                 IsNewSlot=newslot; 
-                 IsCheckAccessOnOverride=strict;
-                 IsAbstract=abstr; }
+            elif virt then MethodKind.Virtual 
             else MethodKind.NonVirtual);
        Access = memberAccessOfFlags flags;
        SecurityDecls=seekReadSecurityDecls ctxt (TaggedIndex(hds_MethodDef,idx));
-       HasSecurity=hassec;
+       ImplementationFlags=enum implflags
+       Flags=enum flags
        IsEntryPoint= (fst ctxt.entryPointToken = TableNames.Method && snd ctxt.entryPointToken = idx);
-       IsReqSecObj=reqsecobj;
-       IsHideBySig=hidebysig;
-       IsSpecialName=specialname;
-       IsUnmanagedExport=export;
-       IsSynchronized=synchronized;
-       IsNoInline=noinline;
-       IsMustRun=mustrun;
-       IsPreserveSig=preservesig;
-       IsManaged = not unmanaged;
-       IsInternalCall = internalcall;
-       IsForwardRef = forwardref;
        mdCodeKind = (if (codetype = 0x00) then MethodCodeKind.IL elif (codetype = 0x01) then MethodCodeKind.Native elif (codetype = 0x03) then MethodCodeKind.Runtime else (dprintn  "unsupported code type"; MethodCodeKind.Native));
        GenericParams=seekReadGenericParams ctxt numtypars (tomd_MethodDef,idx);
        CustomAttrs=seekReadCustomAttrs ctxt (TaggedIndex(hca_MethodDef,idx)); 

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1242,7 +1242,6 @@ let emitLocal cenv emEnv (ilG : ILGenerator) (local: ILLocal) =
 
 let emitILMethodBody cenv modB emEnv (ilG:ILGenerator) ilmbody =
     // XXX - REVIEW:
-    //      NoInlining: bool;
     //      SourceMarker: source option }
     // emit locals and record emEnv
     let localBs = Array.map (emitLocal cenv emEnv ilG) (ILList.toArray ilmbody.Locals)
@@ -1354,18 +1353,6 @@ let convMethodAttributes (mdef: ILMethodDef) =
    
     mdef.Flags ||| attrAccess 
 
-let convMethodImplFlags mdef =    
-    (match  mdef.mdCodeKind with 
-     | MethodCodeKind.Native -> MethodImplAttributes.Native
-     | MethodCodeKind.Runtime -> MethodImplAttributes.Runtime
-     | MethodCodeKind.IL  -> MethodImplAttributes.IL) 
-    ||| flagsIf mdef.IsInternalCall MethodImplAttributes.InternalCall
-    ||| (if mdef.IsManaged then MethodImplAttributes.Managed else MethodImplAttributes.Unmanaged)
-    ||| flagsIf mdef.IsForwardRef MethodImplAttributes.ForwardRef
-    ||| flagsIf mdef.IsPreserveSig MethodImplAttributes.PreserveSig
-    ||| flagsIf mdef.IsSynchronized MethodImplAttributes.Synchronized
-    ||| flagsIf (match mdef.mdBody.Contents with MethodBody.IL b -> b.NoInlining | _ -> false) MethodImplAttributes.NoInlining
-
 //----------------------------------------------------------------------------
 // buildMethodPass2
 //----------------------------------------------------------------------------
@@ -1376,7 +1363,7 @@ let rec buildMethodPass2 cenv tref (typB:TypeBuilder) emEnv (mdef : ILMethodDef)
    // IsUnmanagedExport: bool; (* -- The method is exported to unmanaged code using COM interop. *)
    // IsMustRun: bool; (* Whidbey feature: SafeHandle finalizer must be run *)
     let attrs = convMethodAttributes mdef
-    let implflags = convMethodImplFlags mdef
+    let implflags = mdef.ImplementationFlags
     let cconv = convCallConv mdef.CallingConv
     let mref = mkRefToILMethod (tref,mdef)   
     let emEnv = if mdef.IsEntryPoint && mdef.ParameterTypes.Length = 0 then 

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1342,18 +1342,6 @@ let emitParameter cenv emEnv (defineParameter : int * ParameterAttributes * stri
 //----------------------------------------------------------------------------
 
 let convMethodAttributes (mdef: ILMethodDef) =    
-    let attrKind = 
-        match mdef.mdKind with 
-        | MethodKind.Static        -> MethodAttributes.Static
-        | MethodKind.Cctor         -> MethodAttributes.Static
-        | MethodKind.Ctor          -> enum 0                 
-        | MethodKind.NonVirtual    -> enum 0
-        | MethodKind.Virtual vinfo -> MethodAttributes.Virtual |||
-                                      flagsIf vinfo.IsNewSlot   MethodAttributes.NewSlot |||
-                                      flagsIf vinfo.IsFinal     MethodAttributes.Final |||
-                                      flagsIf vinfo.IsCheckAccessOnOverride    MethodAttributes.CheckAccessOnOverride |||
-                                      flagsIf vinfo.IsAbstract  MethodAttributes.Abstract
-   
     let attrAccess = 
         match mdef.Access with
         | ILMemberAccess.Assembly -> MethodAttributes.Assembly
@@ -1364,12 +1352,7 @@ let convMethodAttributes (mdef: ILMethodDef) =
         | ILMemberAccess.Private            -> MethodAttributes.Private
         | ILMemberAccess.Public             -> MethodAttributes.Public
    
-    let attrOthers = flagsIf mdef.HasSecurity MethodAttributes.HasSecurity |||
-                     flagsIf mdef.IsSpecialName MethodAttributes.SpecialName |||
-                     flagsIf mdef.IsHideBySig   MethodAttributes.HideBySig |||
-                     flagsIf mdef.IsReqSecObj   MethodAttributes.RequireSecObject 
-   
-    attrKind ||| attrAccess ||| attrOthers
+    mdef.Flags ||| attrAccess 
 
 let convMethodImplFlags mdef =    
     (match  mdef.mdCodeKind with 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -1424,29 +1424,7 @@ let rec GetTypeDefAsRow cenv env _enc (td:ILTypeDef) =
           | ILTypeDefLayout.Sequential _  -> 0x00000008
           | ILTypeDefLayout.Explicit _ -> 0x00000010
         end |||
-        begin 
-          match td.tdKind with
-          | ILTypeDefKind.Interface -> 0x00000020
-          | _ -> 0x00000000
-        end |||
-        (if td.IsAbstract then 0x00000080l else 0x00000000) |||
-        (if td.IsSealed then 0x00000100l else 0x00000000) ||| 
-        (if td.IsComInterop then 0x00001000l else 0x00000000)  |||
-        (if td.IsSerializable then 0x00002000l else 0x00000000) |||
-        begin 
-          match td.Encoding with 
-          | ILDefaultPInvokeEncoding.Ansi -> 0x00000000
-          | ILDefaultPInvokeEncoding.Auto -> 0x00020000
-          | ILDefaultPInvokeEncoding.Unicode ->  0x00010000
-        end |||
-        begin 
-          match td.InitSemantics with
-          |  ILTypeInit.BeforeField when not (match td.tdKind with ILTypeDefKind.Interface -> true | _ -> false) -> 0x00100000 
-          | _ -> 0x00000000
-        end |||
-        (if td.IsSpecialName then 0x00000400 else 0x00000000) |||
-          // @REVIEW    (if rtspecialname_of_tdef td then 0x00000800 else 0x00000000) ||| 
-        (if td.HasSecurity || not td.SecurityDecls.AsList.IsEmpty then 0x00040000 else 0x00000000)
+        (if not td.SecurityDecls.AsList.IsEmpty then 0x00040000 else 0x00000000)
 
     let tdorTag, tdorRow = GetTypeOptionAsTypeDefOrRef cenv env td.Extends
     UnsharedRow 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -1417,12 +1417,17 @@ let rec GetTypeDefAsRow cenv env _enc (td:ILTypeDef) =
       if (isTypeNameForGlobalFunctions td.Name) then 0x00000000
       else
         
-        GetTypeAccessFlags td.Access |||
         (int td.Flags) |||
+        // TODO: put the access in the flags
+        GetTypeAccessFlags td.Access |||
+        // TODO: put the kind in the flags
+        (match td.tdKind with ILTypeDefKind.Interface -> 0x00000020  | _ -> 0x00000000) |||
+        // TODO: put the layout in the flags
         (match td.Layout with 
           | ILTypeDefLayout.Auto ->  0x00000000
           | ILTypeDefLayout.Sequential _  -> 0x00000008
           | ILTypeDefLayout.Explicit _ -> 0x00000010) |||
+        // TODO: this should always be set 
         (if not td.SecurityDecls.AsList.IsEmpty then 0x00040000 else 0x00000000)
 
     let tdorTag, tdorRow = GetTypeOptionAsTypeDefOrRef cenv env td.Extends
@@ -2851,9 +2856,10 @@ let GenMethodDefSigAsBlobIdx cenv env mdef =
 
 let GenMethodDefAsRow cenv env midx (md: ILMethodDef) = 
     let flags = 
+        (int md.Flags) |||
+        // TODO: put these in the flags
         GetMemberAccessFlags md.Access |||
         (match md.mdKind with MethodKind.Static | MethodKind.Cctor -> 0x0010 | _ -> 0x0) |||
-        (int md.Flags) |||
         (match md.mdBody.Contents with MethodBody.PInvoke _ -> 0x2000 | _ -> 0x0) |||
         (match md.mdKind with MethodKind.Ctor | MethodKind.Cctor -> 0x1000 | _ -> 0x0) ||| // RTSpecialName 
         (if not md.SecurityDecls.AsList.IsEmpty then 0x4000 else 0x0)

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2878,33 +2878,16 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
         (if (match md.mdKind with
               | MethodKind.Static | MethodKind.Cctor -> true
               | _ -> false) then 0x0010 else 0x0) |||
-        (if (match md.mdKind with MethodKind.Virtual vinfo -> vinfo.IsFinal | _ -> false) then 0x0020 else 0x0) |||
-        (if (match md.mdKind with MethodKind.Virtual _ -> true | _ -> false) then 0x0040 else 0x0) |||
-        (if md.IsHideBySig then 0x0080 else 0x0) |||
-        (if (match md.mdKind with MethodKind.Virtual vinfo -> vinfo.IsCheckAccessOnOverride | _ -> false) then 0x0200 else 0x0) |||
-        (if (match md.mdKind with MethodKind.Virtual vinfo -> vinfo.IsNewSlot | _ -> false) then 0x0100 else 0x0) |||
-        (if (match md.mdKind with MethodKind.Virtual vinfo -> vinfo.IsAbstract | _ -> false) then 0x0400 else 0x0) |||
-        (if md.IsSpecialName then 0x0800 else 0x0) |||
+        (int md.Flags) |||
         (if (match md.mdBody.Contents with MethodBody.PInvoke _ -> true | _ -> false) then 0x2000 else 0x0) |||
-        (if md.IsUnmanagedExport then 0x0008 else 0x0) |||
         (if 
           (match md.mdKind with
           | MethodKind.Ctor | MethodKind.Cctor -> true 
           | _ -> false) then 0x1000 else 0x0) ||| // RTSpecialName 
-        (if md.IsReqSecObj then 0x8000 else 0x0) |||
-        (if md.HasSecurity || not md.SecurityDecls.AsList.IsEmpty then 0x4000 else 0x0)
+        (if not md.SecurityDecls.AsList.IsEmpty then 0x4000 else 0x0)
     let implflags = 
-        (match  md.mdCodeKind with 
-         | MethodCodeKind.Native -> 0x0001
-         | MethodCodeKind.Runtime -> 0x0003
-         | MethodCodeKind.IL  -> 0x0000) |||
-        (if md.IsInternalCall then 0x1000 else 0x0000) |||
-        (if md.IsManaged then 0x0000 else 0x0004) |||
-        (if md.IsForwardRef then 0x0010 else 0x0000) |||
-        (if md.IsPreserveSig then 0x0080 else 0x0000) |||
-        (if md.IsSynchronized then 0x0020 else 0x0000) |||
-        (if md.IsMustRun then 0x0040 else 0x0000) |||
-        (if (md.IsNoInline || (match md.mdBody.Contents with MethodBody.IL il -> il.NoInlining | _ -> false)) then 0x0008 else 0x0000)
+        (int md.ImplementationFlags) |||
+        (if (match md.mdBody.Contents with MethodBody.IL il -> il.NoInlining | _ -> false) then 0x0008 else 0x0000)
 
     if md.IsEntryPoint then 
         if cenv.entrypoint <> None then failwith "duplicate entrypoint"

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2875,15 +2875,10 @@ let GenMethodDefSigAsBlobIdx cenv env mdef =
 let GenMethodDefAsRow cenv env midx (md: ILMethodDef) = 
     let flags = 
         GetMemberAccessFlags md.Access |||
-        (if (match md.mdKind with
-              | MethodKind.Static | MethodKind.Cctor -> true
-              | _ -> false) then 0x0010 else 0x0) |||
+        (match md.mdKind with MethodKind.Static | MethodKind.Cctor -> 0x0010 | _ -> 0x0) |||
         (int md.Flags) |||
-        (if (match md.mdBody.Contents with MethodBody.PInvoke _ -> true | _ -> false) then 0x2000 else 0x0) |||
-        (if 
-          (match md.mdKind with
-          | MethodKind.Ctor | MethodKind.Cctor -> true 
-          | _ -> false) then 0x1000 else 0x0) ||| // RTSpecialName 
+        (match md.mdBody.Contents with MethodBody.PInvoke _ -> 0x2000 | _ -> 0x0) |||
+        (match md.mdKind with MethodKind.Ctor | MethodKind.Cctor -> 0x1000 | _ -> 0x0) ||| // RTSpecialName 
         (if not md.SecurityDecls.AsList.IsEmpty then 0x4000 else 0x0)
     let implflags = int md.ImplementationFlags
 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -1416,18 +1416,12 @@ let rec GetTypeDefAsRow cenv env _enc (td:ILTypeDef) =
     let flags = 
       if (isTypeNameForGlobalFunctions td.Name) then 0x00000000
       else
-        
         (int td.Flags) |||
-        // TODO: put the access in the flags
-        GetTypeAccessFlags td.Access |||
-        // TODO: put the kind in the flags
-        (match td.tdKind with ILTypeDefKind.Interface -> 0x00000020  | _ -> 0x00000000) |||
-        // TODO: put the layout in the flags
+        (if td.IsInterface then 0x00000020  else 0x00000000) |||
         (match td.Layout with 
           | ILTypeDefLayout.Auto ->  0x00000000
           | ILTypeDefLayout.Sequential _  -> 0x00000008
           | ILTypeDefLayout.Explicit _ -> 0x00000010) |||
-        // TODO: this should always be set 
         (if not td.SecurityDecls.AsList.IsEmpty then 0x00040000 else 0x00000000)
 
     let tdorTag, tdorRow = GetTypeOptionAsTypeDefOrRef cenv env td.Extends
@@ -2858,7 +2852,6 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
     let flags = 
         (int md.Flags) |||
         // TODO: put these in the flags
-        GetMemberAccessFlags md.Access |||
         (match md.mdKind with MethodKind.Static | MethodKind.Cctor -> 0x0010 | _ -> 0x0) |||
         (match md.mdBody.Contents with MethodBody.PInvoke _ -> 0x2000 | _ -> 0x0) |||
         (match md.mdKind with MethodKind.Ctor | MethodKind.Cctor -> 0x1000 | _ -> 0x0) ||| // RTSpecialName 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2851,10 +2851,7 @@ let GenMethodDefSigAsBlobIdx cenv env mdef =
 let GenMethodDefAsRow cenv env midx (md: ILMethodDef) = 
     let flags = 
         (int md.Flags) |||
-        // TODO: put these in the flags
-        (match md.mdKind with MethodKind.Static | MethodKind.Cctor -> 0x0010 | _ -> 0x0) |||
         (match md.mdBody.Contents with MethodBody.PInvoke _ -> 0x2000 | _ -> 0x0) |||
-        (match md.mdKind with MethodKind.Ctor | MethodKind.Cctor -> 0x1000 | _ -> 0x0) ||| // RTSpecialName 
         (if not md.SecurityDecls.AsList.IsEmpty then 0x4000 else 0x0)
     let implflags = int md.ImplementationFlags
 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2885,9 +2885,7 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
           | MethodKind.Ctor | MethodKind.Cctor -> true 
           | _ -> false) then 0x1000 else 0x0) ||| // RTSpecialName 
         (if not md.SecurityDecls.AsList.IsEmpty then 0x4000 else 0x0)
-    let implflags = 
-        (int md.ImplementationFlags) |||
-        (if (match md.mdBody.Contents with MethodBody.IL il -> il.NoInlining | _ -> false) then 0x0008 else 0x0000)
+    let implflags = int md.ImplementationFlags
 
     if md.IsEntryPoint then 
         if cenv.entrypoint <> None then failwith "duplicate entrypoint"

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -1418,12 +1418,11 @@ let rec GetTypeDefAsRow cenv env _enc (td:ILTypeDef) =
       else
         
         GetTypeAccessFlags td.Access |||
-        begin 
-          match td.Layout with 
+        (int td.Flags) |||
+        (match td.Layout with 
           | ILTypeDefLayout.Auto ->  0x00000000
           | ILTypeDefLayout.Sequential _  -> 0x00000008
-          | ILTypeDefLayout.Explicit _ -> 0x00000010
-        end |||
+          | ILTypeDefLayout.Explicit _ -> 0x00000010) |||
         (if not td.SecurityDecls.AsList.IsEmpty then 0x00040000 else 0x00000000)
 
     let tdorTag, tdorRow = GetTypeOptionAsTypeDefOrRef cenv env td.Extends

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -3586,7 +3586,7 @@ and GenLambdaClosure cenv (cgbuf:CodeGenBuffer) eenv isLocalTypeFunc selfv expr 
                 let ilContractTy = mkILFormalBoxedTy ilContractTypeRef ilContractGenericParams
                 let ilContractCtor =  mkILNonGenericEmptyCtor None cenv.g.ilg.typ_Object
 
-                let ilContractMeths = [ilContractCtor; mkILGenericVirtualMethod("DirectInvoke",ILMemberAccess.Assembly,ilContractMethTyargs,[],mkILReturn ilContractFormalRetTy, MethodBody.Abstract) ]
+                let ilContractMeths = [ilContractCtor; mkILGenericVirtualMethod("DirectInvoke",ILMemberAccess.Assembly,ilContractMethTyargs,[],mkILReturn ilContractFormalRetTy, MethodBody.None) ]
 
                 let ilContractTypeDefFlags = 
                     TypeAttributes.Abstract
@@ -5893,7 +5893,7 @@ and GenAbstractBinding cenv eenv tref (vref:ValRef) =
         let ilParams = GenParams cenv eenvForMeth mspec argInfos None
         
         let compileAsInstance = ValRefIsCompiledAsInstanceMember cenv.g vref
-        let mdef = mkILGenericVirtualMethod (vref.CompiledName,ILMemberAccess.Public,ilMethTypars,ilParams,ilReturn,MethodBody.Abstract)
+        let mdef = mkILGenericVirtualMethod (vref.CompiledName,ILMemberAccess.Public,ilMethTypars,ilParams,ilReturn,MethodBody.None)
 
         let mdef = fixupVirtualSlotFlags mdef
         let mdef = 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1577,7 +1577,8 @@ module StaticLinker =
                               if debugStaticLinking then printfn "Relocating %s to %s " ilOrigTyRef.QualifiedName ilTgtTyRef.QualifiedName
                               { ilOrigTypeDef with 
                                     Name = ilTgtTyRef.Name
-                                    Access = (match ilOrigTypeDef.Access with 
+                                    Flags = ilOrigTypeDef.Flags.SetAccess
+                                             (match ilOrigTypeDef.Access with 
                                               | ILTypeDefAccess.Public when isNested -> ILTypeDefAccess.Nested ILMemberAccess.Public 
                                               | ILTypeDefAccess.Private when isNested -> ILTypeDefAccess.Nested ILMemberAccess.Assembly 
                                               | x -> x)

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -3337,7 +3337,7 @@ let GetIntrinsicConstructorInfosOfType (infoReader:InfoReader) m ty =
         | ILTypeMetadata _ -> 
             let tinfo = ILTypeInfo.FromType g ty
             tinfo.RawMetadata.Methods.FindByName ".ctor" 
-            |> List.filter (fun md -> match md.mdKind with MethodKind.Ctor -> true | _ -> false) 
+            |> List.filter (fun md -> md.IsConstructor) 
             |> List.map (fun mdef -> MethInfo.CreateILMeth (amap, m, ty, mdef)) 
 
         | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> 

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -709,10 +709,7 @@ type ILMethInfo =
     member x.IsFinal = x.RawMetadata.IsFinal
 
     /// Indicates if the IL method is marked abstract.
-    member x.IsAbstract = 
-        match x.RawMetadata.mdKind with 
-        | MethodKind.Virtual vinfo -> vinfo.IsAbstract 
-        | _ -> false
+    member x.IsAbstract = x.RawMetadata.IsAbstract
 
     /// Does it appear to the user as a static method?
     member x.IsStatic = 
@@ -720,10 +717,7 @@ type ILMethInfo =
         x.RawMetadata.CallingConv.IsStatic
 
     /// Does it have the .NET IL 'newslot' flag set, and is also a virtual?
-    member x.IsNewSlot = 
-        match x.RawMetadata.mdKind with 
-        | MethodKind.Virtual vinfo -> vinfo.IsNewSlot 
-        | _ -> false
+    member x.IsNewSlot = x.RawMetadata.IsNewSlot
     
     /// Does it appear to the user as an instance method?
     member x.IsInstance = not x.IsConstructor &&  not x.IsStatic

--- a/src/ilx/EraseClosures.fs
+++ b/src/ilx/EraseClosures.fs
@@ -455,7 +455,7 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
               let laterTypeDefs = 
                 convIlxClosureDef cenv mdefGen encl
                   {td with GenericParams=laterGenericParams;
-                            Access=laterAccess;
+                            Flags=td.Flags.SetAccess(laterAccess);
                             Name=laterTypeName} 
                   {clo with cloStructure=laterStruct;
                             cloFreeVars=laterFields;
@@ -507,14 +507,20 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
                      mkILCloFldSpecs cenv nowFields,
                      ILMemberAccess.Assembly)
 
+              let cloTypeDefFlags =
+                  TypeAttributes.None
+                      .SetEncoding(ILDefaultPInvokeEncoding.Ansi)
+                      .SetSerializable(td.IsSerializable)
+                      .SetInitSemantics(ILTypeInit.BeforeField)
+                      .SetAccess(td.Access)
+
               let cloTypeDef = 
                 { Name = td.Name;
                   GenericParams= td.GenericParams;
-                  Access=td.Access;
                   Implements = ILList.empty;
                   NestedTypes = emptyILTypeDefs;
                   Layout=ILTypeDefLayout.Auto;
-                  Flags=TypeAttributes.AnsiClass.SetSerializable(td.IsSerializable).SetInitSemantics(ILTypeInit.BeforeField);
+                  Flags=cloTypeDefFlags;
                   Extends= Some cenv.mkILTyFuncTy;
                   Methods= mkILMethods ([ctorMethodDef] @ [nowApplyMethDef]); 
                   Fields= mkILFields (mkILCloFldDefs cenv nowFields);
@@ -567,7 +573,7 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
               let laterTypeDefs = 
                 convIlxClosureDef cenv mdefGen encl
                   {td with GenericParams=laterGenericParams;
-                             Access=laterAccess;
+                             Flags=td.Flags.SetAccess(laterAccess);
                              Name=laterTypeName} 
                   {clo with cloStructure=laterStruct;
                         cloFreeVars=laterFields;
@@ -581,6 +587,14 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
                 // CASE 2b2. Build a term application as a virtual method. 
                 
                 let nowEnvParentClass = typ_Func cenv (typesOfILParamsList nowParams) nowReturnTy 
+
+                let cloTypeDefFlags =
+                  TypeAttributes.None
+                      .SetEncoding(ILDefaultPInvokeEncoding.Ansi)
+                      .SetSerializable(td.IsSerializable)
+                      .SetInitSemantics(ILTypeInit.BeforeField)
+                      .SetAccess(td.Access)
+
                 let cloTypeDef = 
                     let nowApplyMethDef =
                         mkILNonGenericVirtualMethod
@@ -597,10 +611,9 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
                             ILMemberAccess.Assembly)
                     { Name = td.Name;
                       GenericParams= td.GenericParams;
-                      Access = td.Access;
                       Implements = mkILTypes [];
                       Layout=ILTypeDefLayout.Auto;
-                      Flags=TypeAttributes.AnsiClass.SetSerializable(td.IsSerializable).SetInitSemantics(ILTypeInit.BeforeField);
+                      Flags=cloTypeDefFlags;
                       NestedTypes = emptyILTypeDefs; 
                       Extends= Some nowEnvParentClass;
                       Methods= mkILMethods ([ctorMethodDef] @ [nowApplyMethDef]); 

--- a/src/ilx/EraseClosures.fs
+++ b/src/ilx/EraseClosures.fs
@@ -2,6 +2,8 @@
 
 module internal Microsoft.FSharp.Compiler.AbstractIL.Extensions.ILX.EraseClosures
 
+open System.Reflection
+
 open Internal.Utilities
 
 open Microsoft.FSharp.Compiler.AbstractIL 
@@ -510,15 +512,9 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
                   GenericParams= td.GenericParams;
                   Access=td.Access;
                   Implements = ILList.empty;
-                  IsAbstract = false;
                   NestedTypes = emptyILTypeDefs;
-                  IsSealed = false;
-                  IsSerializable=td.IsSerializable; 
-                  IsComInterop=false;
-                  IsSpecialName=false;
                   Layout=ILTypeDefLayout.Auto;
-                  Encoding=ILDefaultPInvokeEncoding.Ansi;
-                  InitSemantics=ILTypeInit.BeforeField;
+                  Flags=TypeAttributes.AnsiClass.SetSerializable(td.IsSerializable).SetInitSemantics(ILTypeInit.BeforeField);
                   Extends= Some cenv.mkILTyFuncTy;
                   Methods= mkILMethods ([ctorMethodDef] @ [nowApplyMethDef]); 
                   Fields= mkILFields (mkILCloFldDefs cenv nowFields);
@@ -526,7 +522,6 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
                   MethodImpls=emptyILMethodImpls;
                   Properties=emptyILProperties;
                   Events=emptyILEvents;
-                  HasSecurity=false; 
                   SecurityDecls=emptyILSecurityDecls; 
                   tdKind = ILTypeDefKind.Class;}
               [ cloTypeDef], []
@@ -604,14 +599,8 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
                       GenericParams= td.GenericParams;
                       Access = td.Access;
                       Implements = mkILTypes [];
-                      IsAbstract = false;
-                      IsSealed = false;
-                      IsSerializable=td.IsSerializable; 
-                      IsComInterop=false;
-                      IsSpecialName=false;
                       Layout=ILTypeDefLayout.Auto;
-                      Encoding=ILDefaultPInvokeEncoding.Ansi;
-                      InitSemantics=ILTypeInit.BeforeField;
+                      Flags=TypeAttributes.AnsiClass.SetSerializable(td.IsSerializable).SetInitSemantics(ILTypeInit.BeforeField);
                       NestedTypes = emptyILTypeDefs; 
                       Extends= Some nowEnvParentClass;
                       Methods= mkILMethods ([ctorMethodDef] @ [nowApplyMethDef]); 
@@ -620,7 +609,6 @@ let rec convIlxClosureDef cenv mdefGen encl (td: ILTypeDef) clo =
                       MethodImpls=emptyILMethodImpls;
                       Properties=emptyILProperties;
                       Events=emptyILEvents;
-                      HasSecurity=false; 
                       SecurityDecls=emptyILSecurityDecls; 
                       tdKind = ILTypeDefKind.Class; } 
                 [cloTypeDef],[]

--- a/src/ilx/EraseUnions.fs
+++ b/src/ilx/EraseUnions.fs
@@ -1060,12 +1060,17 @@ let rec convClassUnionDef cenv enc td cud =
         if tagEnumFields.Length <= 1 then 
             None
         else
+            let flags = 
+                TypeAttributes.None
+                    .SetAbstract(true)
+                    .SetSealed(true)
+                    .SetEncoding(ILDefaultPInvokeEncoding.Ansi)
+                    .SetAccess(ILTypeDefAccess.Nested cud.cudReprAccess)
             Some 
                 { Name = "Tags";
                   NestedTypes = emptyILTypeDefs;
                   GenericParams= td.GenericParams;
-                  Access = ILTypeDefAccess.Nested cud.cudReprAccess;
-                  Flags = TypeAttributes.Abstract ||| TypeAttributes.Sealed ||| TypeAttributes.AnsiClass;
+                  Flags = flags
                   Layout=ILTypeDefLayout.Auto; 
                   Implements = mkILTypes [];
                   Extends= Some cenv.ilg.typ_Object ;
@@ -1079,7 +1084,7 @@ let rec convClassUnionDef cenv enc td cud =
                   tdKind = ILTypeDefKind.Enum; }
 
     let baseTypeDefFlags = 
-        (enum<TypeAttributes>(0))
+        TypeAttributes.None
             .SetAbstract(isAbstract)
             .SetSealed(altTypeDefs.IsEmpty)
             .SetSerializable(td.IsSerializable)
@@ -1087,6 +1092,7 @@ let rec convClassUnionDef cenv enc td cud =
             .SetSpecialName(td.IsSpecialName)
             .SetHasSecurity(td.HasSecurity)
             .SetInitSemantics(ILTypeInit.BeforeField)
+            .SetAccess(td.Access)
 
     let baseTypeDef = 
         { Name = td.Name;
@@ -1095,7 +1101,6 @@ let rec convClassUnionDef cenv enc td cud =
                                altDebugTypeDefs @
                                (convTypeDefs cenv (enc@[td]) td.NestedTypes).AsList);
           GenericParams= td.GenericParams;
-          Access = td.Access;
           Flags =  baseTypeDefFlags
           Layout=td.Layout; 
           Implements = td.Implements;


### PR DESCRIPTION
I am making some effort to reduce the memory usage of some of the more common object types in F# compilation and editing.  The fixes here will eventually flow through to all users of the FSharp.Compiler.Service too.

An analysis of some aspects of memory usage is here: https://github.com/fsharp/fsharp.github.io/blob/master/_posts/2015-09-29-fsharp-compiler-guide.md#compiler-memory-usage

The ILMethodDef and ILTypeDef types are particularly needlessly fat.  This PR trims ILMethodDef by about 15 words and ILTypeDef by ~7 words.  

We now reuse the existing System.Reflection flag enumerations in Abstract IL.  There is no fundamental reason not to do this - the fact we used the bloated representation was mostly historical.

* When generating assemblies, If the target assembly being contains 20,000 methods, the ILMethodDef will save ~1.2MB of long-lived data during code gen, approximately 1% overall

* When reading assemblies, the savings from the ILMethodDef change will depend on the surface area of imported .NET assemblies being used by the F# code, since ILMethodDefs are read on-demand.  in typical medium-sized scenarios (e.g. FSharp.Data project) it seems we have at least ~10,000 ILMethodDef objects even after opening just a few files.  So this will save ~0.5MB of long-lived data, and say 10x more in larger solutions, so worthwhile. 

* When reading assemblies, the savings from the ILTypeDef change will again depend on the surface area being accessed.  Quite a lot of ILTypeDef objects are created though - normally more than ILMethodDef, so about the same level of saving can be expected.




