### PR TITLE
skip more coreclr steps on plain build.cmd

### DIFF
--- a/tests/BuildTestTools.cmd
+++ b/tests/BuildTestTools.cmd
@@ -60,34 +60,39 @@ if exist %~dp0..\%1\net40\bin (
 echo set NUNITPATH=%~dp0%..\packages\NUnit.Console.3.0.0\tools\
 set NUNITPATH=%~dp0%..\packages\NUnit.Console.3.0.0\tools\
 echo if not exist "%NUNITPATH%" 
-if not exist "%NUNITPATH%" (
-    echo here
-    pushd %~dp0..
-    ..\.nuget\nuget.exe restore ..\packages.config -PackagesDirectory ..\packages
-    popd
-)    
 
-echo %_fsiexe%
-rem deploy x86 version of compiler and dependencies
-%_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/win7-x86 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x86 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\fsc\win7-x86 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:yes --v:quiet
-%_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/win7-x86 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x86 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\win7-x86 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:no --v:quiet
+if '%BUILD_CORECLR%' == '1' (
 
-rem deploy x64 version of compiler
-%_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/win7-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\fsc\win7-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:yes --v:quiet
-%_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/win7-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\win7-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:no --v:quiet
+  if not exist "%NUNITPATH%" (
+      echo here
+      pushd %~dp0..
+      ..\.nuget\nuget.exe restore ..\packages.config -PackagesDirectory ..\packages
+      popd
+  )    
+  echo %_fsiexe%
+  rem deploy x86 version of compiler and dependencies
+  %_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/win7-x86 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x86 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\fsc\win7-x86 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:yes --v:quiet
+  %_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/win7-x86 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x86 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\win7-x86 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:no --v:quiet
 
-rem deploy linux version of built compiler
-%_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/ubuntu.14.04-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/ubuntu.14.04-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\fsc\ubuntu.14.04-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:yes --v:quiet
-%_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/ubuntu.14.04-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\ubuntu.14.04-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:no --v:quiet
+  rem deploy x64 version of compiler
+  %_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/win7-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\fsc\win7-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:yes --v:quiet
+  %_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/win7-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\win7-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:no --v:quiet
 
-rem deploy osx version of built compiler
-%_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/osx.10.10-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/ubuntu.14.04-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\fsc\osx.10.10-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:yes --v:quiet
-%_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/osx.10.10-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\osx.10.10-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:no --v:quiet
+  rem deploy linux version of built compiler
+  %_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/ubuntu.14.04-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/ubuntu.14.04-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\fsc\ubuntu.14.04-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:yes --v:quiet
+  %_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/ubuntu.14.04-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\ubuntu.14.04-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:no --v:quiet
 
-echo  "%NUNITPATH%*.*"  "%~dp0fsharpqa\testenv\bin\nunit\*.*" /S /Q /Y
-xcopy "%NUNITPATH%*.*"  "%~dp0fsharpqa\testenv\bin\nunit\*.*" /S /Q /Y
-echo  "%~dp0fsharpqa\testenv\src\nunit*.*" "%~dp0fsharpqa\testenv\bin\nunit\*.*" /S /Q /Y
-xcopy "%~dp0fsharpqa\testenv\src\nunit*.*" "%~dp0fsharpqa\testenv\bin\nunit\*.*" /S /Q /Y
+  rem deploy osx version of built compiler
+  %_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/osx.10.10-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/ubuntu.14.04-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\fsc\osx.10.10-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:yes --v:quiet
+  %_fsiexe% --exec %~dp0fsharpqa\testenv\src\DeployProj\DeployProj.fsx --TargetPlatformName:DNXCore,Version=v5.0/osx.10.10-x64 --projectJson:%~dp0fsharp\project.json --projectJsonLock:%~dp0fsharp\project.lock.json --packagesDir:%~dp0..\packages --targetPlatformName:DNXCore,Version=v5.0/win7-x64 --fsharpCore:%~dp0..\%1\coreclr\bin\fsharp.core.dll --output:%~dp0testbin\%1\coreclr\osx.10.10-x64 --nugetPath:%~dp0..\.nuget\nuget.exe --nugetConfig:%~dp0..\.nuget\nuget.config --copyCompiler:no --v:quiet
+
+  echo  "%NUNITPATH%*.*"  "%~dp0fsharpqa\testenv\bin\nunit\*.*" /S /Q /Y
+  xcopy "%NUNITPATH%*.*"  "%~dp0fsharpqa\testenv\bin\nunit\*.*" /S /Q /Y
+  echo  "%~dp0fsharpqa\testenv\src\nunit*.*" "%~dp0fsharpqa\testenv\bin\nunit\*.*" /S /Q /Y
+  xcopy "%~dp0fsharpqa\testenv\src\nunit*.*" "%~dp0fsharpqa\testenv\bin\nunit\*.*" /S /Q /Y
+
+)
+
 goto :EOF
 
 :error


### PR DESCRIPTION
This skips some test preparation steps on a plain ``build.cmd``, is an extension of #1047 
