### PR TITLE
Cleanup of cross-version tests

### DIFF
--- a/tests/fsharpqa/Source/MultiTargeting/env.lst
+++ b/tests/fsharpqa/Source/MultiTargeting/env.lst
@@ -5,6 +5,6 @@ NOMONO	SOURCE=E_BadPathToFSharpCore.fsx             SCFLAGS="--noframework -r %W
 # FSharp.Core is checked in for this test to verify a particular error message related to it. It shouldn't be accidentally picked up by other tests since it isn't in the working directory for them
 NOMONO	SOURCE=E_UseBinaryIncompatibleLibrary.fs     SCFLAGS="--noframework -r ..\\Common\\FSharp.Core.dll"	# E_UseBinaryIncompatibleLibrary.fs
 
-ReqOpen	SOURCE=dummy.fs  POSTCMD="\$FSI_PIPE --nologo --quiet --exec .\\MultiTargetMatrix.fsx   QuotedCommaTypeName_author.fs QuotedCommaTypeName_consumer.fsx 0,8"		#  QuotedCommaTypeName
+ReqOpen	SOURCE=dummy.fs  POSTCMD="\$FSI_PIPE --nologo --quiet --exec .\\MultiTargetMatrix.fsx   QuotedCommaTypeName_author.fs QuotedCommaTypeName_consumer.fsx"		#  QuotedCommaTypeName
 ReqOpen	SOURCE=dummy.fs  POSTCMD="\$FSI_PIPE --nologo --quiet --exec .\\MultiTargetMatrix.fsx   InlineCoreResource_author.fs InlineCoreResource_consumer.fsx"		#  InlineCoreResource
 ReqOpen	SOURCE=dummy.fs  POSTCMD="\$FSI_PIPE --nologo --quiet --exec .\\MultiTargetMatrix.fsx   OptimizedForLoops_author.fs OptimizedForLoops_consumer.fsx"		#  OptimizedForLoops


### PR DESCRIPTION
Now that the compiler copies FSharp.Core.dll locally by default, the cross-version tests are passing somewhat by accident.  They will fail if you run them outside of the Perl test runner - they only pass because the `dummy.fs` compile caused an initial copy-local that happens to make things work.

This is a small change that makes things more robust/explicit/intentional.

  - Explicitly copy the desired FSharp.Core version locally before invoking the test exe
    - Ensures resolution is fully controlled for both new and old compiler versions
  - Delete any local FSharp.Core copies before invoking FSI
    - Old FSI crashes on startup if FSharp.Core 4.4.0.0 is in the local directory due to "can't find sigdata/optdata" error

Also went ahead and removed 2 excluded test scenarios which now work post- F# 4.0