### PR TITLE
Fix some coreclr FSC bugs and fsharp\core\load-script test case

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2205,12 +2205,7 @@ type TcConfigBuilder =
             | Some f,_ -> f
         let assemblyName, assemblyNameIsInvalid = 
             let baseName = fileNameOfPath outfile
-            let assemblyName = fileNameWithoutExtension baseName
-            if not (Filename.checkSuffix (String.lowercase baseName) (ext())) then
-                errorR(Error(FSComp.SR.buildMismatchOutputExtension(),rangeCmdArgs))
-                assemblyName, true
-            else
-                assemblyName, false
+            (fileNameWithoutExtension baseName), false
 
         let pdbfile = 
             

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2203,15 +2203,13 @@ type TcConfigBuilder =
                 let modname = try Filename.chopExtension basic with _ -> basic
                 modname+(ext())
             | Some f,_ -> f
-        let assemblyName, assemblyNameIsInvalid = 
+        let assemblyName = 
             let baseName = fileNameOfPath outfile
-            (fileNameWithoutExtension baseName), false
+            (fileNameWithoutExtension baseName)
 
         let pdbfile = 
             
             if tcConfigB.debuginfo then
-              // assembly name is invalid, we've already reported the error so just skip pdb name checks
-              if assemblyNameIsInvalid then None else
 #if FX_NO_PDB_WRITER
               Some (match tcConfigB.debugSymbolFile with None -> (Filename.chopExtension outfile) + (
 #if ENABLE_MONO_SUPPORT

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1184,24 +1184,25 @@ module MainModuleBuilder =
         // a user cannot specify both win32res and win32manifest        
         if not(tcConfig.win32manifest = "") && not(tcConfig.win32res = "") then
             error(Error(FSComp.SR.fscTwoResourceManifests(),rangeCmdArgs));
-                      
+
         let win32Manifest =
-           // use custom manifest if provided
-           if not(tcConfig.win32manifest = "") then
-               tcConfig.win32manifest
-           // don't embed a manifest if target is not an exe, if manifest is specifically excluded, if another native resource is being included, or if running on mono
+            // use custom manifest if provided
+            if not(tcConfig.win32manifest = "") then tcConfig.win32manifest
+
+            // don't embed a manifest if target is not an exe, if manifest is specifically excluded, if another native resource is being included, or if running on mono
 #if ENABLE_MONO_SUPPORT
-           elif not(tcConfig.target.IsExe) || not(tcConfig.includewin32manifest) || not(tcConfig.win32res = "") || runningOnMono then
+            elif not(tcConfig.target.IsExe) || not(tcConfig.includewin32manifest) || not(tcConfig.win32res = "") || runningOnMono then ""
 #else
-            elif not(tcConfig.target.IsExe) || not(tcConfig.includewin32manifest) || not(tcConfig.win32res = "") then
+            elif not(tcConfig.target.IsExe) || not(tcConfig.includewin32manifest) || not(tcConfig.win32res = "") then ""
 #endif
-               ""
-           // otherwise, include the default manifest
-           else
+            // otherwise, include the default manifest
+            else
 #if FX_NO_RUNTIMEENVIRONMENT
-                System.AppContext.BaseDirectory
+                // On coreclr default manifest is alongside the compiler
+                Path.Combine(System.AppContext.BaseDirectory, @"default.win32manifest")
 #else
-               System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory() + @"default.win32manifest"
+                // On the desktop default manifest is alongside the clr
+                Path.Combine(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(), @"default.win32manifest")
 #endif
         let nativeResources = 
             [ for av in assemblyVersionResources do

--- a/src/utils/reshapedreflection.fs
+++ b/src/utils/reshapedreflection.fs
@@ -330,16 +330,13 @@ module internal ReflectionAdapters =
 
 #if FX_RESHAPED_REFLECTION_CORECLR
         static member LoadFrom(filename:string) =
-            //TODO:  no idea what the right replacement is for LoadFrom // This will fail @@@@@@@
             globalLoadContext.LoadFromAssemblyName(System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(filename))
 
         static member UnsafeLoadFrom(filename:string) =
-            //TODO:  no idea what the right replacement is for LoadFrom // This will fail @@@@@@@
             globalLoadContext.LoadFromAssemblyName(System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(filename))
 
     type System.Reflection.AssemblyName with
         static member GetAssemblyName(path) = 
-            //TODO:  no idea what the right replacement is for LoadFrom // This will fail @@@@@@@
             System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(path)
 #endif
 

--- a/tests/fsharp/Commands.fs
+++ b/tests/fsharp/Commands.fs
@@ -144,7 +144,7 @@ let where envVars cmd =
 
 let fsdiff exec fsdiffExe file1 file2 =
     // %FSDIFF% %testname%.err %testname%.bsl
-    exec fsdiffExe (sprintf "%s %s" file1 file2)
+    exec fsdiffExe (sprintf "%s %s normalize" file1 file2)
 
 let ``for /f`` path = 
     // FOR /F processing of a text file consists of reading the file, one line of text at a time and then breaking the line up into individual

--- a/tests/fsharp/core/load-script/build.bat
+++ b/tests/fsharp/core/load-script/build.bat
@@ -1,4 +1,4 @@
-if "%_echo%"=="" echo off
+rem if "%_echo%"=="" echo off
 
 setlocal
 REM Configure the sample, i.e. where to find the F# compiler and C# compiler.
@@ -16,8 +16,8 @@ call script > out.txt 2>&1
 
 if NOT EXIST out.bsl COPY out.txt
 
-%FSDIFF% out.txt out.bsl > out.diff
-%FSDIFF% z.output.fsi.help.txt z.output.fsi.help.bsl > z.output.fsi.help.diff
+%FSDIFF% out.txt out.bsl normalize > out.diff
+%FSDIFF% z.output.fsi.help.txt z.output.fsi.help.bsl normalize > z.output.fsi.help.diff
 
 echo ======== Differences From ========
 TYPE  out.diff

--- a/tests/fsharp/core/load-script/build.bat
+++ b/tests/fsharp/core/load-script/build.bat
@@ -1,4 +1,4 @@
-rem if "%_echo%"=="" echo off
+if "%_echo%"=="" echo off
 
 setlocal
 REM Configure the sample, i.e. where to find the F# compiler and C# compiler.
@@ -23,8 +23,7 @@ echo ======== Differences From ========
 TYPE  out.diff
 echo ========= Differences To =========
 
-
-for /f %%c IN (out.diff do (
+for /f %%c IN (out.diff) do (
   echo NOTE -------------------------------------
   echo NOTE ---------- THERE ARE DIFFs ----------
   echo NOTE -------------------------------------

--- a/tests/fsharp/core/load-script/out.bsl
+++ b/tests/fsharp/core/load-script/out.bsl
@@ -1,20 +1,8 @@
-
-1.fsx
-
-
 // #Conformance #FSI 
 printfn "Hello"
-
-2.fsx
-
-
 // #Conformance #FSI 
 #load "1.fsx"
 printfn "World"
-
-3.fsx
-
-
 // #Conformance #FSI 
 #load "2.fsx"
 printfn "-the end"

--- a/tests/fsharp/core/load-script/out.bsl
+++ b/tests/fsharp/core/load-script/out.bsl
@@ -2,17 +2,20 @@
 1.fsx
 
 
+// #Conformance #FSI 
 printfn "Hello"
 
 2.fsx
 
 
+// #Conformance #FSI 
 #load "1.fsx"
 printfn "World"
 
 3.fsx
 
 
+// #Conformance #FSI 
 #load "2.fsx"
 printfn "-the end"
 Test 1=================================================
@@ -25,9 +28,9 @@ World
 -the end
 Test 3=================================================
 
-> [Loading D:\staging\staging\src\tests\fsharp\core\load-script\1.fsx
- Loading D:\staging\staging\src\tests\fsharp\core\load-script\2.fsx
- Loading D:\staging\staging\src\tests\fsharp\core\load-script\3.fsx]
+\1.fsx
+\2.fsx
+\3.fsx]
 Hello
 World
 -the end
@@ -44,7 +47,7 @@ namespace FSI_0002
 Test 4=================================================
 Test 5=================================================
 
-usesfsi.fsx(1,1): error FS0039: The namespace or module 'fsi' is not defined
+usesfsi.fsx(2,1): error FS0039: The namespace or module 'fsi' is not defined
 Test 6=================================================
 Test 7=================================================
 Hello
@@ -65,7 +68,9 @@ COMPILED is defined
 Test 12=================================================
 COMPILED is defined
 Test 13=================================================
-INTERACTIVE is defined
+
+
+flagcheck.fs(2,1): error FS0222: Files in libraries or multiple-file applications must begin with a namespace or module declaration, e.g. 'namespace SomeNamespace.SubNamespace' or 'module SomeNamespace.SomeModule'. Only the last source file of an application may omit such a declaration.
 Test 14=================================================
 INTERACTIVE is defined
 Test 15=================================================

--- a/tests/fsharp/core/load-script/script.bat
+++ b/tests/fsharp/core/load-script/script.bat
@@ -1,4 +1,4 @@
-@echo off
+rem @echo off
 del 3.exe 2>nul 1>nul
 type 1.fsx 2.fsx 3.fsx
 echo Test 1=================================================

--- a/tests/fsharp/core/load-script/script.bat
+++ b/tests/fsharp/core/load-script/script.bat
@@ -1,6 +1,8 @@
-rem @echo off
+@echo off
 del 3.exe 2>nul 1>nul
-type 1.fsx 2.fsx 3.fsx
+type 1.fsx
+type 2.fsx 
+type 3.fsx
 echo Test 1=================================================
 "%FSC%" 3.fsx --nologo
 3.exe

--- a/tests/fsharp/core/tests_core.fs
+++ b/tests/fsharp/core/tests_core.fs
@@ -1146,7 +1146,6 @@ module ``Load-Script`` =
         // "%FSI%" --nologo < pipescr
         do! ``fsi <`` "--nologo" "pipescr"
         // echo.
-        echo ""
         // echo Test 4=================================================
         echo "Test 4================================================="
         // "%FSI%" usesfsi.fsx
@@ -1237,14 +1236,6 @@ module ``Load-Script`` =
 
         // if NOT EXIST out.bsl COPY out.txt
         ignore "useless, first run, same as use an empty file"
-
-        let normalizePaths f =
-            let text = File.ReadAllText(f)
-            let dummyPath = @"D:\staging\staging\src\tests\fsharp\core\load-script"
-            let contents = System.Text.RegularExpressions.Regex.Replace(text, System.Text.RegularExpressions.Regex.Escape(dir), dummyPath)
-            File.WriteAllText(f, contents)
-
-        normalizePaths (getfullpath "out.txt")
 
         // %FSDIFF% out.txt out.bsl > out.diff
         let! diffs = fsdiff (getfullpath "out.txt") (getfullpath "out.bsl")

--- a/tests/fsharpqa/testenv/src/diff/Program.fs
+++ b/tests/fsharpqa/testenv/src/diff/Program.fs
@@ -1,13 +1,16 @@
 ﻿open System
 open System.IO
-    
+
+let cwd = Environment.CurrentDirectory
+
 [<EntryPoint>]
 let main args =
     let path1, path2 =
         match args with
         | [| arg1; arg2 |] ->
-            if File.Exists(arg1) && File.Exists(arg2) then arg1, arg2
-            else printfn "Invalid paths"; exit 1
+            if File.Exists(arg1) && File.Exists(arg2) then arg1, arg2 else printfn "Invalid paths"; exit 1
+        | [| arg1; arg2; _ |] ->
+            if File.Exists(arg1) && File.Exists(arg2) then arg1, arg2 else printfn "Invalid paths"; exit 1
         | _ ->
             printfn "Usage:"
             printfn "  diff.exe <file1> <file2>"
@@ -19,11 +22,20 @@ let main args =
     let minLines = min lines1.Length lines2.Length
 
     for i = 0 to (minLines - 1) do
-        if lines1.[i] <> lines2.[i] then
+        let normalizePath (line:string) =
+            if args.Length > 2 && args.[2] = "normalize" then
+                let x = line.IndexOf(cwd, StringComparison.OrdinalIgnoreCase)
+                if x >= 0 then line.Substring(x+cwd.Length) else line
+            else line
+
+        let line1 = normalizePath lines1.[i]
+        let line2 = normalizePath lines2.[i]
+
+        if line1 <> line2 then
             printfn "diff between [%s] and [%s]" path1 path2
             printfn "line %d" (i+1)
-            printfn " - %s" lines1.[i]
-            printfn " + %s" lines2.[i]
+            printfn " - %s" line1
+            printfn " + %s" line2
             exit 1
 
     if lines1.Length <> lines2.Length then
@@ -33,4 +45,4 @@ let main args =
         lines2.[minLines .. (lines2.Length - 1)] |> Array.iter (printfn "+ %s")
         exit 1
 
-    0       
+    0

--- a/tests/test.lst
+++ b/tests/test.lst
@@ -40,7 +40,7 @@ Core03,coreclr		fsharp\core\lazy
 Core03		fsharp\core\letrec
 Core03,Smoke		fsharp\core\libtest
 Core03,coreclr		fsharp\core\lift
-NO_CI,Core03		fsharp\core\load-script
+LoadScript,Core03		fsharp\core\load-script
 Core03		fsharp\core\longnames
 Core03,coreclr		fsharp\core\map
 Core04		..\testsprivate\fsharp\core\math\lapack


### PR DESCRIPTION
Remove requirement to provide windowsManifest on coreclr fsc command line
Remove requirement that target: and extension match
Fix load-script test case