### PR TITLE
Make ReferencedAssemblies in type provider config report correct results

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3631,6 +3631,13 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
         | Some(importsBase)-> importsBase.GetDllInfos() @ dllInfos
         | None -> dllInfos
         
+    member tcImports.AllAssemblyResolutions() = 
+        CheckDisposed()
+        let ars = resolutions.GetAssemblyResolutions()
+        match importsBase with 
+        | Some(importsBase)-> importsBase.AllAssemblyResolutions() @ ars
+        | None -> ars
+        
     member tcImports.TryFindDllInfo (m,assemblyName,lookupOnly) =
         CheckDisposed()
         let rec look (t:TcImports) =       
@@ -3966,7 +3973,7 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
                  { resolutionFolder       = tcConfig.implicitIncludeDir
                    outputFile             = tcConfig.outputFile
                    showResolutionMessages = tcConfig.showExtensionTypeMessages 
-                   referencedAssemblies   = [| for r in resolutions.GetAssemblyResolutions() -> r.resolvedPath |]
+                   referencedAssemblies   = Array.distinct [| for r in tcImports.AllAssemblyResolutions() -> r.resolvedPath |]
                    temporaryFolder        = FileSystem.GetTempPathShim() }
 
             // The type provider should not hold strong references to disposed

--- a/tests/fsharp/typeProviders/helloWorld/provider.fsx
+++ b/tests/fsharp/typeProviders/helloWorld/provider.fsx
@@ -108,13 +108,15 @@ type public GlobalNamespaceProvider() =
 
 
 [<TypeProvider>]
-type public Provider() =
+type public Provider(config: TypeProviderConfig) =
     let thisAssembly = typeof<Provider>.Assembly
     let modul = thisAssembly.GetModules().[0]
     let rootNamespace = "FSharp.HelloWorld"
     let nestedNamespaceName1 = "FSharp.HelloWorld.NestedNamespace1"
     let nestedNamespaceName2 = "FSharp.HelloWorld.Nested.Nested.Nested.Namespace2"
 
+    do if not (config.ReferencedAssemblies |> Seq.exists (fun s -> s.Contains("FSharp.Core")) ) then 
+          failwith "expected FSharp.Core in type provider config references"
 
     // Test provision of erase methods with static parameters
     let helloWorldMethodWithStaticParameters =


### PR DESCRIPTION
This resurrects https://github.com/Microsoft/visualfsharp/pull/478.  

This fix should really be applied even if at some future point we do type provider type binding in a different way.

To quote the original PR:

----

I've been looking for what we can do to help with type-provider multi-targeting as described in #23. This is a major issue for F# type providers and, as NETCore-on-Linux comes around, we will really need to be looking at this closely. Anything we can do in F# 4.0 to help with this will be important.

As mentioned in #23 (comment), the ReferencedAssemblies field of the type provider config is missing entries for basic assemblies such as FSharp.Core. This is a mistake in the implementation of F#, and is bad, as this data is crucial to help give better multi-targeting type providers.

The underlying bug is that the ReferencedAssemblies property only includes the "non-framework" assemblies, and not "framework" assemblies such as FSharp.Core and mscorlib. (The framework v. non-frameworks distinction being referred to here is a somewhat artificial distinction made in the F# compiler to share resources between projects in the IDE in some situations

This corrects this problem by adding the framework references to the ReferencedAssemblies property in the type provider config.

---