### PR TITLE
[WIP] Fix coreclr build

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -199,10 +199,8 @@ if not exist %_dotnetexe% (
     @if ERRORLEVEL 1 echo Error: fetch dotnetcli failed && goto :failure
 )
 
-pushd .\lkg & ..\%_dotnetexe% restore project.json &popd
-@if ERRORLEVEL 1 echo Error: dotnet restore failed  && goto :failure
-pushd .\lkg & ..\%_dotnetexe% publish project.json -f dnxcore50 -r win7-x64 -o ..\packages\lkg &popd
-@if ERRORLEVEL 1 echo Error: dotnet publish failed  && goto :failure
+copy /y .\packages\dotnet\bin\* .\packages\lkg
+@if ERRORLEVEL 1 echo Error: copy of dotnet bin to lkg failed && goto :failure
 
 rem rename fsc and coreconsole to allow fsc.exe to to start compiler
 pushd .\packages\lkg & ren fsc.exe fsc.dll & popd

--- a/scripts/install-dotnetcli.ps1
+++ b/scripts/install-dotnetcli.ps1
@@ -6,6 +6,6 @@ $clipath = $args[0]
 $BackUpPath = [System.IO.Path]::Combine($args[1], "dotnet-latest.zip")
 $Destination = [System.IO.Path]::Combine($args[1], "dotnet")
 
-Invoke-WebRequest $clipath -OutFile $BackUpPath
+Invoke-WebRequest -UseBasicParsing $clipath -OutFile $BackUpPath
 Add-Type -assembly "system.io.compression.filesystem"
 [io.compression.zipfile]::ExtractToDirectory($BackUpPath, $destination)


### PR DESCRIPTION
dotnet cli now bundle fsc/fsi coreclr, not need to publish. 

Let's doogfood dotnet/cli F# (we can also try project.json)

the `-UseBasicParsing` speedup the download of dotnet/cli ( a lot )

TODO:

- [ ] fix compile errors
- [ ] fix package versions ( latest is `-rc3` )
