### PR TITLE
Fix missing sigdata optdata in package

### DIFF
--- a/src/fsharp/fsharp.core.netcore.nuget/Microsoft.FSharp.Core.netcore.nuspec
+++ b/src/fsharp/fsharp.core.netcore.nuget/Microsoft.FSharp.Core.netcore.nuspec
@@ -31,6 +31,8 @@
     </metadata>
     <files>
         <file src="fsharp.core.dll"     target="lib/DNXCore50" />
+        <file src="fsharp.core.sigdata" target="lib/DNXCore50" />
+        <file src="fsharp.core.optdata" target="lib/DNXCore50" />
         <file src="fsharp.core.sigdata" target="runtimes/any/native/" />
         <file src="fsharp.core.optdata" target="runtimes/any/native/" />
     </files>


### PR DESCRIPTION
fix #1015

the sigdata/optdata in the lib folder are required because the compiler search the same directory of the referenced `FSharp.Core.dll`
