### PR TITLE
multiproc build.cmd and fix VisualFSharp.Unittests.dll.config

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -198,7 +198,7 @@ if defined APPVEYOR (
 	set _msbuildexe=%_msbuildexe% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
     )
 )
-
+set msbuildflags=/maxcpucount
 set _ngenexe="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ngen.exe"
 if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
 
@@ -209,67 +209,67 @@ if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
 
 :: Build Proto
 if NOT EXIST Proto\net40\bin\fsc-proto.exe (
-%_msbuildexe% src\fsharp-proto-build.proj
+%_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj 
 @if ERRORLEVEL 1 echo Error: compiler proto build failed && goto :failure
 )
 if '%BUILD_PROTO%' == '1' (
-%_msbuildexe% src\fsharp-proto-build.proj
+%_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj
 @if ERRORLEVEL 1 echo Error: compiler proto build failed && goto :failure
 )
 
 %_ngenexe% install Proto\net40\bin\fsc-proto.exe
 @if ERRORLEVEL 1 echo Error: NGen of proto failed  && goto :failure
 
-%_msbuildexe% src/fsharp-library-build.proj /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library build failed && goto :failure
 
-%_msbuildexe% src/fsharp-compiler-build.proj /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-compiler-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: compiler build failed && goto :failure
 
 if '%BUILD_FSHARP_DATA_TYPEPROVIDERS%' == '1' (
-%_msbuildexe% src/fsharp-typeproviders-build.proj /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-typeproviders-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: type provider build failed && goto :failure
 )
 
 if '%BUILD_PORTABLE%' == '1' (
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library portable47 build failed && goto :failure
 
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library portable7 build failed && goto :failure
 
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library portable78 build failed && goto :failure
 
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library portable259 build failed && goto :failure
 )
 
 if '%TEST_COMPILERUNIT%' == '1' (
-%_msbuildexe% src/fsharp-compiler-unittests-build.proj /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-compiler-unittests-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: compiler unittests build failed && goto :failure
 )
 if '%TEST_COREUNIT%' == '1' (
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-unittests-build.proj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed && goto :failure
 )
 
 if '%TEST_PORTABLE_COREUNIT%' == '1' (
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable47 && goto :failure
 
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable7 && goto :failure
 
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable78 && goto :failure
 
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: library unittests build failed portable259 && goto :failure
 )
 
 if '%BUILD_VS%' == '1' (
-%_msbuildexe% VisualFSharp.sln /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% VisualFSharp.sln /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: VS integration build failed && goto :failure
 )
 
@@ -291,7 +291,7 @@ call BuildTestTools.cmd %BUILD_CONFIG_LOWERCASE%
 if '%TEST_FSHARP_SUITE%' == '1' (
 set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=true
 
-%_msbuildexe% fsharp\fsharp.tests.fsproj /p:Configuration=%BUILD_CONFIG%
+%_msbuildexe% %msbuildflags% fsharp\fsharp.tests.fsproj /p:Configuration=%BUILD_CONFIG%
 @if ERRORLEVEL 1 echo Error: fsharp cambridge tests for nunit failed && goto :failure
 
 call RunTests.cmd %BUILD_CONFIG_LOWERCASECASE% fsharp %TEST_TAGS% 

--- a/vsintegration/src/unittests/VisualFSharp.Unittests.fsproj
+++ b/vsintegration/src/unittests/VisualFSharp.Unittests.fsproj
@@ -80,7 +80,10 @@
     <Compile Include="..\..\..\tests\service\MultiProjectAnalysisTests.fs">
       <Link>MultiProjectAnalysisTests.fs</Link>
     </Compile>
-	<None Include="app.config" />
+    <CustomCopyLocal Include="app.config">
+      <TargetFilename>VisualFSharp.Unittests.dll.config</TargetFilename>
+    </CustomCopyLocal>
+    <None Include="app.runsettings" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/FSHarp.VS.FSI.fsproj
+++ b/vsintegration/src/vs/FsPkgs/FSharp.VS.FSI/FSHarp.VS.FSI.fsproj
@@ -41,6 +41,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\src\fsharp\FSharp.Compiler\FSharp.Compiler.fsproj">
+      <Name>FSharp.Compiler</Name>
+      <Project>{2e4d67b4-522d-4cf7-97e4-ba940f0b18f3}</Project>
+      <Private>True</Private>
+    </ProjectReference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop.dll" />
     <Reference Include="Microsoft.VisualStudio.Package.LanguageService.$(VisualStudioVersion)" />
     <Reference Include="EnvDTE.dll" />
@@ -89,10 +94,6 @@
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Server.Shared\FSharp.Compiler.Server.Shared.fsproj">
       <Name>FSharp.Compiler.Server.Shared</Name>
       <Project>{d5870cf0-ed51-4cbc-b3d7-6f56da84ac06}</Project>
-    </ProjectReference>
-    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler\FSharp.Compiler.fsproj">
-      <Name>FSharp.Compiler</Name>
-      <Project>{62499922-7085-43bd-b9f2-bb352bfbc408}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />


### PR DESCRIPTION
Minor things

- enable multiproc build for MSBUILD calls in build.cmd
- fix a mistake I made in the copy of VisualFSharp.Unittests.dll.config
- fix a problem with the FSharp.VS.FSI.fsproj project reference