### PR TITLE
Fix error in optimization of for loops over strings and lists

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta7" />
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00085" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.16-prerelease" />
   <package id="FsCheck" version="2.0.3" />
   <package id="NUnit" version="3.0.0" targetFramework="net45" />
   <package id="NUnit.Console" version="3.0.0" targetFramework="net45" />

--- a/tests/RunTests.cmd
+++ b/tests/RunTests.cmd
@@ -172,7 +172,7 @@ IF NOT DEFINED GACUTILEXE64 IF EXIST "%WINSDKNETFXTOOLS%x64\gacutil.exe" set GAC
 set FSC=%FSCBINPATH%\fsc.exe
 set PATH=%FSCBINPATH%;%PATH%
 
-set FSCVPREVBINPATH=%X86_PROGRAMFILES%\Microsoft SDKs\F#\3.1\Framework\v4.0
+set FSCVPREVBINPATH=%X86_PROGRAMFILES%\Microsoft SDKs\F#\4.0\Framework\v4.0
 set FSCVPREV=%FSCVPREVBINPATH%\fsc.exe
 
 REM == VS-installed paths to FSharp.Core.dll


### PR DESCRIPTION
We recently discovered this issue in FAKE:
https://github.com/fsharp/FAKE/issues/985

Which actually comes from FAKE's dependency on FSharp.Compiler.Service, which is based on the latest version of visualfsharp, which contains the actual bug :)

The problem is that the optimization looks for code of the form:
let s = "to loop over"
for x in s do
    System.Consolve.WriteLine(x)

This works when code loops over the string, as might be expected, but if you declare a string before the for loop and loop over something else the optimization is triggered and produces a bizarre compile error: For example the following program 
let configure () =
    let aSequence = seq { yield "" } 
    let aString = new System.String([||])
    for _ in aSequence do
        System.Console.WriteLine(aString)
        
configure ()

Give the following compile error:
myrepo.fs(5,65): error FS0971: Undefined value 'aString: string'

This pull request fixes the issue by looping at the expression that GetEnumator is called on, rather than the let declaration before the loop.