### PR TITLE
List sum, sumBy perf

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -712,34 +712,6 @@ type ListModule02() =
        
         ()
 
-
-    [<Test>]
-    member this.ListSumPerfVsSeqSumPerf() =
-        let stopWatch = new System.Diagnostics.Stopwatch()
-        let ResetStopWatch() = stopWatch.Reset(); stopWatch.Start()
-        let time1 op a message = 
-            ResetStopWatch()
-            let result = op a
-            printf "%s %d ms\n" message stopWatch.ElapsedMilliseconds
-            result
-        
-        let list = [1..1000000] |> List.map (fun i -> 1)
-
-        let seqSum() =
-            for i in [0..100] do
-                let sum = Seq.sum list
-                ()
-
-        let listSum() =
-            for i in [0..100] do
-                let sum = List.sum list
-                ()
-
-        time1 seqSum () "Time take for Seq.Sum"
-
-        time1 listSum () "Time take for List.Sum"
-
-
     [<Test>]
     member this.SumBy() =
         // empty integer List 

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -712,6 +712,34 @@ type ListModule02() =
        
         ()
 
+
+    [<Test>]
+    member this.ListSumPerfVsSeqSumPerf() =
+        let stopWatch = new System.Diagnostics.Stopwatch()
+        let ResetStopWatch() = stopWatch.Reset(); stopWatch.Start()
+        let time1 op a message = 
+            ResetStopWatch()
+            let result = op a
+            printf "%s %d ms\n" message stopWatch.ElapsedMilliseconds
+            result
+        
+        let list = [1..1000000] |> List.map (fun i -> 1)
+
+        let seqSum() =
+            for i in [0..100] do
+                let sum = Seq.sum list
+                ()
+
+        let listSum() =
+            for i in [0..100] do
+                let sum = List.sum list
+                ()
+
+        time1 seqSum () "Time take for Seq.Sum"
+
+        time1 listSum () "Time take for List.Sum"
+
+
     [<Test>]
     member this.SumBy() =
         // empty integer List 

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -590,7 +590,15 @@ namespace Microsoft.FSharp.Collections
         let tryFindIndexBack f list = list |> toArray |> Array.tryFindIndexBack f
 
         [<CompiledName("Sum")>]
-        let inline sum          (list:list<'T>) = fold Checked.(+) LanguagePrimitives.GenericZero< 'T > list
+        let inline sum          (list:list<'T>) =
+            match list with 
+            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | _ ->
+                let rec loop xs sum = 
+                    match xs with 
+                    | [] -> sum
+                    | h::t -> loop t (Checked.(+) sum h)
+                loop list LanguagePrimitives.GenericZero< 'T >
 
         [<CompiledName("SumBy")>]
         let inline sumBy f     (list:list<_>) = Seq.sumBy f list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -590,7 +590,7 @@ namespace Microsoft.FSharp.Collections
         let tryFindIndexBack f list = list |> toArray |> Array.tryFindIndexBack f
 
         [<CompiledName("Sum")>]
-        let inline sum          (list:list<_>) = Seq.sum list
+        let inline sum          (list:list<'T>) = fold Checked.(+) LanguagePrimitives.GenericZero< 'T > list
 
         [<CompiledName("SumBy")>]
         let inline sumBy f     (list:list<_>) = Seq.sumBy f list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -592,24 +592,22 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Sum")>]
         let inline sum          (list:list<'T>) =
             match list with 
-            | [] -> LanguagePrimitives.GenericZero< 'T >
-            | _ ->
-                let rec loop xs sum = 
-                    match xs with 
-                    | [] -> sum
-                    | h::t -> loop t (Checked.(+) sum h)
-                loop list LanguagePrimitives.GenericZero< 'T >
+            | [] ->  LanguagePrimitives.GenericZero< 'T >
+            | t ->
+                let mutable acc = LanguagePrimitives.GenericZero< 'T >
+                for x in t do
+                    acc <- Checked.(+) acc x
+                acc
 
         [<CompiledName("SumBy")>]
         let inline sumBy (f: 'T -> 'U)     (list:list<'T>) =
             match list with 
-            | [] -> LanguagePrimitives.GenericZero< 'U >
-            | _ ->
-                let rec loop xs sum = 
-                    match xs with 
-                    | [] -> sum
-                    | h::t -> loop t (Checked.(+) sum (f h))
-                loop list LanguagePrimitives.GenericZero< 'U >
+            | [] ->  LanguagePrimitives.GenericZero< 'U >
+            | t ->
+                let mutable acc = LanguagePrimitives.GenericZero< 'U >
+                for x in t do
+                    acc <- Checked.(+) acc (f x)
+                acc
 
         [<CompiledName("Max")>]
         let inline max          (list:list<_>) = Seq.max list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -592,7 +592,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Sum")>]
         let inline sum          (list:list<'T>) =
             match list with 
-            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | [] -> LanguagePrimitives.GenericZero< 'T >
             | _ ->
                 let rec loop xs sum = 
                     match xs with 
@@ -603,7 +603,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("SumBy")>]
         let inline sumBy (f: 'T -> 'U)     (list:list<'T>) =
             match list with 
-            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | [] -> LanguagePrimitives.GenericZero< 'U >
             | _ ->
                 let rec loop xs sum = 
                     match xs with 

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -601,7 +601,15 @@ namespace Microsoft.FSharp.Collections
                 loop list LanguagePrimitives.GenericZero< 'T >
 
         [<CompiledName("SumBy")>]
-        let inline sumBy f     (list:list<_>) = Seq.sumBy f list
+        let inline sumBy (f: 'T -> 'U)     (list:list<'T>) =
+            match list with 
+            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | _ ->
+                let rec loop xs sum = 
+                    match xs with 
+                    | [] -> sum
+                    | h::t -> loop t (Checked.(+) sum (f h))
+                loop list LanguagePrimitives.GenericZero< 'U >
 
         [<CompiledName("Max")>]
         let inline max          (list:list<_>) = Seq.max list


### PR DESCRIPTION
Changing the implementation of List.sum/sumBy from Seq.sum/sumBy that use IEnumerable
to implementation like List.fold which is more native way to traverse the list implemented by recursion
that compiles to while loop
benchmarks: https://gist.github.com/AviAvni/0a3576a619ff9bf4acf1958b8ca1c63b