### PR TITLE
simplify DEVGUIDE and TESTGUIDE, rename appveyor-build.cmd to build.cmd

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -19,24 +19,52 @@ The primary technical documents for the F# compiler code are
 
 **Questions?** If you have questions about the source code, please ask in the issues.
 
-## 0.  A Shortcut to Build and Smoke Test
+## Quick Start: Build, Test, Develop
 
-You can build a subset of functionality (including bootstrapped compiler and library) and run a very 
-small number of 'smoke' tests using the script used by continuous integration on Windows:
+You can build the compiler+tools and run the subset the tests used for continuous integration as follows:
 
-    .\appveyor-build.cmd
+    build.cmd
 
-See the script for what this does.  After you do this, you can do further testing, see  [TESTGUIDE.md](TESTGUIDE.md).
+There are various qualifiers:
 
+    build.cmd release         -- build release (the default)
+    build.cmd debug           -- build debug instead of release
 
-## 1.  Building a Proto Compiler
+    build.cmd compiler        -- build/tests only the compiler (not the Visual F# IDE Tools)
+    build.cmd vs              -- build/tests the Visual F# IDE Tools
+    build.cmd pcls            -- build/tests the PCL FSharp.Core libraries
 
-The compiler is compiled as a set of .NET 4.0 components using a bootstrap process. This uses the Last Known Good (LKG) compiler to build.  
-Note that you need the .NET framework 3.5 installed on your machine in order to complete this step.
+    build.cmd build           -- build, do not test
+    build.cmd smoke           -- build, run smoke tests
+    build.cmd ci              -- build, run the same tests as CI 
+    build.cmd all             -- build, run all tests
+
+Combinations are also allowed:
+
+    build.cmd debug,compiler,smoke   -- build the debug compiler and run smoke tests
+
+After you build the first time you can open and use this solution:
+
+    .\VisualFSharp.sln
+
+or just build it directly:
+
+    msbuild VisualFSharp.sln 
+
+Building ``VisualFSharp.sln`` builds _nearly_ everything. However building portable profiles of 
+FSharp.Core.dll is not included.  If you are just developing the core compiler, library
+and Visual F# Tools then building the solution will be enough.
+
+## Step by Step: 
+
+### 1. Building a Proto Compiler
+
+The compiler is compiled as a set of .NET 4.0 components using a bootstrap process. 
+This uses a Last Known Good (LKG) compiler checked into this repository to build.  
 
     msbuild src\fsharp-proto-build.proj
     
-## 2.  Building an F# (Debug) library and compiler
+### 2.  Building an F# (Debug) library and compiler
 
 This uses the proto compiler to build `FSharp.Core.dll`, `FSharp.Compiler.dll`, `fsc.exe`, and `fsi.exe`.
 
@@ -47,17 +75,24 @@ You can now use the updated F# compiler in `debug\net40\bin\fsc.exe` and F# Inte
 
 **Note:** The updated library is not used until you run `update.cmd`, see below.  The updated compiler is not run 'pre-compiled' until you run `update.cmd -ngen`, see below.
 
-## 3. Full Steps Before Running Tests
+### 3. Full Steps Before Running Tests
 
 See [TESTGUIDE.md](TESTGUIDE.md) for full details on how to run tests.
     
-Prior to a **Debug** test run, you need to complete **all** of these steps:
+Prior to a full **Debug** test run, you need to complete **all** of the steps in build.cmd
+
+    build.cmd debug,build
+
+Likewise prior to a **Release** test run:
+
+    build.cmd release,build
+
+For **Debug** this corresponds to these steps, which you can run individually for more incremental builds:
 
     msbuild src/fsharp-library-build.proj
     msbuild src/fsharp-compiler-build.proj
     msbuild src/fsharp-typeproviders-build.proj
     msbuild src/fsharp-compiler-unittests-build.proj
-    msbuild src/fsharp-library-build.proj /p:TargetFramework=net20
     msbuild src/fsharp-library-build.proj /p:TargetFramework=portable47
     msbuild src/fsharp-library-build.proj /p:TargetFramework=portable7
     msbuild src/fsharp-library-build.proj /p:TargetFramework=portable78
@@ -67,22 +102,18 @@ Prior to a **Debug** test run, you need to complete **all** of these steps:
     msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7
     msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78
     msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259
+    msbuild VisualFSharp.sln 
+    msbuild vsintegration\fsharp-vsintegration-unittests-build.proj 
     src\update.cmd debug -ngen
     tests\BuildTestTools.cmd debug 
 
 
-[Optional] If testing the Visual Studio bits (see below) you will also need:
-
-    msbuild VisualFSharp.sln 
-    msbuild vsintegration\fsharp-vsintegration-unittests-build.proj
-
-Prior to a **Release** test run, you need to do **all** of these:
+For **Release** this corresponds to these steps, which you can run individually for more incremental builds:
 
     msbuild src/fsharp-library-build.proj  /p:Configuration=Release
     msbuild src/fsharp-compiler-build.proj  /p:Configuration=Release
     msbuild src/fsharp-typeproviders-build.proj  /p:Configuration=Release
     msbuild src/fsharp-compiler-unittests-build.proj  /p:Configuration=Release
-    msbuild src/fsharp-library-build.proj /p:TargetFramework=net20 /p:Configuration=Release
     msbuild src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
     msbuild src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
     msbuild src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
@@ -92,16 +123,12 @@ Prior to a **Release** test run, you need to do **all** of these:
     msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
     msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
     msbuild src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
+    msbuild VisualFSharp.sln /p:Configuration=Release
+    msbuild vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=Release
     src\update.cmd release -ngen
     tests\BuildTestTools.cmd release 
 
-
-[Optional] If testing **Release** build of the Visual F# IDE Tools (see below) you will also need:
-
-    msbuild VisualFSharp.sln /p:Configuration=Release
-    msbuild vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=Release
-
-## 4. [Optional] Install the Visual F# IDE Tools and Clobber the F# SDK on the machine
+### 4. [Optional] Install the Visual F# IDE Tools and Clobber the F# SDK on the machine
 
 **Note:** Step #2 below will install a VSIX extension into Visual Studio 2015 that changes the Visual F# IDE Tools 
 components installed into Visual Studio 2015.  You can revert this step by disabling or uninstalling the addin.
@@ -140,7 +167,7 @@ Restart Visual Studio, it should now be running your freshly-built Visual F# IDE
  - We use the proto compiler to compile the source for `FSharp.Core.dll` in this distribution.
  - We use the proto compiler to compile the source for `FSharp.Compiler.dll`, `fsc.exe`, `fsi.exe`, and other binaries found in this distribution.
 
-### Further technical resources
+## Resources
 
 The primary technical guide to the core compiler code is [The F# Compiler Technical Guide](http://fsharp.github.io/2015/09/29/fsharp-compiler-guide.html).  Please read and contribute to that guide.
 

--- a/TESTGUIDE.md
+++ b/TESTGUIDE.md
@@ -1,51 +1,87 @@
 # F# Compiler, Core Library and Visual F# Tools Tests
 
-## Test Suites
-
-The F# tests are split into a few different suites.  Understanding the suites' structure, similarities, and differences is important when running, debugging, or authoring the tests.
-
-### FSharp Suite (aka "Cambridge Suite")
-The test cases for this suite reside under `tests\fsharp`. This suite dates back to F#'s origins at Microsoft Research, Cambridge, and utilizes a simple batch script framework to execute.  In general, this suite has broad coverage of mainline compiler and runtime scenarios.
-
-### FSharpQA Suite (aka "Redmond Suite")
-The test cases for this suite reside under `tests\fsharpqa\source`.
-This suite was first created when F# 2.0 was being added to Visual Studio 2010.  Tests for this suite are driven by the "RunAll" framework, implemented in Perl.  This suite is rather large and has broad and deep coverage of a variety of compiler, runtime, and syntax scenarios.
-
-### Compiler and Library Core Unit Test Suites
-The test cases for these suites reside next to the F# core library code, at `src\fsharp\FSharp.Core.Unittests` and `src\fsharp\FSharp.Compiler.Unittests`. These suites are standard NUnit test cases, implemented in F#.  The FSharp.Core.Unittests suite focuses on validation of the core F# types and the public surface area of `FSharp.Core.dll`, and the FSharp.Compiler.Unittests suite focuses on validation of compiler internals.
-
-### Visual F# Tools IDE Unit Test Suite
-The test cases for this suite reside next to the Visual F# Tools code, at `vsintegration\src\unittests`.  This suite is a set of standard NUnit test cases, implemented in F#.  This suite exercises a wide range of behaviors in the F# Visual Studio project system and language service.
-
-
 ## Prerequisites
-In order to run all of the tests, you will need to install
 
-* [Perl](http://www.perl.org/get.html) (ActiveState Perl 5.16.3 is known to work fine)
-
+In order to run the FSharpQA auite, you will need to install [Perl](http://www.perl.org/get.html) (ActiveState Perl 5.16.3 is known to work fine).
 Perl must be included in the `%PATH%` for the below steps to work.  It is also recommended that you run tests from an elevated command prompt, as there are a couple of test cases which require administrative privileges.
 
-Before running tests, make sure you have successfully built all required projects as specified in the 'Prepare For Tests' section of the [DEVGUIDE](DEVGUIDE.md).
+The Perl requirement is gradually being removed.
 
-Don't forget to build and install the Visual Studio components, as well, if you want to run the IDE tests below.
+## Quick start: Running Tests
 
-## Running Tests
+To run tests, use variations such as the following, depending on which test suite and build configuration you want:
 
-Note: **Don't** run tests from a Visual Studio developer command prompt (see below).
+    build.cmd compiler,smoke
+    build.cmd compiler
+    build.cmd ci
+    build.cmd all
+    build.cmd debug,compiler
+    build.cmd debug,ci
+    build.cmd debug,all
 
-The script `tests\RunTests.cmd` has been provided to make execution of the above suites simple.  You can kick off a full test run of any of the above suites like this:
+Default is ``ci`
 
-```
-RunTests.cmd <debug|release> fsharp [tags to run] [tags not to run]
-RunTests.cmd <debug|release> fsharpqa [tags to run] [tags not to run]
-RunTests.cmd <debug|release> compilerunit
-RunTests.cmd <debug|release> coreunit
-RunTests.cmd <debug|release> coreunitportable47
-RunTests.cmd <debug|release> coreunitportable7
-RunTests.cmd <debug|release> coreunitportable78
-RunTests.cmd <debug|release> coreunitportable259
-RunTests.cmd <debug|release> ideunit
-```
+* ``ci`` = the build and tests done by continuous integration
+* ``compiler`` = build the compiler 
+* ``compiler,smoke`` = build the compiler and run some smoke tests
+* ``debug`` = use Debug configuration instead of Release
+* ``pcls`` = build and test the Portable PCL libraries for FSharp.Core
+* ``build_only`` = build, don't test
+* ``all`` = build and test everything
+
+## Test Suites
+
+The F# tests are split as follows:
+
+* [FSharp Suite](tests\fsharp). Older suite with broad coverage of mainline compiler and runtime scenarios.
+
+* [FSharpQA Suite](tests\fsharpqa\source) - Broad and deep coverage of a variety of compiler, runtime, and syntax scenarios.
+
+* [FSharp.Core.Unittests](src\fsharp\FSharp.Core.Unittests) - Validation of the core F# types and the public surface area of `FSharp.Core.dll`.
+
+* [FSharp.Compiler.Unittests](src\fsharp\FSharp.Compiler.Unittests) - Validation of compiler internals.
+
+* [VisualFSharp.UnitTests](vsintegration\src\unittests) - Visual F# Tools IDE Unit Test Suite
+  This suite exercises a wide range of behaviors in the F# Visual Studio project system and language service.
+
+
+## More Details
+
+### FSharp Suite
+
+This is now compiled usinng [tests\fsharp\FSharp.Tests.fsproj] to a unit test DLL which acts as a driver script.
+
+This compiles and execute the `test.fsx` file using some combination of compiler or fsi flags.  
+If the compilation and execution encounter no errors, the test is considered to have passed.
+
+### FSharpQA Suite
+
+These tests require use of the `RunAll.pl` framework to execute. 
+Test area directories in this suite will contain a number of source code files and a single `env.lst` file.  The `env.lst` file defines a series of test cases, one per line.  
+Test cases will run an optional "pre command," compile some set of source files using some set of flags, optionally run the resulting binary, then optionally run a final "post command." 
+If all of these steps complete without issue, the test is considered to have passed.
+
+### FSharp.Compiler.Unittests, FSharp.Core.Unittests, VisualFSharp.Unittests
+
+These are all NUnit tests. You can execute these tests individually via the Visual Studio NUnit3 runner 
+extension or the command line via `nunit3-console.exe`.
+
+Note that for compatibility reasons, the IDE unit tests should be run in a 32-bit process, either `nunit3-console-x86.exe` or `nunit3-x86.exe`
+(todo: check if this comment still applies to NUnit3)
+
+### RunTests.cmd
+
+The script `tests\RunTests.cmd` is used to execute the suites.  It's used like this:
+
+    RunTests.cmd <debug|release> fsharp [tags to run] [tags not to run]
+    RunTests.cmd <debug|release> fsharpqa [tags to run] [tags not to run]
+    RunTests.cmd <debug|release> compilerunit
+    RunTests.cmd <debug|release> coreunit
+    RunTests.cmd <debug|release> coreunitportable47
+    RunTests.cmd <debug|release> coreunitportable7
+    RunTests.cmd <debug|release> coreunitportable78
+    RunTests.cmd <debug|release> coreunitportable259
+    RunTests.cmd <debug|release> ideunit
 
 `RunTests.cmd` sets a handful of environment variables which allow for the tests to work, then puts together and executes the appropriate command line to start the specified test suite.
 
@@ -53,10 +89,8 @@ All test execution logs and result files will be dropped into the `tests\TestRes
 
 For the FSharp and FSharpQA suites, the list of test areas and their associated "tags" is stored at
 
-```
-tests\test.lst                   // FSharp suite
-tests\fsharpqa\source\test.lst   // FSharpQA suite
-```
+    tests\test.lst                   // FSharp suite
+    tests\fsharpqa\source\test.lst   // FSharpQA suite
 
 Tags are in the left column, paths to to corresponding test folders are in the right column.  If no tags are specified to `RunTests.cmd`, all tests will be run.
 
@@ -69,63 +103,11 @@ From a Powershell environment, make sure the double quotes are passed literally,
 `RunTests.cmd` is mostly just a simple wrapper over `tests\fsharpqa\testenv\bin\RunAll.pl`, which has capabilities not discussed here. More advanced test execution scenarios can be achieved by invoking `RunAll.pl` directly.  
 Run `perl tests\fsharpqa\testenv\bin\RunAll.pl -?` to see a full list of flags and options.
 
-## More Details
-
-### FSharp Suite
-
-These tests are fairly easy to execute directly when needed, without help from `RunTests.cmd` or `RunAll.pl`. 
-
-Test area directories in this suite will have either a `Build.bat` script, a `Run.bat` script, or both. 
-
-To run the test area, you can simply call `Build.bat` (if it exists), then `Run.bat` (if it exists).  In this way it is simple to re-run a specific test area by itself. 
-
-**NOTE:** If you are re-running tests manually like this, make sure you set environment variables similarly to how `RunTests.cmd` does (e.g. set `%FSCBINPATH%` to `%root%\release\net40\bin` for a release test run), to ensure tests are running against your open-built bits, and not against another deployment of F#.
-
-`Build.bat` and `Run.bat` scripts typically invoke `tests\Config.bat` to pick up a variety of environment variables and configuration options, then invoke `tests\fsharp\single-test-build.bat` and `tests\fsharp\single-test-run.bat`.
-
-This will compile and execute the local `test.fsx` file using some combination of compiler or fsi flags.  If the compilation and execution encounter no errors, the test is considered to have passed.
-
-### FSharpQA Suite
-
-These tests require use of the `RunAll.pl` framework to execute. 
-
-Test area directories in this suite will contain a number of source code files and a single `env.lst` file.  The `env.lst` file defines a series of test cases, one per line.  
-
-Test cases will run an optional "pre command," compile some set of source files using some set of flags, optionally run the resulting binary, then optionally run a final "post command." 
-If all of these steps complete without issue, the test is considered to have passed.
-
-### FSharp.Compiler and FSharp.Core Unit Test Suites
-
-To build these unit test binaries, from the `src` directory call 
-
-- `msbuild fsharp-compiler-unittests-build.proj`
-  - Output binary is `FSharp.Compiler.Unittests.dll`
-- `msbuild fsharp-library-unittests-build.proj`
-  - Output binary is `FSharp.Core.Unittests.dll`
-
-You can execute and re-run these tests using any standard NUnit approach - via graphical `nunit.exe` or on the command line via `nunit3-console.exe`.
-
-### Visual F# Tools IDE Unit Test Suite
-
-To build the unit test binary, call 
-
-```
-msbuild fsharp-vsintegration-unittests-build.proj
-```
-
-from the `src` directory.  Tests are contained in the binary `VisualFSharp.Unittests.dll`. 
-
-The IDE unit tests rely on the "VisualFSharp.Salsa" library, which is a set of Visual Studio mocks. The code for Salsa resides at `vsintegration\src\Salsa`.
-
-Note that for compatibility reasons, the IDE unit tests should be run in a 32-bit process, either `nunit-console-x86.exe` or `nunit-x86.exe`.
-
-You can execute and re-run these tests using any standard NUnit approach - via graphical `nunit-x86.exe` or on the command line via `nunit-console-x86.exe`.
-
 
 ### Other Tips
 
 * Run as admin, or a handful of tests will fail
-* **Don't** run tests from a Visual Studio developer command prompt.  Running from a developer command prompt will put the Visual Studio F# tools on the `%PATH%`, which is not desirable when testing open F# tools.
+
 * Making the tests run faster
   * NGen-ing the F# bits (fsc, fsi, FSharp.Core, etc) will result in tests executing much faster.  Make sure you run `src\update.cmd` with the `-ngen` flag before running tests.
   * The Fsharp and FsharpQA suites will run test cases in parallel by default. You can comment out the relevant line in `RunTests.cmd` (look for `PARALLEL_ARG`) to disable this.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,13 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - BUILD_PROFILE: net40,portable7,portable47,portable78,portable259,vs
-    - BUILD_PROFILE: cambridge_suite,smoke_only
-    - BUILD_PROFILE: qa_suite,smoke_only
+    - BUILD_PROFILE: ci_part1
+    - BUILD_PROFILE: ci_part2
+    - BUILD_PROFILE: ci_part3
 
 init: 
 build_script: 
-  - cmd: appveyor-build.cmd %BUILD_PROFILE%
+  - cmd: build.cmd %BUILD_PROFILE%
 
 # scripts that run after cloning repository
 install:

--- a/build.cmd
+++ b/build.cmd
@@ -13,25 +13,25 @@ echo Build and run a subset of test suites
 echo.
 echo Usage:
 echo.
-echo appveyor-build.cmd ^<all^|net40^|portable47^|portable7^|portable78^|portable259^|vs^|cambridge_suite^|qa_suite^|smoke^|smoke_only^|build_only^>
+echo appveyor-build.cmd ^<all^|compiler^|pcls^|vs^|ci^|ci_part1^|ci_part2^|ci_part3^|build^|debug^>
 echo.
-echo No arguments default to 'smoke' ( build all profiles, run all unit tests, cambridge Smoke, fsharpqa Smoke)
+echo No arguments default to 'ci' ( build all profiles, run all unit tests, cambridge Smoke, fsharpqa Smoke)
 echo.
 echo To specify multiple values, separate strings by comma
 echo.
-echo The example below run portable47, vs and qa:
+echo The example below run pcls, vs and qa:
 echo.
-echo appveyor-build.cmd portable47,vs,qa_suite
+echo appveyor-build.cmd pcls,vs,debug
 exit /b 1
 
 :ARGUMENTS_OK
 
-set DO_NET40=0
-set DO_PORTABLE47=0
-set DO_PORTABLE7=0
-set DO_PORTABLE78=0
-set DO_PORTABLE259=0
-set DO_VS=0
+set BUILD_NET40=1
+set BUILD_PORTABLE47=0
+set BUILD_PORTABLE7=0
+set BUILD_PORTABLE78=0
+set BUILD_PORTABLE259=0
+set BUILD_VS=0
 set TEST_NET40=0
 set TEST_PORTABLE47=0
 set TEST_PORTABLE7=0
@@ -42,6 +42,8 @@ set TEST_CAMBRIDGE_SUITE=0
 set CONF_CAMBRIDGE_SUITE=
 set TEST_QA_SUITE=0
 set CONF_QA_SUITE=
+set BUILD_CONFIG=Release
+set BUILD_CONFIG_LOWER=release
 
 setlocal enableDelayedExpansion
 set /a counter=0
@@ -56,63 +58,42 @@ echo.
 goto :MAIN
 
 :SET_CONFIG
-set BUILD_PROFILE=%~1
+set ARG=%~1
 
-if "%BUILD_PROFILE%" == "1" if "%2" == "" (
-    set BUILD_PROFILE=smoke
+if "%ARG%" == "1" if "%2" == "" (
+    set ARG=ci
 )
 
-if "%2" == "" if not "%BUILD_PROFILE%" == "smoke" goto :EOF
+if "%2" == "" if not "%ARG%" == "ci" goto :EOF
 
-echo Parse argument %BUILD_PROFILE%
+echo Parse argument %ARG%
 
-if /i '%BUILD_PROFILE%' == 'net40' (
-    set DO_NET40=1
+if /i '%ARG%' == 'compiler' (
     set TEST_NET40=1
 )
 
-if /i '%BUILD_PROFILE%' == 'portable47' (
-    set DO_PORTABLE47=1
+if /i '%ARG%' == 'pcls' (
+    set BUILD_PORTABLE47=1
     set TEST_PORTABLE47=1
-)
-
-if /i '%BUILD_PROFILE%' == 'portable7' (
-    set DO_PORTABLE7=1
+    set BUILD_PORTABLE7=1
     set TEST_PORTABLE7=1
-)
-
-if /i '%BUILD_PROFILE%' == 'portable78' (
-    set DO_PORTABLE78=1
+    set BUILD_PORTABLE78=1
     set TEST_PORTABLE78=1
-)
-
-if /i '%BUILD_PROFILE%' == 'portable259' (
-    set DO_PORTABLE259=1
+    set BUILD_PORTABLE259=1
     set TEST_PORTABLE259=1
 )
 
-if /i '%BUILD_PROFILE%' == 'vs' (
-    set DO_VS=1
+if /i '%ARG%' == 'vs' (
+    set BUILD_VS=1
     set TEST_VS=1
 )
 
-if /i '%BUILD_PROFILE%' == 'cambridge_suite' (
-    set DO_NET40=1
-    set TEST_CAMBRIDGE_SUITE=1
-)
-
-if /i '%BUILD_PROFILE%' == 'qa_suite' (
-    set DO_NET40=1
-    set TEST_QA_SUITE=1
-)
-
-if /i '%BUILD_PROFILE%' == 'all' (
-    set DO_NET40=1
-    set DO_PORTABLE47=1
-    set DO_PORTABLE7=1
-    set DO_PORTABLE78=1
-    set DO_PORTABLE259=1
-    set DO_VS=1
+if /i '%ARG%' == 'all' (
+    set BUILD_PORTABLE47=1
+    set BUILD_PORTABLE7=1
+    set BUILD_PORTABLE78=1
+    set BUILD_PORTABLE259=1
+    set BUILD_VS=1
     set TEST_NET40=1
     set TEST_PORTABLE47=1
     set TEST_PORTABLE7=1
@@ -123,13 +104,13 @@ if /i '%BUILD_PROFILE%' == 'all' (
     set TEST_QA_SUITE=1
 )
 
-if /i '%BUILD_PROFILE%' == 'smoke' (
-    set DO_NET40=1
-    set DO_PORTABLE47=1
-    set DO_PORTABLE7=1
-    set DO_PORTABLE78=1
-    set DO_PORTABLE259=1
-    set DO_VS=1
+REM Same as 'all' but smoke testing only
+if /i '%ARG%' == 'ci' (
+    set BUILD_PORTABLE47=1
+    set BUILD_PORTABLE7=1
+    set BUILD_PORTABLE78=1
+    set BUILD_PORTABLE259=1
+    set BUILD_VS=1
     set TEST_NET40=1
     set TEST_PORTABLE47=1
     set TEST_PORTABLE7=1
@@ -142,12 +123,46 @@ if /i '%BUILD_PROFILE%' == 'smoke' (
     set CONF_QA_SUITE=Smoke
 )
 
-if /i '%BUILD_PROFILE%' == 'smoke_only' (
+REM These divide 'ci' into three chunks which can be done in parallel
+
+if /i '%ARG%' == 'ci_part1' (
+    set BUILD_PORTABLE47=1
+    set BUILD_PORTABLE7=1
+    set BUILD_PORTABLE78=1
+    set BUILD_PORTABLE259=1
+    set BUILD_VS=1
+    set TEST_NET40=1
+    set TEST_PORTABLE47=1
+    set TEST_PORTABLE7=1
+    set TEST_PORTABLE78=1
+    set TEST_PORTABLE259=1
+    set TEST_VS=1
+)
+
+if /i '%ARG%' == 'ci_part2' (
+    set TEST_CAMBRIDGE_SUITE=1
     set CONF_CAMBRIDGE_SUITE=Smoke
+)
+
+
+if /i '%ARG%' == 'ci_part3' (
+    set TEST_QA_SUITE=1
     set CONF_QA_SUITE=Smoke
 )
 
-if /i '%BUILD_PROFILE%' == 'build_only' (
+if /i '%ARG%' == 'smoke' (
+    set TEST_CAMBRIDGE_SUITE=1
+    set CONF_CAMBRIDGE_SUITE=Smoke
+    set TEST_QA_SUITE=1
+    set CONF_QA_SUITE=Smoke
+)
+
+if /i '%ARG%' == 'debug' (
+    set BUILD_CONFIG=Debug
+    set BUILD_CONFIG_LOWER=debug
+)
+
+if /i '%ARG%' == 'build' (
     set TEST_NET40=0
     set TEST_PORTABLE47=0
     set TEST_PORTABLE7=0
@@ -162,16 +177,16 @@ goto :EOF
 
 :MAIN
 
-REM after this point, BUILD_PROFILE variable should not be used, use only DO_* or TEST_*
+REM after this point, ARG variable should not be used, use only BUILD_* or TEST_*
 
 echo Build/Tests configuration:
 echo.
-echo DO_NET40=%DO_NET40%
-echo DO_PORTABLE47=%DO_PORTABLE47%
-echo DO_PORTABLE7=%DO_PORTABLE7%
-echo DO_PORTABLE78=%DO_PORTABLE78%
-echo DO_PORTABLE259=%DO_PORTABLE259%
-echo DO_VS=%DO_VS%
+echo BUILD_NET40=%BUILD_NET40%
+echo BUILD_PORTABLE47=%BUILD_PORTABLE47%
+echo BUILD_PORTABLE7=%BUILD_PORTABLE7%
+echo BUILD_PORTABLE78=%BUILD_PORTABLE78%
+echo BUILD_PORTABLE259=%BUILD_PORTABLE259%
+echo BUILD_VS=%BUILD_VS%
 echo.
 echo TEST_NET40=%TEST_NET40%
 echo TEST_PORTABLE47=%TEST_PORTABLE47%
@@ -183,6 +198,8 @@ echo TEST_CAMBRIDGE_SUITE=%TEST_CAMBRIDGE_SUITE%
 echo CONF_CAMBRIDGE_SUITE=%CONF_CAMBRIDGE_SUITE%
 echo TEST_QA_SUITE=%TEST_QA_SUITE%
 echo CONF_QA_SUITE=%CONF_QA_SUITE%
+echo BUILD_CONFIG=%BUILD_CONFIG%
+echo BUILD_CONFIG_LOWER=%BUILD_CONFIG_LOWER%
 echo.
 
 @echo on
@@ -218,6 +235,8 @@ if defined APPVEYOR (
 set _ngenexe="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ngen.exe"
 if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
 
+%_ngenexe% install .\.nuget\NuGet.exe 
+
 .\.nuget\NuGet.exe restore packages.config -PackagesDirectory packages -ConfigFile .nuget\nuget.config
 @if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
 
@@ -228,123 +247,127 @@ if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
 %_ngenexe% install Proto\net40\bin\fsc-proto.exe
 @if ERRORLEVEL 1 echo Error: NGen of proto failed  && goto :failure
 
-%_msbuildexe% src/fsharp-library-build.proj /p:Configuration=Release
+%_msbuildexe% src/fsharp-library-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library build failed && goto :failure
 
-%_msbuildexe% src/fsharp-compiler-build.proj /p:Configuration=Release
+%_msbuildexe% src/fsharp-compiler-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: compiler build failed && goto :failure
 
-if '%DO_PORTABLE47%' == '1' (
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
+if '%BUILD_PORTABLE47%' == '1' (
+%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library portable47 build failed && goto :failure
 )
 
-if '%DO_PORTABLE7%' == '1' (
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
+if '%BUILD_PORTABLE7%' == '1' (
+%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library portable7 build failed && goto :failure
 )
 
-if '%DO_PORTABLE78%' == '1' (
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
+if '%BUILD_PORTABLE78%' == '1' (
+%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library portable78 build failed && goto :failure
 )
 
-if '%DO_PORTABLE259%' == '' (
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
+if '%BUILD_PORTABLE259%' == '' (
+%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library portable259 build failed && goto :failure
 )
 
 if '%TEST_NET40%' == '1' (
-%_msbuildexe% src/fsharp-compiler-unittests-build.proj /p:Configuration=Release
+%_msbuildexe% src/fsharp-compiler-unittests-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: compiler unittests build failed && goto :failure
 
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:Configuration=Release
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed && goto :failure
 )
 
 if '%TEST_PORTABLE47%' == '1' (
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=Release
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable47 && goto :failure
 )
 
 if '%TEST_PORTABLE7%' == '1' (
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=Release
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable7 && goto :failure
 )
 
 if '%TEST_PORTABLE78%' == '1' (
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable78 && goto :failure
 )
 
 if '%TEST_PORTABLE259%' == '1' (
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
+%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable259 && goto :failure
 )
 
-if '%DO_VS%' == '1' (
-%_msbuildexe% VisualFSharp.sln /p:Configuration=Release
+if '%BUILD_VS%' == '1' (
+%_msbuildexe% VisualFSharp.sln /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: VS integration build failed && goto :failure
 )
 
 if '%TEST_VS%' == '1' (
-%_msbuildexe% vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=Release
+%_msbuildexe% vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: VS integration unit tests build failed && goto :failure
 )
 
 @echo on
-call src\update.cmd release -ngen
+call src\update.cmd %BUILD_CONFIG_LOWER% -ngen
+
+REM Remove lingering copies of the OSS FSharp.Core from the GAC
+gacutil /u "FSharp.Core, Version=4.4.1.9055, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+
 REM This clobbers the installed F# SDK on the machine
-REM call vsintegration\update-vsintegration.cmd release
+REM call vsintegration\update-vsintegration.cmd %BUILD_CONFIG_LOWER%
 pushd tests
 
 @echo on
-call BuildTestTools.cmd release 
-@if ERRORLEVEL 1 echo Error: 'BuildTestTools.cmd release' failed && goto :failure
+call BuildTestTools.cmd %BUILD_CONFIG_LOWER% 
+@if ERRORLEVEL 1 echo Error: 'BuildTestTools.cmd %BUILD_CONFIG_LOWER%' failed && goto :failure
 
 @echo on
 if '%TEST_CAMBRIDGE_SUITE%' == '1' (
 set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=true
 
-%_msbuildexe% fsharp\fsharp.tests.fsproj /p:Configuration=Release
+%_msbuildexe% fsharp\fsharp.tests.fsproj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: fsharp cambridge tests for nunit failed && goto :failure
 
-call RunTests.cmd release fsharp %CONF_CAMBRIDGE_SUITE%
-@if ERRORLEVEL 1 type testresults\fsharp_failures.log && echo Error: 'RunTests.cmd release fsharp %CONF_CAMBRIDGE_SUITE%' failed && goto :failure
+call RunTests.cmd %BUILD_CONFIG_LOWER% fsharp %CONF_CAMBRIDGE_SUITE%
+@if ERRORLEVEL 1 type testresults\fsharp_failures.log && echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% fsharp %CONF_CAMBRIDGE_SUITE%' failed && goto :failure
 set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=
 )
 
 if '%TEST_QA_SUITE%' == '1' (
-call RunTests.cmd release fsharpqa %CONF_QA_SUITE%
-@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd release fsharpqa %CONF_QA_SUITE%' failed && goto :failure
+call RunTests.cmd %BUILD_CONFIG_LOWER% fsharpqa %CONF_QA_SUITE%
+@if ERRORLEVEL 1 type testresults\fsharpqa_failures.log && echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% fsharpqa %CONF_QA_SUITE%' failed && goto :failure
 )
 
 if '%TEST_NET40%' == '1' (
-call RunTests.cmd release compilerunit
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release compilerunit' failed && goto :failure
+call RunTests.cmd %BUILD_CONFIG_LOWER% compilerunit
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% compilerunit' failed && goto :failure
 
-call RunTests.cmd release coreunit
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunit' failed && goto :failure
+call RunTests.cmd %BUILD_CONFIG_LOWER% coreunit
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% coreunit' failed && goto :failure
 )
 
 if '%TEST_PORTABLE47%' == '1' (
-call RunTests.cmd release coreunitportable47
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunitportable47' failed && goto :failure
+call RunTests.cmd %BUILD_CONFIG_LOWER% coreunitportable47
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% coreunitportable47' failed && goto :failure
 )
 
 if '%TEST_PORTABLE7%' == '1' (
-call RunTests.cmd release coreunitportable7
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunitportable7' failed && goto :failure
+call RunTests.cmd %BUILD_CONFIG_LOWER% coreunitportable7
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% coreunitportable7' failed && goto :failure
 )
 
 if '%TEST_PORTABLE78%' == '1' (
-call RunTests.cmd release coreunitportable78
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunitportable78' failed && goto :failure
+call RunTests.cmd %BUILD_CONFIG_LOWER% coreunitportable78
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% coreunitportable78' failed && goto :failure
 )
 
 if '%TEST_PORTABLE259%' == '1' (
-call RunTests.cmd release coreunitportable259
-@if ERRORLEVEL 1 echo Error: 'RunTests.cmd release coreunitportable259' failed && goto :failure
+call RunTests.cmd %BUILD_CONFIG_LOWER% coreunitportable259
+@if ERRORLEVEL 1 echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% coreunitportable259' failed && goto :failure
 )
 
 rem tests for TEST_VS are not executed


### PR DESCRIPTION

In the process of tracking down test failures and looking at our CI coverage, I've gone over the DEVGUIDE.md and TESTGUIDE.md to make it easier to get going with dev, test and build of Visual F#

I renamed ``appveyor-build.cmd`` to ``build.cmd`` and simplified the set of arguments it takes:
Here are some other quick-fire invocations:

    build.cmd         -- build and run everything

    build.cmd release         -- build release (the default)
    build.cmd debug           -- build debug instead of release

    build.cmd compiler        -- build/tests only the compiler (not the Visual F# IDE Tools)
    build.cmd vs              -- build/tests the Visual F# IDE Tools
    build.cmd pcls            -- build/tests the PCL FSharp.Core libraries

    build.cmd build           -- build, do not test
    build.cmd smoke           -- build, run smoke tests
    build.cmd ci              -- build, run the same tests as CI 
    build.cmd all             -- build, run all tests

As before combinations are also allowed:

    build.cmd debug,compiler,smoke   -- build the debug compiler and run smoke tests


