### PR TITLE
Fix 'Object reference not set to an instance of an object' in FSI when .ToString() returns null

### DIFF
--- a/src/utils/sformat.fs
+++ b/src/utils/sformat.fs
@@ -1194,7 +1194,7 @@ namespace Microsoft.FSharp.Text.StructuredFormat
             | :? bool   as b -> (if b then "true" else "false")
             | :? char   as c -> "\'" + formatChar true c + "\'"
             | _ -> try  let text = obj.ToString()
-                        text
+                        if text = null then "" else text
                    with e ->
                      // If a .ToString() call throws an exception, catch it and use the message as the result.
                      // This may be informative, e.g. division by zero etc...

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/ToStringNull.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/ToStringNull.fsx
@@ -1,0 +1,12 @@
+// #Regression #NoMT #FSI 
+// Microsoft.Analysis.Server overrides ToString() to return isNull
+// instead of a string. This would make FSI fail in pretty-printing 
+// when displaying results. 
+//<Expects status="success">val n : NullToString = </Expects>
+
+type NullToString() = 
+  override __.ToString() = null;;
+
+let n = NullToString();;
+#q;;
+

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/env.lst
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/env.lst
@@ -27,6 +27,8 @@ ReqENU	SOURCE=E_InterfaceCrossConstrained02.fsx   COMPILE_ONLY=1 FSIMODE=PIPE SC
 
 	SOURCE=EmptyList.fsx COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="--nologo"	# EmptyList.fsx
 
+	SOURCE=ToStringNull.fsx COMPILE_ONLY=1 FSIMODE=PIPE SCFLAGS="--nologo"	# ToStringNull.fsx
+
 # These are the regression tests for FSHARP1.0:5427
 # The scenario is a bit convoluted because of the way we end up doing the verification
 # In the last 2 cases, the verification is achieved by dumping the output of FSI to a file


### PR DESCRIPTION
Fixes #706.