### PR TITLE
Add links to DEVGUIDE and TESTGUIDE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ For those contributing to the core of the F# compiler, we recommend ["The F# Com
 - Install required software
 - Clone the repo
  - `git clone https://github.com/microsoft/visualfsharp.git`
-- How to build
-- How to run tests
+- How to build ([DEVGUIDE](DEVGUIDE.md))
+- How to run tests ([TESTGUIDE](TESTGUIDE.md))
 
 ###What to Contribute?
 


### PR DESCRIPTION
I'm not completely sure if we need this "getting started" section in the Contributing guide at all, but when we need it then it should at least point to relevant sections.