### PR TITLE
add jenkins badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 ## Windows build
 
-| |Release|
-|:--:|:--:|
-|**master**| [![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/master.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/master) |
-|**vs2015**| [![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/vs2015.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/vs2015) |
-|**coreclr**| [![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/coreclr.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/coreclr) |
+|            |Debug (Build only)|Release (Build only)|Release (Build and tests)|
+|:----------:|:----------------:|:------------------:|:-----------------------:|
+|**master**  |[![Build Status](http://dotnet-ci.cloudapp.net/buildStatus/icon?job=Microsoft_visualfsharp/debug_windows_nt)](http://dotnet-ci.cloudapp.net/job/Microsoft_visualfsharp/job/debug_windows_nt/)|[![Build Status](http://dotnet-ci.cloudapp.net/buildStatus/icon?job=Microsoft_visualfsharp/release_windows_nt)](http://dotnet-ci.cloudapp.net/job/Microsoft_visualfsharp/job/release_windows_nt/)| [![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/master.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/master) |
+|**vs2015**  ||| [![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/vs2015.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/vs2015) |
+|**coreclr** ||| [![Build status](https://img.shields.io/appveyor/ci/KevinRansom/visualfsharp-radou/coreclr.svg)](https://ci.appveyor.com/project/KevinRansom/visualfsharp-radou/branch/coreclr) |
 
 ###Contributing to the F# Language, Library, and Tools
 


### PR DESCRIPTION
@otawfik-ms  about other branches, what's the url?
Or there is only one jenkins debug for all branches?

I expected to find multiple job like:

-  `Microsoft_visualfsharp/master_release_windows_nt` (master branch)
-  `Microsoft_visualfsharp/coreclr_release_windows_nt` (coreclr branch)

maybe we should explode by branch, like [roslyn netci.groovy](https://github.com/dotnet/roslyn/blob/3cb8ed39ba17351de6f53dd5666007d156d4f700/netci.groovy#L153)

so something like `Microsoft_visualfsharp/visualfsharp_master_release_windows_nt`

the prefix `visualfsharp` maybe it's usefull, if we need more jobs inside the same jenkins project group [Microsoft_visualfsharp](http://dotnet-ci.cloudapp.net/job/Microsoft_visualfsharp/)


/cc @mmitche