### PR TITLE
Fix 671

### DIFF
--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -528,7 +528,7 @@ and CheckExprInContext (cenv:cenv) (env:env) expr (context:ByrefCallContext) =
           CheckMultipleInterfaceInstantiations cenv interfaces m
 
     // Allow base calls to F# methods
-    | Expr.App((InnerExprPat(Expr.Val(v,vFlags,_) as f)),fty,tyargs,(Expr.Val(baseVal,_,_)::rest),m) 
+    | Expr.App((InnerExprPat(ExprValWithPossibleTypeInst(v,vFlags,_,_)  as f)),fty,tyargs,(Expr.Val(baseVal,_,_)::rest),m) 
           when ((match vFlags with VSlotDirectCall -> true | _ -> false) && 
                 baseVal.BaseOrThisInfo = BaseVal) ->
         // dprintfn "GOT BASE VAL USE"

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -61,6 +61,7 @@ val ensureCcuHasModuleOrNamespaceAtPath : CcuThunk -> Ident list -> CompilationP
 val stripExpr : Expr -> Expr
 
 val valsOfBinds : Bindings -> FlatVals 
+val (|ExprValWithPossibleTypeInst|_|) : Expr -> (ValRef * ValUseFlag * TType list * range) option
 
 //-------------------------------------------------------------------------
 // Build decision trees imperatively

--- a/tests/fsharp/typecheck/sigs/pos22.fs
+++ b/tests/fsharp/typecheck/sigs/pos22.fs
@@ -2,3 +2,12 @@
 
 let rec recValNeverUsedAtRuntime = recFuncIgnoresFirstArg (fun _ -> recValNeverUsedAtRuntime) 1
 and recFuncIgnoresFirstArg g v = v
+
+// https://github.com/Microsoft/visualfsharp/issues/671
+type Base() =
+    abstract member Method : 't -> unit
+    default this.Method(t) = ()
+
+and Derived() =
+    inherit Base()
+    override this.Method(t) = base.Method(t)


### PR DESCRIPTION
Fixes the issue https://github.com/Microsoft/visualfsharp/issues/671

The base-calling rule was not taking into account the fact that the call may have been subject to a type inference/generalization fixup.


