### PR TITLE
List average, averageBy perf

### DIFF
--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -608,7 +608,15 @@ namespace Microsoft.FSharp.Collections
         let inline minBy f (list:list<_>) = Seq.minBy f list
 
         [<CompiledName("Average")>]
-        let inline average      (list:list<'T>) = LanguagePrimitives.DivideByInt< 'T > (sum list) list.Length
+        let inline average      (list:list<'T>) =
+            match list with 
+            | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | _ ->
+                let rec loop xs sum count = 
+                    match xs with 
+                    | [] -> LanguagePrimitives.DivideByInt sum count
+                    | h::t -> loop t (Checked.(+) sum h) (count + 1)
+                loop list LanguagePrimitives.GenericZero< 'T > 0
 
         [<CompiledName("AverageBy")>]
         let inline averageBy f (list:list<_>) = Seq.averageBy f list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -616,7 +616,7 @@ namespace Microsoft.FSharp.Collections
         let inline average      (list:list<'T>) =
             checkNonNull "list" list
             match list with 
-            | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             | _ ->
                 let rec loop xs sum count = 
                     match xs with 

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -19,6 +19,11 @@ namespace Microsoft.FSharp.Collections
 
         let inline indexNotFound() = raise (new System.Collections.Generic.KeyNotFoundException(SR.GetString(SR.keyNotFoundAlt)))
 
+        let inline checkNonNull argName arg = 
+            match box arg with 
+            | null -> nullArg argName 
+            | _ -> ()
+
         [<CompiledName("Length")>]
         let length (list: 'T list) = list.Length
         
@@ -609,6 +614,7 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Average")>]
         let inline average      (list:list<'T>) =
+            checkNonNull "list" list
             match list with 
             | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             | _ ->

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -19,11 +19,6 @@ namespace Microsoft.FSharp.Collections
 
         let inline indexNotFound() = raise (new System.Collections.Generic.KeyNotFoundException(SR.GetString(SR.keyNotFoundAlt)))
 
-        let inline checkNonNull argName arg = 
-            match box arg with 
-            | null -> nullArg argName 
-            | _ -> ()
-
         [<CompiledName("Length")>]
         let length (list: 'T list) = list.Length
         
@@ -614,7 +609,6 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Average")>]
         let inline average      (list:list<'T>) =
-            checkNonNull "list" list
             match list with 
             | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             | _ ->
@@ -625,7 +619,15 @@ namespace Microsoft.FSharp.Collections
                 loop list LanguagePrimitives.GenericZero< 'T > 0
 
         [<CompiledName("AverageBy")>]
-        let inline averageBy f (list:list<_>) = Seq.averageBy f list
+        let inline averageBy (f : 'T -> 'U) (list:list<'T>) =
+            match list with 
+            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | _ ->
+                let rec loop xs sum count = 
+                    match xs with 
+                    | [] -> LanguagePrimitives.DivideByInt sum count
+                    | h::t -> loop t (Checked.(+) sum (f h)) (count + 1)
+                loop list LanguagePrimitives.GenericZero< 'U > 0
 
         [<CompiledName("Collect")>]
         let collect f list = Microsoft.FSharp.Primitives.Basics.List.collect f list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -608,7 +608,7 @@ namespace Microsoft.FSharp.Collections
         let inline minBy f (list:list<_>) = Seq.minBy f list
 
         [<CompiledName("Average")>]
-        let inline average      (list:list<_>) = Seq.average list
+        let inline average      (list:list<'T>) = LanguagePrimitives.DivideByInt< 'T > (sum list) list.Length
 
         [<CompiledName("AverageBy")>]
         let inline averageBy f (list:list<_>) = Seq.averageBy f list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -610,7 +610,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Average")>]
         let inline average      (list:list<'T>) =
             match list with 
-            | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             | xs ->
                 let mutable sum = LanguagePrimitives.GenericZero< 'T >
                 let mutable count = 0
@@ -622,7 +622,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("AverageBy")>]
         let inline averageBy (f : 'T -> 'U) (list:list<'T>) =
             match list with 
-            | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
             | xs ->
                 let mutable sum = LanguagePrimitives.GenericZero< 'U >
                 let mutable count = 0

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -610,24 +610,26 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Average")>]
         let inline average      (list:list<'T>) =
             match list with 
-            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
-            | _ ->
-                let rec loop xs sum count = 
-                    match xs with 
-                    | [] -> LanguagePrimitives.DivideByInt sum count
-                    | h::t -> loop t (Checked.(+) sum h) (count + 1)
-                loop list LanguagePrimitives.GenericZero< 'T > 0
+            | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | h::t ->
+                let mutable sum = h
+                let mutable count = 0
+                for x in t do
+                    sum <- Checked.(+) sum x
+                    count <- count + 1
+                LanguagePrimitives.DivideByInt sum count
 
         [<CompiledName("AverageBy")>]
         let inline averageBy (f : 'T -> 'U) (list:list<'T>) =
             match list with 
-            | [] -> invalidArg "source" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
-            | _ ->
-                let rec loop xs sum count = 
-                    match xs with 
-                    | [] -> LanguagePrimitives.DivideByInt sum count
-                    | h::t -> loop t (Checked.(+) sum (f h)) (count + 1)
-                loop list LanguagePrimitives.GenericZero< 'U > 0
+            | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
+            | h::t ->
+                let mutable sum = f h
+                let mutable count = 0
+                for x in t do
+                    sum <- Checked.(+) sum (f x)
+                    count <- count + 1
+                LanguagePrimitives.DivideByInt sum count
 
         [<CompiledName("Collect")>]
         let collect f list = Microsoft.FSharp.Primitives.Basics.List.collect f list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -611,10 +611,10 @@ namespace Microsoft.FSharp.Collections
         let inline average      (list:list<'T>) =
             match list with 
             | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
-            | h::t ->
-                let mutable sum = h
+            | xs ->
+                let mutable sum = LanguagePrimitives.GenericZero< 'T >
                 let mutable count = 0
-                for x in t do
+                for x in xs do
                     sum <- Checked.(+) sum x
                     count <- count + 1
                 LanguagePrimitives.DivideByInt sum count
@@ -623,10 +623,10 @@ namespace Microsoft.FSharp.Collections
         let inline averageBy (f : 'T -> 'U) (list:list<'T>) =
             match list with 
             | [] -> invalidArg "list" LanguagePrimitives.ErrorStrings.InputSequenceEmptyString;
-            | h::t ->
-                let mutable sum = f h
+            | xs ->
+                let mutable sum = LanguagePrimitives.GenericZero< 'U >
                 let mutable count = 0
-                for x in t do
+                for x in xs do
                     sum <- Checked.(+) sum (f x)
                     count <- count + 1
                 LanguagePrimitives.DivideByInt sum count


### PR DESCRIPTION
Changing the implementation of List.average/averageBy from Seq.average/averageBy that use IEnumerable
to implementation like List.fold which is more native way to traverse the list implemented by recursion
that compiles to while loop
benchmarks: https://gist.github.com/AviAvni/0a3576a619ff9bf4acf1958b8ca1c63b