### PR TITLE
Use one build in the appveyor matrix (to improve CI test time)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,7 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - BUILD_PROFILE: ci_part1
-    - BUILD_PROFILE: ci_part2
-    - BUILD_PROFILE: ci_part3
+    - BUILD_PROFILE: ci
 
 init: 
 build_script: 


### PR DESCRIPTION
This changes appveyor to use just one variation in the build matrix, which should save 20min off overall build time (since appveyor is using one serialized build queue)

