### PR TITLE
Fix 659 - disallow constructors as extension members

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1345,3 +1345,4 @@ estApplyStaticArgumentsForMethodNotImplemented,"A type provider implemented GetS
 3188,checkNotSufficientlyGenericBecauseOfScopeAnon,"Type inference caused an inference type variable to escape its scope. Consider adding type annotations to make your code less generic."
 3189,checkRaiseFamilyFunctionArgumentCount,"Redundant arguments are being ignored in function '%s'. Expected %d but got %d arguments."
 3190,checkLowercaseLiteralBindingInPattern,"Lowercase literal '%s' is being shadowed by a new pattern with the same name. Only uppercase and module-prefixed literals can be used as named patterns."
+3191,tcConstructorsIllegalInAugmentation,"Constructors are not permitted as extension members - they must be defined as part of the original definition of the type"

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -9995,6 +9995,8 @@ and TcLetBindings cenv env containerInfo declKind tpenv (binds,bindsm,scopem) =
 and CheckMemberFlags _g optIntfSlotTy newslotsOK overridesOK memberFlags m = 
     if newslotsOK = NoNewSlots && memberFlags.IsDispatchSlot then 
       errorR(Error(FSComp.SR.tcAbstractMembersIllegalInAugmentation(),m))
+    if overridesOK <> OverridesOK && memberFlags.MemberKind = MemberKind.Constructor then 
+      errorR(Error(FSComp.SR.tcConstructorsIllegalInAugmentation(),m))
     if overridesOK = WarnOnOverrides && memberFlags.IsOverrideOrExplicitImpl && isNone optIntfSlotTy then 
       warning(OverrideInIntrinsicAugmentation(m))
     if overridesOK = ErrorOnOverrides && memberFlags.IsOverrideOrExplicitImpl then 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -9995,7 +9995,7 @@ and TcLetBindings cenv env containerInfo declKind tpenv (binds,bindsm,scopem) =
 and CheckMemberFlags _g optIntfSlotTy newslotsOK overridesOK memberFlags m = 
     if newslotsOK = NoNewSlots && memberFlags.IsDispatchSlot then 
       errorR(Error(FSComp.SR.tcAbstractMembersIllegalInAugmentation(),m))
-    if overridesOK <> OverridesOK && memberFlags.MemberKind = MemberKind.Constructor then 
+    if overridesOK = ErrorOnOverrides && memberFlags.MemberKind = MemberKind.Constructor then 
       errorR(Error(FSComp.SR.tcConstructorsIllegalInAugmentation(),m))
     if overridesOK = WarnOnOverrides && memberFlags.IsOverrideOrExplicitImpl && isNone optIntfSlotTy then 
       warning(OverrideInIntrinsicAugmentation(m))

--- a/tests/fsharp/typecheck/sigs/build.bat
+++ b/tests/fsharp/typecheck/sigs/build.bat
@@ -5,6 +5,9 @@ setlocal
 REM Configure the sample, i.e. where to find the F# compiler and C# compiler.
 call %~d0%~p0..\..\..\config.bat
 
+call ..\..\single-neg-test.bat neg46
+@if ERRORLEVEL 1 goto Error
+
 call ..\..\single-neg-test.bat neg91
 @if ERRORLEVEL 1 goto Error
 
@@ -273,9 +276,6 @@ call ..\..\single-neg-test.bat neg48
 @if ERRORLEVEL 1 goto Error
 
 call ..\..\single-neg-test.bat neg47
-@if ERRORLEVEL 1 goto Error
-
-call ..\..\single-neg-test.bat neg46
 @if ERRORLEVEL 1 goto Error
 
 call ..\..\single-neg-test.bat neg10

--- a/tests/fsharp/typecheck/sigs/build.bat
+++ b/tests/fsharp/typecheck/sigs/build.bat
@@ -5,6 +5,9 @@ setlocal
 REM Configure the sample, i.e. where to find the F# compiler and C# compiler.
 call %~d0%~p0..\..\..\config.bat
 
+call ..\..\single-neg-test.bat neg91
+@if ERRORLEVEL 1 goto Error
+
 call ..\..\single-neg-test.bat neg94
 @if ERRORLEVEL 1 goto Error
 
