### PR TITLE
update project files

### DIFF
--- a/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
+++ b/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
@@ -47,11 +47,11 @@
     <Reference Include="$(FSCoreLKGPath)" />
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
-    <Reference Include="Microsoft.Build.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build.Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build.Engine, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build.Utilities.$(MSBuildVersionSuffix)" />
+    <Reference Include="Microsoft.Build.Tasks.$(MSBuildVersionSuffix)" />
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
 </Project>

--- a/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
+++ b/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
@@ -427,17 +427,15 @@
     <Reference Include="mscorlib" />
     <Reference Include="$(FSCoreLKGPath)" />
     <Reference Include="System" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Drawing" />
+    <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Remoting" />
-    <Reference Include="Microsoft.Build.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build.Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="ISymWrapper, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Microsoft.Build.Tasks.v4.0" />
-
+    <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build.Engine, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build.Utilities.$(MSBuildVersionSuffix)" />
+    <Reference Include="Microsoft.Build.Tasks.$(MSBuildVersionSuffix)" />
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
   <Import Project="$(FSharpSourcesRoot)\..\lkg\FSharp-$(LkgVersion)\bin\FSharp.PowerPack.targets" />

--- a/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj
+++ b/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj
@@ -447,60 +447,6 @@
     <Compile Include="..\fsc.fs">
       <Link>Driver\fsc.fs</Link>
     </Compile>
-    <Compile Include="..\vs\IncrementalBuild.fsi">
-      <Link>Driver\IncrementalBuild.fsi</Link>
-    </Compile>
-    <Compile Include="..\vs\IncrementalBuild.fs">
-      <Link>Driver\IncrementalBuild.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\Reactor.fsi">
-      <Link>Service\Reactor.fsi</Link>
-    </Compile>
-    <Compile Include="..\vs\Reactor.fs">
-      <Link>Service\Reactor.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceLexing.fsi">
-      <Link>Service\ServiceLexing.fsi</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceLexing.fs">
-      <Link>Service\ServiceLexing.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceConstants.fs">
-      <Link>Service\ServiceConstants.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceParseTreeWalk.fs">
-      <Link>Service\ServiceParseTreeWalk.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceNavigation.fsi">
-      <Link>Service\ServiceNavigation.fsi</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceNavigation.fs">
-      <Link>Service\ServiceNavigation.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceParamInfoLocations.fsi">
-      <Link>Service\ServiceParamInfoLocations.fsi</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceParamInfoLocations.fs">
-      <Link>Service\ServiceParamInfoLocations.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceUntypedParse.fsi">
-      <Link>Service\ServiceUntypedParse.fsi</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceUntypedParse.fs">
-      <Link>Service\ServiceUntypedParse.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceDeclarations.fsi">
-      <Link>Service\ServiceDeclarations.fsi</Link>
-    </Compile>
-    <Compile Include="..\vs\ServiceDeclarations.fs">
-      <Link>Service\ServiceDeclarations.fs</Link>
-    </Compile>
-    <Compile Include="..\vs\service.fsi">
-      <Link>Service\service.fsi</Link>
-    </Compile>
-    <Compile Include="..\vs\service.fs">
-      <Link>Service\service.fs</Link>
-    </Compile>
     <Compile Include="InternalsVisibleTo.fs">
       <Link>InternalsVisibleTo.fs</Link>
     </Compile>
@@ -510,9 +456,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Runtime.Remoting" />
     <Reference Include="ISymWrapper, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Engine, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />


### PR DESCRIPTION
Removes the service API files from FSharp.Compiler.dll since that DLL is only used by fsi.exe and fsc.exe and they don't need the service API.