### PR TITLE
[CORECLR] fix appveyor badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-[![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/master.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/master)
 
 [![Join the chat at https://gitter.im/Microsoft/visualfsharp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Microsoft/visualfsharp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 #Visual F# Tools
+
+## Windows build
+
+| |Release|
+|:--:|:--:|
+|**master**| [![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/master.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/master) |
+|**coreclr**| [![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/coreclr.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/coreclr) |
 
 ###Contributing to the F# Language, Library, and Tools
 


### PR DESCRIPTION
Badge was targeting master branch, now it's a matrix branch x badge
It's possible to merge this one also in master branch?
