### PR TITLE
use appveyor build matrix

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -148,7 +148,9 @@ if /i '%BUILD_PROFILE%' == 'smoke_only' (
 )
 goto :EOF
 
-:SHOW_CONF
+:MAIN
+
+REM after this point, BUILD_PROFILE variable should not be used, use only DO_* or TEST_*
 
 echo Build/Tests configuration:
 echo.
@@ -170,14 +172,6 @@ echo CONF_CAMBRIDGE_SUITE=%CONF_CAMBRIDGE_SUITE%
 echo TEST_QA_SUITE=%TEST_QA_SUITE%
 echo CONF_QA_SUITE=%CONF_QA_SUITE%
 echo.
-
-goto :EOF
-
-:MAIN
-
-REM after this point, BUILD_PROFILE variable should not be used, use only DO_* or TEST_*
-
-call :SHOW_CONF
 
 @echo on
 

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -59,10 +59,10 @@ goto :MAIN
 set BUILD_PROFILE=%~1
 
 if "%BUILD_PROFILE%" == "1" if "%2" == "" (
-    set BUILD_PROFILE=all
+    set BUILD_PROFILE=smoke
 )
 
-if "%2" == "" if not "%BUILD_PROFILE%" == "all" goto :EOF
+if "%2" == "" if not "%BUILD_PROFILE%" == "smoke" goto :EOF
 
 echo Parse argument %BUILD_PROFILE%
 

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -280,8 +280,8 @@ set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=
 )
 
 if '%TEST_QA_SUITE%' == '1' (
-call RunTests.cmd release fsharpqa Smoke
-@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :failure
+call RunTests.cmd release fsharpqa
+@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa' failed && goto :failure
 )
 
 if '%TEST_NET40%' == '1' (

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -2,20 +2,10 @@
 
 :ARGUMENTS_VALIDATION
 
-set BUILD_PROFILE=%1
-
-if '%BUILD_PROFILE%' == '' SET BUILD_PROFILE=all
-
-if /I "%BUILD_PROFILE%" == "all"               (goto :ARGUMENTS_OK)
-if /I "%BUILD_PROFILE%" == "net40"             (goto :ARGUMENTS_OK)
-if /I "%BUILD_PROFILE%" == "portable47"        (goto :ARGUMENTS_OK)
-if /I "%BUILD_PROFILE%" == "portable7"         (goto :ARGUMENTS_OK)
-if /I "%BUILD_PROFILE%" == "portable78"        (goto :ARGUMENTS_OK)
-if /I "%BUILD_PROFILE%" == "portable259"       (goto :ARGUMENTS_OK)
-if /I "%BUILD_PROFILE%" == "vs"                (goto :ARGUMENTS_OK)
-if /I "%BUILD_PROFILE%" == "cambridge_suite"   (goto :ARGUMENTS_OK)
-if /I "%BUILD_PROFILE%" == "qa_suite"          (goto :ARGUMENTS_OK)
-goto :USAGE
+if /I "%1" == "/help"   (goto :USAGE)
+if /I "%1" == "/h"      (goto :USAGE)
+if /I "%1" == "/?"      (goto :USAGE)
+goto :ARGUMENTS_OK
 
 :USAGE
 
@@ -25,60 +15,90 @@ echo Usage:
 echo.
 echo appveyor-build.cmd ^<all^|net40^|portable47^|portable7^|portable78^|portable259^|vs^|cambridge_suite^|qa_suite^>
 echo.
-echo no arguments default to 'all'
+echo No arguments default to 'all'
+echo.
+echo To specify multiple values, separate strings by comma
+echo.
+echo The example below run portable47, vs and qa:
+echo.
+echo appveyor-build.cmd portable47,vs,qa_suite
 exit /b 1
 
 :ARGUMENTS_OK
 
 set DO_NET40=0
+set DO_PORTABLE47=0
+set DO_PORTABLE7=0
+set DO_PORTABLE78=0
+set DO_PORTABLE259=0
+set DO_VS=0
 set TEST_NET40=0
+set TEST_PORTABLE47=0
+set TEST_PORTABLE7=0
+set TEST_PORTABLE78=0
+set TEST_PORTABLE259=0
+set TEST_VS=0
+set TEST_CAMBRIDGE_SUITE=0
+set TEST_QA_SUITE=0
+
+setlocal enableDelayedExpansion
+set /a counter=0
+for /l %%x in (1 1 9) do (
+    set /a counter=!counter!+1
+    call :SET_CONFIG %%!counter! "!counter!"
+)
+setlocal disableDelayedExpansion
+echo.
+echo.
+
+goto :MAIN
+
+:SET_CONFIG
+set BUILD_PROFILE=%~1
+
+if "%BUILD_PROFILE%" == "1" if "%2" == "" (
+    set BUILD_PROFILE=all
+)
+
+if "%2" == "" if not "%BUILD_PROFILE%" == "all" goto :EOF
+
+echo Parse argument %BUILD_PROFILE%
+
 if /i '%BUILD_PROFILE%' == 'net40' (
     set DO_NET40=1
     set TEST_NET40=1
 )
 
-set DO_PORTABLE47=0
-set TEST_PORTABLE47=0
 if /i '%BUILD_PROFILE%' == 'portable47' (
     set DO_PORTABLE47=1
     set TEST_PORTABLE47=1
 )
 
-set DO_PORTABLE7=0
-set TEST_PORTABLE7=0
 if /i '%BUILD_PROFILE%' == 'portable7' (
     set DO_PORTABLE7=1
     set TEST_PORTABLE7=1
 )
 
-set DO_PORTABLE78=0
-set TEST_PORTABLE78=0
 if /i '%BUILD_PROFILE%' == 'portable78' (
     set DO_PORTABLE78=1
     set TEST_PORTABLE78=1
 )
 
-set DO_PORTABLE259=0
-set TEST_PORTABLE259=0
 if /i '%BUILD_PROFILE%' == 'portable259' (
     set DO_PORTABLE259=1
     set TEST_PORTABLE259=1
 )
 
-set DO_VS=0
-set TEST_VS=0
 if /i '%BUILD_PROFILE%' == 'vs' (
     set DO_VS=1
     set TEST_VS=1
 )
 
-set TEST_CAMBRIDGE_SUITE=0
 if /i '%BUILD_PROFILE%' == 'cambridge_suite' (
     set DO_NET40=1
     set TEST_CAMBRIDGE_SUITE=1
 )
 
-set TEST_QA_SUITE=0
 if /i '%BUILD_PROFILE%' == 'qa_suite' (
     set DO_NET40=1
     set TEST_QA_SUITE=1
@@ -101,11 +121,7 @@ if /i '%BUILD_PROFILE%' == 'all' (
     set TEST_QA_SUITE=1
 )
 
-REM after this point, BUILD_PROFILE variable should not be used, use only DO_* or TEST_*
-
-call :SHOW_CONF
-
-goto :MAIN
+goto :EOF
 
 :SHOW_CONF
 
@@ -131,6 +147,10 @@ echo.
 goto :EOF
 
 :MAIN
+
+REM after this point, BUILD_PROFILE variable should not be used, use only DO_* or TEST_*
+
+call :SHOW_CONF
 
 @echo on
 

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -1,3 +1,137 @@
+@echo off
+
+:ARGUMENTS_VALIDATION
+
+set BUILD_PROFILE=%1
+
+if '%BUILD_PROFILE%' == '' SET BUILD_PROFILE=all
+
+if /I "%BUILD_PROFILE%" == "all"               (goto :ARGUMENTS_OK)
+if /I "%BUILD_PROFILE%" == "net40"             (goto :ARGUMENTS_OK)
+if /I "%BUILD_PROFILE%" == "portable47"        (goto :ARGUMENTS_OK)
+if /I "%BUILD_PROFILE%" == "portable7"         (goto :ARGUMENTS_OK)
+if /I "%BUILD_PROFILE%" == "portable78"        (goto :ARGUMENTS_OK)
+if /I "%BUILD_PROFILE%" == "portable259"       (goto :ARGUMENTS_OK)
+if /I "%BUILD_PROFILE%" == "vs"                (goto :ARGUMENTS_OK)
+if /I "%BUILD_PROFILE%" == "cambridge_suite"   (goto :ARGUMENTS_OK)
+if /I "%BUILD_PROFILE%" == "qa_suite"          (goto :ARGUMENTS_OK)
+goto :USAGE
+
+:USAGE
+
+echo Build and run a subset of test suites
+echo.
+echo Usage:
+echo.
+echo appveyor-build.cmd ^<all^|net40^|portable47^|portable7^|portable78^|portable259^|vs^|cambridge_suite^|qa_suite^>
+echo.
+echo no arguments default to 'all'
+exit /b 1
+
+:ARGUMENTS_OK
+
+set DO_NET40=0
+set TEST_NET40=0
+if /i '%BUILD_PROFILE%' == 'net40' (
+    set DO_NET40=1
+    set TEST_NET40=1
+)
+
+set DO_PORTABLE47=0
+set TEST_PORTABLE47=0
+if /i '%BUILD_PROFILE%' == 'portable47' (
+    set DO_PORTABLE47=1
+    set TEST_PORTABLE47=1
+)
+
+set DO_PORTABLE7=0
+set TEST_PORTABLE7=0
+if /i '%BUILD_PROFILE%' == 'portable7' (
+    set DO_PORTABLE7=1
+    set TEST_PORTABLE7=1
+)
+
+set DO_PORTABLE78=0
+set TEST_PORTABLE78=0
+if /i '%BUILD_PROFILE%' == 'portable78' (
+    set DO_PORTABLE78=1
+    set TEST_PORTABLE78=1
+)
+
+set DO_PORTABLE259=0
+set TEST_PORTABLE259=0
+if /i '%BUILD_PROFILE%' == 'portable259' (
+    set DO_PORTABLE259=1
+    set TEST_PORTABLE259=1
+)
+
+set DO_VS=0
+set TEST_VS=0
+if /i '%BUILD_PROFILE%' == 'vs' (
+    set DO_VS=1
+    set TEST_VS=1
+)
+
+set TEST_CAMBRIDGE_SUITE=0
+if /i '%BUILD_PROFILE%' == 'cambridge_suite' (
+    set DO_NET40=1
+    set TEST_CAMBRIDGE_SUITE=1
+)
+
+set TEST_QA_SUITE=0
+if /i '%BUILD_PROFILE%' == 'qa_suite' (
+    set DO_NET40=1
+    set TEST_QA_SUITE=1
+)
+
+if /i '%BUILD_PROFILE%' == 'all' (
+    set DO_NET40=1
+    set DO_PORTABLE47=1
+    set DO_PORTABLE7=1
+    set DO_PORTABLE78=1
+    set DO_PORTABLE259=1
+    set DO_VS=1
+    set TEST_NET40=1
+    set TEST_PORTABLE47=1
+    set TEST_PORTABLE7=1
+    set TEST_PORTABLE78=1
+    set TEST_PORTABLE259=1
+    set TEST_VS=1
+    set TEST_CAMBRIDGE_SUITE=1
+    set TEST_QA_SUITE=1
+)
+
+REM after this point, BUILD_PROFILE variable should not be used, use only DO_* or TEST_*
+
+call :SHOW_CONF
+
+goto :MAIN
+
+:SHOW_CONF
+
+echo Build/Tests configuration:
+echo.
+echo DO_NET40=%DO_NET40%
+echo DO_PORTABLE47=%DO_PORTABLE47%
+echo DO_PORTABLE7=%DO_PORTABLE7%
+echo DO_PORTABLE78=%DO_PORTABLE78%
+echo DO_PORTABLE259=%DO_PORTABLE259%
+echo DO_VS=%DO_VS%
+echo.
+echo TEST_NET40=%TEST_NET40%
+echo TEST_PORTABLE47=%TEST_PORTABLE47%
+echo TEST_PORTABLE7=%TEST_PORTABLE7%
+echo TEST_PORTABLE78=%TEST_PORTABLE78%
+echo TEST_PORTABLE259=%TEST_PORTABLE259%
+echo TEST_VS=%TEST_VS%
+echo TEST_CAMBRIDGE_SUITE=%TEST_CAMBRIDGE_SUITE%
+echo TEST_QA_SUITE=%TEST_QA_SUITE%
+echo.
+
+goto :EOF
+
+:MAIN
+
 @echo on
 
 set APPVEYOR_CI=1
@@ -47,42 +181,63 @@ if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
 %_msbuildexe% src/fsharp-compiler-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: compiler build failed && goto :failure
 
+if '%DO_PORTABLE47%' == '1' (
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library portable47 build failed && goto :failure
+)
 
+if '%DO_PORTABLE7%' == '1' (
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library portable7 build failed && goto :failure
+)
 
+if '%DO_PORTABLE78%' == '1' (
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library portable78 build failed && goto :failure
+)
 
+if '%DO_PORTABLE259%' == '' (
 %_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library portable259 build failed && goto :failure
+)
 
+if '%TEST_NET40%' == '1' (
 %_msbuildexe% src/fsharp-compiler-unittests-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: compiler unittests build failed && goto :failure
 
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library unittests build failed && goto :failure
+)
 
+if '%TEST_PORTABLE47%' == '1' (
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable47 && goto :failure
+)
 
+if '%TEST_PORTABLE7%' == '1' (
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable7 && goto :failure
+)
 
+if '%TEST_PORTABLE78%' == '1' (
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable78 && goto :failure
+)
 
+if '%TEST_PORTABLE259%' == '1' (
 %_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable259 && goto :failure
+)
 
+if '%DO_VS%' == '1' (
 %_msbuildexe% vsintegration\fsharp-vsintegration-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: VS integration build failed && goto :failure
+)
 
+if '%TEST_VS%' == '1' (
 %_msbuildexe% vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: VS integration unit tests build failed && goto :failure
-
+)
 
 @echo on
 call src\update.cmd release -ngen
@@ -93,6 +248,7 @@ call BuildTestTools.cmd release
 @if ERRORLEVEL 1 echo Error: 'BuildTestTools.cmd release' failed && goto :failure
 
 @echo on
+if '%TEST_CAMBRIDGE_SUITE%' == '1' (
 set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=true
 
 %_msbuildexe% fsharp\fsharp.tests.fsproj /p:Configuration=Release
@@ -101,18 +257,42 @@ set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=true
 call RunTests.cmd release fsharp Smoke
 @if ERRORLEVEL 1 type testresults\fsharp_failures.log && echo Error: 'RunTests.cmd release fsharp Smoke' failed && goto :failure
 set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=
+)
 
+if '%TEST_QA_SUITE%' == '1' (
 call RunTests.cmd release fsharpqa Smoke
 @if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa Smoke' failed && goto :failure
+)
 
+if '%TEST_NET40%' == '1' (
 call RunTests.cmd release compilerunit
 @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release compilerunit' failed && goto :failure
 
 call RunTests.cmd release coreunit
 @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunit' failed && goto :failure
+)
 
+if '%TEST_PORTABLE47%' == '1' (
+call RunTests.cmd release coreunitportable47
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunitportable47' failed && goto :failure
+)
+
+if '%TEST_PORTABLE7%' == '1' (
+call RunTests.cmd release coreunitportable7
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunitportable7' failed && goto :failure
+)
+
+if '%TEST_PORTABLE78%' == '1' (
+call RunTests.cmd release coreunitportable78
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunitportable78' failed && goto :failure
+)
+
+if '%TEST_PORTABLE259%' == '1' (
 call RunTests.cmd release coreunitportable259
 @if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunitportable259' failed && goto :failure
+)
+
+rem tests for TEST_VS are not executed
 
 popd
 

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -13,7 +13,7 @@ echo Build and run a subset of test suites
 echo.
 echo Usage:
 echo.
-echo appveyor-build.cmd ^<all^|net40^|portable47^|portable7^|portable78^|portable259^|vs^|cambridge_suite^|qa_suite^|smoke^>
+echo appveyor-build.cmd ^<all^|net40^|portable47^|portable7^|portable78^|portable259^|vs^|cambridge_suite^|qa_suite^|smoke^|smoke_only^>
 echo.
 echo No arguments default to 'smoke' ( build all profiles, run all unit tests, cambridge Smoke, fsharpqa Smoke)
 echo.
@@ -142,6 +142,10 @@ if /i '%BUILD_PROFILE%' == 'smoke' (
     set CONF_QA_SUITE=Smoke
 )
 
+if /i '%BUILD_PROFILE%' == 'smoke_only' (
+    set CONF_CAMBRIDGE_SUITE=Smoke
+    set CONF_QA_SUITE=Smoke
+)
 goto :EOF
 
 :SHOW_CONF

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -13,9 +13,9 @@ echo Build and run a subset of test suites
 echo.
 echo Usage:
 echo.
-echo appveyor-build.cmd ^<all^|net40^|portable47^|portable7^|portable78^|portable259^|vs^|cambridge_suite^|qa_suite^>
+echo appveyor-build.cmd ^<all^|net40^|portable47^|portable7^|portable78^|portable259^|vs^|cambridge_suite^|qa_suite^|smoke^>
 echo.
-echo No arguments default to 'all'
+echo No arguments default to 'smoke' ( build all profiles, run all unit tests, cambridge Smoke, fsharpqa Smoke)
 echo.
 echo To specify multiple values, separate strings by comma
 echo.
@@ -39,7 +39,9 @@ set TEST_PORTABLE78=0
 set TEST_PORTABLE259=0
 set TEST_VS=0
 set TEST_CAMBRIDGE_SUITE=0
+set CONF_CAMBRIDGE_SUITE=
 set TEST_QA_SUITE=0
+set CONF_QA_SUITE=
 
 setlocal enableDelayedExpansion
 set /a counter=0
@@ -121,6 +123,25 @@ if /i '%BUILD_PROFILE%' == 'all' (
     set TEST_QA_SUITE=1
 )
 
+if /i '%BUILD_PROFILE%' == 'smoke' (
+    set DO_NET40=1
+    set DO_PORTABLE47=1
+    set DO_PORTABLE7=1
+    set DO_PORTABLE78=1
+    set DO_PORTABLE259=1
+    set DO_VS=1
+    set TEST_NET40=1
+    set TEST_PORTABLE47=1
+    set TEST_PORTABLE7=1
+    set TEST_PORTABLE78=1
+    set TEST_PORTABLE259=1
+    set TEST_VS=1
+    set TEST_CAMBRIDGE_SUITE=1
+    set CONF_CAMBRIDGE_SUITE=Smoke
+    set TEST_QA_SUITE=1
+    set CONF_QA_SUITE=Smoke
+)
+
 goto :EOF
 
 :SHOW_CONF
@@ -141,7 +162,9 @@ echo TEST_PORTABLE78=%TEST_PORTABLE78%
 echo TEST_PORTABLE259=%TEST_PORTABLE259%
 echo TEST_VS=%TEST_VS%
 echo TEST_CAMBRIDGE_SUITE=%TEST_CAMBRIDGE_SUITE%
+echo CONF_CAMBRIDGE_SUITE=%CONF_CAMBRIDGE_SUITE%
 echo TEST_QA_SUITE=%TEST_QA_SUITE%
+echo CONF_QA_SUITE=%CONF_QA_SUITE%
 echo.
 
 goto :EOF
@@ -274,14 +297,14 @@ set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=true
 %_msbuildexe% fsharp\fsharp.tests.fsproj /p:Configuration=Release
 @if ERRORLEVEL 1 echo Error: fsharp cambridge tests for nunit failed && goto :failure
 
-call RunTests.cmd release fsharp Smoke
-@if ERRORLEVEL 1 type testresults\fsharp_failures.log && echo Error: 'RunTests.cmd release fsharp Smoke' failed && goto :failure
+call RunTests.cmd release fsharp %CONF_CAMBRIDGE_SUITE%
+@if ERRORLEVEL 1 type testresults\fsharp_failures.log && echo Error: 'RunTests.cmd release fsharp %CONF_CAMBRIDGE_SUITE%' failed && goto :failure
 set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=
 )
 
 if '%TEST_QA_SUITE%' == '1' (
-call RunTests.cmd release fsharpqa
-@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa' failed && goto :failure
+call RunTests.cmd release fsharpqa %CONF_QA_SUITE%
+@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa %CONF_QA_SUITE%' failed && goto :failure
 )
 
 if '%TEST_NET40%' == '1' (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,7 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - BUILD_PROFILE: net40,portable7,portable47,portable78,portable259
-    - BUILD_PROFILE: vs
+    - BUILD_PROFILE: net40,portable7,portable47,portable78,portable259,vs
     - BUILD_PROFILE: cambridge_suite
     - BUILD_PROFILE: qa_suite
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,7 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - BUILD_PROFILE: net40
-    - BUILD_PROFILE: portable7
-    - BUILD_PROFILE: portable47
-    - BUILD_PROFILE: portable78
-    - BUILD_PROFILE: portable259
+    - BUILD_PROFILE: net40,portable7,portable47,portable78,portable259
     - BUILD_PROFILE: vs
     - BUILD_PROFILE: cambridge_suite
     - BUILD_PROFILE: qa_suite

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,19 @@
 os: Visual Studio 2015
 
+environment:
+  matrix:
+    - BUILD_PROFILE: net40
+    - BUILD_PROFILE: portable7
+    - BUILD_PROFILE: portable47
+    - BUILD_PROFILE: portable78
+    - BUILD_PROFILE: portable259
+    - BUILD_PROFILE: vs
+    - BUILD_PROFILE: cambridge_suite
+    - BUILD_PROFILE: qa_suite
+
 init: 
 build_script: 
-  - cmd: appveyor-build.cmd
+  - cmd: appveyor-build.cmd %BUILD_PROFILE%
 
 # scripts that run after cloning repository
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ os: Visual Studio 2015
 environment:
   matrix:
     - BUILD_PROFILE: net40,portable7,portable47,portable78,portable259,vs
-    - BUILD_PROFILE: cambridge_suite
+    - BUILD_PROFILE: cambridge_suite,smoke_only
     - BUILD_PROFILE: qa_suite
 
 init: 

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/highentropyva/CheckHighEntropyASLR.bat
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/highentropyva/CheckHighEntropyASLR.bat
@@ -8,8 +8,11 @@ IF ERRORLEVEL 1 (
     )
 )
 
+
+SET LINK_EXE=%VS140COMNTOOLS%\..\..\VC\bin\link.exe
+
 REM %1 -- assembly to check
 REM %2 -- expected value ("yes" or "no")
-link /dump /headers %1 | find "High Entropy Virtual Addresses" > NUL
+"%LINK_EXE%" /dump /headers %1 | find "High Entropy Virtual Addresses" > NUL
 IF /I "%2"=="yes" IF     ERRORLEVEL 1 EXIT /B 1
 IF /I "%2"=="no"  IF NOT ERRORLEVEL 1 EXIT /B 1

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/subsystemversion/CheckSubsystemVersion.bat
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/subsystemversion/CheckSubsystemVersion.bat
@@ -10,6 +10,8 @@ IF ERRORLEVEL 1 (
     )
 )
 
