### PR TITLE
Fix duplicate key in a project.json

### DIFF
--- a/tests/fsharp/project.json
+++ b/tests/fsharp/project.json
@@ -43,7 +43,6 @@
     "System.Threading.Tasks": "4.0.11-rc2-23616" ,
     "System.Threading.Tasks.Parallel": "4.0.1-rc2-23616" ,
     "System.Threading.Thread": "4.0.0-rc2-23616" ,
-    "System.Threading.Thread": "4.0.0-rc2-23616" ,
     "System.Threading.Overlapped": "4.0.1-rc2-23616" ,
     "System.Threading.Timer": "4.0.1-rc2-23616" 
   },


### PR DESCRIPTION
The duplicate key was preventing the "dotnet restore" command
succeeding.