### PR TITLE
Remove commented code in Async.Parallel

### DIFF
--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1414,8 +1414,7 @@ namespace Microsoft.FSharp.Control
                     let count = ref tasks.Length
                     let firstExn = ref None
                     let results = Array.zeroCreate tasks.Length
-                    // Attept to cancel the individual operations if an exception happens on any the other threads
-                    //let failureCTS = new CancellationTokenSource()
+                    // Attept to cancel the individual operations if an exception happens on any of the other threads
                     let innerCTS = new LinkedSubSource(aux.token)
                     let trampolineHolder = aux.trampolineHolder
                     


### PR DESCRIPTION
While discussing Asnyc.Choice implementations with @dsyme and @eiriktsarpalis I wondered about that uncommented line. It confused me and Eirik suggested this unit test to see if things cancel properly.

=> we should remove the uncommented line to avoid confusion