### PR TITLE
[WIP] Intrinsic extensions fix for #49

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3726,7 +3726,7 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
                   FileName=fileName;
                   ProviderGeneratedAssembly=Some theActualAssembly
                   IsProviderGenerated=true;
-                  ProviderGeneratedStaticLinkMap= if g.isInteractive then None else Some (ProvidedAssemblyStaticLinkingMap.CreateNew())
+                  ProviderGeneratedStaticLinkMap= Some (ProvidedAssemblyStaticLinkingMap.CreateNew())
                   ILScopeRef = ilScopeRef;
                   ILAssemblyRefs = ilAssemblyRefs }
             tcImports.RegisterDll(dllinfo);

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -1262,7 +1262,7 @@ let CreateIlxAssemblyGenerator (_tcConfig:TcConfig,tcImports:TcImports,tcGlobals
     ilxGenerator.AddExternalCcus ccus
     ilxGenerator
 
-let GenerateIlxCode (ilxBackend, isInteractiveItExpr, isInteractiveOnMono, tcConfig:TcConfig, topAttrs, optimizedImpls, fragName, netFxHasSerializableAttribute, ilxGenerator : IlxAssemblyGenerator) =
+let GenerateIlxCode (ilxBackend, isInteractiveItExpr, isInteractiveOnMono, tcConfig:TcConfig, topAttrs, optimizedImpls, fragName, netFxHasSerializableAttribute, ilxGenerator : IlxAssemblyGenerator, providedTypes) =
     if !progress then dprintf "Generating ILX code...\n";
     let ilxGenOpts : IlxGenOptions = 
         { generateFilterBlocks = tcConfig.generateFilterBlocks;
@@ -1279,7 +1279,7 @@ let GenerateIlxCode (ilxBackend, isInteractiveItExpr, isInteractiveOnMono, tcCon
           netFxHasSerializableAttribute = netFxHasSerializableAttribute;
           alwaysCallVirt = tcConfig.alwaysCallVirt }
 
-    ilxGenerator.GenerateCode (ilxGenOpts, optimizedImpls, topAttrs.assemblyAttrs,topAttrs.netModuleAttrs) 
+    ilxGenerator.GenerateCode (ilxGenOpts, optimizedImpls, topAttrs.assemblyAttrs,topAttrs.netModuleAttrs, providedTypes) 
 #endif // !NO_COMPILER_BACKEND
 
 //----------------------------------------------------------------------------

--- a/src/fsharp/CompileOptions.fsi
+++ b/src/fsharp/CompileOptions.fsi
@@ -85,7 +85,7 @@ val ApplyAllOptimizations : TcConfig * TcGlobals * ConstraintSolver.TcValF * str
 
 val CreateIlxAssemblyGenerator : TcConfig * TcImports * TcGlobals * ConstraintSolver.TcValF * CcuThunk -> IlxGen.IlxAssemblyGenerator
 
-val GenerateIlxCode : IlxGen.IlxGenBackend * bool * bool * TcConfig * TypeChecker.TopAttribs * TypedAssembly * string * bool * IlxGen.IlxAssemblyGenerator -> IlxGen.IlxGenResults
+val GenerateIlxCode : IlxGen.IlxGenBackend * bool * bool * TcConfig * TypeChecker.TopAttribs * TypedAssembly * string * bool * IlxGen.IlxAssemblyGenerator * (ILTypeRef * ILTypeDef) list -> IlxGen.IlxGenResults
 #endif
 
 // Used during static linking

--- a/src/fsharp/IlxGen.fsi
+++ b/src/fsharp/IlxGen.fsi
@@ -71,7 +71,7 @@ type public IlxAssemblyGenerator =
     member AddIncrementalLocalAssemblyFragment : isIncrementalFragment: bool * fragName:string * typedAssembly: TypedAssembly -> unit
 
     /// Generate ILX code for an assembly fragment
-    member GenerateCode : IlxGenOptions * TypedAssembly * Attribs * Attribs -> IlxGenResults
+    member GenerateCode : IlxGenOptions * TypedAssembly * Attribs * Attribs * (ILTypeRef * ILTypeDef) list -> IlxGenResults
 
     /// Create the CAS permission sets for an assembly fragment
     member CreatePermissionSets : Attrib list ->  ILPermission list

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -13793,7 +13793,7 @@ module EstablishTypeDefinitionCores = begin
             // Adjust the representation of the container type
             let repr = Construct.NewProvidedTyconRepr(resolutionEnvironment,theRootTypeWithRemapping,
                                                       Import.ImportProvidedType cenv.amap m,
-                                                      isSuppressRelocate, 
+                                                      isForcedSuppressRelocate,
                                                       m=m)
             tycon.Data.entity_tycon_repr <- repr
             // Record the details so we can map System.Type --> TyconRef
@@ -13801,7 +13801,7 @@ module EstablishTypeDefinitionCores = begin
             theRootTypeWithRemapping.PUntaint ((fun st -> ignore(lookupTyconRef.Remove(st.RawSystemType)) ; lookupTyconRef.Add(st.RawSystemType, tcref)), m)
 
             // Record the details so we can map System.Type --> ILTypeRef, including the relocation if any
-            if not isSuppressRelocate then 
+            if not isForcedSuppressRelocate then
                 let ilTgtRootTyRef = tycon.CompiledRepresentationForNamedType
                 theRootTypeWithRemapping.PUntaint ((fun st -> ignore(lookupILTypeRef.Remove(st.RawSystemType)) ; lookupILTypeRef.Add(st.RawSystemType, ilTgtRootTyRef)), m)
 
@@ -13829,7 +13829,7 @@ module EstablishTypeDefinitionCores = begin
 
                 let nestedTycon = Construct.NewProvidedTycon(resolutionEnvironment, st, 
                                                              Import.ImportProvidedType cenv.amap m, 
-                                                             isSuppressRelocate, 
+                                                             isForcedSuppressRelocate, 
                                                              m=m, cpath=cpath, access = access)
                 eref.ModuleOrNamespaceType.AddProvidedTypeEntity(nestedTycon)
 
@@ -13845,7 +13845,7 @@ module EstablishTypeDefinitionCores = begin
                     st.PUntaint ((fun st -> ignore(lookupILTypeRef.Remove(st.RawSystemType)) ; lookupILTypeRef.Add(st.RawSystemType, ilTgtTyRef)), m)
 
                     // Record the details so we can build correct ILTypeDefs during static linking rewriting
-                    if not isSuppressRelocate then 
+                    if not isForcedSuppressRelocate then 
                         match provAssemStaticLinkInfoOpt with 
                         | Some provAssemStaticLinkInfo -> provAssemStaticLinkInfo.ILTypeMap.[ilOrigTypeRef] <- ilTgtTyRef
                         | None -> ()
@@ -13863,7 +13863,7 @@ module EstablishTypeDefinitionCores = begin
                 |> Array.toList
 
             let nested = doNestedTypes tcref theRootTypeWithRemapping 
-            if not isSuppressRelocate then 
+            if not isForcedSuppressRelocate then 
 
                 let ilTgtRootTyRef = tycon.CompiledRepresentationForNamedType
                 match rootProvAssemStaticLinkInfoOpt with 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -13788,7 +13788,6 @@ module EstablishTypeDefinitionCores = begin
             if isForcedSuppressRelocate && canAccessFromEverywhere tycon.Accessibility && not cenv.isScript then 
                 errorR(Error(FSComp.SR.tcGeneratedTypesShouldBeInternalOrPrivate(),tcref.Range))
 
-            let isSuppressRelocate = cenv.g.isInteractive || isForcedSuppressRelocate
     
             // Adjust the representation of the container type
             let repr = Construct.NewProvidedTyconRepr(resolutionEnvironment,theRootTypeWithRemapping,

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1626,7 +1626,7 @@ module StaticLinker =
               Morphs.disablemorphCustomAttributeData()
 #else
               let providerGeneratedILModules = []
-            let generatedILTypeDefs = []
+            let generatedILTypeDefs = [] : (ILTypeRef * ILTypeDef) list
 #endif
             generatedILTypeDefs, (fun ilxMainModule  ->
               ReportTime tcConfig "Find assembly references";

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1528,22 +1528,15 @@ module StaticLinker =
                         | Some provAssemStaticLinkInfo -> yield (importedBinary,provAssemStaticLinkInfo) ]
 #endif
         if tcConfig.compilingFslib && tcConfig.compilingFslib20.IsSome then 
-            (fun ilxMainModule -> LegacyFindAndAddMscorlibTypesForStaticLinkingIntoFSharpCoreLibraryForNet20 (tcConfig, ilGlobals, ilxMainModule))
+            [], (fun ilxMainModule -> LegacyFindAndAddMscorlibTypesForStaticLinkingIntoFSharpCoreLibraryForNet20 (tcConfig, ilGlobals, ilxMainModule))
           
         elif not tcConfig.standalone && tcConfig.extraStaticLinkRoots.IsEmpty 
 #if EXTENSIONTYPING
              && providerGeneratedAssemblies.IsEmpty 
 #endif
              then 
-            (fun ilxMainModule -> ilxMainModule)
+            [], (fun ilxMainModule -> ilxMainModule)
         else 
-            (fun ilxMainModule  ->
-              ReportTime tcConfig "Find assembly references";
-
-              let dependentILModules = FindDependentILModulesForStaticLinking (tcConfig, tcImports,ilxMainModule)
-
-              ReportTime tcConfig "Static link";
-
 #if EXTENSIONTYPING
               Morphs.enablemorphCustomAttributeData()
               let providerGeneratedILModules =  FindProviderGeneratedILModules (tcImports, providerGeneratedAssemblies) 
@@ -1572,7 +1565,6 @@ module StaticLinker =
                       (ccu,ilOrigScopeRef,ilModule))
 
               // Relocate provider generated type definitions into the expected shape for the [<Generate>] declarations in an assembly
-              let providerGeneratedILModules, ilxMainModule = 
                   // Build a dictionary of all remapped IL type defs 
                   let ilOrigTyRefsForProviderGeneratedTypesToRelocate = 
                       let rec walk acc (ProviderGeneratedType(ilOrigTyRef,_,xs) as node) = List.fold walk ((ilOrigTyRef,node)::acc) xs 
@@ -1617,40 +1609,6 @@ module StaticLinker =
                       [ for (ProviderGeneratedType(_, ilTgtTyRef, _) as node) in tcImports.ProviderGeneratedTypeRoots  do
                            yield (ilTgtTyRef, buildRelocatedGeneratedType node) ]
                   
-                  // Implant all the generated type definitions into the ilxMainModule (generating a new ilxMainModule)
-                  let ilxMainModule = 
-
-                      /// Split the list into left, middle and right parts at the first element satisfying 'p'. If no element matches return
-                      /// 'None' for the middle part.
-                      let trySplitFind p xs = 
-                          let rec loop xs acc = 
-                              match xs with 
-                              | [] -> List.rev acc, None, [] 
-                              | h::t -> if p h then List.rev acc, Some h, t else loop t (h::acc)
-                          loop xs []
-
-                      /// Implant the (nested) type definition 'td' at path 'enc' in 'tdefs'. 
-                      let rec implantTypeDef isNested (tdefs: ILTypeDefs) (enc:string list) (td: ILTypeDef) = 
-                          match enc with 
-                          | [] -> addILTypeDef td tdefs
-                          | h::t -> 
-                               let tdefs = tdefs.AsList
-                               let (ltdefs,htd,rtdefs) = 
-                                   match tdefs |> trySplitFind (fun td -> td.Name = h) with 
-                                   | (ltdefs,None,rtdefs) -> 
-                                       let fresh = mkILSimpleClass ilGlobals (h, (if isNested  then ILTypeDefAccess.Nested ILMemberAccess.Public else ILTypeDefAccess.Public), emptyILMethods, emptyILFields, emptyILTypeDefs, emptyILProperties, emptyILEvents, emptyILCustomAttrs, ILTypeInit.OnAny)
-                                       (ltdefs, fresh, rtdefs)
-                                   | (ltdefs, Some htd, rtdefs) -> 
-                                       (ltdefs, htd, rtdefs)
-                               let htd = { htd with NestedTypes = implantTypeDef true htd.NestedTypes t td }
-                               mkILTypeDefs (ltdefs @ [htd] @ rtdefs)
-
-                      let newTypeDefs = 
-                          (ilxMainModule.TypeDefs, generatedILTypeDefs) ||> List.fold (fun acc (ilTgtTyRef,td) -> 
-                              if debugStaticLinking then printfn "implanting '%s' at '%s'" td.Name ilTgtTyRef.QualifiedName 
-                              implantTypeDef false acc ilTgtTyRef.Enclosing td) 
-                      { ilxMainModule with TypeDefs = newTypeDefs } 
-                  
                   // Remove any ILTypeDefs from the provider generated modules if they have been relocated because of a [<Generate>] declaration.
                   let providerGeneratedILModules = 
                       providerGeneratedILModules |> List.map (fun (ccu,ilOrigScopeRef,ilModule) -> 
@@ -1665,12 +1623,17 @@ module StaticLinker =
                               rw [] ilModule.TypeDefs
                           (ccu, { ilModule with TypeDefs = ilTypeDefsAfterRemovingRelocatedTypes }))
 
-                  providerGeneratedILModules, ilxMainModule
-             
               Morphs.disablemorphCustomAttributeData()
 #else
               let providerGeneratedILModules = []
+            let generatedILTypeDefs = []
 #endif
+            generatedILTypeDefs, (fun ilxMainModule  ->
+              ReportTime tcConfig "Find assembly references";
+
+              let dependentILModules = FindDependentILModulesForStaticLinking (tcConfig, tcImports,ilxMainModule)
+
+              ReportTime tcConfig "Static link";
 
               // Glue all this stuff into ilxMainModule 
               let ilxMainModule,rewriteExternalRefsToLocalRefs = 
@@ -1941,7 +1904,7 @@ let main2b(Args(tcConfig: TcConfig, tcImports, tcGlobals, errorLogger, generated
     let ilGlobals = tcGlobals.ilg
     if tcConfig.standalone && generatedCcu.UsesFSharp20PlusQuotations then    
         error(Error(FSComp.SR.fscQuotationLiteralsStaticLinking0(),rangeStartup));  
-    let staticLinker = StaticLinker.StaticLink (tcConfig,tcImports,ilGlobals)
+    let providedTypes, staticLinker = StaticLinker.StaticLink (tcConfig,tcImports,ilGlobals)
 
     ReportTime tcConfig "TAST -> ILX";
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind  (BuildPhase.IlxGen)
@@ -1951,7 +1914,7 @@ let main2b(Args(tcConfig: TcConfig, tcImports, tcGlobals, errorLogger, generated
     // so that make sure the compiler only emits "serializable" bit into IL metadata when it is available.
     // Note that SerializableAttribute may be relocated in the future but now resides in mscorlib.
     let netFxHasSerializableAttribute = tcImports.SystemRuntimeContainsType "System.SerializableAttribute"
-    let codegenResults = GenerateIlxCode (IlWriteBackend, false, false, tcConfig, topAttrs, optimizedImpls, generatedCcu.AssemblyName, netFxHasSerializableAttribute, ilxGenerator)
+    let codegenResults = GenerateIlxCode (IlWriteBackend, false, false, tcConfig, topAttrs, optimizedImpls, generatedCcu.AssemblyName, netFxHasSerializableAttribute, ilxGenerator, providedTypes)
     let casApplied = new Dictionary<Stamp,bool>()
     let securityAttrs,topAssemblyAttrs = topAttrs.assemblyAttrs |> List.partition (fun a -> TypeChecker.IsSecurityAttribute tcGlobals (tcImports.GetImportMap()) casApplied a rangeStartup)
     // remove any security attributes from the top-level assembly attribute list

--- a/src/fsharp/fsc.fsi
+++ b/src/fsharp/fsc.fsi
@@ -32,6 +32,9 @@ type ILResource with
 /// Proccess the given set of command line arguments
 val internal ProcessCommandLineFlags : TcConfigBuilder * setProcessThreadLocals:(TcConfigBuilder -> unit) * lcidFromCodePage : int option * argv:string[] -> string list
 
+module internal StaticLinker =
+    val internal StaticLink : TcConfig * TcImports * ILGlobals -> (ILTypeRef * ILTypeDef) list * (ILModuleDef -> ILModuleDef)
+
 //---------------------------------------------------------------------------
 // The entry point used by fsc.exe
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -821,7 +821,7 @@ type internal FsiDynamicCompiler
         errorLogger.AbortOnError();
             
         let fragName = textOfLid prefixPath 
-        let providedTypes, staticLinker = Driver.StaticLinker.StaticLink(tcConfig, tcImports, ilGlobals)
+        let providedTypes, _staticLinker = Driver.StaticLinker.StaticLink(tcConfig, tcImports, ilGlobals)
         let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator, providedTypes)
         errorLogger.AbortOnError();
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -821,7 +821,7 @@ type internal FsiDynamicCompiler
         errorLogger.AbortOnError();
             
         let fragName = textOfLid prefixPath 
-        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator)
+        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator, [])
         errorLogger.AbortOnError();
 
         // Each input is like a small separately compiled extension to a single source file. 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -821,7 +821,8 @@ type internal FsiDynamicCompiler
         errorLogger.AbortOnError();
             
         let fragName = textOfLid prefixPath 
-        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator, [])
+        let providedTypes, staticLinker = Driver.StaticLinker.StaticLink(tcConfig, tcImports, ilGlobals)
+        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator, providedTypes)
         errorLogger.AbortOnError();
 
         // Each input is like a small separately compiled extension to a single source file. 

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -3187,12 +3187,15 @@ let TrySelectMemberVal g optFilter typ pri _membInfo (vref:ValRef) =
     else 
         None
 
+/// Query the immediate methods of a type, tuple, ByRef, or type extension.
+/// If the type is a not a named type then returns an empty list
+let GetArrayOrByrefOrTupleOrExnTypeMetadata g typ optFilter =
+    if not (isAppTy g typ) then []
+    else SelectImmediateMemberVals g optFilter (TrySelectMemberVal g optFilter typ None) (tcrefOfAppTy g typ)
+
 /// Query the immediate methods of an F# type, not taking into account inherited methods. The optFilter
 /// parameter is an optional name to restrict the set of properties returned.
 let GetImmediateIntrinsicMethInfosOfType (optFilter,ad) g amap m typ =
-    let getFSharpMetadata() =
-        if not (isAppTy g typ) then []
-        else SelectImmediateMemberVals g optFilter (TrySelectMemberVal g optFilter typ None) (tcrefOfAppTy g typ)
     let minfos =
 
         match metadataOfTy g typ with 
@@ -3203,15 +3206,16 @@ let GetImmediateIntrinsicMethInfosOfType (optFilter,ad) g amap m typ =
                 match optFilter with
                 | Some name ->  st.PApplyArray ((fun st -> st.GetMethods() |> Array.filter (fun mi -> mi.Name = name) ), "GetMethods", m)
                 | None -> st.PApplyArray ((fun st -> st.GetMethods()), "GetMethods", m)
-            [   for mi in meths -> ProvidedMeth(amap,mi.Coerce(m),None,m) ]
-            |> List.append (getFSharpMetadata()) // to account for any intrinsic type extensions
+            [   for mi in meths -> ProvidedMeth(amap,mi.Coerce(m),None,m)
+                // to account for any intrinsic type extensions
+                yield! GetArrayOrByrefOrTupleOrExnTypeMetadata g typ optFilter ]
 #endif
         | ILTypeMetadata (_,tdef) -> 
             let mdefs = tdef.Methods
             let mdefs = (match optFilter with None -> mdefs.AsList | Some nm -> mdefs.FindByName nm)
             mdefs |> List.map (fun mdef -> MethInfo.CreateILMeth(amap, m, typ, mdef)) 
         | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> 
-            getFSharpMetadata()
+            GetArrayOrByrefOrTupleOrExnTypeMetadata g typ optFilter
     let minfos = minfos |> List.filter (IsMethInfoAccessible amap m ad)
     minfos
 
@@ -3257,17 +3261,20 @@ type PropertyCollector(g,amap,m,typ,optFilter,ad) =
 
     member x.Close() = [ for KeyValue(_,pinfo) in props -> pinfo ]
 
+/// Query the immediate properties of a type, tuple, ByRef, or type extension.
+/// If the type is a not a named type then returns an empty list
+let GetFSharpOrArrayOrByrefOrTupleOrExnTypeMetadata optFilter ad g amap m typ =
+    if not (isAppTy g typ) then []
+    else
+        let propCollector = new PropertyCollector(g,amap,m,typ,optFilter,ad)
+        SelectImmediateMemberVals g None
+                   (fun membInfo vref -> propCollector.Collect(membInfo,vref); None)
+                   (tcrefOfAppTy g typ) |> ignore
+        propCollector.Close()
+            
 /// Query the immediate properties of an F# type, not taking into account inherited properties. The optFilter
 /// parameter is an optional name to restrict the set of properties returned.
 let GetImmediateIntrinsicPropInfosOfType (optFilter,ad) g amap m typ =
-    let getFSharpMetadata() =
-        if not (isAppTy g typ) then []
-        else
-            let propCollector = new PropertyCollector(g,amap,m,typ,optFilter,ad)
-            SelectImmediateMemberVals g None
-                       (fun membInfo vref -> propCollector.Collect(membInfo,vref); None)
-                       (tcrefOfAppTy g typ) |> ignore
-            propCollector.Close()
     let pinfos =
 
         match metadataOfTy g typ with 
@@ -3282,10 +3289,9 @@ let GetImmediateIntrinsicPropInfosOfType (optFilter,ad) g amap m typ =
                         |   pi -> [|pi|]
                 |   None ->
                         st.PApplyArray((fun st -> st.GetProperties()), "GetProperties", m)
-            matchingProps
-            |> Seq.map(fun pi -> ProvidedProp(amap,pi,m)) 
-            |> List.ofSeq
-            |> List.append (getFSharpMetadata()) // to account for any intrinsic type extensions
+            [ for pi in matchingProps -> ProvidedProp(amap,pi,m) 
+              // to account for any intrinsic type extensions
+              yield! GetFSharpOrArrayOrByrefOrTupleOrExnTypeMetadata optFilter ad g amap m typ ]
 #endif
         | ILTypeMetadata (_,tdef) -> 
             let tinfo = ILTypeInfo.FromType g typ
@@ -3293,7 +3299,7 @@ let GetImmediateIntrinsicPropInfosOfType (optFilter,ad) g amap m typ =
             let pdefs = match optFilter with None -> pdefs.AsList | Some nm -> pdefs.LookupByName nm
             pdefs |> List.map (fun pd -> ILProp(g,ILPropInfo(tinfo,pd))) 
         | FSharpOrArrayOrByrefOrTupleOrExnTypeMetadata -> 
-            getFSharpMetadata()
+            GetFSharpOrArrayOrByrefOrTupleOrExnTypeMetadata optFilter ad g amap m typ
     let pinfos = pinfos |> List.filter (IsPropInfoAccessible g amap m ad)
     pinfos
 


### PR DESCRIPTION
Ok this is a combination of the work Alex Corrado and I have done to get intrinsic type extensions on generative provided types working correctly.  

The gist of the fix is that provided types were calculated far for ahead in the compile chain for them to be available in the type checking phase so this PR moves that phase to be slightly earlier in the compilation chain.  This is also detailed in the commit comnents.

I have tested in both fsi and fsc and everything looks good:

Given a generative type provider that simply creates a generated type with a method named `MyMethod` and a property names `MyProperty`, and then intrinsically extends it with a `Foo` property

```
#r "IntrinsicTypeExtensions.dll"
type t = BasicProvider.Generative.MyType with
  override x.ToString() = "Hello World"
  member x.Foo = 42""")
      Some exp
    with ex -> None
```

```
F# Interactive for F# 4.0 (private)
Freely distributed under the Apache 2.0 Open Source License

For help type #help;;

> 
--> Referenced '/Users/dave/Projects/IntrinsicTypeExtensions/IntrinsicTypeExtensions/bin/Debug/IntrinsicTypeExtensions.dll' (file may be locked by F# Interactive process)

type t =
  class
    new : unit -> t
    member Foo : int
    member MyMethod : unit -> string
    member MyProperty : string
    member ToString : unit -> string
```

Using static linker debug output, we get the following:

```
adding provider-generated assembly 'tmp43eaf32e' into static linking set
deciding whether to rewrite type ref "System.Object"
deciding whether to rewrite type ref "BasicProvider.Generative.MyType"
rewriting type ref "BasicProvider.Generative.MyType" to "FSI_0001+t"
deciding whether to rewrite type ref "System.String"
Have [<Generate>] root 'BasicProvider.Generative.MyType, tmp43eaf32e, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
Relocating BasicProvider.Generative.MyType, tmp43eaf32e, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null to FSI_0001+t 
Keep provided type <Module>, tmp43eaf32e, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null in place because it wasn't relocated
```

I can add tests etc as long as I know what and where to add them to.
