### PR TITLE
fix 532 - accumulate hiding information

### DIFF
--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -3193,7 +3193,7 @@ and OptimizeModuleDefs cenv (env,bindInfosColl) defs =
     let defs,minfos = List.unzip defs
     (defs,UnionOptimizationInfos minfos),(env,bindInfosColl)
    
-and OptimizeImplFileInternal cenv env isIncrementalFragment (TImplFile(qname, pragmas, (ModuleOrNamespaceExprWithSig(mty,_,_) as mexpr), hasExplicitEntryPoint,isScript)) =
+and OptimizeImplFileInternal cenv env isIncrementalFragment hidden (TImplFile(qname, pragmas, (ModuleOrNamespaceExprWithSig(mty,_,_) as mexpr), hasExplicitEntryPoint,isScript)) =
     let env,mexpr',minfo  = 
         match mexpr with 
         // FSI: FSI compiles everything as if you're typing incrementally into one module 
@@ -3209,16 +3209,16 @@ and OptimizeImplFileInternal cenv env isIncrementalFragment (TImplFile(qname, pr
             let env = { env with localExternalVals=env.localExternalVals.MarkAsCollapsible() } // take the chance to flatten to a dictionary
             env, mexpr', minfo
 
-    let hidden = ComputeHidingInfoAtAssemblyBoundary mty
+    let hidden = ComputeHidingInfoAtAssemblyBoundary mty hidden
 
     let minfo = AbstractLazyModulInfoByHiding true hidden minfo
-    env, TImplFile(qname,pragmas,mexpr',hasExplicitEntryPoint,isScript), minfo
+    env, TImplFile(qname,pragmas,mexpr',hasExplicitEntryPoint,isScript), minfo, hidden
 
 //-------------------------------------------------------------------------
 // Entry point
 //------------------------------------------------------------------------- 
 
-let OptimizeImplFile(settings,ccu,tcGlobals,tcVal, importMap,optEnv,isIncrementalFragment,emitTailcalls,mimpls) =
+let OptimizeImplFile(settings,ccu,tcGlobals,tcVal, importMap,optEnv,isIncrementalFragment,emitTailcalls,hidden,mimpls) =
     let cenv = 
         { settings=settings;
           scope=ccu; 
@@ -3229,7 +3229,7 @@ let OptimizeImplFile(settings,ccu,tcGlobals,tcVal, importMap,optEnv,isIncrementa
           localInternalVals=new System.Collections.Generic.Dictionary<Stamp,ValInfo>(10000);
           emitTailcalls=emitTailcalls;
           casApplied=new Dictionary<Stamp,bool>() }
-    OptimizeImplFileInternal cenv optEnv isIncrementalFragment mimpls 
+    OptimizeImplFileInternal cenv optEnv isIncrementalFragment hidden mimpls  
 
 
 //-------------------------------------------------------------------------

--- a/src/fsharp/Optimizer.fsi
+++ b/src/fsharp/Optimizer.fsi
@@ -5,6 +5,7 @@ module internal Microsoft.FSharp.Compiler.Optimizer
 open Internal.Utilities
 open Microsoft.FSharp.Compiler 
 open Microsoft.FSharp.Compiler.Tast
+open Microsoft.FSharp.Compiler.Tastops
 open Microsoft.FSharp.Compiler.TcGlobals 
 open Microsoft.FSharp.Compiler.AbstractIL 
 open Microsoft.FSharp.Compiler.AbstractIL.Internal 
@@ -43,7 +44,7 @@ type IncrementalOptimizationEnv =
 val internal BindCcu : CcuThunk -> CcuOptimizationInfo -> IncrementalOptimizationEnv -> TcGlobals -> IncrementalOptimizationEnv
 
 /// Optimize one implementation file in the given environment
-val internal OptimizeImplFile : OptimizationSettings *  CcuThunk * TcGlobals * ConstraintSolver.TcValF * Import.ImportMap * IncrementalOptimizationEnv * isIncrementalFragment: bool * emitTaicalls: bool * TypedImplFile -> IncrementalOptimizationEnv * TypedImplFile * ImplFileOptimizationInfo
+val internal OptimizeImplFile : OptimizationSettings *  CcuThunk * TcGlobals * ConstraintSolver.TcValF * Import.ImportMap * IncrementalOptimizationEnv * isIncrementalFragment: bool * emitTaicalls: bool * SignatureHidingInfo * TypedImplFile -> IncrementalOptimizationEnv * TypedImplFile * ImplFileOptimizationInfo * SignatureHidingInfo
 
 #if DEBUG
 /// Displaying optimization data

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -3695,9 +3695,9 @@ let rec accModuleOrNamespaceHidingInfoAtAssemblyBoundary mty acc =
     let acc = QueueList.foldBack accValHidingInfoAtAssemblyBoundary mty.AllValsAndMembers acc
     acc 
 
-let ComputeHidingInfoAtAssemblyBoundary mty = 
+let ComputeHidingInfoAtAssemblyBoundary mty acc = 
 //     dprintf "ComputeRemappingFromInferredSignatureToExplicitSignature,\nmty = %s\nmmsigty=%s\n" (showL(entityTypeL mty)) (showL(entityTypeL msigty)); 
-    accModuleOrNamespaceHidingInfoAtAssemblyBoundary mty SignatureHidingInfo.Empty
+    accModuleOrNamespaceHidingInfoAtAssemblyBoundary mty acc
 
 //--------------------------------------------------------------------------
 // Compute instances of the above for mexpr -> mty

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -745,10 +745,11 @@ type SignatureHidingInfo =
       mhiVals       : Zset<Val>; 
       mhiRecdFields : Zset<RecdFieldRef>;
       mhiUnionCases : Zset<UnionCaseRef> }
+    static member Empty : SignatureHidingInfo
 
 val ComputeRemappingFromInferredSignatureToExplicitSignature : TcGlobals -> ModuleOrNamespaceType -> ModuleOrNamespaceType -> SignatureRepackageInfo * SignatureHidingInfo
 val ComputeRemappingFromImplementationToSignature : TcGlobals -> ModuleOrNamespaceExpr -> ModuleOrNamespaceType -> SignatureRepackageInfo * SignatureHidingInfo
-val ComputeHidingInfoAtAssemblyBoundary : ModuleOrNamespaceType -> SignatureHidingInfo
+val ComputeHidingInfoAtAssemblyBoundary : ModuleOrNamespaceType -> SignatureHidingInfo -> SignatureHidingInfo
 val mkRepackageRemapping : SignatureRepackageInfo -> Remap 
 
 val wrapModuleOrNamespaceExprInNamespace : Ident -> CompilationPath -> ModuleOrNamespaceExpr -> ModuleOrNamespaceExpr

--- a/tests/fsharp/optimize/inline/build.bat
+++ b/tests/fsharp/optimize/inline/build.bat
@@ -9,16 +9,23 @@ if NOT "%FSC:NOTAVAIL=X%" == "%FSC%" (
   goto Skip
 )
 
-"%FSC%" %fsc_flags% -g --optimize- --target:library -o:lib.dll lib.fs
+"%FSC%" %fsc_flags% -g --optimize- --target:library -o:lib.dll lib.fs lib2.fs
 if ERRORLEVEL 1 goto Error
 
-"%FSC%" %fsc_flags% --optimize --target:library -o:lib--optimize.dll -g lib.fs
+"%FSC%" %fsc_flags% -g --optimize- --target:library -o:lib3.dll -r:lib.dll lib3.fs
 if ERRORLEVEL 1 goto Error
 
-"%FSC%" %fsc_flags% -g --optimize- -o:test.exe test.fs -r:lib.dll
+"%FSC%" %fsc_flags% -g --optimize- -o:test.exe test.fs -r:lib.dll -r:lib3.dll
 if ERRORLEVEL 1 goto Error
 
-"%FSC%" %fsc_flags% --optimize -o:test--optimize.exe -g test.fs -r:lib--optimize.dll
+
+"%FSC%" %fsc_flags% --optimize --target:library -o:lib--optimize.dll -g lib.fs  lib2.fs
+if ERRORLEVEL 1 goto Error
+
+"%FSC%" %fsc_flags% --optimize --target:library -o:lib3--optimize.dll -r lib-optimize.dll -g lib3.fs  
+if ERRORLEVEL 1 goto Error
+
+"%FSC%" %fsc_flags% --optimize -o:test--optimize.exe -g test.fs -r:lib--optimize.dll  -r:lib3--optimize.dll
 if ERRORLEVEL 1 goto Error
 
 :Ok

--- a/tests/fsharp/optimize/inline/lib.fs
+++ b/tests/fsharp/optimize/inline/lib.fs
@@ -1,4 +1,4 @@
-module Test.Lib
+namespace ThisNamespaceHasToBeTheSame
 
 #nowarn "9"
 
@@ -69,3 +69,20 @@ module Vector3GenericInt =
 module Vector3GenericObj =
     let inline test (v1: Vector3Generic<obj>) (v2: Vector3Generic<obj>) =
         v1.x
+
+type HiddenRecord = 
+    private { x : int } 
+    member this.X = this.x
+
+type HiddenUnion = 
+    private A of int | B of string
+    member this.X = match this with A x -> x | B s -> s.Length
+
+type internal Foo private () = 
+    static member FooMethod() = ()
+
+[<System.Runtime.CompilerServices.InternalsVisibleToAttribute("lib3")>]
+do()
+
+[<System.Runtime.CompilerServices.InternalsVisibleToAttribute("lib3--optimize")>]
+do()

--- a/tests/fsharp/optimize/inline/lib2.fs
+++ b/tests/fsharp/optimize/inline/lib2.fs
@@ -1,0 +1,9 @@
+namespace ThisNamespaceHasToBeTheSame
+module Factory = 
+    let NewRecord () = { x = 0 } 
+    let NewUnionA () = A 1
+    let NewUnionB () = B "1"
+
+type Bar () = 
+    member x.BarMethod() =
+       Foo.FooMethod()

--- a/tests/fsharp/optimize/inline/lib3.fs
+++ b/tests/fsharp/optimize/inline/lib3.fs
@@ -1,0 +1,7 @@
+namespace ASecondLibrary
+
+open ThisNamespaceHasToBeTheSame
+
+type Bar () = 
+    member x.BarMethod() =
+       Foo.FooMethod()

--- a/tests/fsharp/optimize/inline/test.fs
+++ b/tests/fsharp/optimize/inline/test.fs
@@ -1,6 +1,7 @@
 module Test.Test
 
-open Test.Lib
+open ThisNamespaceHasToBeTheSame
+open ASecondLibrary
 
 let testVector3DotInline (v1: Vector3) =
     Vector3.dot v1 v1
@@ -16,3 +17,17 @@ let testVector3GenericInline (v1: Vector3Generic<int>) =
 
 let testVector3GenericInline2 (v1: Vector3Generic<obj>) =
     Vector3GenericObj.test v1 v1
+
+// This was the failing case for the first bug reported in https://github.com/Microsoft/visualfsharp/issues/532
+//
+let testAccessingSomethingInlinableThatUsesAPrivateInlinedConstructFromAThirdModule = 
+    let boom1 = ThisNamespaceHasToBeTheSame.Factory.NewRecord ()
+    let boom2 = ThisNamespaceHasToBeTheSame.Factory.NewUnionA ()
+    let boom3 = ThisNamespaceHasToBeTheSame.Factory.NewUnionB ()
+    boom1.X, boom2.X, boom3.X
+
+// This is the failing case for the second bug reported in https://github.com/Microsoft/visualfsharp/issues/532
+//
+//let testAccessingSomethingInlinableThatUsesAInternalConstructFromAnInternalsVisibleToAssembly = 
+//    Bar().BarMethod()
+


### PR DESCRIPTION
This fixes the first bug reported in  #532 (which is the more serious one, since the second requires 3 DLLs and a use of InternalsVisibleTo attribute).  

A full test run is needed.  I've run all of the "fsharp" suite.  

The problem was that we were only hiding optimization information w.r.t. the module being optimized, and not w.r.t. all the types hidden across a whole assembly. We instead accumulate the hiding information across the assembly and the problem is solved.
