### PR TITLE
Fix handling of optional IDispatch, IUnknown method args

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -9174,7 +9174,7 @@ and TcMethodApplication
                               | Some assemblyRef ->
                                   let tref = mkILNonGenericBoxedTy(mkILTyRef(assemblyRef, "System.Runtime.InteropServices.DispatchWrapper"))
                                   let mref = mkILCtorMethSpecForTy(tref,[cenv.g.ilg.typ_Object]).MethodRef
-                                  let expr = Expr.Op(TOp.ILCall(false,false,false,false,CtorValUsedAsSuperInit,false,false,mref,[],[],[cenv.g.obj_ty]),[],[mkDefault(mMethExpr,currCalledArgTy)],mMethExpr)
+                                  let expr = Expr.Op(TOp.ILCall(false,false,false,true,NormalValUse,false,false,mref,[],[],[cenv.g.obj_ty]),[],[mkDefault(mMethExpr,currCalledArgTy)],mMethExpr)
                                   emptyPreBinder,expr
                           | WrapperForIUnknown ->
                               match cenv.g.ilg.traits.SystemRuntimeInteropServicesScopeRef.Value with
@@ -9182,7 +9182,7 @@ and TcMethodApplication
                               | Some assemblyRef ->
                                   let tref = mkILNonGenericBoxedTy(mkILTyRef(assemblyRef, "System.Runtime.InteropServices.UnknownWrapper"))
                                   let mref = mkILCtorMethSpecForTy(tref,[cenv.g.ilg.typ_Object]).MethodRef
-                                  let expr = Expr.Op(TOp.ILCall(false,false,false,false,CtorValUsedAsSuperInit,false,false,mref,[],[],[cenv.g.obj_ty]),[],[mkDefault(mMethExpr,currCalledArgTy)],mMethExpr)
+                                  let expr = Expr.Op(TOp.ILCall(false,false,false,true,NormalValUse,false,false,mref,[],[],[cenv.g.obj_ty]),[],[mkDefault(mMethExpr,currCalledArgTy)],mMethExpr)
                                   emptyPreBinder,expr
                           | PassByRef (ty, dfltVal2) ->
                               let v,_ = mkCompGenLocal mMethExpr "defaultByrefArg" ty

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -9128,11 +9128,13 @@ and TcMethodApplication
         // Handle CallerSide optional arguments. 
         //
         // CallerSide optional arguments are largely for COM interop, e.g. to PIA assemblies for Word etc.
-        // As a result we follow the VB spec here. To quote from an email exchange between the C# and VB teams.
+        // As a result we follow the VB and C# behavior here.
         //
-        //   "1.        If the parameter is statically typed as System.Object and does not have a value, then there are two cases:
-        //       a.     The parameter may have the IDispatchConstantAttribute or IUnknownConstantAttribute attribute. If this is the case, the VB compiler then create an instance of the System.Runtime.InteropServices.DispatchWrapper /System.Runtime.InteropServices.UnknownWrapper type at the call site to wrap the value Nothing/null.
-        //       b.     If the parameter does not have those two attributes, we will emit Missing.Value.
+        //   "1.        If the parameter is statically typed as System.Object and does not have a value, then there are four cases:
+        //       a.     The parameter is marked with MarshalAs(IUnknown), MarshalAs(Interface), or MarshalAs(IDispatch). In this case we pass null.
+        //       b.     Else if the parameter is marked with IUnknownConstantAttribute. In this case we pass new System.Runtime.InteropServices.UnknownWrapper(null)
+        //       c.     Else if the parameter is marked with IDispatchConstantAttribute. In this case we pass new System.Runtime.InteropServices.DispatchWrapper(null)
+        //       d.     Else, we will pass Missing.Value.
         //    2.        Otherwise, if there is a value attribute, then emit the default value.
         //    3.        Otherwise, we emit default(T).
         //    4.        Finally, we apply conversions from the value to the parameter type. This is where the nullable conversions take place for VB.

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -499,9 +499,12 @@ type OptionalArgInfo =
                         let ty = destByrefTy g ty
                         PassByRef (ty, analyze ty)
                     elif isObjTy g ty then
-                        if   TryFindILAttributeOpt g.attrib_IDispatchConstantAttribute ilParam.CustomAttrs then WrapperForIDispatch
-                        elif TryFindILAttributeOpt g.attrib_IUnknownConstantAttribute ilParam.CustomAttrs then WrapperForIUnknown
-                        else MissingValue
+                        match ilParam.Marshal with
+                        | Some(ILNativeType.IUnknown | ILNativeType.IDispatch | ILNativeType.Interface) -> Constant(ILFieldInit.Null)
+                        | _ -> 
+                            if   TryFindILAttributeOpt g.attrib_IUnknownConstantAttribute ilParam.CustomAttrs then WrapperForIUnknown
+                            elif TryFindILAttributeOpt g.attrib_IDispatchConstantAttribute ilParam.CustomAttrs then WrapperForIDispatch
+                            else MissingValue
                     else 
                         DefaultValue
                 CallerSide (analyze (ImportTypeFromMetadata amap m ilScope ilTypeInst [] ilParam.Type))

