### PR TITLE
Fix 631 and 592 - bad metadata production in corner cases

### DIFF
--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -311,7 +311,8 @@ type ValRemap = ValMap<ValRef>
 type Remap =
     { tpinst : TyparInst;
       valRemap: ValRemap;
-      tyconRefRemap : TyconRefRemap }
+      tyconRefRemap : TyconRefRemap;
+      removeTraitSolutions: bool }
 
     static member Empty : Remap
 

--- a/src/fsharp/TypeRelations.fs
+++ b/src/fsharp/TypeRelations.fs
@@ -1438,9 +1438,11 @@ module DispatchSlotChecking =
         allImmediateMembersThatMightImplementDispatchSlots |> List.iter (fun overrideBy -> 
 
             let isFakeEventProperty = overrideBy.IsFSharpEventProperty(g)
-            if not isFakeEventProperty then 
-                
-                let overriden = 
+            let overriden = 
+                if isFakeEventProperty then 
+                    let slotsigs = overrideBy.MemberInfo.Value.ImplementedSlotSigs 
+                    slotsigs |> List.map (ReparentSlotSigToUseMethodTypars g overrideBy.Range overrideBy)
+                else
                     [ for ((reqdTy,m),(SlotImplSet(_dispatchSlots,dispatchSlotsKeyed,_,_))) in allImpls do
                           let overrideByInfo = GetTypeMemberOverrideInfo g reqdTy overrideBy
                           let overridenForThisSlotImplSet = 
@@ -1466,7 +1468,7 @@ module DispatchSlotChecking =
                           //    assert nonNil overridenForThisSlotImplSet
                           yield! overridenForThisSlotImplSet ]
                 
-                overrideBy.MemberInfo.Value.ImplementedSlotSigs <- overriden)
+            overrideBy.MemberInfo.Value.ImplementedSlotSigs <- overriden)
 
 
 //-------------------------------------------------------------------------

--- a/tests/fsharp/single-neg-test.bat
+++ b/tests/fsharp/single-neg-test.bat
@@ -40,8 +40,22 @@ if exist "%testname%b.ml" (set sources=%sources% %testname%b.ml)
 if exist "%testname%b.fs" (set sources=%sources% %testname%b.fs)
 if exist "helloWorldProvider.dll" (set sources=%sources% -r:helloWorldProvider.dll)
 
