### PR TITLE
[WIP] Add --preferreduilang

### DIFF
--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -750,7 +750,7 @@ let preferreduilangFlag (tcConfigB : TcConfigBuilder) =
                                                    tcConfigB.lcid <- Some(culture.LCID)
                                                | Choice2Of2 () ->
                                                    error(Error(FSComp.SR.optsInvalidPreferredUILang(s),rangeCmdArgs))), None,
-                           Some (FSComp.SR.optsPreferredUILang()))
+                           Some (FSComp.SR.optsPreferredUiLang()))
 
           
 let advancedFlagsBoth tcConfigB =

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1292,3 +1292,5 @@ estApplyStaticArgumentsForMethodNotImplemented,"A type provider implemented GetS
 3195,optsResponseFileNameInvalid,"Response file name '%s' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long"
 3196,fsharpCoreNotFoundToBeCopied,"Cannot find FSharp.Core.dll in compiler's directory"
 3197,etMissingStaticArgumentsToMethod,"This provided method requires static parameters"
+3198,optsInvalidPreferredUILang,"The language name '%s' is invalid."
+optsPreferredUILang,"Specify the preferred output language name."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1293,4 +1293,3 @@ estApplyStaticArgumentsForMethodNotImplemented,"A type provider implemented GetS
 3196,fsharpCoreNotFoundToBeCopied,"Cannot find FSharp.Core.dll in compiler's directory"
 3197,etMissingStaticArgumentsToMethod,"This provided method requires static parameters"
 3198,optsInvalidPreferredUILang,"The language name '%s' is invalid."
-optsPreferredUILang,"Specify the preferred output language name."

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1852,8 +1852,9 @@ let main0(argv,bannerAlreadyPrinted,exiter:Exiter, errorLoggerProvider : ErrorLo
         if (Console.OutputEncoding.CodePage <> 65001) &&
            (Console.OutputEncoding.CodePage <> Thread.CurrentThread.CurrentUICulture.TextInfo.OEMCodePage) &&
            (Console.OutputEncoding.CodePage <> Thread.CurrentThread.CurrentUICulture.TextInfo.ANSICodePage) then
-                Thread.CurrentThread.CurrentUICulture <- new CultureInfo("en-US")
-                Some(1033)
+                let enCulture = new CultureInfo("en-US")
+                Thread.CurrentThread.CurrentUICulture <- enCulture
+                Some(enCulture.LCID)
         else
             None
 #endif

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/preferreduilang/E_InvalidCulture.fs
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/preferreduilang/E_InvalidCulture.fs
@@ -1,0 +1,4 @@
+// #NoMT #CompilerOptions 
+//<Expects id="FS3198" status="error">'kli'</Expects>
+
+exit 1

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/preferreduilang/env.lst
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/preferreduilang/env.lst
@@ -1,0 +1,5 @@
+
+	SOURCE=validCulture.fs        SCFLAGS="--preferreduilang:it-IT"					# validCultureLong.fs valid culture
+	SOURCE=validCulture.fs        SCFLAGS="--preferreduilang:it"					# validCulture.fs valid culture
+	SOURCE=E_InvalidCulture.fs    COMPILE_ONLY=1  SCFLAGS="--preferreduilang:kli"	# E_InvalidCulture.fs invalid culture
+

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/preferreduilang/validCulture.fs
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/preferreduilang/validCulture.fs
@@ -1,0 +1,4 @@
+// #NoMT #CompilerOptions 
+//<Expects status="success"></Expects>
+
+exit 0

--- a/tests/fsharpqa/Source/test.lst
+++ b/tests/fsharpqa/Source/test.lst
@@ -49,6 +49,7 @@ CompilerOptions01,NoMT				CompilerOptions\fsc\optimize
 CompilerOptions01,NoMT				CompilerOptions\fsc\out
 CompilerOptions01,NoMT				CompilerOptions\fsc\pdb
 CompilerOptions01,NoMT				CompilerOptions\fsc\platform
+CompilerOptions01,NoMT				CompilerOptions\fsc\preferreduilang
 CompilerOptions01,NoMT				CompilerOptions\fsc\reference
 CompilerOptions01,NoMT				CompilerOptions\fsc\Removed
 CompilerOptions01,NoMT				CompilerOptions\fsc\standalone


### PR DESCRIPTION
ref #815 

It's the same as internal `--LCID` but take the language name ( `en-US` ) instead of locale id ( 1033 )

i cannot add a real test because resources files are not inside this repository ( why not @KevinRansom ?), so the build is only in english

it's possible to test it with

```
Release\net40\bin\fsc --simulateException:fsc-oom --preferreduilang:en tests\fsharpqa\Source\CompilerOptions\fsc\preferreduilang\validCulture.fs

Microsoft (R) F# Compiler version (private)
Copyright (c) Microsoft Corporation. All Rights Reserved.

warning FS0075: The command-line option '--simulateException' is for test purpos
es only

error FS0193: internal error: Insufficient memory to continue the execution of t
he program.

Unhandled Exception: OutOfMemoryException.
```

with another language
```
Release\net40\bin\fsc --simulateException:fsc-oom --preferreduilang:it tests\fsharpqa\Source\CompilerOptions\fsc\preferreduilang\validCulture.fs

Microsoft (R) F# Compiler version (private)
Copyright (c) Microsoft Corporation. All Rights Reserved.

warning FS0075: The command-line option '--simulateException' is for test purpos
es only

error FS0193: internal error: Memoria insufficiente per continuare l'esecuzione
del programma.

Eccezione non gestita: OutOfMemoryException.
```

