### PR TITLE
add fsc --version

### DIFF
--- a/src/fsharp/fscmain.fs
+++ b/src/fsharp/fscmain.fs
@@ -246,7 +246,14 @@ module Driver =
         if argv |> Array.exists  (fun x -> x = "/pause" || x = "--pause") then 
             Console.WriteLine("Press any key to continue...")
             Console.ReadKey() |> ignore
-        if runningOnMono && argv |> Array.exists  (fun x -> x = "/resident" || x = "--resident") then 
+        let showVersion =
+            match argv with
+            | [| _; a |] when a = "/version" || a = "--version" || a = "-v" || a = "/v" -> true
+            | _ -> false
+        if showVersion then
+            printfn "%s" FSharpEnvironment.FSharpTeamVersionNumber
+            0
+        elif runningOnMono && argv |> Array.exists  (fun x -> x = "/resident" || x = "--resident") then 
             let argv = argv |> Array.filter (fun x -> x <> "/resident" && x <> "--resident")
 
             if not (argv |> Array.exists (fun x -> x = "/nologo" || x = "--nologo")) then 


### PR DESCRIPTION
I need help about what to print, if it's ok implemented like that. If ok i'll add tests.

This add to fsc the argument `--version` ( alias `/version`, short version `-v` or `/v` ) to print current version info and set exit code **0** .

```
$ fsc --version
2.0.0.0
```

I know there is already a deprecated argument `--version`, but this work if there is **only** one argument `--version`, if yes then print version and exit with code 0.
Otherwise old code is used, so `--version` mean the old deprecated ( used only internally by visualfsharp i think, because use `AssemblyVersionAttribute` is easier )

The only way now to print current version **and exit code 0**  is to pass a valid code to fsc, otherwise the version is printed, but exitcode is not zero. It should be easier to print version, is usefull to log/diagnose and `--version` is the standard.
