### PR TITLE
List sum by perf

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -756,32 +756,6 @@ type ListModule02() =
         ()
     
     [<Test>]
-    member this.ListSumByPerfVsSeqSumByPerf() =
-        let stopWatch = new System.Diagnostics.Stopwatch()
-        let ResetStopWatch() = stopWatch.Reset(); stopWatch.Start()
-        let time1 op a message = 
-            ResetStopWatch()
-            let result = op a
-            printf "%s %d ms\n" message stopWatch.ElapsedMilliseconds
-            result
-        
-        let list = [1..1000000] |> List.map (fun i -> (1, 0))
-  
-        let seqSum() =
-            for i in [0..100] do
-                let sum = Seq.sumBy fst list
-                ()
-  
-        let listSum() =
-            for i in [0..100] do
-                let sum = List.sumBy fst list
-                ()
-  
-        time1 seqSum () "Time take for Seq.SumBy"
-  
-        time1 listSum () "Time take for List.SumBy"
-
-    [<Test>]
     member this.Tl() =
         // integer List  
         let resultInt = List.tail [1..10]        

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -754,6 +754,32 @@ type ListModule02() =
         Assert.AreEqual(38.03M, resultDecimal)
         
         ()
+    
+    [<Test>]
+    member this.ListSumByPerfVsSeqSumByPerf() =
+        let stopWatch = new System.Diagnostics.Stopwatch()
+        let ResetStopWatch() = stopWatch.Reset(); stopWatch.Start()
+        let time1 op a message = 
+            ResetStopWatch()
+            let result = op a
+            printf "%s %d ms\n" message stopWatch.ElapsedMilliseconds
+            result
+        
+        let list = [1..1000000] |> List.map (fun i -> (1, 0))
+  
+        let seqSum() =
+            for i in [0..100] do
+                let sum = Seq.sumBy fst list
+                ()
+  
+        let listSum() =
+            for i in [0..100] do
+                let sum = List.sumBy fst list
+                ()
+  
+        time1 seqSum () "Time take for Seq.SumBy"
+  
+        time1 listSum () "Time take for List.SumBy"
 
     [<Test>]
     member this.Tl() =

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -593,7 +593,7 @@ namespace Microsoft.FSharp.Collections
         let inline sum          (list:list<_>) = Seq.sum list
 
         [<CompiledName("SumBy")>]
-        let inline sumBy f     (list:list<_>) = Seq.sumBy f list
+        let inline sumBy (f:'T -> 'U)     (list:list<'T>) = fold (fun s i -> Checked.(+) s (f i)) LanguagePrimitives.GenericZero< 'U > list
 
         [<CompiledName("Max")>]
         let inline max          (list:list<_>) = Seq.max list


### PR DESCRIPTION
Changing the implementation of List.sumBy from Seq.sumBy that use IEnumerable
to List.fold which is more native way to traverse the list implemented by recursion
that compiles to while loop
benchmarks: https://gist.github.com/AviAvni/0a3576a619ff9bf4acf1958b8ca1c63b