-link /dump /headers %1 | find "%2 subsystem version" > NUL
+SET LINK_EXE=%VS140COMNTOOLS%\..\..\VC\bin\link.exe
+
+"%LINK_EXE%" /dump /headers %1 | find "%2 subsystem version" > NUL
 IF ERRORLEVEL 1 EXIT /B 1
 EXIT /B 0

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/env.lst
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/StringsAndCharacters/env.lst
@@ -32,4 +32,4 @@ NO_CI	SOURCE=ByteString03.fs							# ByteString03.fs
 NO_CI	SOURCE=TripleQuoteString01.fs						# TripleQuoteString01.fs
 	SOURCE=TripleQuoteString02.fs						# TripleQuoteString02.fs
 NoMT	SOURCE=TripleQuoteStringInFSI01.fsx  FSIMODE=PIPE  COMPILE_ONLY=1	# TripleQuoteStringInFSI01.fsx
-NoMT	SOURCE=TripleQuoteStringInFSI02.fsx  FSIMODE=FEED  COMPILE_ONLY=1	# TripleQuoteStringInFSI02.fsx
+NO_CI,NoMT	SOURCE=TripleQuoteStringInFSI02.fsx  FSIMODE=FEED  COMPILE_ONLY=1	# TripleQuoteStringInFSI02.fsx


### PR DESCRIPTION
job build time limit is 60 minutes, but we are running only one job.

we can use the [build matrix feature](http://www.appveyor.com/docs/build-configuration#build-matrix) to split test suite in multiple jobs (each with 60min quota)

>Every AppVeyor build consists of one or more jobs. A build is considered successful if all jobs are successful. A build immediately fails when any of its jobs fail.

without the env var `TESTSUITE` set, the old workflow is executed so no difference from command line.

We can discuss how to split better the matrix ( fsc/library/vs extension ) to use less time for compilation and more time for test suite. 
I think we can run the full `tests/fsharp` suite in appveyor ( really good for community )

this pr add `RunTests.cmd release` of

- coreunitportable7
- coreunitportable47
- coreunitportable78
- coreunitportabl259

