### PR TITLE
Implement support for System.TimeSpan for the F# `abs` operator

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -238,6 +238,8 @@ let isFpTy g ty =
 let isDecimalTy g ty = 
     typeEquivAux EraseMeasures g g.decimal_ty ty 
 
+let isTimespanTy g ty = typeEquiv g g.timespan_ty ty
+
 let IsNonDecimalNumericOrIntegralEnumType g ty = isIntegerOrIntegerEnumTy g ty || isFpTy g ty
 let IsNumericOrIntegralEnumType g ty = IsNonDecimalNumericOrIntegralEnumType g ty || isDecimalTy g ty
 let IsNonDecimalNumericType g ty = isIntegerTy g ty || isFpTy g ty
@@ -1077,7 +1079,7 @@ and SolveMemberConstraint (csenv:ConstraintSolverEnv) permitWeakResolution ndeep
           ResultD TTraitBuiltIn))
 
       | _,_,false,("Abs"),[argty] 
-          when isSignedIntegerTy g argty || isFpTy g argty || isDecimalTy g argty ->
+          when isSignedIntegerTy g argty || isFpTy g argty || isDecimalTy g argty || isTimespanTy g argty ->
 
           SolveTypEqualsTypKeepAbbrevs csenv ndeep m2 trace rty argty ++ (fun () -> 
           ResultD TTraitBuiltIn)

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -6799,7 +6799,7 @@ namespace Microsoft.FSharp.Core
                  when ^T : int16       = let x : int16     = retype x in System.Math.Abs(x)
                  when ^T : sbyte       = let x : sbyte     = retype x in System.Math.Abs(x)
                  when ^T : decimal     = System.Math.Abs(retype x : decimal) 
-                 when ^T : TimeSpan    = let x : TimeSpan = retype x in x.Duration
+                 when ^T : TimeSpan    = let x : TimeSpan = retype x in x.Duration()
             
             [<NoDynamicInvocation>]
             let inline  acosImpl(x: ^T) : ^T = 

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -6799,6 +6799,10 @@ namespace Microsoft.FSharp.Core
                  when ^T : int16       = let x : int16     = retype x in System.Math.Abs(x)
                  when ^T : sbyte       = let x : sbyte     = retype x in System.Math.Abs(x)
                  when ^T : decimal     = System.Math.Abs(retype x : decimal) 
+                 when ^T : TimeSpan    = 
+                    let x : TimeSpan = retype x in
+                    if x >= TimeSpan.Zero then x
+                    else -x
             
             [<NoDynamicInvocation>]
             let inline  acosImpl(x: ^T) : ^T = 

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -6799,10 +6799,7 @@ namespace Microsoft.FSharp.Core
                  when ^T : int16       = let x : int16     = retype x in System.Math.Abs(x)
                  when ^T : sbyte       = let x : sbyte     = retype x in System.Math.Abs(x)
                  when ^T : decimal     = System.Math.Abs(retype x : decimal) 
-                 when ^T : TimeSpan    = 
-                    let x : TimeSpan = retype x in
-                    if x >= TimeSpan.Zero then x
-                    else -x
+                 when ^T : TimeSpan    = let x : TimeSpan = retype x in x.Duration
             
             [<NoDynamicInvocation>]
             let inline  acosImpl(x: ^T) : ^T = 

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -215,6 +215,7 @@ type public TcGlobals =
       exn_ty         : TType 
       char_ty        : TType 
       decimal_ty                   : TType 
+      timespan_ty                  : TType
       float_ty                     : TType 
       float32_ty                   : TType 
       system_Array_typ             : TType 
@@ -657,6 +658,7 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
   let string_ty       = mkNonGenericTy string_tcr
   let byte_ty         = mkNonGenericTy byte_tcr
   let decimal_ty      = mkSysNonGenericTy sys "Decimal"
+  let timespan_ty     = mkSysNonGenericTy sys "TimeSpan"
   let unit_ty         = mkNonGenericTy unit_tcr_nice 
   let system_Type_typ = mkSysNonGenericTy sys "Type" 
 
@@ -1093,6 +1095,7 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
     exn_ty        = mkNonGenericTy exn_tcr
     char_ty       = mkNonGenericTy char_tcr
     decimal_ty    = mkNonGenericTy decimal_tcr
+    timespan_ty   = timespan_ty
     float_ty      = mkNonGenericTy float_tcr 
     float32_ty    = mkNonGenericTy float32_tcr
     memoize_file  = memoize_file.Apply


### PR DESCRIPTION
Here's a quick hack I pulled together that adds support for `System.TimeSpan` for the FSharp.Core `abs` operator. This includes the actual implementation and introduces changes to the constraint solver to accommodate the addition. Feel free to review and/or reject this addition :-)

This is kind of useful when performing calculations using dates:
```fsharp
open System
let d1 = DateTimeOffset.Now
let d2 = DateTimeOffset.Now

if abs(d1 - d2) < TimeSpan.FromMinutes 5. then ...
```