### PR TITLE
Don't build coreclr by default for plain ``build.cmd``

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -28,7 +28,7 @@ exit /b 1
 
 set BUILD_PROTO=0
 set BUILD_NET40=1
-set BUILD_CORECLR=1
+set BUILD_CORECLR=0
 set BUILD_PORTABLE=0
 set BUILD_VS=0
 set BUILD_FSHARP_DATA_TYPEPROVIDERS=0
@@ -90,6 +90,7 @@ if /i '%ARG%' == 'all' (
 REM Same as 'all' but smoke testing only
 if /i '%ARG%' == 'ci' (
     set SKIP_EXPENSIVE_TESTS=1
+    set BUILD_CORECLR=1
     set BUILD_PORTABLE=1
     set BUILD_VS=1
     set BUILD_FSHARP_DATA_TYPEPROVIDERS=1
@@ -108,6 +109,7 @@ REM These divide 'ci' into three chunks which can be done in parallel
 
 if /i '%ARG%' == 'ci_part1' (
     set SKIP_EXPENSIVE_TESTS=1
+    set BUILD_CORECLR=1
     set BUILD_PORTABLE=1
     set BUILD_VS=1
     set BUILD_FSHARP_DATA_TYPEPROVIDERS=1
@@ -137,6 +139,12 @@ if /i '%ARG%' == 'smoke' (
     set TEST_FSHARP_SUITE=1
     set TEST_FSHARPQA_SUITE=0
     set TEST_TAGS=Smoke
+)
+
+if /i '%ARG%' == 'coreclr' (
+    REM Smoke tests are a very small quick subset of tests
+
+    set BUILD_CORECLR=1
 )
 
 if /i '%ARG%' == 'debug' (
@@ -218,11 +226,12 @@ if '%RestorePackages%' == 'true' (
     @if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
 )
 
-set DOTNET_HOME  .\packages\dotnet
 
-rem check to see if the dotnet cli tool exists
+set DOTNET_HOME=.\packages\dotnet
 set _dotnetexe=.\packages\dotnet\dotnet.exe
-if not exist %_dotnetexe% (
+if '%BUILD_CORECLR%' == '1' (
+  rem check to see if the dotnet cli tool exists
+  if not exist %_dotnetexe% (
     echo Error: Could not find %_dotnetexe%.
     rem do zipfile install nonsense
     if not exist packages ( md packages )
@@ -230,24 +239,25 @@ if not exist %_dotnetexe% (
     powershell.exe -executionpolicy unrestricted -command .\scripts\install-dotnetcli.ps1 https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-dev-win-x64.latest.zip packages
     @if ERRORLEVEL 1 echo Error: fetch dotnetcli failed && goto :failure
     popd
+  )
+
+  pushd .\lkg & ..\%_dotnetexe% restore &popd
+  @if ERRORLEVEL 1 echo Error: dotnet restore failed  && goto :failure
+  pushd .\lkg & ..\%_dotnetexe% publish project.json &popd
+  @if ERRORLEVEL 1 echo Error: dotnet publish failed  && goto :failure
+
+  rem rename fsc and coreconsole to allow fsc.exe to to start compiler
+  pushd .\lkg\bin\Debug\dnxcore50\win7-x64\publish
+  ren fsc.exe fsc.dll
+  copy corehost.exe fsc.exe
+  popd
+
+  rem rename fsi and coreconsole to allow fsi.exe to to start interative
+  pushd .\lkg\bin\Debug\dnxcore50\win7-x64\publish 
+  ren fsi.exe fsi.dll
+  copy corehost.exe fsi.exe
+  popd
 )
-
-pushd .\lkg & ..\%_dotnetexe% restore &popd
-@if ERRORLEVEL 1 echo Error: dotnet restore failed  && goto :failure
-pushd .\lkg & ..\%_dotnetexe% publish project.json &popd
-@if ERRORLEVEL 1 echo Error: dotnet publish failed  && goto :failure
-
-rem rename fsc and coreconsole to allow fsc.exe to to start compiler
-pushd .\lkg\bin\Debug\dnxcore50\win7-x64\publish
-ren fsc.exe fsc.dll
-copy corehost.exe fsc.exe
-popd
-
-rem rename fsi and coreconsole to allow fsi.exe to to start interative
-pushd .\lkg\bin\Debug\dnxcore50\win7-x64\publish 
-ren fsi.exe fsi.dll
-copy corehost.exe fsi.exe
-popd
 
 :: Build Proto
 if NOT EXIST Proto\net40\bin\fsc-proto.exe (set BUILD_PROTO=1)


### PR DESCRIPTION
With CoreCLR support now in master, this adjusts ``build.cmd`` so CoreCLR support is not built by default, and only if you use one of these:

    build.cmd coreclr    (can be combined with other flags)
    build.cmd ci
    build.cmd ci_part1

The problem is that building CoreCLR support by default downloads several gigabytes of stuff at the start of the build, even for people not yet working on CoreCLR support. 

