### PR TITLE
Don't clobber F# SDK during CI build

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -294,7 +294,8 @@ if '%TEST_VS%' == '1' (
 
 @echo on
 call src\update.cmd release -ngen
-call vsintegration\update-vsintegration.cmd release
+REM This clobbers the installed F# SDK on the machine
+REM call vsintegration\update-vsintegration.cmd release
 pushd tests
 
 @echo on

--- a/jenkins-build.cmd
+++ b/jenkins-build.cmd
@@ -22,7 +22,7 @@ goto :USAGE
 
 echo Usage:
 echo Builds the source tree using a specific configuration
-echo appveyor-build.cmd ^<debug^|release^>
+echo jenkins-build.cmd ^<debug^|release^>
 exit /b 1
 
 :ARGUMENTS_OK


### PR DESCRIPTION
See https://github.com/Microsoft/visualfsharp/issues/883#issuecomment-175631830.  AFAIK this step shouldn't be necessary in the CI build