--- a/tests/RunTests.cmd
+++ b/tests/RunTests.cmd
@@ -170,6 +170,9 @@ set OSARCH=%PROCESSOR_ARCHITECTURE%
 set X86_PROGRAMFILES=%ProgramFiles%
 if "%OSARCH%"=="AMD64" set X86_PROGRAMFILES=%ProgramFiles(x86)%
 
+set SYSWOW64=.
+if "%OSARCH%"=="AMD64" set SYSWOW64=SysWoW64
+
 set REGEXE32BIT=reg.exe
 if not "%OSARCH%"=="x86" set REGEXE32BIT=%WINDIR%\syswow64\reg.exe
 

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/OptionalArguments/OptArgsFromCOM.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/OptionalArguments/OptArgsFromCOM.fs
@@ -1,0 +1,34 @@
+open System
+open WbemScripting
+
+let doStuff() =
+    let locator =
+            let comTy = Type.GetTypeFromProgID("WbemScripting.SWbemLocator")
+            Activator.CreateInstance(comTy) :?> SWbemLocator
+
+    // SWBemLocator.ConnectServer https://msdn.microsoft.com/en-us/library/windows/desktop/aa393720(v=vs.85).aspx
+    // SWbemServices ConnectServer(
+    //      [MarshalAs(UnmanagedType.BStr)] [In] string strServer = ".",
+    //      [MarshalAs(UnmanagedType.BStr)] [In] string strNamespace = "",
+    //      [MarshalAs(UnmanagedType.BStr)] [In] string strUser = "",
+    //      [MarshalAs(UnmanagedType.BStr)] [In] string strPassword = "",
+    //      [MarshalAs(UnmanagedType.BStr)] [In] string strLocale = "",
+    //      [MarshalAs(UnmanagedType.BStr)] [In] string strAuthority = "",
+    //      [In] int iSecurityFlags = 0,
+    //      [IDispatchConstant] [MarshalAs(UnmanagedType.IDispatch)] [In] object objWbemNamedValueSet = null);
+    let services = locator.ConnectServer()
+
+    // SWbemServices.ExecQuery https://msdn.microsoft.com/en-us/library/windows/desktop/aa393866(v=vs.85).aspx
+    // SWbemObjectSet ExecQuery(
+    //      [MarshalAs(UnmanagedType.BStr)] [In] string strQuery,
+    //      [MarshalAs(UnmanagedType.BStr)] [In] string strQueryLanguage = "WQL",
+    //      [In] int iFlags = 16,
+    //      [IDispatchConstant] [MarshalAs(UnmanagedType.IDispatch)] [In] object objWbemNamedValueSet = null);
+    let resultSet = services.ExecQuery("select * from Win32_Processor")
+
+    resultSet
+    |> Seq.cast<SWbemObject>
+    |> Seq.map (fun o -> o.GetObjectText_(0))
+    |> Seq.iter (printfn "%s")
+
+doStuff()

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/OptionalArguments/env.lst
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/OptionalArguments/env.lst
@@ -5,6 +5,7 @@
 	SOURCE=E_SanityCheck02.fs
 	SOURCE=SanityCheck03.fs
     
+	SOURCE=OptArgsFromCOM.fs      SCFLAGS="-r:WbemScripting.dll"  PRECMD="tlbimp %SystemRoot%\\%SYSWOW64%\\wbem\\wbemdisp.tlb"	# OptArgsFromCOM.fs
 	SOURCE=NullOptArgsFromVB.fs   SCFLAGS="-r:TestLibVB.dll" PRECMD="\$VBC_PIPE /t:library TestLibVB.vb"	# NullOptArgsFromVB.fs
 	SOURCE=NullOptArgsFromCS.fs   SCFLAGS="-r:TestLib.dll" PRECMD="\$CSC_PIPE /t:library TestLib.cs"	# NullOptArgsFromCS.fs
 	SOURCE=SanityOptArgsFromCS.fs SCFLAGS="-r:TestLib.dll" PRECMD="\$CSC_PIPE /t:library TestLib.cs"	# SanityOptArgsFromCS.fs


### PR DESCRIPTION
Fixes https://github.com/Microsoft/visualfsharp/issues/907

Aligns F# compiler's treatment of these optional arguments with what C# and VB do.

For omitted `obj` optional args:

  - If it has `MarshalAs(IUnknown)`, `MarshalAs(IDispatch)`, or `MarshalAs(Interface)`, emit a `null` default value
  - Else if it has `IUnknownConstantAttribute` emit `UnknownWrapper(null)`
  - Else if it has `IDispatchConstantAttribute` emit `DispatchWrapper(null)`
  - Else emit `Type.Missing`

See relevant bits of the [C# compiler](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs#L1028-L1065) and [VB compiler](https://github.com/dotnet/roslyn/blob/a4e375b95953e471660e9686a46893c97db70b0e/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb#L3155-L3172).