### PR TITLE
change implementation of List.Min from Seq.Min to List.reduce

### DIFF
--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -602,7 +602,7 @@ namespace Microsoft.FSharp.Collections
         let inline maxBy f (list:list<_>) = Seq.maxBy f list
 
         [<CompiledName("Min")>]
-        let inline min          (list:list<_>) = Seq.min list
+        let inline min          (list:list<_>) = reduce min list
 
         [<CompiledName("MinBy")>]
         let inline minBy f (list:list<_>) = Seq.minBy f list


### PR DESCRIPTION
Changing the implementation of List.min from Seq.min that use IEnumerable
to List.reduce which is more native way to traverse the list implemented by recursion
that compiles to while loop
benchmarks: https://gist.github.com/AviAvni/0a3576a619ff9bf4acf1958b8ca1c63b