+if exist "%testname%-pre.fs" (
+    echo set sources=%sources% -r:%testname%-pre.dll
+    set sources=%sources% -r:%testname%-pre.dll
+)
+
 REM check negative tests for bootstrapped fsc.exe due to line-ending differences
 if "%FSC:fscp=X%" == "%FSC%" ( 
+
+    if exist "%testname%-pre.fs" (
+        echo "sources=%sources%"
+	    "%FSC%" %fsc_flags% -a -o:%testname%-pre.dll  "%testname%-pre.fs" 
+        @if ERRORLEVEL 1 (
+            set ERRORMSG=%ERRORMSG% FSC failed for precursor library code for  %sources%;
+            goto SetError
+		)
+    )
 
     echo Negative typechecker testing: %testname%
     echo "%FSC%" %fsc_flags% --vserrors --warnaserror --nologo --maxerrors:10000 -a -o:%testname%.dll  %sources%

--- a/tests/fsharp/typecheck/sigs/build.bat
+++ b/tests/fsharp/typecheck/sigs/build.bat
@@ -5,6 +5,9 @@ setlocal
 REM Configure the sample, i.e. where to find the F# compiler and C# compiler.
 call %~d0%~p0..\..\..\config.bat
 
+call ..\..\single-neg-test.bat neg94
+@if ERRORLEVEL 1 goto Error
+
 "%FSC%" %fsc_flags% --target:exe -o:pos22.exe  pos22.fs 
 @if ERRORLEVEL 1 goto Error
 
@@ -337,7 +340,6 @@ call ..\..\single-neg-test.bat neg42
 
 "%PEVERIFY%" pos03a.dll
 @if ERRORLEVEL 1 goto Error
-
 
 call ..\..\single-neg-test.bat neg34
 @if ERRORLEVEL 1 goto Error

--- a/tests/fsharp/typecheck/sigs/neg94-pre.fs
+++ b/tests/fsharp/typecheck/sigs/neg94-pre.fs
@@ -1,5 +1,19 @@
 namespace Neg94Pre
 
+open System
+
 type Class1() =
   static member inline ($) (r:'R, _) = fun (x:'T) -> ((^R) : (static member method2: ^T -> ^R) x)
   static member inline method1 x = Unchecked.defaultof<'r> $ Class1()
+
+type IComm = 
+    [<CLIEvent>]
+    abstract CanExecuteChanged : IEvent<EventHandler,EventArgs> 
+
+type Interface2<'T> =
+    inherit IComm
+
+type Class<'T>() =
+    interface Interface2<'T> with
+        [<CLIEvent>]
+        member __.CanExecuteChanged : IEvent<EventHandler,EventArgs> = Event<EventHandler,EventArgs>().Publish

--- a/tests/fsharp/typecheck/sigs/neg94-pre.fs
+++ b/tests/fsharp/typecheck/sigs/neg94-pre.fs
@@ -1,0 +1,5 @@
+namespace Neg94Pre
+
+type Class1() =
+  static member inline ($) (r:'R, _) = fun (x:'T) -> ((^R) : (static member method2: ^T -> ^R) x)
+  static member inline method1 x = Unchecked.defaultof<'r> $ Class1()

--- a/tests/fsharp/typecheck/sigs/neg94.bsl
+++ b/tests/fsharp/typecheck/sigs/neg94.bsl
@@ -1,0 +1,2 @@
+
+neg94.fs(6,12,6,21): typecheck error FS0039: The value or constructor 'undefined' is not defined

--- a/tests/fsharp/typecheck/sigs/neg94.fs
+++ b/tests/fsharp/typecheck/sigs/neg94.fs
@@ -1,0 +1,10 @@
+namespace Neg94
+
+module Repro1 = 
+  let v = Neg94Pre.Class1()
+
+  let v2 = undefined  
+  // We're expecting the compile of this file to fail, but the point is that the 
+  // reference of neg94-pre.dll shouldn't give extra warnings about bad definitions.
+  // See https://github.com/Microsoft/visualfsharp/issues/631
+

--- a/tests/fsharp/typecheck/sigs/neg94.fs
+++ b/tests/fsharp/typecheck/sigs/neg94.fs
@@ -6,5 +6,7 @@ module Repro1 =
   let v2 = undefined  
   // We're expecting the compile of this file to fail, but the point is that the 
   // reference of neg94-pre.dll shouldn't give extra warnings about bad definitions.
-  // See https://github.com/Microsoft/visualfsharp/issues/631
+  // See 
+  //    https://github.com/Microsoft/visualfsharp/issues/631
+  //    https://github.com/Microsoft/visualfsharp/issues/592
 


### PR DESCRIPTION
https://github.com/Microsoft/visualfsharp/issues/631 and https://github.com/Microsoft/visualfsharp/issues/592 are two glitches in the F# metadata format for DLLs uncovered when we enabled this warning in F# 4.0: https://github.com/Microsoft/visualfsharp/commit/e5cdef919d43fc527ca412688af21d10f36f063a#diff-c357695ff5c54532cf4bebc7af8ac2aa

The https://github.com/Microsoft/visualfsharp/issues/631 glitch is due to the incorrect remapping of the value references in the "value linkage data"  stored for trait solutions associated with some constrained type parameters.  There is no need to store these trait solutions in the value linkage data, because the information is ignored.  (This also explains why this wasn't a problem in practice)

The https://github.com/Microsoft/visualfsharp/issues/592 glitch is because some (unused) type information for "fake event properties" was not being adjusted properly after type inference. ("fake event properties" are used by the F# compiler to make .NET CLIEvent events look as if they are first-class properties in F# even though they get compiled as events in .NET code).

This is a somewhat low-priority fix since it's just removing a spurious warning (though that warning is obviously disturbing to users).  An alternative solution is simply to revert https://github.com/Microsoft/visualfsharp/commit/e5cdef919d43fc527ca412688af21d10f36f063a#diff-c357695ff5c54532cf4bebc7af8ac2aa for now, and users can just add a nowarn directive to their code or project options.