@@ -26,9 +29,6 @@ call ..\..\single-neg-test.bat neg93
 call ..\..\single-neg-test.bat neg92
 @if ERRORLEVEL 1 goto Error
 
-
-call ..\..\single-neg-test.bat neg91
-@if ERRORLEVEL 1 goto Error
 
 "%FSC%" %fsc_flags% --target:exe -o:pos20.exe  pos20.fs 
 @if ERRORLEVEL 1 goto Error

--- a/tests/fsharp/typecheck/sigs/neg46.bsl
+++ b/tests/fsharp/typecheck/sigs/neg46.bsl
@@ -23,6 +23,8 @@ neg46.fs(48,8,48,34): typecheck error FS0912: This declaration element is not pe
 
 neg46.fs(52,8,52,39): typecheck error FS0912: This declaration element is not permitted in an augmentation
 
+neg46.fs(56,8,56,11): typecheck error FS3191: Constructors are not permitted as extension members - they must be defined as part of the original definition of the type
+
 neg46.fs(56,8,56,11): typecheck error FS0871: Constructors cannot be defined for this type
 
 neg46.fs(56,17,56,20): typecheck error FS0787: The inherited type is not an object model type

--- a/tests/fsharp/typecheck/sigs/neg91.bsl
+++ b/tests/fsharp/typecheck/sigs/neg91.bsl
@@ -10,3 +10,5 @@ neg91.fs(34,13,34,16): typecheck error FS0044: This construct is deprecated. Don
 neg91.fs(44,13,44,16): typecheck error FS3003: Don't touch me
 
 neg91.fs(54,13,54,16): typecheck error FS0057: It was just an experiment!. This warning can be disabled using '--nowarn:57' or '#nowarn "57"'.
+
+neg91.fs(64,29,64,32): typecheck error FS3191: Constructors are not permitted as extension members - they must be defined as part of the original definition of the type

--- a/tests/fsharp/typecheck/sigs/neg91.fs
+++ b/tests/fsharp/typecheck/sigs/neg91.fs
@@ -55,10 +55,25 @@ module TestExperimentalSet =
 
 
 
-module TestExtensionConstructor = 
+module TestExtrinsicExtensionConstructor = 
     // See https://github.com/Microsoft/visualfsharp/issues/659
 
     type AugmentMe() = class end
 
     module M = 
         type AugmentMe with new(i) = AugmentMe()
+
+// don't expect an error here
+module TestIntrinsicExtensionConstructor1 = 
+    type AugmentMe = val _i : int
+    type AugmentMe with member i.I = i._i
+    type AugmentMe with new(i) = { _i = i } // don't expect an error here
+    let v = AugmentMe(42).I
+
+// don't expect an error here
+module TestIntrinsicExtensionConstructor2 = 
+    type AugmentMe() = class end
+    type AugmentMe with member i.I = 1
+    type AugmentMe with new(i) = AugmentMe()  // don't expect an error here
+    let v = AugmentMe(42).I
+

--- a/tests/fsharp/typecheck/sigs/neg91.fs
+++ b/tests/fsharp/typecheck/sigs/neg91.fs
@@ -54,3 +54,11 @@ module TestExperimentalSet =
             A.x <- 1     
 
 
+
+module TestExtensionConstructor = 
+    // See https://github.com/Microsoft/visualfsharp/issues/659
+
+    type AugmentMe() = class end
+
+    module M = 
+        type AugmentMe with new(i) = AugmentMe()

--- a/tests/test.lst
+++ b/tests/test.lst
@@ -181,5 +181,5 @@ Misc02		fsharp\tools\bundle
 Misc02		fsharp\tools\eval
 Misc02		..\testsprivate\fsharp\tools\queries
 Misc02,TypeChecker		fsharp\typecheck\misc
-Misc02,TypeChecker		fsharp\typecheck\sigs
+Misc02,TypeChecker,TypeCheckerSigs		fsharp\typecheck\sigs
 Misc02,TypeChecker		fsharp\typecheck\full-rank-arrays


### PR DESCRIPTION

This fixes https://github.com/Microsoft/visualfsharp/issues/659.

Constructors should not be allowed as extension members.  Using them has always given a warning during code generation and they have not been actually callable.  So giving an error is appropriate.

