### PR TITLE
Use environment variable if present to detect VS version for build

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -4,9 +4,11 @@ set APPVEYOR_CI=1
 
 :: Check prerequisites
 if not '%VisualStudioVersion%' == '' goto vsversionset
+if exist "%VS140COMNTOOLS%..\ide\devenv.exe" set VisualStudioVersion=14.0
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
 if exist "%ProgramFiles%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
 if not '%VisualStudioVersion%' == '' goto vsversionset
+if exist "%VS120COMNTOOLS%..\ide\devenv.exe" set VisualStudioVersion=12.0
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
 if exist "%ProgramFiles%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
 


### PR DESCRIPTION
When Visual Studio is installed, a system environment variable of the form 'VS<VERSION>COMNTOOLS' is created pointing to the <VSDIR>\common7\tools directory.  We can use this to detect if Visual Studio is installed in a non-standard location, like for example it is on my machine, so that local runs of the appveyor-build.cmd file work in more general cases.