### PR TITLE
Fix Out/Error streams chunking in Fsi tool window

### DIFF
--- a/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -59,7 +59,7 @@ module internal Locals =
     /// Given a list of (key,value)
     /// Chunk into (key,values) where the values are keys of (key,value) with the same key.    
     /// Complexity: this code is linear in (length kxs).
-    let rec chunkKeyValues allEntries =
+    let chunkKeyValues allEntries =
         allEntries
         |> List.groupBy(fun (responseType, line) -> responseType)
         |> List.map(fun (responseType, entries) -> (responseType, entries |> List.map(fun (_, line) -> line)))

--- a/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -59,16 +59,10 @@ module internal Locals =
     /// Given a list of (key,value)
     /// Chunk into (key,values) where the values are keys of (key,value) with the same key.    
     /// Complexity: this code is linear in (length kxs).
-    let rec chunkKeyValues kxs = 
-        let rec loop kxs acc = 
-            match kxs with
-            | [] -> List.rev acc
-            | (key, v)::rest -> accumulate key [v] rest acc
-        and accumulate k chunk rest acc =
-            match rest with
-            | (key, v)::rest when equal key k -> accumulate k (v::chunk) rest acc
-            | rest -> loop rest ((k, (List.rev chunk))::acc)
-        loop kxs []
+    let rec chunkKeyValues allEntries =
+        allEntries
+        |> List.groupBy(fun (responseType, line) -> responseType)
+        |> List.map(fun (responseType, entries) -> (responseType, entries |> List.map(fun (_, line) -> line)))
 
     
 open Util


### PR DESCRIPTION
Fixes #864
The issue is that chunking the output streams (standard output and error) was done in order:

|Index|Type|Line|
|-----|----|----|
|1|error|System.DivideByZeroException: Attempted to divide by zero.|
|2|out|>|
|3|error|at <StartupCode$FSI_0077>.$FSI_0077.main@()|
|4|error|Stopped due to error|

Per the previous chunking function, this produced chunks of [(1), (2), (3,4)], and the following output (notice that the prompt is after the first line):

```
System.DivideByZeroException: Attempted to divide by zero.
>   at <StartupCode$FSI_0077>.$FSI_0077.main@()
Stopped due to error
```

The new chunking function groups across lines, producing chunks of [(1,3,4), (2)], and the following output (the prompt is now separate from error lines):

```
System.DivideByZeroException: Attempted to divide by zero.
    at <StartupCode$FSI_0077>.$FSI_0077.main@()
Stopped due to error
>
```

@dsyme @abelbraaksma @Microsoft/fsharp-compiler 