### PR TITLE
re-enable build in jenkins

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,3 +25,31 @@ artifacts:
 
 #on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+os: Visual Studio 2015
+
+environment:
+  matrix:
+    - BUILD_PROFILE: ci_part1
+    - BUILD_PROFILE: ci_part2
+
+init:
+  - git config --global core.autocrlf true
+
+build_script: 
+  - cmd: build.cmd %BUILD_PROFILE%
+
+# scripts that run after cloning repository
+install:
+# by default, all script lines are interpreted as batch
+
+test: off 
+version: 0.0.1.{build} 
+artifacts: 
+  - path: Release
+    name: Release
+  - path: tests\TestResults
+    name: TestResults
+    type: zip
+
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,33 +2,6 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - BUILD_PROFILE:
-
-init:
-  - git config --global core.autocrlf true
-
-build_script: 
-  - cmd: build.cmd %BUILD_PROFILE%
-
-# scripts that run after cloning repository
-install:
-# by default, all script lines are interpreted as batch
-
-test: off 
-version: 0.0.1.{build} 
-artifacts: 
-  - path: Release
-    name: Release
-  - path: tests\TestResults
-    name: TestResults
-    type: zip
-
-#on_finish:
-#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-os: Visual Studio 2015
-
-environment:
-  matrix:
     - BUILD_PROFILE: ci_part1
     - BUILD_PROFILE: ci_part2
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,7 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - BUILD_PROFILE: ci_part1
-    - BUILD_PROFILE: ci_part2
+    - BUILD_PROFILE:
 
 init:
   - git config --global core.autocrlf true

--- a/build.cmd
+++ b/build.cmd
@@ -32,7 +32,7 @@ set BUILD_CORECLR=0
 set BUILD_PORTABLE=0
 set BUILD_VS=0
 set BUILD_FSHARP_DATA_TYPEPROVIDERS=0
-set BUILD_CONFIG=Release
+set BUILD_CONFIG=release
 set BUILD_CONFIG_LOWERCASE=release
 
 set TEST_COMPILERUNIT=0
@@ -148,7 +148,7 @@ if /i '%ARG%' == 'coreclr' (
 )
 
 if /i '%ARG%' == 'debug' (
-    set BUILD_CONFIG=Debug
+    set BUILD_CONFIG=debug
     set BUILD_CONFIG_LOWERCASE=debug
 )
 
@@ -257,13 +257,13 @@ if not exist %_dotnetexe% (
   @if ERRORLEVEL 1 echo Error: dotnet publish failed  && goto :failure
 
   rem rename fsc and coreconsole to allow fsc.exe to to start compiler
-  pushd .\lkg\bin\Debug\dnxcore50\win7-x64\publish
+  pushd .\lkg\bin\debug\dnxcore50\win7-x64\publish
   ren fsc.exe fsc.dll
   copy corehost.exe fsc.exe
   popd
 
   rem rename fsi and coreconsole to allow fsi.exe to to start interative
-  pushd .\lkg\bin\Debug\dnxcore50\win7-x64\publish 
+  pushd .\lkg\bin\debug\dnxcore50\win7-x64\publish 
   ren fsi.exe fsi.dll
   copy corehost.exe fsi.exe
   popd

--- a/jenkins-build.cmd
+++ b/jenkins-build.cmd
@@ -9,7 +9,7 @@ if /I "%1" == "/?"      (goto :USAGE)
 set BUILD_PROFILE=%*
 
 if /I "%BUILD_PROFILE%" == "debug" (
-    set BUILD_ARGS=debug  compiler coreclr pcls vs notests
+    set BUILD_ARGS=debug compiler coreclr pcls vs notests
     goto :ARGUMENTS_OK
 )
 if /I "%BUILD_PROFILE%" == "release" (
@@ -30,8 +30,7 @@ exit /b 1
 :ARGUMENTS_OK
 
 rem Do build only for now
-call build.cmd 
-rem call build.cmd %BUILD_ARGS%
+call build.cmd %BUILD_ARGS%
 
 goto :eof
 

--- a/jenkins-build.cmd
+++ b/jenkins-build.cmd
@@ -12,15 +12,11 @@ if /I "%BUILD_PROFILE%" == "debug" (
     set BUILD_ARGS=debug  compiler coreclr pcls vs notests
     goto :ARGUMENTS_OK
 )
-if /I "%BUILD_PROFILE%" == "release ci_part1" (
+if /I "%BUILD_PROFILE%" == "release" (
     set BUILD_ARGS=release compiler coreclr pcls vs notests
     goto :ARGUMENTS_OK
 )
 
-if /I "%BUILD_PROFILE%" == "release ci_part2" (
-    set BUILD_ARGS=release  compiler coreclr pcls vs notests
-    goto :ARGUMENTS_OK
-)
 echo '%BUILD_PROFILE%' is not a valid profile
 goto :USAGE
 

--- a/jenkins-build.cmd
+++ b/jenkins-build.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if "%_echo%"=="" echo off
 
 :ARGUMENTS_VALIDATION
 
@@ -6,15 +6,21 @@ if /I "%1" == "/help"   (goto :USAGE)
 if /I "%1" == "/h"      (goto :USAGE)
 if /I "%1" == "/?"      (goto :USAGE)
 
-set BUILD_PROFILE=%1
+set BUILD_PROFILE=%*
 
 if /I "%BUILD_PROFILE%" == "debug" (
-	goto :ARGUMENTS_OK
+    set BUILD_ARGS=debug  compiler coreclr pcls vs notests
+    goto :ARGUMENTS_OK
 )
-if /I "%BUILD_PROFILE%" == "release" (
-	goto :ARGUMENTS_OK
+if /I "%BUILD_PROFILE%" == "release ci_part1" (
+    set BUILD_ARGS=release compiler coreclr pcls vs notests
+    goto :ARGUMENTS_OK
 )
 
+if /I "%BUILD_PROFILE%" == "release ci_part2" (
+    set BUILD_ARGS=release  compiler coreclr pcls vs notests
+    goto :ARGUMENTS_OK
+)
 echo '%BUILD_PROFILE%' is not a valid profile
 goto :USAGE
 
@@ -27,90 +33,9 @@ exit /b 1
 
 :ARGUMENTS_OK
 
-if not '%VisualStudioVersion%' == '' goto vsversionset
-if exist "%VS140COMNTOOLS%..\ide\devenv.exe" set VisualStudioVersion=14.0
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
-if exist "%ProgramFiles%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
-if not '%VisualStudioVersion%' == '' goto vsversionset
-if exist "%VS120COMNTOOLS%..\ide\devenv.exe" set VisualStudioVersion=12.0
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
-if exist "%ProgramFiles%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
-
-:vsversionset
-if '%VisualStudioVersion%' == '' echo Error: Could not find an installation of Visual Studio && goto :failure
-
-if exist "%ProgramFiles(x86)%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe" set _msbuildexe="%ProgramFiles(x86)%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe"
-if exist "%ProgramFiles%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe"      set _msbuildexe="%ProgramFiles%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe"
-if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe. && goto :failure
-
-set _ngenexe="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ngen.exe"
-if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
-
-echo Restoring nuget packages:
-
-.\.nuget\NuGet.exe restore packages.config -PackagesDirectory packages -ConfigFile .nuget\nuget.config
-@if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
-
-echo Building the source tree using configuration: %BUILD_PROFILE%
-
-%_msbuildexe% src\fsharp-proto-build.proj
-@if ERRORLEVEL 1 echo Error: compiler proto build failed && goto :failure
-
-%_ngenexe% install Proto\net40\bin\fsc-proto.exe
-@if ERRORLEVEL 1 echo Error: NGen of proto failed  && goto :failure
-
-%_msbuildexe% src/fsharp-library-build.proj /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library build failed && goto :failure
-
-%_msbuildexe% src/fsharp-compiler-build.proj /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: compiler build failed && goto :failure
-
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable47 /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library portable47 build failed && goto :failure
-
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable7 /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library portable7 build failed && goto :failure
-
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library portable78 build failed && goto :failure
-
-%_msbuildexe% src/fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library portable259 build failed && goto :failure
-
-echo Building the test tree using configuration: %BUILD_PROFILE%
-
-%_msbuildexe% src/fsharp-compiler-unittests-build.proj /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: compiler unittests build failed && goto :failure
-
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library unittests build failed && goto :failure
-
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable47 /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library unittests build failed portable47 && goto :failure
-
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable7 /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library unittests build failed portable7 && goto :failure
-
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable78 /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library unittests build failed portable78 && goto :failure
-
-%_msbuildexe% src/fsharp-library-unittests-build.proj /p:TargetFramework=portable259 /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: library unittests build failed portable259 && goto :failure
-
-%_msbuildexe% tests/fsharp\fsharp.tests.fsproj /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: fsharp cambridge tests for nunit failed && goto :failure
-
-%_msbuildexe% VisualFSharp.sln /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: VS integration build failed && goto :failure
-
-%_msbuildexe% vsintegration\fsharp-vsintegration-unittests-build.proj /p:Configuration=%BUILD_PROFILE%
-@if ERRORLEVEL 1 echo Error: VS integration unit tests build failed && goto :failure
-
-echo Running update scripts
-
-@echo on
-call tests/BuildTestTools.cmd %BUILD_PROFILE% 
-@if ERRORLEVEL 1 echo Error: 'BuildTestTools.cmd %BUILD_PROFILE%' failed && goto :failure
+rem Do build only for now
+call build.cmd 
+rem call build.cmd %BUILD_ARGS%
 
 goto :eof
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -15,7 +15,7 @@ def static getBuildJobName(def configuration, def os) {
 }
 
 [true, false].each { isPullRequest ->
-    ['Debug', 'Release ci_part', 'Release ci_part2'].each { configuration ->
+    ['Debug', 'Release'].each { configuration ->
         osList.each { os ->
 
             def lowerConfiguration = configuration.toLowerCase()

--- a/netci.groovy
+++ b/netci.groovy
@@ -15,7 +15,7 @@ def static getBuildJobName(def configuration, def os) {
 }
 
 [true, false].each { isPullRequest ->
-    ['Debug', 'Release ci_part1', 'Release ci_part2'].each { configuration ->
+    ['Debug', 'Release ci_part', 'Release ci_part2'].each { configuration ->
         osList.each { os ->
 
             def lowerConfiguration = configuration.toLowerCase()
@@ -48,11 +48,11 @@ def static getBuildJobName(def configuration, def os) {
 
             // TODO: set to false after tests are fully enabled
             def skipIfNoTestFiles = true
-            
+
             Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
             Utilities.standardJobSetup(newJob, project, isPullRequest, "*/${branch}")
             Utilities.addXUnitDotNETResults(newJob, 'tests/TestResults/**/*_Xml.xml', skipIfNoTestFiles)
-            Utilities.addArchival(newJob, "${lowerConfiguration}/**")
+            //Utilities.addArchival(newJob, "${lowerConfiguration}/**")
 
             if (isPullRequest) {
                 Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${configuration} Build")

--- a/netci.groovy
+++ b/netci.groovy
@@ -51,8 +51,8 @@ def static getBuildJobName(def configuration, def os) {
 
             Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
             Utilities.standardJobSetup(newJob, project, isPullRequest, "*/${branch}")
-            Utilities.addXUnitDotNETResults(newJob, 'tests/TestResults/**/*_Xml.xml', skipIfNoTestFiles)
-            Utilities.addArchival(newJob, "${lowerConfiguration}/**")
+            //Utilities.addXUnitDotNETResults(newJob, 'tests/TestResults/**/*_Xml.xml', skipIfNoTestFiles)
+            //Utilities.addArchival(newJob, "${lowerConfiguration}/**")
 
             if (isPullRequest) {
                 Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${configuration} Build")

--- a/netci.groovy
+++ b/netci.groovy
@@ -15,7 +15,7 @@ def static getBuildJobName(def configuration, def os) {
 }
 
 [true, false].each { isPullRequest ->
-    ['debug', 'release'].each { configuration ->
+    ['Debug', 'Release'].each { configuration ->
         osList.each { os ->
 
             def lowerConfiguration = configuration.toLowerCase()
@@ -51,8 +51,8 @@ def static getBuildJobName(def configuration, def os) {
 
             Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
             Utilities.standardJobSetup(newJob, project, isPullRequest, "*/${branch}")
-            //Utilities.addXUnitDotNETResults(newJob, 'tests/TestResults/**/*_Xml.xml', skipIfNoTestFiles)
-            //Utilities.addArchival(newJob, "${lowerConfiguration}/**")
+            Utilities.addXUnitDotNETResults(newJob, 'tests/TestResults/**/*_Xml.xml', skipIfNoTestFiles)
+            Utilities.addArchival(newJob, "${lowerConfiguration}/**")
 
             if (isPullRequest) {
                 Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${configuration} Build")

--- a/netci.groovy
+++ b/netci.groovy
@@ -15,7 +15,7 @@ def static getBuildJobName(def configuration, def os) {
 }
 
 [true, false].each { isPullRequest ->
-    ['Debug', 'Release'].each { configuration ->
+    ['debug', 'release'].each { configuration ->
         osList.each { os ->
 
             def lowerConfiguration = configuration.toLowerCase()
@@ -52,7 +52,7 @@ def static getBuildJobName(def configuration, def os) {
             Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
             Utilities.standardJobSetup(newJob, project, isPullRequest, "*/${branch}")
             Utilities.addXUnitDotNETResults(newJob, 'tests/TestResults/**/*_Xml.xml', skipIfNoTestFiles)
-            //Utilities.addArchival(newJob, "${lowerConfiguration}/**")
+            Utilities.addArchival(newJob, "${lowerConfiguration}/**")
 
             if (isPullRequest) {
                 Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${configuration} Build")

--- a/netci.groovy
+++ b/netci.groovy
@@ -15,7 +15,7 @@ def static getBuildJobName(def configuration, def os) {
 }
 
 [true, false].each { isPullRequest ->
-    ['Debug', 'Release'].each { configuration ->
+    ['Debug', 'Release ci_part1', 'Release ci_part2'].each { configuration ->
         osList.each { os ->
 
             def lowerConfiguration = configuration.toLowerCase()
@@ -49,17 +49,17 @@ def static getBuildJobName(def configuration, def os) {
             // TODO: set to false after tests are fully enabled
             def skipIfNoTestFiles = true
             
-			Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
-			Utilities.standardJobSetup(newJob, project, isPullRequest, "*/${branch}")
-			Utilities.addXUnitDotNETResults(newJob, 'tests/TestResults/**/*_Xml.xml', skipIfNoTestFiles)
-			Utilities.addArchival(newJob, "${lowerConfiguration}/**")
-			
-			if (isPullRequest) {
-				Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${configuration} Build")
-			}
-			else {
-				Utilities.addGithubPushTrigger(newJob)
-			}
+            Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
+            Utilities.standardJobSetup(newJob, project, isPullRequest, "*/${branch}")
+            Utilities.addXUnitDotNETResults(newJob, 'tests/TestResults/**/*_Xml.xml', skipIfNoTestFiles)
+            Utilities.addArchival(newJob, "${lowerConfiguration}/**")
+
+            if (isPullRequest) {
+                Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${configuration} Build")
+            }
+            else {
+                Utilities.addGithubPushTrigger(newJob)
+            }
         }
     }
 }

--- a/src/fsharp/FSharp.Core.Unittests/project.lock.json
+++ b/src/fsharp/FSharp.Core.Unittests/project.lock.json
@@ -1,223 +1,1125 @@
 {
   "locked": false,
-  "version": 1,
+  "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
-      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {},
+      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Platforms/1.0.1-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "[1.0.1-rc2-23911, )"
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "[1.0.2-rc2-23911, )",
-          "Microsoft.NETCore.Runtime.Native": "[1.0.2-rc2-23911, )"
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911",
+          "Microsoft.NETCore.Runtime.Native": "1.0.2-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "[1.0.1-rc2-23911, )"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {},
+      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Targets/1.0.1-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[5.0.0-rc2-23911, )"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {},
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {},
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {
+        "type": "package"
+      },
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {
+        "type": "package"
+      },
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "NETStandard.Library/1.5.0-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.DotNet.CoreHost": "[0.0.1-beta-00001, )",
-          "Microsoft.NETCore.Platforms": "[1.0.1-rc2-23911, )",
-          "Microsoft.NETCore.Runtime": "[1.0.2-rc2-23911, )",
-          "Microsoft.Win32.Primitives": "[4.0.1-rc2-23911, )",
-          "System.AppContext": "[4.1.0-rc2-23911, )",
-          "System.Collections": "[4.0.11-rc2-23911, )",
-          "System.Collections.Concurrent": "[4.0.12-rc2-23911, )",
-          "System.Console": "[4.0.0-rc2-23911, )",
-          "System.Diagnostics.Debug": "[4.0.11-rc2-23911, )",
-          "System.Diagnostics.Tools": "[4.0.1-rc2-23911, )",
-          "System.Diagnostics.Tracing": "[4.1.0-rc2-23911, )",
-          "System.Globalization": "[4.0.11-rc2-23911, )",
-          "System.Globalization.Calendars": "[4.0.1-rc2-23911, )",
-          "System.IO": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression.ZipFile": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Linq": "[4.1.0-rc2-23911, )",
-          "System.Net.Http": "[4.0.1-rc2-23911, )",
-          "System.Net.Primitives": "[4.0.11-rc2-23911, )",
-          "System.Net.Sockets": "[4.1.0-rc2-23911, )",
-          "System.ObjectModel": "[4.0.12-rc2-23911, )",
-          "System.Reflection": "[4.1.0-rc2-23911, )",
-          "System.Reflection.Extensions": "[4.0.1-rc2-23911, )",
-          "System.Reflection.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Resources.ResourceManager": "[4.0.1-rc2-23911, )",
-          "System.Runtime": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Extensions": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Handles": "[4.0.1-rc2-23911, )",
-          "System.Runtime.InteropServices": "[4.1.0-rc2-23911, )",
-          "System.Runtime.InteropServices.RuntimeInformation": "[4.0.0-rc2-23911, )",
-          "System.Runtime.Numerics": "[4.0.1-rc2-23911, )",
-          "System.Text.Encoding": "[4.0.11-rc2-23911, )",
-          "System.Text.Encoding.Extensions": "[4.0.11-rc2-23911, )",
-          "System.Text.RegularExpressions": "[4.0.12-rc2-23911, )",
-          "System.Threading": "[4.0.11-rc2-23911, )",
-          "System.Threading.Tasks": "[4.0.11-rc2-23911, )",
-          "System.Threading.Timer": "[4.0.1-rc2-23911, )",
-          "System.Xml.ReaderWriter": "[4.0.11-rc2-23911, )",
-          "System.Xml.XDocument": "[4.0.11-rc2-23911, )"
+          "Microsoft.DotNet.CoreHost": "0.0.1-beta-00001",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
+          "Microsoft.NETCore.Runtime": "1.0.2-rc2-23911",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.AppContext": "4.1.0-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.12-rc2-23911",
+          "System.Console": "4.0.0-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Diagnostics.Tracing": "4.1.0-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.1.0-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Linq": "4.1.0-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.Sockets": "4.1.0-rc2-23911",
+          "System.ObjectModel": "4.0.12-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Extensions": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.1.0-rc2-23911",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.12-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Timer": "4.0.1-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911",
+          "System.Xml.XDocument": "4.0.11-rc2-23911"
         }
       },
-      "System.AppContext/4.1.0-rc2-23911": {},
-      "System.Collections/4.0.11-rc2-23911": {},
-      "System.Collections.Concurrent/4.0.12-rc2-23911": {},
-      "System.Console/4.0.0-rc2-23911": {},
-      "System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "System.Globalization/4.0.11-rc2-23911": {},
-      "System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "System.IO/4.1.0-rc2-23911": {},
-      "System.IO.Compression/4.1.0-rc2-23911": {},
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {},
-      "System.Linq/4.1.0-rc2-23911": {},
-      "System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "System.Linq.Queryable/4.0.1-rc2-23911": {},
-      "System.Net.Http/4.0.1-rc2-23911": {},
-      "System.Net.Primitives/4.0.11-rc2-23911": {},
-      "System.Net.Requests/4.0.11-rc2-23911": {},
-      "System.Net.Sockets/4.1.0-rc2-23911": {},
-      "System.ObjectModel/4.0.12-rc2-23911": {},
-      "System.Reflection/4.1.0-rc2-23911": {},
-      "System.Reflection.Emit/4.0.1-rc2-23911": {},
-      "System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "System.Runtime/4.1.0-rc2-23911": {},
-      "System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
-      "System.Runtime.Loader/4.0.0-rc2-23911": {},
-      "System.Runtime.Numerics/4.0.1-rc2-23911": {},
-      "System.Text.Encoding/4.0.11-rc2-23911": {},
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "System.Text.RegularExpressions/4.0.12-rc2-23911": {},
-      "System.Threading/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {},
-      "System.Threading.Thread/4.0.0-rc2-23911": {},
-      "System.Threading.ThreadPool/4.0.10-rc2-23911": {},
-      "System.Threading.Timer/4.0.1-rc2-23911": {},
-      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {},
-      "System.Xml.XDocument/4.0.11-rc2-23911": {}
+      "System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "System.Buffers/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Buffers.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        }
+      },
+      "System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Buffers": "4.0.0-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Linq/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Linq.Expressions": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Specialized": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.PInvoke/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Runtime.Loader/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Runtime.Loader.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Extensions/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Threading.Tasks.Extensions.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.2/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Tasks.Extensions": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.XDocument.dll": {}
+        }
+      }
     },
     "DNXCore,Version=v5.0/osx.10.10-x64": {
-      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {},
-      "Microsoft.NETCore.Platforms/1.0.1-rc2-23911": {
+      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "[1.0.1-rc2-23911, )"
+          "runtime.osx.10.10-x64.Microsoft.DotNet.CoreHost": "0.0.1-beta-00001"
+        }
+      },
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "[1.0.2-rc2-23911, )",
-          "Microsoft.NETCore.Runtime.Native": "[1.0.2-rc2-23911, )"
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911",
+          "Microsoft.NETCore.Runtime.Native": "1.0.2-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "[1.0.1-rc2-23911, )"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23911",
+          "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {},
+      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Targets/1.0.1-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[5.0.0-rc2-23911, )"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {},
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {},
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {
+        "type": "package"
+      },
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {
+        "type": "package"
+      },
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.Microsoft.Win32.Primitives": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "NETStandard.Library/1.5.0-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.DotNet.CoreHost": "[0.0.1-beta-00001, )",
-          "Microsoft.NETCore.Platforms": "[1.0.1-rc2-23911, )",
-          "Microsoft.NETCore.Runtime": "[1.0.2-rc2-23911, )",
-          "Microsoft.Win32.Primitives": "[4.0.1-rc2-23911, )",
-          "System.AppContext": "[4.1.0-rc2-23911, )",
-          "System.Collections": "[4.0.11-rc2-23911, )",
-          "System.Collections.Concurrent": "[4.0.12-rc2-23911, )",
-          "System.Console": "[4.0.0-rc2-23911, )",
-          "System.Diagnostics.Debug": "[4.0.11-rc2-23911, )",
-          "System.Diagnostics.Tools": "[4.0.1-rc2-23911, )",
-          "System.Diagnostics.Tracing": "[4.1.0-rc2-23911, )",
-          "System.Globalization": "[4.0.11-rc2-23911, )",
-          "System.Globalization.Calendars": "[4.0.1-rc2-23911, )",
-          "System.IO": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression.ZipFile": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Linq": "[4.1.0-rc2-23911, )",
-          "System.Net.Http": "[4.0.1-rc2-23911, )",
-          "System.Net.Primitives": "[4.0.11-rc2-23911, )",
-          "System.Net.Sockets": "[4.1.0-rc2-23911, )",
-          "System.ObjectModel": "[4.0.12-rc2-23911, )",
-          "System.Reflection": "[4.1.0-rc2-23911, )",
-          "System.Reflection.Extensions": "[4.0.1-rc2-23911, )",
-          "System.Reflection.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Resources.ResourceManager": "[4.0.1-rc2-23911, )",
-          "System.Runtime": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Extensions": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Handles": "[4.0.1-rc2-23911, )",
-          "System.Runtime.InteropServices": "[4.1.0-rc2-23911, )",
-          "System.Runtime.InteropServices.RuntimeInformation": "[4.0.0-rc2-23911, )",
-          "System.Runtime.Numerics": "[4.0.1-rc2-23911, )",
-          "System.Text.Encoding": "[4.0.11-rc2-23911, )",
-          "System.Text.Encoding.Extensions": "[4.0.11-rc2-23911, )",
-          "System.Text.RegularExpressions": "[4.0.12-rc2-23911, )",
-          "System.Threading": "[4.0.11-rc2-23911, )",
-          "System.Threading.Tasks": "[4.0.11-rc2-23911, )",
-          "System.Threading.Timer": "[4.0.1-rc2-23911, )",
-          "System.Xml.ReaderWriter": "[4.0.11-rc2-23911, )",
-          "System.Xml.XDocument": "[4.0.11-rc2-23911, )"
+          "Microsoft.DotNet.CoreHost": "0.0.1-beta-00001",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
+          "Microsoft.NETCore.Runtime": "1.0.2-rc2-23911",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.AppContext": "4.1.0-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.12-rc2-23911",
+          "System.Console": "4.0.0-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Diagnostics.Tracing": "4.1.0-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.1.0-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Linq": "4.1.0-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.Sockets": "4.1.0-rc2-23911",
+          "System.ObjectModel": "4.0.12-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Extensions": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.1.0-rc2-23911",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.12-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Timer": "4.0.1-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911",
+          "System.Xml.XDocument": "4.0.11-rc2-23911"
         }
       },
-      "runtime.any.System.AppContext/4.1.0-rc2-23911": {},
-      "runtime.any.System.Collections/4.0.11-rc2-23911": {},
-      "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "runtime.any.System.Globalization/4.0.11-rc2-23911": {},
-      "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "runtime.any.System.IO/4.1.0-rc2-23911": {},
-      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "runtime.any.System.Reflection/4.1.0-rc2-23911": {},
-      "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "runtime.any.System.Runtime/4.1.0-rc2-23911": {},
-      "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {},
-      "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {},
+      "runtime.any.System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "runtime.any.System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "runtime.any.System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.ObjectModel": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit": "4.0.1-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Timer.dll": {}
+        }
+      },
+      "runtime.native.System/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System": "1.0.1-rc2-23911"
+        }
+      },
+      "runtime.native.System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": "1.0.1-rc2-23911"
+        }
+      },
+      "runtime.native.System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System.Net.Http": "1.0.1-rc2-23911"
+        }
+      },
+      "runtime.native.System.Security.Cryptography/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography": "1.0.1-rc2-23911"
+        }
+      },
       "runtime.osx.10.10-x64.Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
+        "type": "package",
         "native": {
           "runtimes/osx.10.10-x64/native/corehost": {},
           "runtimes/osx.10.10-x64/native/libhostpolicy.dylib": {}
         }
       },
       "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
         },
@@ -225,172 +1127,1685 @@
           "runtimes/osx.10.10-x64/lib/dotnet/mscorlib.dll": {}
         },
         "native": {
+          "runtimes/osx.10.10-x64/native/System.Globalization.Native.dylib": {},
           "runtimes/osx.10.10-x64/native/libcoreclr.dylib": {},
           "runtimes/osx.10.10-x64/native/libdbgshim.dylib": {},
           "runtimes/osx.10.10-x64/native/libmscordaccore.dylib": {},
           "runtimes/osx.10.10-x64/native/libmscordbi.dylib": {},
           "runtimes/osx.10.10-x64/native/libsos.dylib": {},
           "runtimes/osx.10.10-x64/native/mscorlib.ni.dll": {},
-          "runtimes/osx.10.10-x64/native/sosdocsunix.txt": {},
-          "runtimes/osx.10.10-x64/native/System.Globalization.Native.dylib": {}
+          "runtimes/osx.10.10-x64/native/sosdocsunix.txt": {}
         }
       },
-      "runtime.osx.10.10.System.Net.Http/4.0.1-rc2-23911": {},
-      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
-      "runtime.unix.System.Console/4.0.0-rc2-23911": {},
-      "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "runtime.unix.System.IO.Compression/4.1.0-rc2-23911": {},
-      "runtime.unix.System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "runtime.unix.System.Net.Primitives/4.0.11-rc2-23911": {},
-      "runtime.unix.System.Net.Requests/4.0.11-rc2-23911": {},
-      "runtime.unix.System.Net.Sockets/4.1.0-rc2-23911": {},
-      "runtime.unix.System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "runtime.unix.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
-      "System.AppContext/4.1.0-rc2-23911": {},
-      "System.Collections/4.0.11-rc2-23911": {},
-      "System.Collections.Concurrent/4.0.12-rc2-23911": {},
-      "System.Console/4.0.0-rc2-23911": {},
-      "System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "System.Globalization/4.0.11-rc2-23911": {},
-      "System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "System.IO/4.1.0-rc2-23911": {},
-      "System.IO.Compression/4.1.0-rc2-23911": {},
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {},
-      "System.Linq/4.1.0-rc2-23911": {},
-      "System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "System.Linq.Queryable/4.0.1-rc2-23911": {},
-      "System.Net.Http/4.0.1-rc2-23911": {},
-      "System.Net.Primitives/4.0.11-rc2-23911": {},
-      "System.Net.Requests/4.0.11-rc2-23911": {},
-      "System.Net.Sockets/4.1.0-rc2-23911": {},
-      "System.ObjectModel/4.0.12-rc2-23911": {},
-      "System.Reflection/4.1.0-rc2-23911": {},
-      "System.Reflection.Emit/4.0.1-rc2-23911": {},
-      "System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "System.Runtime/4.1.0-rc2-23911": {},
-      "System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
-      "System.Runtime.Loader/4.0.0-rc2-23911": {},
-      "System.Runtime.Numerics/4.0.1-rc2-23911": {},
-      "System.Text.Encoding/4.0.11-rc2-23911": {},
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "System.Text.RegularExpressions/4.0.12-rc2-23911": {},
-      "System.Threading/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {},
-      "System.Threading.Thread/4.0.0-rc2-23911": {},
-      "System.Threading.ThreadPool/4.0.10-rc2-23911": {},
-      "System.Threading.Timer/4.0.1-rc2-23911": {},
-      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {},
-      "System.Xml.XDocument/4.0.11-rc2-23911": {}
+      "runtime.osx.10.10-x64.runtime.native.System/1.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/osx.10.10-x64/native/System.Native.a": {},
+          "runtimes/osx.10.10-x64/native/System.Native.dylib": {}
+        }
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.IO.Compression/1.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/osx.10.10-x64/native/System.IO.Compression.Native.dylib": {}
+        }
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Net.Http/1.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/osx.10.10-x64/native/System.Net.Http.Native.dylib": {}
+        }
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography/1.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/osx.10.10-x64/native/System.Security.Cryptography.Native.dylib": {}
+        }
+      },
+      "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Thread": "4.0.0-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/osx/lib/netstandard1.3/System.IO.FileSystem.Watcher.dll": {}
+        }
+      },
+      "runtime.osx.10.10.System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.DiagnosticSource": "4.0.0-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.X509Certificates": "4.1.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911",
+          "runtime.native.System.Net.Http": "4.0.1-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/osx/lib/netstandard1.4/System.Net.Http.dll": {}
+        }
+      },
+      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "runtime.unix.System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "runtime.unix.System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System.IO.Compression": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "runtime.unix.System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "runtime.unix.System.Net.NameResolution/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Net.NameResolution.dll": {}
+        }
+      },
+      "runtime.unix.System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "runtime.unix.System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "runtime.unix.System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.Net.NameResolution": "4.0.0-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.ThreadPool": "4.0.10-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "runtime.unix.System.Private.Uri/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Private.Uri.dll": {}
+        }
+      },
+      "runtime.unix.System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.native.System": "4.0.0-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "runtime.unix.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "runtime.unix.System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "runtime.unix.System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911",
+          "runtime.native.System.Net.Http": "4.0.1-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.AppContext": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "System.Buffers/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Buffers.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Collections": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.unix.System.Console": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.System.Diagnostics.Debug": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Diagnostics.Tools": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Diagnostics.Tracing": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Globalization": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Globalization.Calendars": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "runtime.unix.System.Globalization.Extensions": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        }
+      },
+      "System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.any.System.IO": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.IO.Compression": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Buffers": "4.0.0-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.IO.FileSystem": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Watcher/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.osx.10.10.System.IO.FileSystem.Watcher": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Watcher.dll": {}
+        }
+      },
+      "System.Linq/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Linq.Expressions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Linq.Expressions": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.osx.10.10.System.Net.Http": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.Net.NameResolution": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.NameResolution.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "runtime.unix.System.Net.Primitives": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.Net.Requests": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.Net.Sockets": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Specialized": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.unix.System.Private.Uri": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        }
+      },
+      "System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.Extensions": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.Primitives": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.TypeExtensions": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Resources.ResourceManager": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.any.System.Runtime": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.System.Runtime.Extensions": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911",
+          "runtime.any.System.Runtime.InteropServices": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.PInvoke/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Runtime.Loader/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Runtime.Loader.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "runtime.unix.System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.System.Security.Cryptography.Encoding": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.OpenSsl.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.4/System.Security.Cryptography.OpenSsl.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "runtime.unix.System.Security.Cryptography.X509Certificates": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.any.System.Text.Encoding.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Extensions/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Threading.Tasks.Extensions.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Threading.Timer": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.2/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Tasks.Extensions": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.XDocument.dll": {}
+        }
+      }
     },
     "DNXCore,Version=v5.0/ubuntu.14.04-x64": {
-      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {},
-      "Microsoft.NETCore.Platforms/1.0.1-rc2-23911": {
+      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "[1.0.1-rc2-23911, )"
+          "runtime.ubuntu.14.04-x64.Microsoft.DotNet.CoreHost": "0.0.1-beta-00001"
+        }
+      },
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "[1.0.2-rc2-23911, )",
-          "Microsoft.NETCore.Runtime.Native": "[1.0.2-rc2-23911, )"
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911",
+          "Microsoft.NETCore.Runtime.Native": "1.0.2-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "[1.0.1-rc2-23911, )"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23911",
+          "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {},
+      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Targets/1.0.1-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[5.0.0-rc2-23911, )"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {},
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {},
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {
+        "type": "package"
+      },
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {
+        "type": "package"
+      },
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.Microsoft.Win32.Primitives": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "NETStandard.Library/1.5.0-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.DotNet.CoreHost": "[0.0.1-beta-00001, )",
-          "Microsoft.NETCore.Platforms": "[1.0.1-rc2-23911, )",
-          "Microsoft.NETCore.Runtime": "[1.0.2-rc2-23911, )",
-          "Microsoft.Win32.Primitives": "[4.0.1-rc2-23911, )",
-          "System.AppContext": "[4.1.0-rc2-23911, )",
-          "System.Collections": "[4.0.11-rc2-23911, )",
-          "System.Collections.Concurrent": "[4.0.12-rc2-23911, )",
-          "System.Console": "[4.0.0-rc2-23911, )",
-          "System.Diagnostics.Debug": "[4.0.11-rc2-23911, )",
-          "System.Diagnostics.Tools": "[4.0.1-rc2-23911, )",
-          "System.Diagnostics.Tracing": "[4.1.0-rc2-23911, )",
-          "System.Globalization": "[4.0.11-rc2-23911, )",
-          "System.Globalization.Calendars": "[4.0.1-rc2-23911, )",
-          "System.IO": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression.ZipFile": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Linq": "[4.1.0-rc2-23911, )",
-          "System.Net.Http": "[4.0.1-rc2-23911, )",
-          "System.Net.Primitives": "[4.0.11-rc2-23911, )",
-          "System.Net.Sockets": "[4.1.0-rc2-23911, )",
-          "System.ObjectModel": "[4.0.12-rc2-23911, )",
-          "System.Reflection": "[4.1.0-rc2-23911, )",
-          "System.Reflection.Extensions": "[4.0.1-rc2-23911, )",
-          "System.Reflection.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Resources.ResourceManager": "[4.0.1-rc2-23911, )",
-          "System.Runtime": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Extensions": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Handles": "[4.0.1-rc2-23911, )",
-          "System.Runtime.InteropServices": "[4.1.0-rc2-23911, )",
-          "System.Runtime.InteropServices.RuntimeInformation": "[4.0.0-rc2-23911, )",
-          "System.Runtime.Numerics": "[4.0.1-rc2-23911, )",
-          "System.Text.Encoding": "[4.0.11-rc2-23911, )",
-          "System.Text.Encoding.Extensions": "[4.0.11-rc2-23911, )",
-          "System.Text.RegularExpressions": "[4.0.12-rc2-23911, )",
-          "System.Threading": "[4.0.11-rc2-23911, )",
-          "System.Threading.Tasks": "[4.0.11-rc2-23911, )",
-          "System.Threading.Timer": "[4.0.1-rc2-23911, )",
-          "System.Xml.ReaderWriter": "[4.0.11-rc2-23911, )",
-          "System.Xml.XDocument": "[4.0.11-rc2-23911, )"
+          "Microsoft.DotNet.CoreHost": "0.0.1-beta-00001",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
+          "Microsoft.NETCore.Runtime": "1.0.2-rc2-23911",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.AppContext": "4.1.0-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.12-rc2-23911",
+          "System.Console": "4.0.0-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Diagnostics.Tracing": "4.1.0-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.1.0-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Linq": "4.1.0-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.Sockets": "4.1.0-rc2-23911",
+          "System.ObjectModel": "4.0.12-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Extensions": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.1.0-rc2-23911",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.12-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Timer": "4.0.1-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911",
+          "System.Xml.XDocument": "4.0.11-rc2-23911"
         }
       },
-      "runtime.any.System.AppContext/4.1.0-rc2-23911": {},
-      "runtime.any.System.Collections/4.0.11-rc2-23911": {},
-      "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "runtime.any.System.Globalization/4.0.11-rc2-23911": {},
-      "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "runtime.any.System.IO/4.1.0-rc2-23911": {},
-      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "runtime.any.System.Reflection/4.1.0-rc2-23911": {},
-      "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "runtime.any.System.Runtime/4.1.0-rc2-23911": {},
-      "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {},
-      "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {},
-      "runtime.linux.System.Net.Http/4.0.1-rc2-23911": {},
+      "runtime.any.System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "runtime.any.System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "runtime.any.System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.ObjectModel": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit": "4.0.1-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Timer.dll": {}
+        }
+      },
+      "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/linux/lib/netstandard1.3/System.IO.FileSystem.Watcher.dll": {}
+        }
+      },
+      "runtime.linux.System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.DiagnosticSource": "4.0.0-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.X509Certificates": "4.1.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911",
+          "runtime.native.System.Net.Http": "4.0.1-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/linux/lib/netstandard1.4/System.Net.Http.dll": {}
+        }
+      },
+      "runtime.native.System/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.ubuntu.14.04-x64.runtime.native.System": "1.0.1-rc2-23911"
+        }
+      },
+      "runtime.native.System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": "1.0.1-rc2-23911"
+        }
+      },
+      "runtime.native.System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": "1.0.1-rc2-23911"
+        }
+      },
+      "runtime.native.System.Security.Cryptography/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography": "1.0.1-rc2-23911"
+        }
+      },
       "runtime.ubuntu.14.04-x64.Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
+        "type": "package",
         "native": {
           "runtimes/ubuntu.14.04-x64/native/corehost": {},
           "runtimes/ubuntu.14.04-x64/native/libhostpolicy.so": {}
         }
       },
       "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
         },
@@ -398,6 +2813,7 @@
           "runtimes/ubuntu.14.04-x64/lib/dotnet/mscorlib.dll": {}
         },
         "native": {
+          "runtimes/ubuntu.14.04-x64/native/System.Globalization.Native.so": {},
           "runtimes/ubuntu.14.04-x64/native/libcoreclr.so": {},
           "runtimes/ubuntu.14.04-x64/native/libcoreclrtraceptprovider.so": {},
           "runtimes/ubuntu.14.04-x64/native/libdbgshim.so": {},
@@ -406,165 +2822,1563 @@
           "runtimes/ubuntu.14.04-x64/native/libsos.so": {},
           "runtimes/ubuntu.14.04-x64/native/libsosplugin.so": {},
           "runtimes/ubuntu.14.04-x64/native/mscorlib.ni.dll": {},
-          "runtimes/ubuntu.14.04-x64/native/sosdocsunix.txt": {},
-          "runtimes/ubuntu.14.04-x64/native/System.Globalization.Native.so": {}
+          "runtimes/ubuntu.14.04-x64/native/sosdocsunix.txt": {}
         }
       },
-      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
-      "runtime.unix.System.Console/4.0.0-rc2-23911": {},
-      "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "runtime.unix.System.IO.Compression/4.1.0-rc2-23911": {},
-      "runtime.unix.System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "runtime.unix.System.Net.Primitives/4.0.11-rc2-23911": {},
-      "runtime.unix.System.Net.Requests/4.0.11-rc2-23911": {},
-      "runtime.unix.System.Net.Sockets/4.1.0-rc2-23911": {},
-      "runtime.unix.System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "runtime.unix.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
-      "System.AppContext/4.1.0-rc2-23911": {},
-      "System.Collections/4.0.11-rc2-23911": {},
-      "System.Collections.Concurrent/4.0.12-rc2-23911": {},
-      "System.Console/4.0.0-rc2-23911": {},
-      "System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "System.Globalization/4.0.11-rc2-23911": {},
-      "System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "System.IO/4.1.0-rc2-23911": {},
-      "System.IO.Compression/4.1.0-rc2-23911": {},
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {},
-      "System.Linq/4.1.0-rc2-23911": {},
-      "System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "System.Linq.Queryable/4.0.1-rc2-23911": {},
-      "System.Net.Http/4.0.1-rc2-23911": {},
-      "System.Net.Primitives/4.0.11-rc2-23911": {},
-      "System.Net.Requests/4.0.11-rc2-23911": {},
-      "System.Net.Sockets/4.1.0-rc2-23911": {},
-      "System.ObjectModel/4.0.12-rc2-23911": {},
-      "System.Reflection/4.1.0-rc2-23911": {},
-      "System.Reflection.Emit/4.0.1-rc2-23911": {},
-      "System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "System.Runtime/4.1.0-rc2-23911": {},
-      "System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
-      "System.Runtime.Loader/4.0.0-rc2-23911": {},
-      "System.Runtime.Numerics/4.0.1-rc2-23911": {},
-      "System.Text.Encoding/4.0.11-rc2-23911": {},
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "System.Text.RegularExpressions/4.0.12-rc2-23911": {},
-      "System.Threading/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {},
-      "System.Threading.Thread/4.0.0-rc2-23911": {},
-      "System.Threading.ThreadPool/4.0.10-rc2-23911": {},
-      "System.Threading.Timer/4.0.1-rc2-23911": {},
-      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {},
-      "System.Xml.XDocument/4.0.11-rc2-23911": {}
+      "runtime.ubuntu.14.04-x64.runtime.native.System/1.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/ubuntu.14.04-x64/native/System.Native.a": {},
+          "runtimes/ubuntu.14.04-x64/native/System.Native.so": {}
+        }
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/1.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/ubuntu.14.04-x64/native/System.IO.Compression.Native.so": {}
+        }
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/1.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/ubuntu.14.04-x64/native/System.Net.Http.Native.so": {}
+        }
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography/1.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/ubuntu.14.04-x64/native/System.Security.Cryptography.Native.so": {}
+        }
+      },
+      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "runtime.unix.System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "runtime.unix.System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System.IO.Compression": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "runtime.unix.System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "runtime.unix.System.Net.NameResolution/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Net.NameResolution.dll": {}
+        }
+      },
+      "runtime.unix.System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "runtime.unix.System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "runtime.unix.System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.Net.NameResolution": "4.0.0-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.ThreadPool": "4.0.10-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "runtime.unix.System.Private.Uri/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.native.System": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Private.Uri.dll": {}
+        }
+      },
+      "runtime.unix.System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.native.System": "4.0.0-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "runtime.unix.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "runtime.unix.System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "runtime.unix.System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "runtime.native.System": "4.0.0-rc2-23911",
+          "runtime.native.System.Net.Http": "4.0.1-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.AppContext": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "System.Buffers/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Buffers.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Collections": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.unix.System.Console": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.System.Diagnostics.Debug": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Diagnostics.Tools": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Diagnostics.Tracing": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Globalization": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Globalization.Calendars": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "runtime.unix.System.Globalization.Extensions": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        }
+      },
+      "System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.any.System.IO": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.IO.Compression": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Buffers": "4.0.0-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.IO.FileSystem": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Watcher/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.linux.System.IO.FileSystem.Watcher": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Watcher.dll": {}
+        }
+      },
+      "System.Linq/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Linq.Expressions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Linq.Expressions": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.linux.System.Net.Http": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.Net.NameResolution": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.NameResolution.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "runtime.unix.System.Net.Primitives": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.Net.Requests": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.unix.System.Net.Sockets": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Specialized": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.unix.System.Private.Uri": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        }
+      },
+      "System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.Extensions": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.Primitives": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.TypeExtensions": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Resources.ResourceManager": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.any.System.Runtime": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.System.Runtime.Extensions": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911",
+          "runtime.any.System.Runtime.InteropServices": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.PInvoke/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Runtime.Loader/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Runtime.Loader.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "runtime.unix.System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.unix.System.Security.Cryptography.Encoding": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.native.System.Security.Cryptography": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.OpenSsl.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.4/System.Security.Cryptography.OpenSsl.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "runtime.unix.System.Security.Cryptography.X509Certificates": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.any.System.Text.Encoding.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Extensions/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Threading.Tasks.Extensions.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Threading.Timer": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.2/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Tasks.Extensions": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.XDocument.dll": {}
+        }
+      }
     },
     "DNXCore,Version=v5.0/win7-x64": {
-      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {},
-      "Microsoft.NETCore.Platforms/1.0.1-rc2-23911": {
+      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "[1.0.1-rc2-23911, )"
+          "runtime.win7-x64.Microsoft.DotNet.CoreHost": "0.0.1-beta-00001"
+        }
+      },
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "[1.0.2-rc2-23911, )",
-          "Microsoft.NETCore.Runtime.Native": "[1.0.2-rc2-23911, )"
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911",
+          "Microsoft.NETCore.Runtime.Native": "1.0.2-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "[1.0.1-rc2-23911, )"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23911",
+          "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {},
+      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Targets/1.0.1-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[5.0.0-rc2-23911, )"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {},
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {},
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {
+        "type": "package"
+      },
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23911"
+        }
+      },
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win7.Microsoft.Win32.Primitives": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "NETStandard.Library/1.5.0-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.DotNet.CoreHost": "[0.0.1-beta-00001, )",
-          "Microsoft.NETCore.Platforms": "[1.0.1-rc2-23911, )",
-          "Microsoft.NETCore.Runtime": "[1.0.2-rc2-23911, )",
-          "Microsoft.Win32.Primitives": "[4.0.1-rc2-23911, )",
-          "System.AppContext": "[4.1.0-rc2-23911, )",
-          "System.Collections": "[4.0.11-rc2-23911, )",
-          "System.Collections.Concurrent": "[4.0.12-rc2-23911, )",
-          "System.Console": "[4.0.0-rc2-23911, )",
-          "System.Diagnostics.Debug": "[4.0.11-rc2-23911, )",
-          "System.Diagnostics.Tools": "[4.0.1-rc2-23911, )",
-          "System.Diagnostics.Tracing": "[4.1.0-rc2-23911, )",
-          "System.Globalization": "[4.0.11-rc2-23911, )",
-          "System.Globalization.Calendars": "[4.0.1-rc2-23911, )",
-          "System.IO": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression.ZipFile": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Linq": "[4.1.0-rc2-23911, )",
-          "System.Net.Http": "[4.0.1-rc2-23911, )",
-          "System.Net.Primitives": "[4.0.11-rc2-23911, )",
-          "System.Net.Sockets": "[4.1.0-rc2-23911, )",
-          "System.ObjectModel": "[4.0.12-rc2-23911, )",
-          "System.Reflection": "[4.1.0-rc2-23911, )",
-          "System.Reflection.Extensions": "[4.0.1-rc2-23911, )",
-          "System.Reflection.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Resources.ResourceManager": "[4.0.1-rc2-23911, )",
-          "System.Runtime": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Extensions": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Handles": "[4.0.1-rc2-23911, )",
-          "System.Runtime.InteropServices": "[4.1.0-rc2-23911, )",
-          "System.Runtime.InteropServices.RuntimeInformation": "[4.0.0-rc2-23911, )",
-          "System.Runtime.Numerics": "[4.0.1-rc2-23911, )",
-          "System.Text.Encoding": "[4.0.11-rc2-23911, )",
-          "System.Text.Encoding.Extensions": "[4.0.11-rc2-23911, )",
-          "System.Text.RegularExpressions": "[4.0.12-rc2-23911, )",
-          "System.Threading": "[4.0.11-rc2-23911, )",
-          "System.Threading.Tasks": "[4.0.11-rc2-23911, )",
-          "System.Threading.Timer": "[4.0.1-rc2-23911, )",
-          "System.Xml.ReaderWriter": "[4.0.11-rc2-23911, )",
-          "System.Xml.XDocument": "[4.0.11-rc2-23911, )"
+          "Microsoft.DotNet.CoreHost": "0.0.1-beta-00001",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
+          "Microsoft.NETCore.Runtime": "1.0.2-rc2-23911",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.AppContext": "4.1.0-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.12-rc2-23911",
+          "System.Console": "4.0.0-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Diagnostics.Tracing": "4.1.0-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.1.0-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Linq": "4.1.0-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.Sockets": "4.1.0-rc2-23911",
+          "System.ObjectModel": "4.0.12-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Extensions": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.1.0-rc2-23911",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.12-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Timer": "4.0.1-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911",
+          "System.Xml.XDocument": "4.0.11-rc2-23911"
         }
       },
-      "runtime.any.System.AppContext/4.1.0-rc2-23911": {},
-      "runtime.any.System.Collections/4.0.11-rc2-23911": {},
-      "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "runtime.any.System.Globalization/4.0.11-rc2-23911": {},
-      "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "runtime.any.System.IO/4.1.0-rc2-23911": {},
-      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "runtime.any.System.Reflection/4.1.0-rc2-23911": {},
-      "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "runtime.any.System.Runtime/4.1.0-rc2-23911": {},
-      "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {},
-      "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {},
-      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
+      "runtime.any.System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "runtime.any.System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "runtime.any.System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.ObjectModel": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit": "4.0.1-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Timer.dll": {}
+        }
+      },
+      "runtime.native.System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7-x64.runtime.native.System.IO.Compression": "4.0.1-rc2-23911"
+        }
+      },
+      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
       "runtime.win7-x64.Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
+        "type": "package",
         "native": {
           "runtimes/win7-x64/native/corehost.exe": {},
           "runtimes/win7-x64/native/hostpolicy.dll": {}
         }
       },
       "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
         },
@@ -584,11 +4398,28 @@
         }
       },
       "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {
+        "type": "package",
         "native": {
           "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -614,9 +4445,6 @@
           "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-localization-l1-2-0.dll": {},
@@ -630,7 +4458,6 @@
           "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-normalization-l1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-2-0.dll": {},
@@ -638,7 +4465,6 @@
           "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-2.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-profile-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-psapi-ansi-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-psapi-l1-1-0.dll": {},
@@ -651,13 +4477,11 @@
           "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -682,21 +4506,12 @@
           "runtimes/win7-x64/native/api-ms-win-core-wow64-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-xstate-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-xstate-l2-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-ro-typeresolution-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-security-base-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-security-cpwl-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-security-provider-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-security-sddl-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-service-core-l1-1-0.dll": {},
@@ -709,155 +4524,1601 @@
           "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll": {}
         }
       },
-      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
-      "runtime.win7.System.Console/4.0.0-rc2-23911": {},
-      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "runtime.win7.System.IO.Compression/4.1.0-rc2-23911": {},
-      "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "runtime.win7.System.Net.Http/4.0.1-rc2-23911": {},
-      "runtime.win7.System.Net.Primitives/4.0.11-rc2-23911": {},
-      "runtime.win7.System.Net.Requests/4.0.11-rc2-23911": {},
-      "runtime.win7.System.Net.Sockets/4.1.0-rc2-23911": {},
-      "runtime.win7.System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "System.AppContext/4.1.0-rc2-23911": {},
-      "System.Collections/4.0.11-rc2-23911": {},
-      "System.Collections.Concurrent/4.0.12-rc2-23911": {},
-      "System.Console/4.0.0-rc2-23911": {},
-      "System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "System.Globalization/4.0.11-rc2-23911": {},
-      "System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "System.IO/4.1.0-rc2-23911": {},
-      "System.IO.Compression/4.1.0-rc2-23911": {},
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {},
-      "System.Linq/4.1.0-rc2-23911": {},
-      "System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "System.Linq.Queryable/4.0.1-rc2-23911": {},
-      "System.Net.Http/4.0.1-rc2-23911": {},
-      "System.Net.Primitives/4.0.11-rc2-23911": {},
-      "System.Net.Requests/4.0.11-rc2-23911": {},
-      "System.Net.Sockets/4.1.0-rc2-23911": {},
-      "System.ObjectModel/4.0.12-rc2-23911": {},
-      "System.Reflection/4.1.0-rc2-23911": {},
-      "System.Reflection.Emit/4.0.1-rc2-23911": {},
-      "System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "System.Runtime/4.1.0-rc2-23911": {},
-      "System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
-      "System.Runtime.Loader/4.0.0-rc2-23911": {},
-      "System.Runtime.Numerics/4.0.1-rc2-23911": {},
-      "System.Text.Encoding/4.0.11-rc2-23911": {},
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "System.Text.RegularExpressions/4.0.12-rc2-23911": {},
-      "System.Threading/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {},
-      "System.Threading.Thread/4.0.0-rc2-23911": {},
-      "System.Threading.ThreadPool/4.0.10-rc2-23911": {},
-      "System.Threading.Timer/4.0.1-rc2-23911": {},
-      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {},
-      "System.Xml.XDocument/4.0.11-rc2-23911": {}
+      "runtime.win7-x64.runtime.native.System.IO.Compression/4.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/win7-x64/native/clrcompression.dll": {}
+        }
+      },
+      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "runtime.win7.System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "runtime.win7.System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System.IO.Compression": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Overlapped": "4.0.1-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.DiagnosticSource": "4.0.0-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.X509Certificates": "4.1.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.Http.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.NameResolution.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Net.NameResolution": "4.0.0-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Overlapped": "4.0.1-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "runtime.win7.System.Private.Uri/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Private.Uri.dll": {}
+        }
+      },
+      "runtime.win7.System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Cng": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Csp": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.AppContext": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "System.Buffers/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Buffers.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Collections": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.win7.System.Console": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win7.System.Diagnostics.Debug": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Diagnostics.Tools": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Diagnostics.Tracing": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Globalization": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Globalization.Calendars": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "runtime.win7.System.Globalization.Extensions": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        }
+      },
+      "System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.any.System.IO": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.IO.Compression": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Buffers": "4.0.0-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.IO.FileSystem": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Linq/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Linq.Expressions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Linq.Expressions": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.Net.Http": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.Net.NameResolution": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.NameResolution.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "runtime.win7.System.Net.Primitives": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.Net.Requests": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.Net.Sockets": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Specialized": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7.System.Private.Uri": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        }
+      },
+      "System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.Extensions": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.Primitives": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.TypeExtensions": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Resources.ResourceManager": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.any.System.Runtime": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win7.System.Runtime.Extensions": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911",
+          "runtime.any.System.Runtime.InteropServices": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.PInvoke/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win.System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Runtime.Loader/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Runtime.Loader.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Security.Claims/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Security.Principal": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Claims.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Claims.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "runtime.win7.System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.Cng.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.4/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win7.System.Security.Cryptography.Encoding": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "runtime.win7.System.Security.Cryptography.X509Certificates": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Security.Principal.dll": {}
+        }
+      },
+      "System.Security.Principal.Windows/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Claims": "4.0.1-rc2-23911",
+          "System.Security.Principal": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Principal.Windows.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Principal.Windows.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.any.System.Text.Encoding.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Overlapped/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Overlapped.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.Threading.Overlapped.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Extensions/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Threading.Tasks.Extensions.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Threading.Timer": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.2/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Tasks.Extensions": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.XDocument.dll": {}
+        }
+      }
     },
     "DNXCore,Version=v5.0/win7-x86": {
-      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {},
+      "Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Platforms/1.0.1-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "[1.0.1-rc2-23911, )"
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "[1.0.2-rc2-23911, )",
-          "Microsoft.NETCore.Runtime.Native": "[1.0.2-rc2-23911, )"
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911",
+          "Microsoft.NETCore.Runtime.Native": "1.0.2-rc2-23911"
         }
       },
       "Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "[1.0.1-rc2-23911, )"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23911",
+          "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {},
+      "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {
+        "type": "package"
+      },
       "Microsoft.NETCore.Targets/1.0.1-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[5.0.0-rc2-23911, )"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23911"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {},
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {},
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {
+        "type": "package"
+      },
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23911"
+        }
+      },
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win7.Microsoft.Win32.Primitives": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "NETStandard.Library/1.5.0-rc2-23911": {
+        "type": "package",
         "dependencies": {
-          "Microsoft.DotNet.CoreHost": "[0.0.1-beta-00001, )",
-          "Microsoft.NETCore.Platforms": "[1.0.1-rc2-23911, )",
-          "Microsoft.NETCore.Runtime": "[1.0.2-rc2-23911, )",
-          "Microsoft.Win32.Primitives": "[4.0.1-rc2-23911, )",
-          "System.AppContext": "[4.1.0-rc2-23911, )",
-          "System.Collections": "[4.0.11-rc2-23911, )",
-          "System.Collections.Concurrent": "[4.0.12-rc2-23911, )",
-          "System.Console": "[4.0.0-rc2-23911, )",
-          "System.Diagnostics.Debug": "[4.0.11-rc2-23911, )",
-          "System.Diagnostics.Tools": "[4.0.1-rc2-23911, )",
-          "System.Diagnostics.Tracing": "[4.1.0-rc2-23911, )",
-          "System.Globalization": "[4.0.11-rc2-23911, )",
-          "System.Globalization.Calendars": "[4.0.1-rc2-23911, )",
-          "System.IO": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression": "[4.1.0-rc2-23911, )",
-          "System.IO.Compression.ZipFile": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem": "[4.0.1-rc2-23911, )",
-          "System.IO.FileSystem.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Linq": "[4.1.0-rc2-23911, )",
-          "System.Net.Http": "[4.0.1-rc2-23911, )",
-          "System.Net.Primitives": "[4.0.11-rc2-23911, )",
-          "System.Net.Sockets": "[4.1.0-rc2-23911, )",
-          "System.ObjectModel": "[4.0.12-rc2-23911, )",
-          "System.Reflection": "[4.1.0-rc2-23911, )",
-          "System.Reflection.Extensions": "[4.0.1-rc2-23911, )",
-          "System.Reflection.Primitives": "[4.0.1-rc2-23911, )",
-          "System.Resources.ResourceManager": "[4.0.1-rc2-23911, )",
-          "System.Runtime": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Extensions": "[4.1.0-rc2-23911, )",
-          "System.Runtime.Handles": "[4.0.1-rc2-23911, )",
-          "System.Runtime.InteropServices": "[4.1.0-rc2-23911, )",
-          "System.Runtime.InteropServices.RuntimeInformation": "[4.0.0-rc2-23911, )",
-          "System.Runtime.Numerics": "[4.0.1-rc2-23911, )",
-          "System.Text.Encoding": "[4.0.11-rc2-23911, )",
-          "System.Text.Encoding.Extensions": "[4.0.11-rc2-23911, )",
-          "System.Text.RegularExpressions": "[4.0.12-rc2-23911, )",
-          "System.Threading": "[4.0.11-rc2-23911, )",
-          "System.Threading.Tasks": "[4.0.11-rc2-23911, )",
-          "System.Threading.Timer": "[4.0.1-rc2-23911, )",
-          "System.Xml.ReaderWriter": "[4.0.11-rc2-23911, )",
-          "System.Xml.XDocument": "[4.0.11-rc2-23911, )"
+          "Microsoft.DotNet.CoreHost": "0.0.1-beta-00001",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
+          "Microsoft.NETCore.Runtime": "1.0.2-rc2-23911",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.AppContext": "4.1.0-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.12-rc2-23911",
+          "System.Console": "4.0.0-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Diagnostics.Tracing": "4.1.0-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.1.0-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Linq": "4.1.0-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.Sockets": "4.1.0-rc2-23911",
+          "System.ObjectModel": "4.0.12-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Extensions": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.1.0-rc2-23911",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.12-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Timer": "4.0.1-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911",
+          "System.Xml.XDocument": "4.0.11-rc2-23911"
         }
       },
-      "runtime.any.System.AppContext/4.1.0-rc2-23911": {},
-      "runtime.any.System.Collections/4.0.11-rc2-23911": {},
-      "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "runtime.any.System.Globalization/4.0.11-rc2-23911": {},
-      "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "runtime.any.System.IO/4.1.0-rc2-23911": {},
-      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "runtime.any.System.Reflection/4.1.0-rc2-23911": {},
-      "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "runtime.any.System.Runtime/4.1.0-rc2-23911": {},
-      "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {},
-      "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {},
-      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
+      "runtime.any.System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "runtime.any.System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "runtime.any.System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.ObjectModel": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit": "4.0.1-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Timer.dll": {}
+        }
+      },
+      "runtime.native.System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7-x86.runtime.native.System.IO.Compression": "4.0.1-rc2-23911"
+        }
+      },
+      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
       "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
+        "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
         },
@@ -877,11 +6138,28 @@
         }
       },
       "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {
+        "type": "package",
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -907,9 +6185,6 @@
           "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-localization-l1-2-0.dll": {},
@@ -923,7 +6198,6 @@
           "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-normalization-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-2-0.dll": {},
@@ -931,7 +6205,6 @@
           "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-2.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-profile-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-psapi-ansi-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-psapi-l1-1-0.dll": {},
@@ -944,13 +6217,11 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -975,21 +6246,12 @@
           "runtimes/win7-x86/native/api-ms-win-core-wow64-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-xstate-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-xstate-l2-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-ro-typeresolution-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-security-base-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-security-cpwl-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-security-provider-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-security-sddl-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-service-core-l1-1-0.dll": {},
@@ -1002,61 +6264,1270 @@
           "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll": {}
         }
       },
-      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {},
-      "runtime.win7.System.Console/4.0.0-rc2-23911": {},
-      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "runtime.win7.System.IO.Compression/4.1.0-rc2-23911": {},
-      "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "runtime.win7.System.Net.Http/4.0.1-rc2-23911": {},
-      "runtime.win7.System.Net.Primitives/4.0.11-rc2-23911": {},
-      "runtime.win7.System.Net.Requests/4.0.11-rc2-23911": {},
-      "runtime.win7.System.Net.Sockets/4.1.0-rc2-23911": {},
-      "runtime.win7.System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "System.AppContext/4.1.0-rc2-23911": {},
-      "System.Collections/4.0.11-rc2-23911": {},
-      "System.Collections.Concurrent/4.0.12-rc2-23911": {},
-      "System.Console/4.0.0-rc2-23911": {},
-      "System.Diagnostics.Debug/4.0.11-rc2-23911": {},
-      "System.Diagnostics.Tools/4.0.1-rc2-23911": {},
-      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {},
-      "System.Globalization/4.0.11-rc2-23911": {},
-      "System.Globalization.Calendars/4.0.1-rc2-23911": {},
-      "System.IO/4.1.0-rc2-23911": {},
-      "System.IO.Compression/4.1.0-rc2-23911": {},
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem/4.0.1-rc2-23911": {},
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {},
-      "System.Linq/4.1.0-rc2-23911": {},
-      "System.Linq.Expressions/4.0.11-rc2-23911": {},
-      "System.Linq.Queryable/4.0.1-rc2-23911": {},
-      "System.Net.Http/4.0.1-rc2-23911": {},
-      "System.Net.Primitives/4.0.11-rc2-23911": {},
-      "System.Net.Requests/4.0.11-rc2-23911": {},
-      "System.Net.Sockets/4.1.0-rc2-23911": {},
-      "System.ObjectModel/4.0.12-rc2-23911": {},
-      "System.Reflection/4.1.0-rc2-23911": {},
-      "System.Reflection.Emit/4.0.1-rc2-23911": {},
-      "System.Reflection.Extensions/4.0.1-rc2-23911": {},
-      "System.Reflection.Primitives/4.0.1-rc2-23911": {},
-      "System.Resources.ResourceManager/4.0.1-rc2-23911": {},
-      "System.Runtime/4.1.0-rc2-23911": {},
-      "System.Runtime.Extensions/4.1.0-rc2-23911": {},
-      "System.Runtime.Handles/4.0.1-rc2-23911": {},
-      "System.Runtime.InteropServices/4.1.0-rc2-23911": {},
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {},
-      "System.Runtime.Loader/4.0.0-rc2-23911": {},
-      "System.Runtime.Numerics/4.0.1-rc2-23911": {},
-      "System.Text.Encoding/4.0.11-rc2-23911": {},
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {},
-      "System.Text.RegularExpressions/4.0.12-rc2-23911": {},
-      "System.Threading/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks/4.0.11-rc2-23911": {},
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {},
-      "System.Threading.Thread/4.0.0-rc2-23911": {},
-      "System.Threading.ThreadPool/4.0.10-rc2-23911": {},
-      "System.Threading.Timer/4.0.1-rc2-23911": {},
-      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {},
-      "System.Xml.XDocument/4.0.11-rc2-23911": {}
+      "runtime.win7-x86.runtime.native.System.IO.Compression/4.0.1-rc2-23911": {
+        "type": "package",
+        "native": {
+          "runtimes/win7-x86/native/clrcompression.dll": {}
+        }
+      },
+      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "runtime.win7.System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "runtime.win7.System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.native.System.IO.Compression": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Overlapped": "4.0.1-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.DiagnosticSource": "4.0.0-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.X509Certificates": "4.1.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.Http.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.NameResolution.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Http": "4.0.1-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "runtime.win7.System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Net.NameResolution": "4.0.0-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Overlapped": "4.0.1-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "runtime.win7.System.Private.Uri/4.0.1-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Private.Uri.dll": {}
+        }
+      },
+      "runtime.win7.System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Calendars": "4.0.1-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Runtime.Numerics": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Cng": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Csp": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.AppContext/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.AppContext": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.AppContext.dll": {}
+        }
+      },
+      "System.Buffers/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Buffers.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Collections": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Globalization.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.Console/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.win7.System.Console": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Console.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win7.System.Diagnostics.Debug": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Diagnostics.Tools": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Diagnostics.Tracing": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Globalization": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Globalization.Calendars": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "runtime.win7.System.Globalization.Extensions": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/_._": {}
+        }
+      },
+      "System.IO/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.any.System.IO": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.IO.Compression": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Buffers": "4.0.0-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.Compression": "4.1.0-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.IO.FileSystem": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Linq/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Linq.Expressions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Linq": "4.0.1-rc2-23911",
+          "System.Linq.Expressions": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Extensions": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.Net.Http": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.Net.NameResolution": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.NameResolution.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "runtime.win7.System.Net.Primitives": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Net.Requests/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.Net.Requests": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Requests.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Net.Primitives": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "runtime.win7.System.Net.Sockets": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Collections.Specialized": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.win7.System.Private.Uri": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard/_._": {}
+        }
+      },
+      "System.Reflection/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.Extensions": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.Primitives": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Reflection.TypeExtensions": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Resources.ResourceManager": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "runtime.any.System.Runtime": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win7.System.Runtime.Extensions": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Reflection.Primitives": "4.0.1-rc2-23911",
+          "System.Runtime": "4.1.0-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-23911",
+          "runtime.any.System.Runtime.InteropServices": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.PInvoke/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win.System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Runtime.Loader/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.5/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.5/System.Runtime.Loader.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Security.Claims/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Security.Principal": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Claims.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Claims.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "runtime.win7.System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.Cng.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.4/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.win7.System.Security.Cryptography.Encoding": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23911",
+          "runtime.win7.System.Security.Cryptography.X509Certificates": "4.1.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.0/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Security.Principal.dll": {}
+        }
+      },
+      "System.Security.Principal.Windows/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23911",
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Security.Claims": "4.0.1-rc2-23911",
+          "System.Security.Principal": "4.0.1-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Security.Principal.Windows.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Security.Principal.Windows.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Text.Encoding": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "runtime.any.System.Text.Encoding.Extensions": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.12-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Overlapped/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Overlapped.dll": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/netstandard1.3/System.Threading.Overlapped.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Extensions/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "lib/netstandard1.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard1.0/System.Threading.Tasks.Extensions.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.1/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Handles": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.1-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.21-rc2-23911",
+          "runtime.any.System.Threading.Timer": "4.0.1-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.2/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.IO.FileSystem": "4.0.1-rc2-23911",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23911",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23911",
+          "System.Threading.Tasks": "4.0.11-rc2-23911",
+          "System.Threading.Tasks.Extensions": "4.0.0-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.11-rc2-23911": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.11-rc2-23911",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23911",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+          "System.Globalization": "4.0.11-rc2-23911",
+          "System.IO": "4.0.11-rc2-23911",
+          "System.Reflection": "4.1.0-rc2-23911",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+          "System.Runtime": "4.0.21-rc2-23911",
+          "System.Runtime.Extensions": "4.0.11-rc2-23911",
+          "System.Text.Encoding": "4.0.11-rc2-23911",
+          "System.Threading": "4.0.11-rc2-23911",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23911"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.XDocument.dll": {}
+        }
+      }
     }
   },
   "libraries": {
@@ -1073,88 +7544,90 @@
       "sha512": "PLTNoM9f3OrcqelayVum+QS1on/wbrt+6ybgJA1CoyCJy3GL3l2t/HXSlpiSy/VA3WKOwu5lNtNosMSSbSTJTA==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Platforms.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
-        "Microsoft.NETCore.Platforms.nuspec",
-        "runtime.json",
-        "ThirdPartyNotices.txt"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.2-rc2-23911": {
       "sha512": "y4qeAWl1Hrprng1WJdb4u5o4fKkPxbH63ib1ixUmxDhT9i1SBNr30oTbsx7sMIDb4VlDeAbuWwCzJT6QKG/C3g==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
-        "dotnet_library_license.txt",
-        "Microsoft.NETCore.Runtime.nuspec",
-        "ThirdPartyNotices.txt"
+        "dotnet_library_license.txt"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
       "sha512": "UIOZGS63HfjQbLyzN3IaciROH+apsGbHUteZa5vHeu1eh/Y5QDyC4k9ZBC7wWAerxeGApn39pvoWbDLZFsC9iA==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
-        "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
-        "runtime.json",
-        "ThirdPartyNotices.txt"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.Native/1.0.2-rc2-23911": {
       "sha512": "QanTJ4QbvzWONh24/+AoAwBZpp33QTFhPJQv8pa0byOk3r11JMb44ZGcgZeCekeFUaEgCD5OeC9n9jy4r4Erfg==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Runtime.Native.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
-        "dotnet_library_license.txt",
-        "Microsoft.NETCore.Runtime.Native.nuspec",
-        "ThirdPartyNotices.txt"
+        "dotnet_library_license.txt"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.1-rc2-23911": {
       "sha512": "Vf2oDvpX+j/ibDYhdb1j89EZxiZBkqNomMHM+0eIsQm5PnWdLz+MUGXF5ea1dBwm1kAMEZ1OXMZ3F/a7fTMygA==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Targets.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
-        "Microsoft.NETCore.Targets.nuspec",
-        "runtime.json",
-        "ThirdPartyNotices.txt"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23911": {
       "sha512": "Q8om6oYs3ZzyzH0n6AhI+VSHxuDA6SzRKnyFZHFI+1E+ijjME/hZ8qMm8XvQn3rrS0TnkLRHu7S4tAnTAvkufg==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Targets.DNXCore.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
-        "Microsoft.NETCore.Targets.DNXCore.nuspec",
-        "runtime.json",
-        "ThirdPartyNotices.txt"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23911": {
       "sha512": "vrKSWyFlvAtsK0S3AY/s4EaqhuPnkBrUO1KkTcHRjTr8a5TA1AcEbVt6fr8SfHk50Yakez5NMEjTnHGqla7X9A==",
       "type": "Package",
       "files": [
+        "Microsoft.NETCore.Windows.ApiSets.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
-        "Microsoft.NETCore.Windows.ApiSets.nuspec",
-        "runtime.json",
-        "ThirdPartyNotices.txt"
+        "runtime.json"
       ]
     },
     "Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
       "sha512": "jKcHlXoNV/y1BFx5QnW02uqhJKUsqbFnJZzCtnwcuTv2xuO4NAra+0lrqoSaTAm3H2WMKMxHwqSSbMjIuqKLTQ==",
       "type": "Package",
       "files": [
+        "Microsoft.Win32.Primitives.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1165,43 +7638,42 @@
         "lib/xamarinmac20/_._",
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
-        "Microsoft.Win32.Primitives.nuspec",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/netstandard1.3/Microsoft.Win32.Primitives.dll",
+        "ref/netstandard1.3/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/de/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/es/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/fr/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/it/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/ja/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/ko/Microsoft.Win32.Primitives.xml",
-        "ref/netstandard1.3/Microsoft.Win32.Primitives.dll",
-        "ref/netstandard1.3/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/ru/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/zh-hans/Microsoft.Win32.Primitives.xml",
         "ref/netstandard1.3/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "NETStandard.Library/1.5.0-rc2-23911": {
       "sha512": "vArkePPN28+5R1+yT/p0h0XJxhfGiFm1WIimeoBOAwhtE64z4DCq4s1yjqEjJ4niHhXZSxl2WjiZDSuabePK9A==",
       "type": "Package",
       "files": [
+        "NETStandard.Library.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
-        "dotnet_library_license.txt",
-        "NETStandard.Library.nuspec",
-        "ThirdPartyNotices.txt"
+        "dotnet_library_license.txt"
       ]
     },
     "runtime.any.System.AppContext/4.1.0-rc2-23911": {
       "sha512": "ftuwjp/+keAj3JiUadfptmi5H0pGv9hfLh9KgCs0wKHYCnqpqeO74sqP8oP7W/sp588lWKJ/lUlIUGU8JSRkFw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1214,14 +7686,14 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.AppContext.nuspec",
-        "ThirdPartyNotices.txt"
+        "runtime.any.System.AppContext.nuspec"
       ]
     },
     "runtime.any.System.Collections/4.0.11-rc2-23911": {
       "sha512": "FM+4Ti2dKSTF6m60q4bhl+4v3Vecaz9clvXEfD0Vo1xlG/Oaag+DTWzWoxXXjdBhiIBViyhnY04AI6n16EMDXA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1239,14 +7711,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Collections.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Diagnostics.Tools/4.0.1-rc2-23911": {
       "sha512": "2uju93nvv3CBtgVLcY7YCkjcKmMdWg7kQZuwcWdUr2dWWde60I7u/u6ZLpiOxxxrtbbF57S1+c21PJuEb4bYNA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1264,14 +7736,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Diagnostics.Tools.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Diagnostics.Tracing/4.1.0-rc2-23911": {
       "sha512": "tNTZSRE/MAspdvMbgOxQCt1KoEG/920scMrOq0AhHDYvOM0fzPRR/E4hfvTD3CVZkaiplp9FrSRdKBBPEmK/ag==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1289,14 +7761,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Diagnostics.Tracing.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Globalization/4.0.11-rc2-23911": {
       "sha512": "5gH/ZqDeWXxV8680AC2KgYdIj9tUhllAfRcKA+W05iZTkL2KalEKkXgyK/9FNs7N9oq0F1zJzgt4LPBZ0a937A==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1314,14 +7786,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Globalization.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Globalization.Calendars/4.0.1-rc2-23911": {
       "sha512": "ZMqfQfaPA85jJ1A99sWLuaavGbbCFU3tnzAVNCOs/4Te/jnr04Z1BtlOJtVcvWouGLM2v7lz+jZyAZhVAbS50A==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1336,14 +7808,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Globalization.Calendars.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.IO/4.1.0-rc2-23911": {
       "sha512": "GF+KauRwGt4bLiF9drzxrt7+Jk5qp0/8jt4HuRzsn+TwNKaDljP03+YWUNeJt6O3n0g6pTtU9yak7ndqdqUqSQ==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1361,14 +7833,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.IO.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Linq.Expressions/4.0.11-rc2-23911": {
       "sha512": "evLIuWoSR1bFS7pDYa0VmqtUaKKC1zJuehLJ1JrjAvL19HAEecrIFrf4cN3tB8TsLTqSenYFa1RldA+/0s8Lmw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1386,14 +7858,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Linq.Expressions.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Reflection/4.1.0-rc2-23911": {
       "sha512": "9qJ07vriga7krmD87O0peau/vVh66T6MXCCeSK59ujkJgDQxMzAWh5ka2H4orLd+CKtbpz57rlFwdhDQ+yLW1Q==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1411,14 +7883,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Reflection.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Reflection.Extensions/4.0.1-rc2-23911": {
       "sha512": "btM8Yyug5u7ofmobt0SMhFV+3jUL3c50d1dlFXBuBHwqpluQygzMiaQoZ2aeuTp8LyXtw7h2iWFdelpTceImxQ==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1436,14 +7908,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Reflection.Extensions.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Reflection.Primitives/4.0.1-rc2-23911": {
       "sha512": "IJtPAOU8N7aEeotfW/2wCtos6GcvsbOirFXincspOoCj/QzJVEnt8v12fC3h1g9ri6bXLT+rQw8nj118PmQJzA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1460,14 +7932,34 @@
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
-        "runtime.any.System.Reflection.Primitives.nuspec",
-        "ThirdPartyNotices.txt"
+        "runtime.any.System.Reflection.Primitives.nuspec"
+      ]
+    },
+    "runtime.any.System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+      "sha512": "vWXLsdb84+b7yrAwHItCppOSaNDE2lJ8kPqTwR0Ma3Ba4t013570Xt4xd316hao0y/JtdrgcavitazGV8VpVAA==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net/_._",
+        "lib/netstandard1.3/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/netstandard/_._",
+        "runtime.any.System.Reflection.TypeExtensions.4.1.0-rc2-23911.nupkg.sha512",
+        "runtime.any.System.Reflection.TypeExtensions.nuspec",
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Resources.ResourceManager/4.0.1-rc2-23911": {
       "sha512": "XpC2SQ3/d6dZ5BN8NjYy6W3vRNygqlzXtd56T1H89LKGPC98rHEkOHoevJy4Q10qfN4uYc1+E7sk6nRsxH3mKw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1485,14 +7977,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Resources.ResourceManager.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Runtime/4.1.0-rc2-23911": {
       "sha512": "J756jvRJhwU18McfPKKYQMMKCruCDXZ+yEuP9tbV604ffKQ7Xw8L81NhITkrBtDvr0csLHFfB2yQPOAiShMM0w==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1510,14 +8002,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Runtime.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Runtime.Handles/4.0.1-rc2-23911": {
       "sha512": "8n68f2JjtcDHWw6mwnJumRKmce1wdvarj4TD6NDCnmL50Vsw2Zz3k7fTH0U7gILkKWjl/Cc01Os5s+nPTociQw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1531,14 +8023,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Runtime.Handles.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Runtime.InteropServices/4.1.0-rc2-23911": {
       "sha512": "ikMH/oLkYefea/ExPB87plbGiBnemoMvjzvqN3DGkN06UwEQ8s9jXcvBayDIOerivP24Ic1GduJPCeyh1lAjTw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1555,14 +8047,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Runtime.InteropServices.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Text.Encoding/4.0.11-rc2-23911": {
       "sha512": "PduHiziGDTUoRmHQMIGijR7fDPQZHFkaKXkMshS74YDq90b2VJPLo4HFa7nMzZRjKYdLHwPlEAlpIEs2zQ9aZw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1579,14 +8071,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Text.Encoding.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
       "sha512": "2LIuldhiRJXGa6dCfkC3TTgzCPGHS0GUXiAzwDOz2WTtre4ksZCAIePiAgpyVv3bdBwvBUUYdMjvrDLalcMstA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1603,14 +8095,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Text.Encoding.Extensions.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Threading.Tasks/4.0.11-rc2-23911": {
       "sha512": "HjjdNxXxoORyXp+oUeJLO1Qju4to5O7Zt8Ts+ZkTGVERoYWF/1YaZKEF2+ve+HFG7ymi4Dnp7WxDT+dhOAz8ag==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1628,14 +8120,14 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Threading.Tasks.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "runtime.any.System.Threading.Timer/4.0.1-rc2-23911": {
       "sha512": "tolI3PUYkWOaYU1yT+9hsD737MJO+KSM9lVn4N0Xd77bQeDfNwJEysjm2F4pkzL5ZbHtVjcvk89xjgZ96ExrDQ==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1652,21 +8144,72 @@
         "lib/xamarinwatchos10/_._",
         "ref/netstandard/_._",
         "runtime.any.System.Threading.Timer.nuspec",
-        "runtimes/aot/lib/netcore50/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-rc2-23911": {
+      "sha512": "Gyxkc5hZc5O7Eqx8+R3cTI4sCxLzQfsbuMB+ykKoBnYyGnC4KpWUW5Lgb3wWAREFW8eQIkuvkoyF9s7Ja/MCyw==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-rc2-23911.nupkg.sha512",
+        "runtime.linux.System.IO.FileSystem.Watcher.nuspec",
+        "runtimes/linux/lib/netstandard1.3/System.IO.FileSystem.Watcher.dll"
       ]
     },
     "runtime.linux.System.Net.Http/4.0.1-rc2-23911": {
       "sha512": "sx2ba7Z5+MlbPawoevMAyVZJ8rqQsS/ffLRMxT64wh5bA6zIX42akK5R+h+QkjxyTfFYrC9W7RtDgk77+g99IA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.linux.System.Net.Http.nuspec",
-        "runtimes/linux/lib/netstandard1.4/System.Net.Http.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/linux/lib/netstandard1.4/System.Net.Http.dll"
+      ]
+    },
+    "runtime.native.System/4.0.0-rc2-23911": {
+      "sha512": "0E/G8Zq2GErojo0amxxNh2DP8HdVGEObjgqDgHt+O33vZTLVfim9HRA+AR8DeO+fXJ1F9ttTh/RE+xvXBg5k5w==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.native.System.4.0.0-rc2-23911.nupkg.sha512",
+        "runtime.native.System.nuspec"
+      ]
+    },
+    "runtime.native.System.IO.Compression/4.1.0-rc2-23911": {
+      "sha512": "qjbIh17F48YHYSb63IUqRxbRpGkpF2PvUBJwKgqAob0uRs6NJEcXLsvtslqZXTvrFBqNvkJ4BduFiM5qnHEihg==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.native.System.IO.Compression.4.1.0-rc2-23911.nupkg.sha512",
+        "runtime.native.System.IO.Compression.nuspec"
+      ]
+    },
+    "runtime.native.System.Net.Http/4.0.1-rc2-23911": {
+      "sha512": "yBpniajvr8aVX4l0ctsweCqNBz21SFb/0nH1d7XD+M+rajt0k10jzlRIPPxYYFllIIU9fC1oWpT6l2q99xrxeA==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.native.System.Net.Http.4.0.1-rc2-23911.nupkg.sha512",
+        "runtime.native.System.Net.Http.nuspec"
+      ]
+    },
+    "runtime.native.System.Security.Cryptography/4.0.0-rc2-23911": {
+      "sha512": "M3f6FQMpfsFRTL30xBvf65GND3k4nfYG72qbKLxENavDaeBB32heLyY8Q2aAlEw/m1e2P65znbdPWthkP0Yubg==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.native.System.Security.Cryptography.4.0.0-rc2-23911.nupkg.sha512",
+        "runtime.native.System.Security.Cryptography.nuspec"
       ]
     },
     "runtime.osx.10.10-x64.Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
@@ -1683,12 +8226,14 @@
       "sha512": "riQgrga7JqyC8ZFJOPN0PZrNANHVkXIl60rShE4gz8zFlEodfSzfwTwuFF52ria2eZcWM4xZa8M+bzILf+S4wA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/dotnet/_._",
         "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/osx.10.10-x64/lib/dotnet/mscorlib.dll",
+        "runtimes/osx.10.10-x64/native/System.Globalization.Native.dylib",
         "runtimes/osx.10.10-x64/native/libcoreclr.dylib",
         "runtimes/osx.10.10-x64/native/libdbgshim.dylib",
         "runtimes/osx.10.10-x64/native/libmscordaccore.dylib",
@@ -1696,22 +8241,77 @@
         "runtimes/osx.10.10-x64/native/libsos.dylib",
         "runtimes/osx.10.10-x64/native/mscorlib.ni.dll",
         "runtimes/osx.10.10-x64/native/sosdocsunix.txt",
-        "runtimes/osx.10.10-x64/native/System.Globalization.Native.dylib",
-        "ThirdPartyNotices.txt",
         "tools/crossgen"
+      ]
+    },
+    "runtime.osx.10.10-x64.runtime.native.System/1.0.1-rc2-23911": {
+      "sha512": "pVUShw66cHuydxeujVQ0O/PSkMdgdkAGo7GWsPsmKIqQ0mQck/i1ZQbMOGJDW/3QPmIMrsj7xvXo1GsB70D7rg==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.osx.10.10-x64.runtime.native.System.1.0.1-rc2-23911.nupkg.sha512",
+        "runtime.osx.10.10-x64.runtime.native.System.nuspec",
+        "runtimes/osx.10.10-x64/native/System.Native.a",
+        "runtimes/osx.10.10-x64/native/System.Native.dylib"
+      ]
+    },
+    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression/1.0.1-rc2-23911": {
+      "sha512": "gUmnmZx6lrdAaC5ioT5jjI1FSUQ90zcb9p7C+t0+jD9qrfy+a9xOIMPUKczPYR2bWnPSwjKyM0Ad2Y9Y6sufAg==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.osx.10.10-x64.runtime.native.System.IO.Compression.1.0.1-rc2-23911.nupkg.sha512",
+        "runtime.osx.10.10-x64.runtime.native.System.IO.Compression.nuspec",
+        "runtimes/osx.10.10-x64/native/System.IO.Compression.Native.dylib"
+      ]
+    },
+    "runtime.osx.10.10-x64.runtime.native.System.Net.Http/1.0.1-rc2-23911": {
+      "sha512": "Gy2fnWtaksLEEugVeHXx7R9iR4J8K7KroLBSkw7EIHNJnbGeGBvHJ1HBEMh1hrem36pw/qmRcu3I3x2dbnAb+g==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.osx.10.10-x64.runtime.native.System.Net.Http.1.0.1-rc2-23911.nupkg.sha512",
+        "runtime.osx.10.10-x64.runtime.native.System.Net.Http.nuspec",
+        "runtimes/osx.10.10-x64/native/System.Net.Http.Native.dylib"
+      ]
+    },
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography/1.0.1-rc2-23911": {
+      "sha512": "uFLdyJpEGHBCFCNjfnfIr/2GKfTpvdZ0OgSvBCjvj9ywbkn8tRYv7goYFfhueKjMD1OcVF2m7syTABBx0NqdnA==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.1.0.1-rc2-23911.nupkg.sha512",
+        "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.nuspec",
+        "runtimes/osx.10.10-x64/native/System.Security.Cryptography.Native.dylib"
+      ]
+    },
+    "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-rc2-23911": {
+      "sha512": "321nUjAyhEskjtHAvMX9we3Qw2vHOBDI3rpHPsScyJqkd9kBwlcQPatF/9gmQnZUlskauCPuvz6sjfvz1N9j5g==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-rc2-23911.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.FileSystem.Watcher.nuspec",
+        "runtimes/osx/lib/netstandard1.3/System.IO.FileSystem.Watcher.dll"
       ]
     },
     "runtime.osx.10.10.System.Net.Http/4.0.1-rc2-23911": {
       "sha512": "ksA7fDTxqWgvD07TigXMdiJjtYcTcrb/Lom4P/aDDLymfeJqa3XEQOIggrrZwCc8F3HRk6fZm8kvRGVBjHWuhA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.osx.10.10.System.Net.Http.nuspec",
-        "runtimes/osx/lib/netstandard1.4/System.Net.Http.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/osx/lib/netstandard1.4/System.Net.Http.dll"
       ]
     },
     "runtime.ubuntu.14.04-x64.Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
@@ -1728,12 +8328,14 @@
       "sha512": "FmybVaiEXfLHEYM2RrSVThEIysNXinsp6FZqScjOPw1EOCDXJsRhfmRqAyEbbZ6y+qEHE/hQxdsRjFmmQ27VAw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/dotnet/_._",
         "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/ubuntu.14.04-x64/lib/dotnet/mscorlib.dll",
+        "runtimes/ubuntu.14.04-x64/native/System.Globalization.Native.so",
         "runtimes/ubuntu.14.04-x64/native/libcoreclr.so",
         "runtimes/ubuntu.14.04-x64/native/libcoreclrtraceptprovider.so",
         "runtimes/ubuntu.14.04-x64/native/libdbgshim.so",
@@ -1743,145 +8345,261 @@
         "runtimes/ubuntu.14.04-x64/native/libsosplugin.so",
         "runtimes/ubuntu.14.04-x64/native/mscorlib.ni.dll",
         "runtimes/ubuntu.14.04-x64/native/sosdocsunix.txt",
-        "runtimes/ubuntu.14.04-x64/native/System.Globalization.Native.so",
-        "ThirdPartyNotices.txt",
         "tools/crossgen"
+      ]
+    },
+    "runtime.ubuntu.14.04-x64.runtime.native.System/1.0.1-rc2-23911": {
+      "sha512": "Ku1GSAW8UBd3iaJSZHN7XMPSTYycKOy1NWLUSzAwdKkO2NpYp2w7ZvP0qg3u9S2/Y6w67kAvtrfMCt7S4AJ68A==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.ubuntu.14.04-x64.runtime.native.System.1.0.1-rc2-23911.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.runtime.native.System.nuspec",
+        "runtimes/ubuntu.14.04-x64/native/System.Native.a",
+        "runtimes/ubuntu.14.04-x64/native/System.Native.so"
+      ]
+    },
+    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/1.0.1-rc2-23911": {
+      "sha512": "a7yh0gpCo0x9AW4S5qzxXA1TuXpRPq8ZEQEDbA0m7dB2pkz6v9XDmmJeOJOPA4ALjIwexHKIyg0UrHFF6KuOBw==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression.1.0.1-rc2-23911.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression.nuspec",
+        "runtimes/ubuntu.14.04-x64/native/System.IO.Compression.Native.so"
+      ]
+    },
+    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/1.0.1-rc2-23911": {
+      "sha512": "strRLoIVOHUhnPwI0LgA54VxCHvuIdYGyOzjTejJ64f6Icn2cwKWiMOpsj2M2nLuOZPGKvGAZDopGxFBxi9m7Q==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http.1.0.1-rc2-23911.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http.nuspec",
+        "runtimes/ubuntu.14.04-x64/native/System.Net.Http.Native.so"
+      ]
+    },
+    "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography/1.0.1-rc2-23911": {
+      "sha512": "KQqYp0WhklxH47QfFSDbLe6akurR9m/6M4e4L6r4uCjWAy8sjgpwX5T5n9G6k9kJNU75/uNRe+YlfljuQmkx1g==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.1.0.1-rc2-23911.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.nuspec",
+        "runtimes/ubuntu.14.04-x64/native/System.Security.Cryptography.Native.so"
       ]
     },
     "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
       "sha512": "IjK3S949cBvnml6ADbfXQyuAd2kv0bdnPJQ3u1zC5XfXm/c2Y2Gmik+QNKNd7Jou3A6TUb988bBfBzMeyN8mDA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.Microsoft.Win32.Primitives.nuspec",
-        "runtimes/unix/lib/netstandard1.3/Microsoft.Win32.Primitives.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/Microsoft.Win32.Primitives.dll"
       ]
     },
     "runtime.unix.System.Console/4.0.0-rc2-23911": {
       "sha512": "ECKAtd3+1tosJPoc1CYkbzLnUGuXd457e2NgLRgPa+RiS7LwmsNfKdjty908BNwYvZZpCBiqXPlxELcw53iLNw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.Console.nuspec",
-        "runtimes/unix/lib/netstandard1.3/System.Console.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/System.Console.dll"
       ]
     },
     "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23911": {
       "sha512": "OQlLwNnmuDpF1Pq2StYDXbQYsLzCwXJq7D5HEqstkJx7q2pXoFYHC9cipe6/MI0jmq3Oehk4TZi2Hh9Uw7qBNA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.Diagnostics.Debug.nuspec",
-        "runtimes/unix/lib/netstandard1.3/System.Diagnostics.Debug.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/System.Diagnostics.Debug.dll"
+      ]
+    },
+    "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23911": {
+      "sha512": "C16W6kAdMqiy38RhyC6n1ZWK+mhnKQo747y+RQIdQ7iyYy4nnousEEQrvGVr4Q8AoidpT2feu1YZjYtXFqnLqg==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.unix.System.Globalization.Extensions.4.0.1-rc2-23911.nupkg.sha512",
+        "runtime.unix.System.Globalization.Extensions.nuspec",
+        "runtimes/unix/lib/netstandard1.3/System.Globalization.Extensions.dll"
       ]
     },
     "runtime.unix.System.IO.Compression/4.1.0-rc2-23911": {
       "sha512": "MWHGZd27K5bdENUedZHz4EWX0Tu+93BohV183gkynR9Grp6seG/AjWeBNEXzGpRB3TIPpA70/tVgKU2IndEbHw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.IO.Compression.nuspec",
-        "runtimes/unix/lib/netstandard1.3/System.IO.Compression.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/System.IO.Compression.dll"
       ]
     },
     "runtime.unix.System.IO.FileSystem/4.0.1-rc2-23911": {
       "sha512": "D6bo49idefnrq0FAQ8O2GgabuwF51ZyT6jX0wB3Wh1cj1yLdyQgUStuo6L1hZTZuffd4cJq93Mqe2EgmKt6R+w==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.IO.FileSystem.nuspec",
-        "runtimes/unix/lib/netstandard1.3/System.IO.FileSystem.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/System.IO.FileSystem.dll"
+      ]
+    },
+    "runtime.unix.System.Net.NameResolution/4.0.0-rc2-23911": {
+      "sha512": "Uc3cLDRhPgNYBvigLz595lbg8oZpkbS9WyFzY9oo72LxHbQ/TYg8M1OU+Shh1fR8FbP6KqF86YfzBQbt7oeK5g==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.unix.System.Net.NameResolution.4.0.0-rc2-23911.nupkg.sha512",
+        "runtime.unix.System.Net.NameResolution.nuspec",
+        "runtimes/unix/lib/netstandard1.3/System.Net.NameResolution.dll"
       ]
     },
     "runtime.unix.System.Net.Primitives/4.0.11-rc2-23911": {
       "sha512": "dt8c9X1uQGdwszsB+LCPdtGJLNCkHnracQfSbayEdP+riHG8vBOoEgaoaDzVNEB/TYl6fJ96VpCTqVYsndvUvQ==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.Net.Primitives.nuspec",
-        "runtimes/unix/lib/netstandard1.3/System.Net.Primitives.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/System.Net.Primitives.dll"
       ]
     },
     "runtime.unix.System.Net.Requests/4.0.11-rc2-23911": {
       "sha512": "4kOTPNo1+g4FaY2TMtVqdrZdY8uDWm0Mvm5qge1xyObj5Jb/9215uR1LDbhT+474Th1ByouCWoezfkWupqInkg==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.Net.Requests.nuspec",
-        "runtimes/unix/lib/netstandard1.3/System.Net.Requests.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/System.Net.Requests.dll"
       ]
     },
     "runtime.unix.System.Net.Sockets/4.1.0-rc2-23911": {
       "sha512": "cvZz5BYV0kaCYHVbrr1pn/egwnOBYXf4UPrDAcSuUh9mhssRUCzFMRzwLWveET3XSMTLzhWlmFph8+ZL4RMm1Q==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.Net.Sockets.nuspec",
-        "runtimes/unix/lib/netstandard1.3/System.Net.Sockets.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/System.Net.Sockets.dll"
+      ]
+    },
+    "runtime.unix.System.Private.Uri/4.0.1-rc2-23911": {
+      "sha512": "gU4gUoj608PrL8j+LTmXHs1rdK59i2NXtnVEnGxQW5spHd6HUV1vEqy7JrBiFGIqe2fK7DjirJIAfFLmmLiJ4w==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/netstandard1.0/System.Private.Uri.dll",
+        "ref/netstandard/_._",
+        "runtime.unix.System.Private.Uri.4.0.1-rc2-23911.nupkg.sha512",
+        "runtime.unix.System.Private.Uri.nuspec"
       ]
     },
     "runtime.unix.System.Runtime.Extensions/4.1.0-rc2-23911": {
       "sha512": "iQXkNHuradc5vg3/xaG0tctvxngN+P+mbSBK/IvNch5dNKI38uYHexFNhSU+XyNoVSjkrKUb7Dtg85O2BDUC1g==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.Runtime.Extensions.nuspec",
-        "runtimes/unix/lib/netstandard1.3/System.Runtime.Extensions.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.3/System.Runtime.Extensions.dll"
       ]
     },
     "runtime.unix.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
       "sha512": "aDeuTwEwFmxehwwpbNms5cYjr+zWCskh8LRC9HKE0XdF8qnHWeJx1G43VmlBNaEUY+vdl7NbJYf4J+YjYyVEeg==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.unix.System.Runtime.InteropServices.RuntimeInformation.nuspec",
-        "runtimes/unix/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/unix/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll"
+      ]
+    },
+    "runtime.unix.System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+      "sha512": "0XW46k02b2P9LDJ76jLHXHDqViKwio6hDclzIRUVNimF0ulOReKxu7AbMndqef7kwnvsNWfrRvfeyGvNirIzsQ==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.unix.System.Security.Cryptography.Algorithms.4.1.0-rc2-23911.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.Algorithms.nuspec",
+        "runtimes/unix/lib/netstandard1.4/System.Security.Cryptography.Algorithms.dll"
+      ]
+    },
+    "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+      "sha512": "N4iEGCFIBb2TzWxyOwW/EtmDiPIHkRwLySHiByAcKfQBS2bm1+tVWQPYxK2Up/iPb6Vydg9RtmLCP6ePiyJB6Q==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-rc2-23911.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.Encoding.nuspec",
+        "runtimes/unix/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll"
+      ]
+    },
+    "runtime.unix.System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+      "sha512": "MLhL1rLAGkHtF0QNzNSwCdoXmzEsTyxx649a7evkAtLdV2jURERBuWFDp/nrp2iImhN/5zDLgY3qANOn0R8/Bw==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.unix.System.Security.Cryptography.X509Certificates.4.1.0-rc2-23911.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.X509Certificates.nuspec",
+        "runtimes/unix/lib/netstandard1.4/System.Security.Cryptography.X509Certificates.dll"
       ]
     },
     "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
       "sha512": "aEdwuDV2gKC5Hyg4lhlTWLgPU/ys3Xok5a/GYh6x0XV5IyuLktGOd6S9kVthoIwBXphGB55dHbltnmTAngHGcw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1890,8 +8608,7 @@
         "runtimes/win/lib/net45/System.Runtime.InteropServices.RuntimeInformation.dll",
         "runtimes/win/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll",
         "runtimes/win7/lib/netcore50/System.Runtime.InteropServices.RuntimeInformation.dll",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.RuntimeInformation.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.RuntimeInformation.dll"
       ]
     },
     "runtime.win7-x64.Microsoft.DotNet.CoreHost/0.0.1-beta-00001": {
@@ -1908,6 +8625,7 @@
       "sha512": "VNHM7iHYTiGtxPzxa75QIFkeLx4XnHdsgMK8HzPCqzY4bVKzLVNMAXIFW4M1XnxDM+iTlWwD95wz1ig094UONA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -1923,7 +8641,6 @@
         "runtimes/win7-x64/native/mscorrc.debug.dll",
         "runtimes/win7-x64/native/mscorrc.dll",
         "runtimes/win7-x64/native/sos.dll",
-        "ThirdPartyNotices.txt",
         "tools/crossgen.exe",
         "tools/sos.dll"
       ]
@@ -1932,14 +8649,31 @@
       "sha512": "UJ+1/XaNG9sBkboZSBVx8lkBrtnZLp2zl2R8blu2BB8F3llf2UpvMg71apeK1yMJ73OfCxRY9liyF+2tPiGsYA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -1965,9 +8699,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-localization-l1-2-0.dll",
@@ -1981,7 +8712,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-normalization-l1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-2-0.dll",
@@ -1989,7 +8719,6 @@
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-2.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-profile-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-psapi-l1-1-0.dll",
@@ -2002,13 +8731,11 @@
         "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -2033,21 +8760,12 @@
         "runtimes/win7-x64/native/api-ms-win-core-wow64-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-xstate-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
-        "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-base-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-provider-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-security-sddl-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-service-core-l1-1-0.dll",
@@ -2057,14 +8775,26 @@
         "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-service-winsvc-l1-1-0.dll",
-        "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll"
+      ]
+    },
+    "runtime.win7-x64.runtime.native.System.IO.Compression/4.0.1-rc2-23911": {
+      "sha512": "XWTDSlVtxRpzaF2aE4l5CO0g72RkCrDRwvHvOXHcSDx2iwPqgV8DTB1CySOt+9BDHIAXrsEkmLRiMUibchYCuQ==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.win7-x64.runtime.native.System.IO.Compression.4.0.1-rc2-23911.nupkg.sha512",
+        "runtime.win7-x64.runtime.native.System.IO.Compression.nuspec",
+        "runtimes/win10-x64/native/clrcompression.dll",
+        "runtimes/win7-x64/native/clrcompression.dll"
       ]
     },
     "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.2-rc2-23911": {
       "sha512": "r6ehoE/wUUaYkSkyxManXfkRWCZ+VkQMeee0FNmyG3gE4+AAYu8SNBsCe/5ZT8VoPZVYZP9lrdL0/AX99yB/kw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2080,7 +8810,6 @@
         "runtimes/win7-x86/native/mscorrc.debug.dll",
         "runtimes/win7-x86/native/mscorrc.dll",
         "runtimes/win7-x86/native/sos.dll",
-        "ThirdPartyNotices.txt",
         "tools/crossgen.exe",
         "tools/sos.dll"
       ]
@@ -2089,14 +8818,31 @@
       "sha512": "QFLw6yyuhkdqa2xo/h1UpBxJA/o+OdGEsWjGorqFvzmBrSWQq+ziyOuwh2g3/GN7JMQdpvxQsMeTpO+9NlUdLQ==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -2122,9 +8868,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
         "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-localization-l1-2-0.dll",
@@ -2138,7 +8881,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-normalization-l1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-2-0.dll",
@@ -2146,7 +8888,6 @@
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-profile-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-psapi-l1-1-0.dll",
@@ -2159,13 +8900,11 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -2190,21 +8929,12 @@
         "runtimes/win7-x86/native/api-ms-win-core-wow64-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-xstate-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-xstate-l2-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
-        "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-base-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-provider-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-security-sddl-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-service-core-l1-1-0.dll",
@@ -2214,42 +8944,54 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
-        "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll"
+      ]
+    },
+    "runtime.win7-x86.runtime.native.System.IO.Compression/4.0.1-rc2-23911": {
+      "sha512": "cMDkL1Ly5bZvDGqfbWyt2rPhy45KoKQc/4R1f5VT3ebPKPrcb/zd5QWXybvlAHiTpVkBrmKAEqgkSZ7r25RfYw==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.win7-x86.runtime.native.System.IO.Compression.4.0.1-rc2-23911.nupkg.sha512",
+        "runtime.win7-x86.runtime.native.System.IO.Compression.nuspec",
+        "runtimes/win10-x86/native/clrcompression.dll",
+        "runtimes/win7-x86/native/clrcompression.dll"
       ]
     },
     "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23911": {
       "sha512": "f/qkLKYIjjy0AfntLvAJqygSWeL9OJUn6f4D+mP9s85ygHBZkhIeNMR/u1VU4WnAd3MaBc9t6YUQRZ4U5PHgkw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.win7.Microsoft.Win32.Primitives.nuspec",
         "runtimes/win7/lib/net/_._",
-        "runtimes/win7/lib/netstandard1.3/Microsoft.Win32.Primitives.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/netstandard1.3/Microsoft.Win32.Primitives.dll"
       ]
     },
     "runtime.win7.System.Console/4.0.0-rc2-23911": {
       "sha512": "XRBpd0Vbrm+lFSdMq2w1+Ezyz2YYKzvqCpSxrhBP4mhHp6pwApXXjycRwRJPGA0LUNZuKaDOco7w962kLlzwgg==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.win7.System.Console.nuspec",
         "runtimes/win7/lib/net/_._",
-        "runtimes/win7/lib/netstandard1.3/System.Console.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/netstandard1.3/System.Console.dll"
       ]
     },
     "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23911": {
       "sha512": "M4tw2VywXd6ErfDxelJtlkU6nIXpYdkjyTuep54zsv77bxS3QPYJgiL8GLj52AkLrRdlbEn41qLkkX39uvovLQ==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2261,14 +9003,27 @@
         "runtimes/win7/lib/netstandard1.3/System.Diagnostics.Debug.dll",
         "runtimes/win7/lib/win8/_._",
         "runtimes/win7/lib/wp80/_._",
-        "runtimes/win7/lib/wpa81/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/wpa81/_._"
+      ]
+    },
+    "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23911": {
+      "sha512": "NCsElfMAr+BGQq2RMpuXm3c6jTslZLrG6qssOVkIjG0tqbo7iSizOVNhIKc8g37izhTb9MArAzf/AI4dkVH11w==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.win7.System.Globalization.Extensions.4.0.1-rc2-23911.nupkg.sha512",
+        "runtime.win7.System.Globalization.Extensions.nuspec",
+        "runtimes/win7/lib/net/_._",
+        "runtimes/win7/lib/netstandard1.3/System.Globalization.Extensions.dll"
       ]
     },
     "runtime.win7.System.IO.Compression/4.1.0-rc2-23911": {
       "sha512": "maXQs/QOQzPFgmV3cVw5CQCyA8u+BpQOmMtwDS2qXoILj/aJfBGL4RS50j7kyiqbi+WMaEZa1z0uaA63L4QvrQ==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2280,14 +9035,14 @@
         "runtimes/win7/lib/netstandard1.3/System.IO.Compression.dll",
         "runtimes/win7/lib/win8/_._",
         "runtimes/win7/lib/wp8/_._",
-        "runtimes/win7/lib/wpa81/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/wpa81/_._"
       ]
     },
     "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23911": {
       "sha512": "UUOQ17URtLxI/gtk2AqxF8r9tdAYSHgWBan6c5kC2v99eQS+UdOZMOh9O0W+LN3C3HyqOwwJ9y9OyZLdtDEzkw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2299,14 +9054,14 @@
         "runtimes/win7/lib/netstandard1.3/System.IO.FileSystem.dll",
         "runtimes/win7/lib/win8/_._",
         "runtimes/win7/lib/wp8/_._",
-        "runtimes/win7/lib/wpa81/_._",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/wpa81/_._"
       ]
     },
     "runtime.win7.System.Net.Http/4.0.1-rc2-23911": {
       "sha512": "zqtuoXCBf5M5GTxZutldoN1lzZZX9+ePjJYOypOg65m2+aEr9ypF06yzhNVWy2VinAVYLsMOQ8B+WrrqQKetpw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2314,14 +9069,28 @@
         "runtime.win7.System.Net.Http.nuspec",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/System.Net.Http.dll",
-        "runtimes/win7/lib/netstandard1.3/System.Net.Http.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/netstandard1.3/System.Net.Http.dll"
+      ]
+    },
+    "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23911": {
+      "sha512": "Lcz0K9jnh7RwIfDVR6LcqeAe/+tuCChLkaRcZdFIFpdA5QvMeFXM1pFX1+FUAMbOwUWyUDken4CaXY4dLjHpng==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.win7.System.Net.NameResolution.4.0.0-rc2-23911.nupkg.sha512",
+        "runtime.win7.System.Net.NameResolution.nuspec",
+        "runtimes/win7/lib/net/_._",
+        "runtimes/win7/lib/netcore50/System.Net.NameResolution.dll",
+        "runtimes/win7/lib/netstandard1.3/System.Net.NameResolution.dll"
       ]
     },
     "runtime.win7.System.Net.Primitives/4.0.11-rc2-23911": {
       "sha512": "ML3ybP9IZ2PUevwv4N75V/ob5/ynbal1v7kLXOORlgW5deMn1QeKNL0S3rk6Y0SeFh6eLVxDELp6PEDZOgTPmw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2329,28 +9098,28 @@
         "ref/netstandard/_._",
         "runtime.win7.System.Net.Primitives.nuspec",
         "runtimes/win7/lib/net/_._",
-        "runtimes/win7/lib/netstandard1.3/System.Net.Primitives.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/netstandard1.3/System.Net.Primitives.dll"
       ]
     },
     "runtime.win7.System.Net.Requests/4.0.11-rc2-23911": {
       "sha512": "SYPtK9dcWNnIaKUiFBjWqehICNcVJ9JuWmRHET3uB5YSZdTy3rZG5ZY+qYHNEh7xG1bjk4Mapkvb1LBAlZsOkA==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "ref/netstandard/_._",
         "runtime.win7.System.Net.Requests.nuspec",
         "runtimes/win7/lib/net/_._",
-        "runtimes/win7/lib/netstandard1.3/System.Net.Requests.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/netstandard1.3/System.Net.Requests.dll"
       ]
     },
     "runtime.win7.System.Net.Sockets/4.1.0-rc2-23911": {
       "sha512": "vyM9Vd0R2Zc5KVufukdWavrlzM5yCenJmqHdd4Z3SC6jSXYeyy6Ril+8j8cbUqGeJNMZwJqReUYdeQELC+mYeQ==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2358,14 +9127,27 @@
         "runtime.win7.System.Net.Sockets.nuspec",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/System.Net.Sockets.dll",
-        "runtimes/win7/lib/netstandard1.3/System.Net.Sockets.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/netstandard1.3/System.Net.Sockets.dll"
+      ]
+    },
+    "runtime.win7.System.Private.Uri/4.0.1-rc2-23911": {
+      "sha512": "BTLMDi8mdhMbFUf8HTnjkxxlkKj32M0bgzY09Ubabtjb6VEPrR+dlclpKz5qL14RXKrZ39tDAiYuJFVnRo5VHw==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/netstandard1.0/System.Private.Uri.dll",
+        "ref/netstandard/_._",
+        "runtime.win7.System.Private.Uri.4.0.1-rc2-23911.nupkg.sha512",
+        "runtime.win7.System.Private.Uri.nuspec",
+        "runtimes/aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
     "runtime.win7.System.Runtime.Extensions/4.1.0-rc2-23911": {
       "sha512": "FEMYJaBQPsH4oqO6+aaSMoNFATVwOWcNZbf3Xcp08jgcq06X8vhD3Ao+8qao1+ba6ObmWZ0BIPwttkM6MKdPIw==",
       "type": "Package",
       "files": [
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2373,14 +9155,55 @@
         "runtime.win7.System.Runtime.Extensions.nuspec",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/System.Runtime.Extensions.dll",
-        "runtimes/win7/lib/netstandard1.3/System.Runtime.Extensions.dll",
-        "ThirdPartyNotices.txt"
+        "runtimes/win7/lib/netstandard1.3/System.Runtime.Extensions.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+      "sha512": "RvCcAy9wEDWHIl8kCiZu+h+mDkisv8f4/NxT02vi5CW7uthwy/IjoiDnI3WUwrKZvd3OFKEGa7RuaprnDU0rXw==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.win7.System.Security.Cryptography.Algorithms.4.1.0-rc2-23911.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.Algorithms.nuspec",
+        "runtimes/win7/lib/net/_._",
+        "runtimes/win7/lib/netstandard1.4/System.Security.Cryptography.Algorithms.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+      "sha512": "OUZOuVMIjlZWndIe6K++Pt0s5RtMUXCJCuQmLHuAESut4kmokIUu5NHQxqKk5/YpiUMlTdi3KZ0bpns8x+WR+A==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-rc2-23911.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.Encoding.nuspec",
+        "runtimes/win7/lib/net/_._",
+        "runtimes/win7/lib/netstandard1.3/System.Security.Cryptography.Encoding.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+      "sha512": "iXi704Cv5NPMbAe18UA+D83b0dEVBMXp0PBL9rDMhRm6CrahP6qyGrmeL4FQKuC7bz1Q/4aFTTOUpX7qJJzHJw==",
+      "type": "package",
+      "files": [
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.4.1.0-rc2-23911.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.nuspec",
+        "runtimes/win7/lib/net/_._",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/netstandard1.4/System.Security.Cryptography.X509Certificates.dll"
       ]
     },
     "System.AppContext/4.1.0-rc2-23911": {
       "sha512": "cM/JLgN+8MHOFKZiwIOEMB0UknZ9talGmKNNAQwn6ZEgMSOjcFsQxQPJYpu8F2u9DRhOr225ONcXGsNxnBBy+g==",
       "type": "Package",
       "files": [
+        "System.AppContext.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2395,6 +9218,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net462/System.AppContext.dll",
+        "ref/netstandard1.3/System.AppContext.dll",
+        "ref/netstandard1.3/System.AppContext.xml",
         "ref/netstandard1.3/de/System.AppContext.xml",
         "ref/netstandard1.3/es/System.AppContext.xml",
         "ref/netstandard1.3/fr/System.AppContext.xml",
@@ -2402,10 +9227,10 @@
         "ref/netstandard1.3/ja/System.AppContext.xml",
         "ref/netstandard1.3/ko/System.AppContext.xml",
         "ref/netstandard1.3/ru/System.AppContext.xml",
-        "ref/netstandard1.3/System.AppContext.dll",
-        "ref/netstandard1.3/System.AppContext.xml",
         "ref/netstandard1.3/zh-hans/System.AppContext.xml",
         "ref/netstandard1.3/zh-hant/System.AppContext.xml",
+        "ref/netstandard1.5/System.AppContext.dll",
+        "ref/netstandard1.5/System.AppContext.xml",
         "ref/netstandard1.5/de/System.AppContext.xml",
         "ref/netstandard1.5/es/System.AppContext.xml",
         "ref/netstandard1.5/fr/System.AppContext.xml",
@@ -2413,22 +9238,32 @@
         "ref/netstandard1.5/ja/System.AppContext.xml",
         "ref/netstandard1.5/ko/System.AppContext.xml",
         "ref/netstandard1.5/ru/System.AppContext.xml",
-        "ref/netstandard1.5/System.AppContext.dll",
-        "ref/netstandard1.5/System.AppContext.xml",
         "ref/netstandard1.5/zh-hans/System.AppContext.xml",
         "ref/netstandard1.5/zh-hant/System.AppContext.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.AppContext.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Buffers/4.0.0-rc2-23911": {
+      "sha512": "2jLOtDtSwFkv6hYbH/mGEdryANw8cLG4FW/OhAUNY3ISo5ARxpkRp7PhBCz0Hn3GSKcVrxo85dRzzebYxVLoYQ==",
+      "type": "package",
+      "files": [
+        "System.Buffers.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Buffers.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/netstandard1.1/.xml",
+        "lib/netstandard1.1/System.Buffers.dll"
       ]
     },
     "System.Collections/4.0.11-rc2-23911": {
       "sha512": "hR7c7uJbv+Ltjn1gdvy5ZM4ZUwwnXoiJ20zJkyYBycwrxRhUDYLiIkHxYQOH15/1LYEghHH2HgRRuToZoApiyQ==",
       "type": "Package",
       "files": [
+        "System.Collections.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2445,6 +9280,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Collections.dll",
+        "ref/netcore50/System.Collections.xml",
         "ref/netcore50/de/System.Collections.xml",
         "ref/netcore50/es/System.Collections.xml",
         "ref/netcore50/fr/System.Collections.xml",
@@ -2452,10 +9289,10 @@
         "ref/netcore50/ja/System.Collections.xml",
         "ref/netcore50/ko/System.Collections.xml",
         "ref/netcore50/ru/System.Collections.xml",
-        "ref/netcore50/System.Collections.dll",
-        "ref/netcore50/System.Collections.xml",
         "ref/netcore50/zh-hans/System.Collections.xml",
         "ref/netcore50/zh-hant/System.Collections.xml",
+        "ref/netstandard1.0/System.Collections.dll",
+        "ref/netstandard1.0/System.Collections.xml",
         "ref/netstandard1.0/de/System.Collections.xml",
         "ref/netstandard1.0/es/System.Collections.xml",
         "ref/netstandard1.0/fr/System.Collections.xml",
@@ -2463,10 +9300,10 @@
         "ref/netstandard1.0/ja/System.Collections.xml",
         "ref/netstandard1.0/ko/System.Collections.xml",
         "ref/netstandard1.0/ru/System.Collections.xml",
-        "ref/netstandard1.0/System.Collections.dll",
-        "ref/netstandard1.0/System.Collections.xml",
         "ref/netstandard1.0/zh-hans/System.Collections.xml",
         "ref/netstandard1.0/zh-hant/System.Collections.xml",
+        "ref/netstandard1.3/System.Collections.dll",
+        "ref/netstandard1.3/System.Collections.xml",
         "ref/netstandard1.3/de/System.Collections.xml",
         "ref/netstandard1.3/es/System.Collections.xml",
         "ref/netstandard1.3/fr/System.Collections.xml",
@@ -2474,8 +9311,6 @@
         "ref/netstandard1.3/ja/System.Collections.xml",
         "ref/netstandard1.3/ko/System.Collections.xml",
         "ref/netstandard1.3/ru/System.Collections.xml",
-        "ref/netstandard1.3/System.Collections.dll",
-        "ref/netstandard1.3/System.Collections.xml",
         "ref/netstandard1.3/zh-hans/System.Collections.xml",
         "ref/netstandard1.3/zh-hant/System.Collections.xml",
         "ref/win8/_._",
@@ -2484,15 +9319,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Collections.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Collections.Concurrent/4.0.12-rc2-23911": {
       "sha512": "Y7a7MELq8TQQd+Kf6Thtps6a8aKdEqjZIuZONEp/HmHa4GivhrDOEzAGNvp6dIBitdolj7q34GdDeaaqhQXWXA==",
       "type": "Package",
       "files": [
+        "System.Collections.Concurrent.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2510,6 +9345,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Collections.Concurrent.dll",
+        "ref/netcore50/System.Collections.Concurrent.xml",
         "ref/netcore50/de/System.Collections.Concurrent.xml",
         "ref/netcore50/es/System.Collections.Concurrent.xml",
         "ref/netcore50/fr/System.Collections.Concurrent.xml",
@@ -2517,10 +9354,10 @@
         "ref/netcore50/ja/System.Collections.Concurrent.xml",
         "ref/netcore50/ko/System.Collections.Concurrent.xml",
         "ref/netcore50/ru/System.Collections.Concurrent.xml",
-        "ref/netcore50/System.Collections.Concurrent.dll",
-        "ref/netcore50/System.Collections.Concurrent.xml",
         "ref/netcore50/zh-hans/System.Collections.Concurrent.xml",
         "ref/netcore50/zh-hant/System.Collections.Concurrent.xml",
+        "ref/netstandard1.1/System.Collections.Concurrent.dll",
+        "ref/netstandard1.1/System.Collections.Concurrent.xml",
         "ref/netstandard1.1/de/System.Collections.Concurrent.xml",
         "ref/netstandard1.1/es/System.Collections.Concurrent.xml",
         "ref/netstandard1.1/fr/System.Collections.Concurrent.xml",
@@ -2528,10 +9365,10 @@
         "ref/netstandard1.1/ja/System.Collections.Concurrent.xml",
         "ref/netstandard1.1/ko/System.Collections.Concurrent.xml",
         "ref/netstandard1.1/ru/System.Collections.Concurrent.xml",
-        "ref/netstandard1.1/System.Collections.Concurrent.dll",
-        "ref/netstandard1.1/System.Collections.Concurrent.xml",
         "ref/netstandard1.1/zh-hans/System.Collections.Concurrent.xml",
         "ref/netstandard1.1/zh-hant/System.Collections.Concurrent.xml",
+        "ref/netstandard1.3/System.Collections.Concurrent.dll",
+        "ref/netstandard1.3/System.Collections.Concurrent.xml",
         "ref/netstandard1.3/de/System.Collections.Concurrent.xml",
         "ref/netstandard1.3/es/System.Collections.Concurrent.xml",
         "ref/netstandard1.3/fr/System.Collections.Concurrent.xml",
@@ -2539,8 +9376,6 @@
         "ref/netstandard1.3/ja/System.Collections.Concurrent.xml",
         "ref/netstandard1.3/ko/System.Collections.Concurrent.xml",
         "ref/netstandard1.3/ru/System.Collections.Concurrent.xml",
-        "ref/netstandard1.3/System.Collections.Concurrent.dll",
-        "ref/netstandard1.3/System.Collections.Concurrent.xml",
         "ref/netstandard1.3/zh-hans/System.Collections.Concurrent.xml",
         "ref/netstandard1.3/zh-hant/System.Collections.Concurrent.xml",
         "ref/win8/_._",
@@ -2548,15 +9383,86 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Collections.Concurrent.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Collections.NonGeneric/4.0.1-rc2-23911": {
+      "sha512": "8Rjdtk6R+ppCCz6mUtco2AI99iC8yCVRYrOv1KvX6qhvh2xpaJU4kMbWS0VsB6eYNef/M2eAmlAe8kzByKtpfA==",
+      "type": "package",
+      "files": [
+        "System.Collections.NonGeneric.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Collections.NonGeneric.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
+        "lib/netstandard1.3/System.Collections.NonGeneric.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/netstandard1.3/System.Collections.NonGeneric.dll",
+        "ref/netstandard1.3/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/de/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/es/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/fr/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/it/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/ja/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/ko/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/ru/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/zh-hans/System.Collections.NonGeneric.xml",
+        "ref/netstandard1.3/zh-hant/System.Collections.NonGeneric.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Collections.Specialized/4.0.1-rc2-23911": {
+      "sha512": "cSKYFnGmQzGPFFCIrHyczUl5lE4Ow6SpGX1KNmzK1C1ySwwjwUXrxRSpUJi4Cp/+FhBRD/YtTvF/CZdA1z1wFA==",
+      "type": "package",
+      "files": [
+        "System.Collections.Specialized.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Collections.Specialized.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.Specialized.dll",
+        "lib/netstandard1.3/System.Collections.Specialized.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.Specialized.dll",
+        "ref/netstandard1.3/System.Collections.Specialized.dll",
+        "ref/netstandard1.3/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/de/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/es/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/fr/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/it/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/ja/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/ko/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/ru/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/zh-hans/System.Collections.Specialized.xml",
+        "ref/netstandard1.3/zh-hant/System.Collections.Specialized.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Console/4.0.0-rc2-23911": {
       "sha512": "vGdCuwxS/8t5m5d9wOM46Degf6XQjfMURyRMCVmRXPpzHx5FzjKIq+cPLReLWRPYWjkGqExGrIaQEHk4As+mkQ==",
       "type": "Package",
       "files": [
+        "System.Console.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2570,6 +9476,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Console.dll",
+        "ref/netstandard1.3/System.Console.dll",
+        "ref/netstandard1.3/System.Console.xml",
         "ref/netstandard1.3/de/System.Console.xml",
         "ref/netstandard1.3/es/System.Console.xml",
         "ref/netstandard1.3/fr/System.Console.xml",
@@ -2577,22 +9485,20 @@
         "ref/netstandard1.3/ja/System.Console.xml",
         "ref/netstandard1.3/ko/System.Console.xml",
         "ref/netstandard1.3/ru/System.Console.xml",
-        "ref/netstandard1.3/System.Console.dll",
-        "ref/netstandard1.3/System.Console.xml",
         "ref/netstandard1.3/zh-hans/System.Console.xml",
         "ref/netstandard1.3/zh-hant/System.Console.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Console.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Diagnostics.Debug/4.0.11-rc2-23911": {
       "sha512": "S6e8YZVxocOB0DQIbFKESNbj7xUjuysTUS1odnqwaf10HuaFnZ7jdr7uP8RRlarOZft6aFxT8CzQo4AnrhjxnQ==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Debug.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2609,6 +9515,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Debug.dll",
+        "ref/netcore50/System.Diagnostics.Debug.xml",
         "ref/netcore50/de/System.Diagnostics.Debug.xml",
         "ref/netcore50/es/System.Diagnostics.Debug.xml",
         "ref/netcore50/fr/System.Diagnostics.Debug.xml",
@@ -2616,10 +9524,10 @@
         "ref/netcore50/ja/System.Diagnostics.Debug.xml",
         "ref/netcore50/ko/System.Diagnostics.Debug.xml",
         "ref/netcore50/ru/System.Diagnostics.Debug.xml",
-        "ref/netcore50/System.Diagnostics.Debug.dll",
-        "ref/netcore50/System.Diagnostics.Debug.xml",
         "ref/netcore50/zh-hans/System.Diagnostics.Debug.xml",
         "ref/netcore50/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/netstandard1.0/System.Diagnostics.Debug.dll",
+        "ref/netstandard1.0/System.Diagnostics.Debug.xml",
         "ref/netstandard1.0/de/System.Diagnostics.Debug.xml",
         "ref/netstandard1.0/es/System.Diagnostics.Debug.xml",
         "ref/netstandard1.0/fr/System.Diagnostics.Debug.xml",
@@ -2627,10 +9535,10 @@
         "ref/netstandard1.0/ja/System.Diagnostics.Debug.xml",
         "ref/netstandard1.0/ko/System.Diagnostics.Debug.xml",
         "ref/netstandard1.0/ru/System.Diagnostics.Debug.xml",
-        "ref/netstandard1.0/System.Diagnostics.Debug.dll",
-        "ref/netstandard1.0/System.Diagnostics.Debug.xml",
         "ref/netstandard1.0/zh-hans/System.Diagnostics.Debug.xml",
         "ref/netstandard1.0/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/netstandard1.3/System.Diagnostics.Debug.dll",
+        "ref/netstandard1.3/System.Diagnostics.Debug.xml",
         "ref/netstandard1.3/de/System.Diagnostics.Debug.xml",
         "ref/netstandard1.3/es/System.Diagnostics.Debug.xml",
         "ref/netstandard1.3/fr/System.Diagnostics.Debug.xml",
@@ -2638,8 +9546,6 @@
         "ref/netstandard1.3/ja/System.Diagnostics.Debug.xml",
         "ref/netstandard1.3/ko/System.Diagnostics.Debug.xml",
         "ref/netstandard1.3/ru/System.Diagnostics.Debug.xml",
-        "ref/netstandard1.3/System.Diagnostics.Debug.dll",
-        "ref/netstandard1.3/System.Diagnostics.Debug.xml",
         "ref/netstandard1.3/zh-hans/System.Diagnostics.Debug.xml",
         "ref/netstandard1.3/zh-hant/System.Diagnostics.Debug.xml",
         "ref/win8/_._",
@@ -2648,15 +9554,29 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Diagnostics.Debug.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Diagnostics.DiagnosticSource/4.0.0-rc2-23911": {
+      "sha512": "7GZ99AFDKir6/CX7SK6jbLrxLk8xulA738AGghNpEHKwwtxmLcqZ3f8RCTRGTickhMS80SrNEgO0XToow/wxZg==",
+      "type": "package",
+      "files": [
+        "System.Diagnostics.DiagnosticSource.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Diagnostics.DiagnosticSource.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.dll",
+        "lib/netstandard1.1/System.Diagnostics.DiagnosticSource.xml",
+        "lib/portable-net45+win8+wpa81/System.Diagnostics.DiagnosticSource.dll",
+        "lib/portable-net45+win8+wpa81/System.Diagnostics.DiagnosticSource.xml"
       ]
     },
     "System.Diagnostics.Tools/4.0.1-rc2-23911": {
       "sha512": "iRHjkTm0NJ0ZLkVuMS+fn4a5aelDykrpTipSao79dI4lLgo5+/zT00ZvojJ/hedBMahF5qSKOp0PL+/O4zXZyw==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Tools.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2673,6 +9593,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Tools.dll",
+        "ref/netcore50/System.Diagnostics.Tools.xml",
         "ref/netcore50/de/System.Diagnostics.Tools.xml",
         "ref/netcore50/es/System.Diagnostics.Tools.xml",
         "ref/netcore50/fr/System.Diagnostics.Tools.xml",
@@ -2680,10 +9602,10 @@
         "ref/netcore50/ja/System.Diagnostics.Tools.xml",
         "ref/netcore50/ko/System.Diagnostics.Tools.xml",
         "ref/netcore50/ru/System.Diagnostics.Tools.xml",
-        "ref/netcore50/System.Diagnostics.Tools.dll",
-        "ref/netcore50/System.Diagnostics.Tools.xml",
         "ref/netcore50/zh-hans/System.Diagnostics.Tools.xml",
         "ref/netcore50/zh-hant/System.Diagnostics.Tools.xml",
+        "ref/netstandard1.0/System.Diagnostics.Tools.dll",
+        "ref/netstandard1.0/System.Diagnostics.Tools.xml",
         "ref/netstandard1.0/de/System.Diagnostics.Tools.xml",
         "ref/netstandard1.0/es/System.Diagnostics.Tools.xml",
         "ref/netstandard1.0/fr/System.Diagnostics.Tools.xml",
@@ -2691,8 +9613,6 @@
         "ref/netstandard1.0/ja/System.Diagnostics.Tools.xml",
         "ref/netstandard1.0/ko/System.Diagnostics.Tools.xml",
         "ref/netstandard1.0/ru/System.Diagnostics.Tools.xml",
-        "ref/netstandard1.0/System.Diagnostics.Tools.dll",
-        "ref/netstandard1.0/System.Diagnostics.Tools.xml",
         "ref/netstandard1.0/zh-hans/System.Diagnostics.Tools.xml",
         "ref/netstandard1.0/zh-hant/System.Diagnostics.Tools.xml",
         "ref/win8/_._",
@@ -2701,15 +9621,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Diagnostics.Tools.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Diagnostics.Tracing/4.1.0-rc2-23911": {
       "sha512": "YKOmWBlamHSpu+Ym9TkCj14OiQcBb0i4ul/3vn8c1ZYcA1c14aXsreHX1B5i901sN9GqMkT3Ms9GIkSDnyIWyA==",
       "type": "Package",
       "files": [
+        "System.Diagnostics.Tracing.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2727,6 +9647,8 @@
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net462/System.Diagnostics.Tracing.dll",
+        "ref/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/netcore50/System.Diagnostics.Tracing.xml",
         "ref/netcore50/de/System.Diagnostics.Tracing.xml",
         "ref/netcore50/es/System.Diagnostics.Tracing.xml",
         "ref/netcore50/fr/System.Diagnostics.Tracing.xml",
@@ -2734,10 +9656,10 @@
         "ref/netcore50/ja/System.Diagnostics.Tracing.xml",
         "ref/netcore50/ko/System.Diagnostics.Tracing.xml",
         "ref/netcore50/ru/System.Diagnostics.Tracing.xml",
-        "ref/netcore50/System.Diagnostics.Tracing.dll",
-        "ref/netcore50/System.Diagnostics.Tracing.xml",
         "ref/netcore50/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/netcore50/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/netstandard1.1/System.Diagnostics.Tracing.dll",
+        "ref/netstandard1.1/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.1/de/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.1/es/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.1/fr/System.Diagnostics.Tracing.xml",
@@ -2745,10 +9667,10 @@
         "ref/netstandard1.1/ja/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.1/ko/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.1/ru/System.Diagnostics.Tracing.xml",
-        "ref/netstandard1.1/System.Diagnostics.Tracing.dll",
-        "ref/netstandard1.1/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.1/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.1/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/netstandard1.2/System.Diagnostics.Tracing.dll",
+        "ref/netstandard1.2/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.2/de/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.2/es/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.2/fr/System.Diagnostics.Tracing.xml",
@@ -2756,10 +9678,10 @@
         "ref/netstandard1.2/ja/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.2/ko/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.2/ru/System.Diagnostics.Tracing.xml",
-        "ref/netstandard1.2/System.Diagnostics.Tracing.dll",
-        "ref/netstandard1.2/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.2/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.2/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/netstandard1.3/System.Diagnostics.Tracing.dll",
+        "ref/netstandard1.3/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.3/de/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.3/es/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.3/fr/System.Diagnostics.Tracing.xml",
@@ -2767,10 +9689,10 @@
         "ref/netstandard1.3/ja/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.3/ko/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.3/ru/System.Diagnostics.Tracing.xml",
-        "ref/netstandard1.3/System.Diagnostics.Tracing.dll",
-        "ref/netstandard1.3/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.3/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.3/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/netstandard1.5/System.Diagnostics.Tracing.dll",
+        "ref/netstandard1.5/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.5/de/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.5/es/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.5/fr/System.Diagnostics.Tracing.xml",
@@ -2778,8 +9700,6 @@
         "ref/netstandard1.5/ja/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.5/ko/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.5/ru/System.Diagnostics.Tracing.xml",
-        "ref/netstandard1.5/System.Diagnostics.Tracing.dll",
-        "ref/netstandard1.5/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.5/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/netstandard1.5/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/win8/_._",
@@ -2787,15 +9707,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Diagnostics.Tracing.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Globalization/4.0.11-rc2-23911": {
       "sha512": "eOCvRVkpnrZgLkCPUfSKexNI5I8TdoqMD+C+9JQ1/AFJF2o5hJAj+7SGqCrfyxOg7cZ6Bm4GOudAsiFVBG15hg==",
       "type": "Package",
       "files": [
+        "System.Globalization.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2812,6 +9732,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Globalization.dll",
+        "ref/netcore50/System.Globalization.xml",
         "ref/netcore50/de/System.Globalization.xml",
         "ref/netcore50/es/System.Globalization.xml",
         "ref/netcore50/fr/System.Globalization.xml",
@@ -2819,10 +9741,10 @@
         "ref/netcore50/ja/System.Globalization.xml",
         "ref/netcore50/ko/System.Globalization.xml",
         "ref/netcore50/ru/System.Globalization.xml",
-        "ref/netcore50/System.Globalization.dll",
-        "ref/netcore50/System.Globalization.xml",
         "ref/netcore50/zh-hans/System.Globalization.xml",
         "ref/netcore50/zh-hant/System.Globalization.xml",
+        "ref/netstandard1.0/System.Globalization.dll",
+        "ref/netstandard1.0/System.Globalization.xml",
         "ref/netstandard1.0/de/System.Globalization.xml",
         "ref/netstandard1.0/es/System.Globalization.xml",
         "ref/netstandard1.0/fr/System.Globalization.xml",
@@ -2830,10 +9752,10 @@
         "ref/netstandard1.0/ja/System.Globalization.xml",
         "ref/netstandard1.0/ko/System.Globalization.xml",
         "ref/netstandard1.0/ru/System.Globalization.xml",
-        "ref/netstandard1.0/System.Globalization.dll",
-        "ref/netstandard1.0/System.Globalization.xml",
         "ref/netstandard1.0/zh-hans/System.Globalization.xml",
         "ref/netstandard1.0/zh-hant/System.Globalization.xml",
+        "ref/netstandard1.3/System.Globalization.dll",
+        "ref/netstandard1.3/System.Globalization.xml",
         "ref/netstandard1.3/de/System.Globalization.xml",
         "ref/netstandard1.3/es/System.Globalization.xml",
         "ref/netstandard1.3/fr/System.Globalization.xml",
@@ -2841,8 +9763,6 @@
         "ref/netstandard1.3/ja/System.Globalization.xml",
         "ref/netstandard1.3/ko/System.Globalization.xml",
         "ref/netstandard1.3/ru/System.Globalization.xml",
-        "ref/netstandard1.3/System.Globalization.dll",
-        "ref/netstandard1.3/System.Globalization.xml",
         "ref/netstandard1.3/zh-hans/System.Globalization.xml",
         "ref/netstandard1.3/zh-hant/System.Globalization.xml",
         "ref/win8/_._",
@@ -2851,15 +9771,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Globalization.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Globalization.Calendars/4.0.1-rc2-23911": {
       "sha512": "kmRCQ8U6lgCxBH8Q/EgBfm1k+I4c9p8L8DV8+RU2aXsxzCkZjlGPI5upitACSpIyels4pQw1Bk/L3XRVW6x/qw==",
       "type": "Package",
       "files": [
+        "System.Globalization.Calendars.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2873,6 +9793,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Calendars.dll",
+        "ref/netstandard1.3/System.Globalization.Calendars.dll",
+        "ref/netstandard1.3/System.Globalization.Calendars.xml",
         "ref/netstandard1.3/de/System.Globalization.Calendars.xml",
         "ref/netstandard1.3/es/System.Globalization.Calendars.xml",
         "ref/netstandard1.3/fr/System.Globalization.Calendars.xml",
@@ -2880,22 +9802,55 @@
         "ref/netstandard1.3/ja/System.Globalization.Calendars.xml",
         "ref/netstandard1.3/ko/System.Globalization.Calendars.xml",
         "ref/netstandard1.3/ru/System.Globalization.Calendars.xml",
-        "ref/netstandard1.3/System.Globalization.Calendars.dll",
-        "ref/netstandard1.3/System.Globalization.Calendars.xml",
         "ref/netstandard1.3/zh-hans/System.Globalization.Calendars.xml",
         "ref/netstandard1.3/zh-hant/System.Globalization.Calendars.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Globalization.Calendars.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Globalization.Extensions/4.0.1-rc2-23911": {
+      "sha512": "t6jHcsDqJUPmGjF2q/mqHvs6gbqDuQA6o4TMIkCTo8FNc9hh1LWKiSdZ5d5Q9Lu2Ayk9g0W4sMeR9uXVycfITw==",
+      "type": "package",
+      "files": [
+        "System.Globalization.Extensions.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Globalization.Extensions.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/netstandard1.3/System.Globalization.Extensions.dll",
+        "ref/netstandard1.3/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/de/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/es/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/fr/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/it/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/ja/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/ko/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/ru/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/zh-hans/System.Globalization.Extensions.xml",
+        "ref/netstandard1.3/zh-hant/System.Globalization.Extensions.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.IO/4.1.0-rc2-23911": {
       "sha512": "zWTjlfc8FnHH3uu48TfVIH3uDBMeA8IT3oOFtFSVh8wI+u78HFJ5vtYpFvKi80DBYtVwFDlA1mKQCJ1TamyL2A==",
       "type": "Package",
       "files": [
+        "System.IO.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2914,6 +9869,8 @@
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net46/System.IO.dll",
+        "ref/netcore50/System.IO.dll",
+        "ref/netcore50/System.IO.xml",
         "ref/netcore50/de/System.IO.xml",
         "ref/netcore50/es/System.IO.xml",
         "ref/netcore50/fr/System.IO.xml",
@@ -2921,10 +9878,10 @@
         "ref/netcore50/ja/System.IO.xml",
         "ref/netcore50/ko/System.IO.xml",
         "ref/netcore50/ru/System.IO.xml",
-        "ref/netcore50/System.IO.dll",
-        "ref/netcore50/System.IO.xml",
         "ref/netcore50/zh-hans/System.IO.xml",
         "ref/netcore50/zh-hant/System.IO.xml",
+        "ref/netstandard1.0/System.IO.dll",
+        "ref/netstandard1.0/System.IO.xml",
         "ref/netstandard1.0/de/System.IO.xml",
         "ref/netstandard1.0/es/System.IO.xml",
         "ref/netstandard1.0/fr/System.IO.xml",
@@ -2932,10 +9889,10 @@
         "ref/netstandard1.0/ja/System.IO.xml",
         "ref/netstandard1.0/ko/System.IO.xml",
         "ref/netstandard1.0/ru/System.IO.xml",
-        "ref/netstandard1.0/System.IO.dll",
-        "ref/netstandard1.0/System.IO.xml",
         "ref/netstandard1.0/zh-hans/System.IO.xml",
         "ref/netstandard1.0/zh-hant/System.IO.xml",
+        "ref/netstandard1.3/System.IO.dll",
+        "ref/netstandard1.3/System.IO.xml",
         "ref/netstandard1.3/de/System.IO.xml",
         "ref/netstandard1.3/es/System.IO.xml",
         "ref/netstandard1.3/fr/System.IO.xml",
@@ -2943,8 +9900,6 @@
         "ref/netstandard1.3/ja/System.IO.xml",
         "ref/netstandard1.3/ko/System.IO.xml",
         "ref/netstandard1.3/ru/System.IO.xml",
-        "ref/netstandard1.3/System.IO.dll",
-        "ref/netstandard1.3/System.IO.xml",
         "ref/netstandard1.3/zh-hans/System.IO.xml",
         "ref/netstandard1.3/zh-hant/System.IO.xml",
         "ref/win8/_._",
@@ -2953,15 +9908,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.IO.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.IO.Compression/4.1.0-rc2-23911": {
       "sha512": "9W77QIHq4YVaVMG2F1eBr+7bh0bL6qXQ1zE62y1d6BDVgTV+ggSPP2nGi9kCCV6u09sECY/bgikTjViNz9KAfA==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -2979,6 +9934,8 @@
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net46/System.IO.Compression.dll",
+        "ref/netcore50/System.IO.Compression.dll",
+        "ref/netcore50/System.IO.Compression.xml",
         "ref/netcore50/de/System.IO.Compression.xml",
         "ref/netcore50/es/System.IO.Compression.xml",
         "ref/netcore50/fr/System.IO.Compression.xml",
@@ -2986,10 +9943,10 @@
         "ref/netcore50/ja/System.IO.Compression.xml",
         "ref/netcore50/ko/System.IO.Compression.xml",
         "ref/netcore50/ru/System.IO.Compression.xml",
-        "ref/netcore50/System.IO.Compression.dll",
-        "ref/netcore50/System.IO.Compression.xml",
         "ref/netcore50/zh-hans/System.IO.Compression.xml",
         "ref/netcore50/zh-hant/System.IO.Compression.xml",
+        "ref/netstandard1.1/System.IO.Compression.dll",
+        "ref/netstandard1.1/System.IO.Compression.xml",
         "ref/netstandard1.1/de/System.IO.Compression.xml",
         "ref/netstandard1.1/es/System.IO.Compression.xml",
         "ref/netstandard1.1/fr/System.IO.Compression.xml",
@@ -2997,10 +9954,10 @@
         "ref/netstandard1.1/ja/System.IO.Compression.xml",
         "ref/netstandard1.1/ko/System.IO.Compression.xml",
         "ref/netstandard1.1/ru/System.IO.Compression.xml",
-        "ref/netstandard1.1/System.IO.Compression.dll",
-        "ref/netstandard1.1/System.IO.Compression.xml",
         "ref/netstandard1.1/zh-hans/System.IO.Compression.xml",
         "ref/netstandard1.1/zh-hant/System.IO.Compression.xml",
+        "ref/netstandard1.3/System.IO.Compression.dll",
+        "ref/netstandard1.3/System.IO.Compression.xml",
         "ref/netstandard1.3/de/System.IO.Compression.xml",
         "ref/netstandard1.3/es/System.IO.Compression.xml",
         "ref/netstandard1.3/fr/System.IO.Compression.xml",
@@ -3008,8 +9965,6 @@
         "ref/netstandard1.3/ja/System.IO.Compression.xml",
         "ref/netstandard1.3/ko/System.IO.Compression.xml",
         "ref/netstandard1.3/ru/System.IO.Compression.xml",
-        "ref/netstandard1.3/System.IO.Compression.dll",
-        "ref/netstandard1.3/System.IO.Compression.xml",
         "ref/netstandard1.3/zh-hans/System.IO.Compression.xml",
         "ref/netstandard1.3/zh-hant/System.IO.Compression.xml",
         "ref/win8/_._",
@@ -3017,15 +9972,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.IO.Compression.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.1-rc2-23911": {
       "sha512": "u5D9re4xW5NrxjUItP82MS7sbq+Ek6c/V0LzlauosGN/VnKFavOjStaMRB1ZC7HpVEQ3Jc3pD8Q0VEBi7/Y1Og==",
       "type": "Package",
       "files": [
+        "System.IO.Compression.ZipFile.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3040,6 +9995,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/netstandard1.3/System.IO.Compression.ZipFile.dll",
+        "ref/netstandard1.3/System.IO.Compression.ZipFile.xml",
         "ref/netstandard1.3/de/System.IO.Compression.ZipFile.xml",
         "ref/netstandard1.3/es/System.IO.Compression.ZipFile.xml",
         "ref/netstandard1.3/fr/System.IO.Compression.ZipFile.xml",
@@ -3047,22 +10004,20 @@
         "ref/netstandard1.3/ja/System.IO.Compression.ZipFile.xml",
         "ref/netstandard1.3/ko/System.IO.Compression.ZipFile.xml",
         "ref/netstandard1.3/ru/System.IO.Compression.ZipFile.xml",
-        "ref/netstandard1.3/System.IO.Compression.ZipFile.dll",
-        "ref/netstandard1.3/System.IO.Compression.ZipFile.xml",
         "ref/netstandard1.3/zh-hans/System.IO.Compression.ZipFile.xml",
         "ref/netstandard1.3/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.IO.Compression.ZipFile.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.IO.FileSystem/4.0.1-rc2-23911": {
       "sha512": "wMNfP0l5Yfe3TdoYcmXvHs0Goj2isGdiee7mI/1wzbcnco8gcXFQPEiQ3AudDoKfRSENOBO2u8GUJ2hD62y9sg==",
       "type": "Package",
       "files": [
+        "System.IO.FileSystem.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3076,6 +10031,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.dll",
+        "ref/netstandard1.3/System.IO.FileSystem.dll",
+        "ref/netstandard1.3/System.IO.FileSystem.xml",
         "ref/netstandard1.3/de/System.IO.FileSystem.xml",
         "ref/netstandard1.3/es/System.IO.FileSystem.xml",
         "ref/netstandard1.3/fr/System.IO.FileSystem.xml",
@@ -3083,22 +10040,20 @@
         "ref/netstandard1.3/ja/System.IO.FileSystem.xml",
         "ref/netstandard1.3/ko/System.IO.FileSystem.xml",
         "ref/netstandard1.3/ru/System.IO.FileSystem.xml",
-        "ref/netstandard1.3/System.IO.FileSystem.dll",
-        "ref/netstandard1.3/System.IO.FileSystem.xml",
         "ref/netstandard1.3/zh-hans/System.IO.FileSystem.xml",
         "ref/netstandard1.3/zh-hant/System.IO.FileSystem.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.IO.FileSystem.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.1-rc2-23911": {
       "sha512": "XnYmRxwGix8/OZJT7+Bqzfqm2eEhETczG53VaQwZbvLgAL2F8cFRUceDzTvSrrNdh9gJqArnA0uBLC2QlC34vQ==",
       "type": "Package",
       "files": [
+        "System.IO.FileSystem.Primitives.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3113,6 +10068,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll",
+        "ref/netstandard1.3/System.IO.FileSystem.Primitives.xml",
         "ref/netstandard1.3/de/System.IO.FileSystem.Primitives.xml",
         "ref/netstandard1.3/es/System.IO.FileSystem.Primitives.xml",
         "ref/netstandard1.3/fr/System.IO.FileSystem.Primitives.xml",
@@ -3120,22 +10077,55 @@
         "ref/netstandard1.3/ja/System.IO.FileSystem.Primitives.xml",
         "ref/netstandard1.3/ko/System.IO.FileSystem.Primitives.xml",
         "ref/netstandard1.3/ru/System.IO.FileSystem.Primitives.xml",
-        "ref/netstandard1.3/System.IO.FileSystem.Primitives.dll",
-        "ref/netstandard1.3/System.IO.FileSystem.Primitives.xml",
         "ref/netstandard1.3/zh-hans/System.IO.FileSystem.Primitives.xml",
         "ref/netstandard1.3/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.IO.FileSystem.Primitives.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.IO.FileSystem.Watcher/4.0.0-rc2-23911": {
+      "sha512": "6jp7PuzlYTu0ycpGhdl5/+g2G4BUH/qf3panbwse91OyLvkA1jOjiglsysL0KDkVypKy000QwkDCn5p+ah+ijg==",
+      "type": "package",
+      "files": [
+        "System.IO.FileSystem.Watcher.4.0.0-rc2-23911.nupkg.sha512",
+        "System.IO.FileSystem.Watcher.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Watcher.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Watcher.dll",
+        "ref/netstandard1.3/System.IO.FileSystem.Watcher.dll",
+        "ref/netstandard1.3/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/de/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/es/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/fr/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/it/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/ja/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/ko/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/ru/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/zh-hans/System.IO.FileSystem.Watcher.xml",
+        "ref/netstandard1.3/zh-hant/System.IO.FileSystem.Watcher.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Linq/4.1.0-rc2-23911": {
       "sha512": "zaZLZewAi/AH0fb3fUWF05sd9ge/aV8+JjihZfeggmOBIGN71dn1Ck8fVhhpcviN96lo7Z8tcnC8OY1vwBNdiA==",
       "type": "Package",
       "files": [
+        "System.Linq.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3156,6 +10146,8 @@
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net462/System.Linq.dll",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
         "ref/netcore50/de/System.Linq.xml",
         "ref/netcore50/es/System.Linq.xml",
         "ref/netcore50/fr/System.Linq.xml",
@@ -3163,10 +10155,10 @@
         "ref/netcore50/ja/System.Linq.xml",
         "ref/netcore50/ko/System.Linq.xml",
         "ref/netcore50/ru/System.Linq.xml",
-        "ref/netcore50/System.Linq.dll",
-        "ref/netcore50/System.Linq.xml",
         "ref/netcore50/zh-hans/System.Linq.xml",
         "ref/netcore50/zh-hant/System.Linq.xml",
+        "ref/netstandard1.0/System.Linq.dll",
+        "ref/netstandard1.0/System.Linq.xml",
         "ref/netstandard1.0/de/System.Linq.xml",
         "ref/netstandard1.0/es/System.Linq.xml",
         "ref/netstandard1.0/fr/System.Linq.xml",
@@ -3174,10 +10166,10 @@
         "ref/netstandard1.0/ja/System.Linq.xml",
         "ref/netstandard1.0/ko/System.Linq.xml",
         "ref/netstandard1.0/ru/System.Linq.xml",
-        "ref/netstandard1.0/System.Linq.dll",
-        "ref/netstandard1.0/System.Linq.xml",
         "ref/netstandard1.0/zh-hans/System.Linq.xml",
         "ref/netstandard1.0/zh-hant/System.Linq.xml",
+        "ref/netstandard1.5/System.Linq.dll",
+        "ref/netstandard1.5/System.Linq.xml",
         "ref/netstandard1.5/de/System.Linq.xml",
         "ref/netstandard1.5/es/System.Linq.xml",
         "ref/netstandard1.5/fr/System.Linq.xml",
@@ -3185,8 +10177,6 @@
         "ref/netstandard1.5/ja/System.Linq.xml",
         "ref/netstandard1.5/ko/System.Linq.xml",
         "ref/netstandard1.5/ru/System.Linq.xml",
-        "ref/netstandard1.5/System.Linq.dll",
-        "ref/netstandard1.5/System.Linq.xml",
         "ref/netstandard1.5/zh-hans/System.Linq.xml",
         "ref/netstandard1.5/zh-hant/System.Linq.xml",
         "ref/win8/_._",
@@ -3195,15 +10185,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Linq.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Linq.Expressions/4.0.11-rc2-23911": {
       "sha512": "r2bYhMP+xdkztVdylszfYWNPyIpi/0hoVAqk2BOF6xeGMeCPmyyp5yZtYl1bfj6EH/hoZxTbsAig0QwGql+ZkQ==",
       "type": "Package",
       "files": [
+        "System.Linq.Expressions.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3220,6 +10210,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Linq.Expressions.dll",
+        "ref/netcore50/System.Linq.Expressions.xml",
         "ref/netcore50/de/System.Linq.Expressions.xml",
         "ref/netcore50/es/System.Linq.Expressions.xml",
         "ref/netcore50/fr/System.Linq.Expressions.xml",
@@ -3227,10 +10219,10 @@
         "ref/netcore50/ja/System.Linq.Expressions.xml",
         "ref/netcore50/ko/System.Linq.Expressions.xml",
         "ref/netcore50/ru/System.Linq.Expressions.xml",
-        "ref/netcore50/System.Linq.Expressions.dll",
-        "ref/netcore50/System.Linq.Expressions.xml",
         "ref/netcore50/zh-hans/System.Linq.Expressions.xml",
         "ref/netcore50/zh-hant/System.Linq.Expressions.xml",
+        "ref/netstandard1.0/System.Linq.Expressions.dll",
+        "ref/netstandard1.0/System.Linq.Expressions.xml",
         "ref/netstandard1.0/de/System.Linq.Expressions.xml",
         "ref/netstandard1.0/es/System.Linq.Expressions.xml",
         "ref/netstandard1.0/fr/System.Linq.Expressions.xml",
@@ -3238,10 +10230,10 @@
         "ref/netstandard1.0/ja/System.Linq.Expressions.xml",
         "ref/netstandard1.0/ko/System.Linq.Expressions.xml",
         "ref/netstandard1.0/ru/System.Linq.Expressions.xml",
-        "ref/netstandard1.0/System.Linq.Expressions.dll",
-        "ref/netstandard1.0/System.Linq.Expressions.xml",
         "ref/netstandard1.0/zh-hans/System.Linq.Expressions.xml",
         "ref/netstandard1.0/zh-hant/System.Linq.Expressions.xml",
+        "ref/netstandard1.3/System.Linq.Expressions.dll",
+        "ref/netstandard1.3/System.Linq.Expressions.xml",
         "ref/netstandard1.3/de/System.Linq.Expressions.xml",
         "ref/netstandard1.3/es/System.Linq.Expressions.xml",
         "ref/netstandard1.3/fr/System.Linq.Expressions.xml",
@@ -3249,8 +10241,6 @@
         "ref/netstandard1.3/ja/System.Linq.Expressions.xml",
         "ref/netstandard1.3/ko/System.Linq.Expressions.xml",
         "ref/netstandard1.3/ru/System.Linq.Expressions.xml",
-        "ref/netstandard1.3/System.Linq.Expressions.dll",
-        "ref/netstandard1.3/System.Linq.Expressions.xml",
         "ref/netstandard1.3/zh-hans/System.Linq.Expressions.xml",
         "ref/netstandard1.3/zh-hant/System.Linq.Expressions.xml",
         "ref/win8/_._",
@@ -3259,15 +10249,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Linq.Expressions.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Linq.Queryable/4.0.1-rc2-23911": {
       "sha512": "lsdzzv9yvLDNgZn7DY5O8H7I66kIfd3JSIKpPubxoj1EeInQEWIDAU4kqHhoi4bdI0k7eHUw0kaWF9JVEVEpYw==",
       "type": "Package",
       "files": [
+        "System.Linq.Queryable.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3286,6 +10276,8 @@
         "ref/monoandroid10/_._",
         "ref/monotouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Linq.Queryable.dll",
+        "ref/netcore50/System.Linq.Queryable.xml",
         "ref/netcore50/de/System.Linq.Queryable.xml",
         "ref/netcore50/es/System.Linq.Queryable.xml",
         "ref/netcore50/fr/System.Linq.Queryable.xml",
@@ -3293,10 +10285,10 @@
         "ref/netcore50/ja/System.Linq.Queryable.xml",
         "ref/netcore50/ko/System.Linq.Queryable.xml",
         "ref/netcore50/ru/System.Linq.Queryable.xml",
-        "ref/netcore50/System.Linq.Queryable.dll",
-        "ref/netcore50/System.Linq.Queryable.xml",
         "ref/netcore50/zh-hans/System.Linq.Queryable.xml",
         "ref/netcore50/zh-hant/System.Linq.Queryable.xml",
+        "ref/netstandard1.0/System.Linq.Queryable.dll",
+        "ref/netstandard1.0/System.Linq.Queryable.xml",
         "ref/netstandard1.0/de/System.Linq.Queryable.xml",
         "ref/netstandard1.0/es/System.Linq.Queryable.xml",
         "ref/netstandard1.0/fr/System.Linq.Queryable.xml",
@@ -3304,8 +10296,6 @@
         "ref/netstandard1.0/ja/System.Linq.Queryable.xml",
         "ref/netstandard1.0/ko/System.Linq.Queryable.xml",
         "ref/netstandard1.0/ru/System.Linq.Queryable.xml",
-        "ref/netstandard1.0/System.Linq.Queryable.dll",
-        "ref/netstandard1.0/System.Linq.Queryable.xml",
         "ref/netstandard1.0/zh-hans/System.Linq.Queryable.xml",
         "ref/netstandard1.0/zh-hant/System.Linq.Queryable.xml",
         "ref/win8/_._",
@@ -3314,30 +10304,33 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Linq.Queryable.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Net.Http/4.0.1-rc2-23911": {
       "sha512": "qwBRqbPxaYBz87DHD16Xaw3Gn3zWChoIw+zPPkIdHZDuj3eET7dIIKj6b2OSXodwhXcfLl+fgfK3aBmSaK6TAg==",
       "type": "Package",
       "files": [
+        "System.Net.Http.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
+        "lib/Xamarinmac20/_._",
         "lib/monoandroid10/_._",
         "lib/monotouch10/_._",
         "lib/net45/_._",
         "lib/win8/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
-        "lib/Xamarinmac20/_._",
         "lib/xamarintvos10/_._",
         "lib/xamarinwatchos10/_._",
+        "ref/Xamarinmac20/_._",
         "ref/monoandroid10/_._",
         "ref/monotouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
         "ref/netcore50/de/System.Net.Http.xml",
         "ref/netcore50/es/System.Net.Http.xml",
         "ref/netcore50/fr/System.Net.Http.xml",
@@ -3345,10 +10338,10 @@
         "ref/netcore50/ja/System.Net.Http.xml",
         "ref/netcore50/ko/System.Net.Http.xml",
         "ref/netcore50/ru/System.Net.Http.xml",
-        "ref/netcore50/System.Net.Http.dll",
-        "ref/netcore50/System.Net.Http.xml",
         "ref/netcore50/zh-hans/System.Net.Http.xml",
         "ref/netcore50/zh-hant/System.Net.Http.xml",
+        "ref/netstandard1.1/System.Net.Http.dll",
+        "ref/netstandard1.1/System.Net.Http.xml",
         "ref/netstandard1.1/de/System.Net.Http.xml",
         "ref/netstandard1.1/es/System.Net.Http.xml",
         "ref/netstandard1.1/fr/System.Net.Http.xml",
@@ -3356,24 +10349,56 @@
         "ref/netstandard1.1/ja/System.Net.Http.xml",
         "ref/netstandard1.1/ko/System.Net.Http.xml",
         "ref/netstandard1.1/ru/System.Net.Http.xml",
-        "ref/netstandard1.1/System.Net.Http.dll",
-        "ref/netstandard1.1/System.Net.Http.xml",
         "ref/netstandard1.1/zh-hans/System.Net.Http.xml",
         "ref/netstandard1.1/zh-hant/System.Net.Http.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/Xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Net.Http.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Net.NameResolution/4.0.0-rc2-23911": {
+      "sha512": "7rXUCGDRPLVFpf3NerY4VbKo9iXLI+dNAlwzMqjJ92EkN/KBjOy3swdltfmJBbfE8LeFclZtmyvTc0mpUWoBuw==",
+      "type": "package",
+      "files": [
+        "System.Net.NameResolution.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Net.NameResolution.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.NameResolution.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.NameResolution.dll",
+        "ref/netstandard1.3/System.Net.NameResolution.dll",
+        "ref/netstandard1.3/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/de/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/es/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/fr/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/it/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/ja/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/ko/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/ru/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/zh-hans/System.Net.NameResolution.xml",
+        "ref/netstandard1.3/zh-hant/System.Net.NameResolution.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Net.Primitives/4.0.11-rc2-23911": {
       "sha512": "kkPR1xKBDqTu+XGngJ3BfDO53o7rh7qZRscQgoFOy6DmUJ2PVWHpGWQ3EGuZ5sllzZ05Gjqv0G6nYp6mFLbepg==",
       "type": "Package",
       "files": [
+        "System.Net.Primitives.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3390,6 +10415,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Net.Primitives.dll",
+        "ref/netcore50/System.Net.Primitives.xml",
         "ref/netcore50/de/System.Net.Primitives.xml",
         "ref/netcore50/es/System.Net.Primitives.xml",
         "ref/netcore50/fr/System.Net.Primitives.xml",
@@ -3397,10 +10424,10 @@
         "ref/netcore50/ja/System.Net.Primitives.xml",
         "ref/netcore50/ko/System.Net.Primitives.xml",
         "ref/netcore50/ru/System.Net.Primitives.xml",
-        "ref/netcore50/System.Net.Primitives.dll",
-        "ref/netcore50/System.Net.Primitives.xml",
         "ref/netcore50/zh-hans/System.Net.Primitives.xml",
         "ref/netcore50/zh-hant/System.Net.Primitives.xml",
+        "ref/netstandard1.0/System.Net.Primitives.dll",
+        "ref/netstandard1.0/System.Net.Primitives.xml",
         "ref/netstandard1.0/de/System.Net.Primitives.xml",
         "ref/netstandard1.0/es/System.Net.Primitives.xml",
         "ref/netstandard1.0/fr/System.Net.Primitives.xml",
@@ -3408,10 +10435,10 @@
         "ref/netstandard1.0/ja/System.Net.Primitives.xml",
         "ref/netstandard1.0/ko/System.Net.Primitives.xml",
         "ref/netstandard1.0/ru/System.Net.Primitives.xml",
-        "ref/netstandard1.0/System.Net.Primitives.dll",
-        "ref/netstandard1.0/System.Net.Primitives.xml",
         "ref/netstandard1.0/zh-hans/System.Net.Primitives.xml",
         "ref/netstandard1.0/zh-hant/System.Net.Primitives.xml",
+        "ref/netstandard1.1/System.Net.Primitives.dll",
+        "ref/netstandard1.1/System.Net.Primitives.xml",
         "ref/netstandard1.1/de/System.Net.Primitives.xml",
         "ref/netstandard1.1/es/System.Net.Primitives.xml",
         "ref/netstandard1.1/fr/System.Net.Primitives.xml",
@@ -3419,10 +10446,10 @@
         "ref/netstandard1.1/ja/System.Net.Primitives.xml",
         "ref/netstandard1.1/ko/System.Net.Primitives.xml",
         "ref/netstandard1.1/ru/System.Net.Primitives.xml",
-        "ref/netstandard1.1/System.Net.Primitives.dll",
-        "ref/netstandard1.1/System.Net.Primitives.xml",
         "ref/netstandard1.1/zh-hans/System.Net.Primitives.xml",
         "ref/netstandard1.1/zh-hant/System.Net.Primitives.xml",
+        "ref/netstandard1.3/System.Net.Primitives.dll",
+        "ref/netstandard1.3/System.Net.Primitives.xml",
         "ref/netstandard1.3/de/System.Net.Primitives.xml",
         "ref/netstandard1.3/es/System.Net.Primitives.xml",
         "ref/netstandard1.3/fr/System.Net.Primitives.xml",
@@ -3430,8 +10457,6 @@
         "ref/netstandard1.3/ja/System.Net.Primitives.xml",
         "ref/netstandard1.3/ko/System.Net.Primitives.xml",
         "ref/netstandard1.3/ru/System.Net.Primitives.xml",
-        "ref/netstandard1.3/System.Net.Primitives.dll",
-        "ref/netstandard1.3/System.Net.Primitives.xml",
         "ref/netstandard1.3/zh-hans/System.Net.Primitives.xml",
         "ref/netstandard1.3/zh-hant/System.Net.Primitives.xml",
         "ref/win8/_._",
@@ -3440,15 +10465,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Net.Primitives.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Net.Requests/4.0.11-rc2-23911": {
       "sha512": "zT1JW8ZrWbSRzmKaUXd6VZvhBdqq+i/GQutlkOIu4LzdJMXcL8KX65vzJsVQOVZVsac+YD5iMXYnMRFdNYy+9Q==",
       "type": "Package",
       "files": [
+        "System.Net.Requests.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3465,6 +10490,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Net.Requests.dll",
+        "ref/netcore50/System.Net.Requests.xml",
         "ref/netcore50/de/System.Net.Requests.xml",
         "ref/netcore50/es/System.Net.Requests.xml",
         "ref/netcore50/fr/System.Net.Requests.xml",
@@ -3472,10 +10499,10 @@
         "ref/netcore50/ja/System.Net.Requests.xml",
         "ref/netcore50/ko/System.Net.Requests.xml",
         "ref/netcore50/ru/System.Net.Requests.xml",
-        "ref/netcore50/System.Net.Requests.dll",
-        "ref/netcore50/System.Net.Requests.xml",
         "ref/netcore50/zh-hans/System.Net.Requests.xml",
         "ref/netcore50/zh-hant/System.Net.Requests.xml",
+        "ref/netstandard1.0/System.Net.Requests.dll",
+        "ref/netstandard1.0/System.Net.Requests.xml",
         "ref/netstandard1.0/de/System.Net.Requests.xml",
         "ref/netstandard1.0/es/System.Net.Requests.xml",
         "ref/netstandard1.0/fr/System.Net.Requests.xml",
@@ -3483,10 +10510,10 @@
         "ref/netstandard1.0/ja/System.Net.Requests.xml",
         "ref/netstandard1.0/ko/System.Net.Requests.xml",
         "ref/netstandard1.0/ru/System.Net.Requests.xml",
-        "ref/netstandard1.0/System.Net.Requests.dll",
-        "ref/netstandard1.0/System.Net.Requests.xml",
         "ref/netstandard1.0/zh-hans/System.Net.Requests.xml",
         "ref/netstandard1.0/zh-hant/System.Net.Requests.xml",
+        "ref/netstandard1.1/System.Net.Requests.dll",
+        "ref/netstandard1.1/System.Net.Requests.xml",
         "ref/netstandard1.1/de/System.Net.Requests.xml",
         "ref/netstandard1.1/es/System.Net.Requests.xml",
         "ref/netstandard1.1/fr/System.Net.Requests.xml",
@@ -3494,10 +10521,10 @@
         "ref/netstandard1.1/ja/System.Net.Requests.xml",
         "ref/netstandard1.1/ko/System.Net.Requests.xml",
         "ref/netstandard1.1/ru/System.Net.Requests.xml",
-        "ref/netstandard1.1/System.Net.Requests.dll",
-        "ref/netstandard1.1/System.Net.Requests.xml",
         "ref/netstandard1.1/zh-hans/System.Net.Requests.xml",
         "ref/netstandard1.1/zh-hant/System.Net.Requests.xml",
+        "ref/netstandard1.3/System.Net.Requests.dll",
+        "ref/netstandard1.3/System.Net.Requests.xml",
         "ref/netstandard1.3/de/System.Net.Requests.xml",
         "ref/netstandard1.3/es/System.Net.Requests.xml",
         "ref/netstandard1.3/fr/System.Net.Requests.xml",
@@ -3505,8 +10532,6 @@
         "ref/netstandard1.3/ja/System.Net.Requests.xml",
         "ref/netstandard1.3/ko/System.Net.Requests.xml",
         "ref/netstandard1.3/ru/System.Net.Requests.xml",
-        "ref/netstandard1.3/System.Net.Requests.dll",
-        "ref/netstandard1.3/System.Net.Requests.xml",
         "ref/netstandard1.3/zh-hans/System.Net.Requests.xml",
         "ref/netstandard1.3/zh-hant/System.Net.Requests.xml",
         "ref/win8/_._",
@@ -3515,15 +10540,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Net.Requests.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Net.Sockets/4.1.0-rc2-23911": {
       "sha512": "9/aI1Mtc608ZjRlkbWt+MNH59tqmW+smOmLOIK9vUI0j/RdAG9sgB1CQeULNWyQYewo3Y0wXhkwBqymM7BsbYA==",
       "type": "Package",
       "files": [
+        "System.Net.Sockets.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3537,6 +10562,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Sockets.dll",
+        "ref/netstandard1.3/System.Net.Sockets.dll",
+        "ref/netstandard1.3/System.Net.Sockets.xml",
         "ref/netstandard1.3/de/System.Net.Sockets.xml",
         "ref/netstandard1.3/es/System.Net.Sockets.xml",
         "ref/netstandard1.3/fr/System.Net.Sockets.xml",
@@ -3544,22 +10571,56 @@
         "ref/netstandard1.3/ja/System.Net.Sockets.xml",
         "ref/netstandard1.3/ko/System.Net.Sockets.xml",
         "ref/netstandard1.3/ru/System.Net.Sockets.xml",
-        "ref/netstandard1.3/System.Net.Sockets.dll",
-        "ref/netstandard1.3/System.Net.Sockets.xml",
         "ref/netstandard1.3/zh-hans/System.Net.Sockets.xml",
         "ref/netstandard1.3/zh-hant/System.Net.Sockets.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Net.Sockets.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Net.WebHeaderCollection/4.0.1-rc2-23911": {
+      "sha512": "MIEwDH+9fD6K74+bhr/ZG607Q0jq8yddqda/9jtIoB4M9tBxTZOV7ryMM7oTWNERBG7yM+pspqxFLA7Fvw+51A==",
+      "type": "package",
+      "files": [
+        "System.Net.WebHeaderCollection.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Net.WebHeaderCollection.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netstandard1.3/System.Net.WebHeaderCollection.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/netstandard1.3/System.Net.WebHeaderCollection.dll",
+        "ref/netstandard1.3/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/de/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/es/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/fr/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/it/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/ja/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/ko/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/ru/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/zh-hans/System.Net.WebHeaderCollection.xml",
+        "ref/netstandard1.3/zh-hant/System.Net.WebHeaderCollection.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.ObjectModel/4.0.12-rc2-23911": {
       "sha512": "1mx3WXLhsFbWUnK4T2Hhc4A8JJC5wFDNWc2iCPs+szm9rVvpqG/mHWlarI6Nw+UyCrqACqDwr9K9Fz3ler8xig==",
       "type": "Package",
       "files": [
+        "System.ObjectModel.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3578,6 +10639,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.ObjectModel.dll",
+        "ref/netcore50/System.ObjectModel.xml",
         "ref/netcore50/de/System.ObjectModel.xml",
         "ref/netcore50/es/System.ObjectModel.xml",
         "ref/netcore50/fr/System.ObjectModel.xml",
@@ -3585,10 +10648,10 @@
         "ref/netcore50/ja/System.ObjectModel.xml",
         "ref/netcore50/ko/System.ObjectModel.xml",
         "ref/netcore50/ru/System.ObjectModel.xml",
-        "ref/netcore50/System.ObjectModel.dll",
-        "ref/netcore50/System.ObjectModel.xml",
         "ref/netcore50/zh-hans/System.ObjectModel.xml",
         "ref/netcore50/zh-hant/System.ObjectModel.xml",
+        "ref/netstandard1.0/System.ObjectModel.dll",
+        "ref/netstandard1.0/System.ObjectModel.xml",
         "ref/netstandard1.0/de/System.ObjectModel.xml",
         "ref/netstandard1.0/es/System.ObjectModel.xml",
         "ref/netstandard1.0/fr/System.ObjectModel.xml",
@@ -3596,10 +10659,10 @@
         "ref/netstandard1.0/ja/System.ObjectModel.xml",
         "ref/netstandard1.0/ko/System.ObjectModel.xml",
         "ref/netstandard1.0/ru/System.ObjectModel.xml",
-        "ref/netstandard1.0/System.ObjectModel.dll",
-        "ref/netstandard1.0/System.ObjectModel.xml",
         "ref/netstandard1.0/zh-hans/System.ObjectModel.xml",
         "ref/netstandard1.0/zh-hant/System.ObjectModel.xml",
+        "ref/netstandard1.3/System.ObjectModel.dll",
+        "ref/netstandard1.3/System.ObjectModel.xml",
         "ref/netstandard1.3/de/System.ObjectModel.xml",
         "ref/netstandard1.3/es/System.ObjectModel.xml",
         "ref/netstandard1.3/fr/System.ObjectModel.xml",
@@ -3607,8 +10670,6 @@
         "ref/netstandard1.3/ja/System.ObjectModel.xml",
         "ref/netstandard1.3/ko/System.ObjectModel.xml",
         "ref/netstandard1.3/ru/System.ObjectModel.xml",
-        "ref/netstandard1.3/System.ObjectModel.dll",
-        "ref/netstandard1.3/System.ObjectModel.xml",
         "ref/netstandard1.3/zh-hans/System.ObjectModel.xml",
         "ref/netstandard1.3/zh-hant/System.ObjectModel.xml",
         "ref/win8/_._",
@@ -3617,15 +10678,26 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.ObjectModel.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Private.Uri/4.0.1-rc2-23911": {
+      "sha512": "TeRnl2WXPlI4irzRX4fxOy2OF5UbsvbRIOLLyXF5Bve7km8M+fUGzxH92Rljp+hczNN1+jURCIuSGZ6jdtLkAQ==",
+      "type": "package",
+      "files": [
+        "System.Private.Uri.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Private.Uri.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "ref/netstandard/_._"
       ]
     },
     "System.Reflection/4.1.0-rc2-23911": {
       "sha512": "cWjXCPzyHsVNLWQCL6w4b/wAIvgbQzN6I8G5HT2yt/BsCgJupgcmVg3QVHy37PQyvzrxsZXERBS3In3Kbjnt8w==",
       "type": "Package",
       "files": [
+        "System.Reflection.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3644,6 +10716,8 @@
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net46/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.xml",
         "ref/netcore50/de/System.Reflection.xml",
         "ref/netcore50/es/System.Reflection.xml",
         "ref/netcore50/fr/System.Reflection.xml",
@@ -3651,10 +10725,10 @@
         "ref/netcore50/ja/System.Reflection.xml",
         "ref/netcore50/ko/System.Reflection.xml",
         "ref/netcore50/ru/System.Reflection.xml",
-        "ref/netcore50/System.Reflection.dll",
-        "ref/netcore50/System.Reflection.xml",
         "ref/netcore50/zh-hans/System.Reflection.xml",
         "ref/netcore50/zh-hant/System.Reflection.xml",
+        "ref/netstandard1.0/System.Reflection.dll",
+        "ref/netstandard1.0/System.Reflection.xml",
         "ref/netstandard1.0/de/System.Reflection.xml",
         "ref/netstandard1.0/es/System.Reflection.xml",
         "ref/netstandard1.0/fr/System.Reflection.xml",
@@ -3662,10 +10736,10 @@
         "ref/netstandard1.0/ja/System.Reflection.xml",
         "ref/netstandard1.0/ko/System.Reflection.xml",
         "ref/netstandard1.0/ru/System.Reflection.xml",
-        "ref/netstandard1.0/System.Reflection.dll",
-        "ref/netstandard1.0/System.Reflection.xml",
         "ref/netstandard1.0/zh-hans/System.Reflection.xml",
         "ref/netstandard1.0/zh-hant/System.Reflection.xml",
+        "ref/netstandard1.3/System.Reflection.dll",
+        "ref/netstandard1.3/System.Reflection.xml",
         "ref/netstandard1.3/de/System.Reflection.xml",
         "ref/netstandard1.3/es/System.Reflection.xml",
         "ref/netstandard1.3/fr/System.Reflection.xml",
@@ -3673,8 +10747,6 @@
         "ref/netstandard1.3/ja/System.Reflection.xml",
         "ref/netstandard1.3/ko/System.Reflection.xml",
         "ref/netstandard1.3/ru/System.Reflection.xml",
-        "ref/netstandard1.3/System.Reflection.dll",
-        "ref/netstandard1.3/System.Reflection.xml",
         "ref/netstandard1.3/zh-hans/System.Reflection.xml",
         "ref/netstandard1.3/zh-hant/System.Reflection.xml",
         "ref/win8/_._",
@@ -3683,15 +10755,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Reflection.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Reflection.Emit/4.0.1-rc2-23911": {
       "sha512": "3wcR2A+5gdKF4OM0KcFLs4n1mRd59VUWe9066PZEZcLUCU/oq0BxIZpasJyM4Xx+tLHGdmdmgIW+aBjeUVkWJQ==",
       "type": "Package",
       "files": [
+        "System.Reflection.Emit.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3702,6 +10774,8 @@
         "lib/xamarinmac20/_._",
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
+        "ref/netstandard1.1/System.Reflection.Emit.dll",
+        "ref/netstandard1.1/System.Reflection.Emit.xml",
         "ref/netstandard1.1/de/System.Reflection.Emit.xml",
         "ref/netstandard1.1/es/System.Reflection.Emit.xml",
         "ref/netstandard1.1/fr/System.Reflection.Emit.xml",
@@ -3709,19 +10783,73 @@
         "ref/netstandard1.1/ja/System.Reflection.Emit.xml",
         "ref/netstandard1.1/ko/System.Reflection.Emit.xml",
         "ref/netstandard1.1/ru/System.Reflection.Emit.xml",
-        "ref/netstandard1.1/System.Reflection.Emit.dll",
-        "ref/netstandard1.1/System.Reflection.Emit.xml",
         "ref/netstandard1.1/zh-hans/System.Reflection.Emit.xml",
         "ref/netstandard1.1/zh-hant/System.Reflection.Emit.xml",
-        "ref/xamarinmac20/_._",
-        "System.Reflection.Emit.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23911": {
+      "sha512": "bmtptARL/oPjcGtfDB+ZjIBW2li/Pd69MjvR0Plnj2wPWwVFTP1ozSZRBcuYWunWzPLQBd9yRDvX4KWKo2VKrg==",
+      "type": "package",
+      "files": [
+        "System.Reflection.Emit.ILGeneration.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/netstandard1.3/System.Reflection.Emit.ILGeneration.dll",
+        "lib/wp80/_._",
+        "ref/net45/_._",
+        "ref/netstandard1.0/System.Reflection.Emit.ILGeneration.dll",
+        "ref/netstandard1.0/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/fr/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/it/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/ja/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/ko/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/zh-hans/System.Reflection.Emit.ILGeneration.xml",
+        "ref/netstandard1.0/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "ref/wp80/_._",
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "System.Reflection.Emit.Lightweight/4.0.1-rc2-23911": {
+      "sha512": "XLz8ObP1r7ehcah3UG4rCZh/AY4ixYkmoIB+xxPAXvtZekgmT6Uom5ZvBPvPKAe9kLVrRuzPpxzRVBkzkHinNw==",
+      "type": "package",
+      "files": [
+        "System.Reflection.Emit.Lightweight.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Reflection.Emit.Lightweight.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/netstandard1.3/System.Reflection.Emit.Lightweight.dll",
+        "lib/wp80/_._",
+        "ref/net45/_._",
+        "ref/netstandard1.0/System.Reflection.Emit.Lightweight.dll",
+        "ref/netstandard1.0/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/fr/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/it/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/ja/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/ko/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/zh-hans/System.Reflection.Emit.Lightweight.xml",
+        "ref/netstandard1.0/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "ref/wp80/_._",
+        "runtimes/aot/lib/netcore50/_._"
       ]
     },
     "System.Reflection.Extensions/4.0.1-rc2-23911": {
       "sha512": "BnelYpY+MSYMuCasPM5Ez/Qcjgk2xEwM281deJ1Fo2BshEY38YVE1dfMSlgJdhlmJzf1Ex6XHMmx9kdXz4vISQ==",
       "type": "Package",
       "files": [
+        "System.Reflection.Extensions.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3738,6 +10866,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Extensions.dll",
+        "ref/netcore50/System.Reflection.Extensions.xml",
         "ref/netcore50/de/System.Reflection.Extensions.xml",
         "ref/netcore50/es/System.Reflection.Extensions.xml",
         "ref/netcore50/fr/System.Reflection.Extensions.xml",
@@ -3745,10 +10875,10 @@
         "ref/netcore50/ja/System.Reflection.Extensions.xml",
         "ref/netcore50/ko/System.Reflection.Extensions.xml",
         "ref/netcore50/ru/System.Reflection.Extensions.xml",
-        "ref/netcore50/System.Reflection.Extensions.dll",
-        "ref/netcore50/System.Reflection.Extensions.xml",
         "ref/netcore50/zh-hans/System.Reflection.Extensions.xml",
         "ref/netcore50/zh-hant/System.Reflection.Extensions.xml",
+        "ref/netstandard1.0/System.Reflection.Extensions.dll",
+        "ref/netstandard1.0/System.Reflection.Extensions.xml",
         "ref/netstandard1.0/de/System.Reflection.Extensions.xml",
         "ref/netstandard1.0/es/System.Reflection.Extensions.xml",
         "ref/netstandard1.0/fr/System.Reflection.Extensions.xml",
@@ -3756,8 +10886,6 @@
         "ref/netstandard1.0/ja/System.Reflection.Extensions.xml",
         "ref/netstandard1.0/ko/System.Reflection.Extensions.xml",
         "ref/netstandard1.0/ru/System.Reflection.Extensions.xml",
-        "ref/netstandard1.0/System.Reflection.Extensions.dll",
-        "ref/netstandard1.0/System.Reflection.Extensions.xml",
         "ref/netstandard1.0/zh-hans/System.Reflection.Extensions.xml",
         "ref/netstandard1.0/zh-hant/System.Reflection.Extensions.xml",
         "ref/win8/_._",
@@ -3766,15 +10894,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Reflection.Extensions.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Reflection.Primitives/4.0.1-rc2-23911": {
       "sha512": "4y4VDr3pJd8vYcDYeWCbiGE3YAfDmTqh7sLjSfBSoL3Dc+LyW9QlQzKNfGPBtF3hFrqplCOIWOlAyAG5PjkaWQ==",
       "type": "Package",
       "files": [
+        "System.Reflection.Primitives.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3791,6 +10919,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
         "ref/netcore50/de/System.Reflection.Primitives.xml",
         "ref/netcore50/es/System.Reflection.Primitives.xml",
         "ref/netcore50/fr/System.Reflection.Primitives.xml",
@@ -3798,10 +10928,10 @@
         "ref/netcore50/ja/System.Reflection.Primitives.xml",
         "ref/netcore50/ko/System.Reflection.Primitives.xml",
         "ref/netcore50/ru/System.Reflection.Primitives.xml",
-        "ref/netcore50/System.Reflection.Primitives.dll",
-        "ref/netcore50/System.Reflection.Primitives.xml",
         "ref/netcore50/zh-hans/System.Reflection.Primitives.xml",
         "ref/netcore50/zh-hant/System.Reflection.Primitives.xml",
+        "ref/netstandard1.0/System.Reflection.Primitives.dll",
+        "ref/netstandard1.0/System.Reflection.Primitives.xml",
         "ref/netstandard1.0/de/System.Reflection.Primitives.xml",
         "ref/netstandard1.0/es/System.Reflection.Primitives.xml",
         "ref/netstandard1.0/fr/System.Reflection.Primitives.xml",
@@ -3809,8 +10939,6 @@
         "ref/netstandard1.0/ja/System.Reflection.Primitives.xml",
         "ref/netstandard1.0/ko/System.Reflection.Primitives.xml",
         "ref/netstandard1.0/ru/System.Reflection.Primitives.xml",
-        "ref/netstandard1.0/System.Reflection.Primitives.dll",
-        "ref/netstandard1.0/System.Reflection.Primitives.xml",
         "ref/netstandard1.0/zh-hans/System.Reflection.Primitives.xml",
         "ref/netstandard1.0/zh-hant/System.Reflection.Primitives.xml",
         "ref/win8/_._",
@@ -3819,15 +10947,50 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Reflection.Primitives.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Reflection.TypeExtensions/4.1.0-rc2-23911": {
+      "sha512": "AGckleUWRo9Fk2cNxE55E2RD2VdOp5hSivltPtybFPC0yrYjLKET8l/piMj4LRGAX8lHUzE2c6a53NyCYHfUHw==",
+      "type": "package",
+      "files": [
+        "System.Reflection.TypeExtensions.4.1.0-rc2-23911.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/netstandard1.3/System.Reflection.TypeExtensions.dll",
+        "ref/netstandard1.3/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/de/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/es/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/fr/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/it/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/ja/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/ko/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/ru/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/zh-hans/System.Reflection.TypeExtensions.xml",
+        "ref/netstandard1.3/zh-hant/System.Reflection.TypeExtensions.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Resources.ResourceManager/4.0.1-rc2-23911": {
       "sha512": "zM41anRBOAfPi2DOlGEAcg9S8PnUNGYDMliC4xycqcPEl2PgbG82lecezs4f5KA51MNyZf9dYpCyy6GUxPd8dA==",
       "type": "Package",
       "files": [
+        "System.Resources.ResourceManager.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3844,6 +11007,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
         "ref/netcore50/de/System.Resources.ResourceManager.xml",
         "ref/netcore50/es/System.Resources.ResourceManager.xml",
         "ref/netcore50/fr/System.Resources.ResourceManager.xml",
@@ -3851,10 +11016,10 @@
         "ref/netcore50/ja/System.Resources.ResourceManager.xml",
         "ref/netcore50/ko/System.Resources.ResourceManager.xml",
         "ref/netcore50/ru/System.Resources.ResourceManager.xml",
-        "ref/netcore50/System.Resources.ResourceManager.dll",
-        "ref/netcore50/System.Resources.ResourceManager.xml",
         "ref/netcore50/zh-hans/System.Resources.ResourceManager.xml",
         "ref/netcore50/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/netstandard1.0/System.Resources.ResourceManager.dll",
+        "ref/netstandard1.0/System.Resources.ResourceManager.xml",
         "ref/netstandard1.0/de/System.Resources.ResourceManager.xml",
         "ref/netstandard1.0/es/System.Resources.ResourceManager.xml",
         "ref/netstandard1.0/fr/System.Resources.ResourceManager.xml",
@@ -3862,8 +11027,6 @@
         "ref/netstandard1.0/ja/System.Resources.ResourceManager.xml",
         "ref/netstandard1.0/ko/System.Resources.ResourceManager.xml",
         "ref/netstandard1.0/ru/System.Resources.ResourceManager.xml",
-        "ref/netstandard1.0/System.Resources.ResourceManager.dll",
-        "ref/netstandard1.0/System.Resources.ResourceManager.xml",
         "ref/netstandard1.0/zh-hans/System.Resources.ResourceManager.xml",
         "ref/netstandard1.0/zh-hant/System.Resources.ResourceManager.xml",
         "ref/win8/_._",
@@ -3872,15 +11035,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Resources.ResourceManager.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Runtime/4.1.0-rc2-23911": {
       "sha512": "e0hI0g01sF2lySgUIVHYZjHlemxvsUfO79AGAbZj2MWjsVp8/DB1TKhul8gOVz1m8ctjJAepOAASOJotyUYqmg==",
       "type": "Package",
       "files": [
+        "System.Runtime.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3899,6 +11062,8 @@
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net46/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.xml",
         "ref/netcore50/de/System.Runtime.xml",
         "ref/netcore50/es/System.Runtime.xml",
         "ref/netcore50/fr/System.Runtime.xml",
@@ -3906,10 +11071,10 @@
         "ref/netcore50/ja/System.Runtime.xml",
         "ref/netcore50/ko/System.Runtime.xml",
         "ref/netcore50/ru/System.Runtime.xml",
-        "ref/netcore50/System.Runtime.dll",
-        "ref/netcore50/System.Runtime.xml",
         "ref/netcore50/zh-hans/System.Runtime.xml",
         "ref/netcore50/zh-hant/System.Runtime.xml",
+        "ref/netstandard1.0/System.Runtime.dll",
+        "ref/netstandard1.0/System.Runtime.xml",
         "ref/netstandard1.0/de/System.Runtime.xml",
         "ref/netstandard1.0/es/System.Runtime.xml",
         "ref/netstandard1.0/fr/System.Runtime.xml",
@@ -3917,10 +11082,10 @@
         "ref/netstandard1.0/ja/System.Runtime.xml",
         "ref/netstandard1.0/ko/System.Runtime.xml",
         "ref/netstandard1.0/ru/System.Runtime.xml",
-        "ref/netstandard1.0/System.Runtime.dll",
-        "ref/netstandard1.0/System.Runtime.xml",
         "ref/netstandard1.0/zh-hans/System.Runtime.xml",
         "ref/netstandard1.0/zh-hant/System.Runtime.xml",
+        "ref/netstandard1.2/System.Runtime.dll",
+        "ref/netstandard1.2/System.Runtime.xml",
         "ref/netstandard1.2/de/System.Runtime.xml",
         "ref/netstandard1.2/es/System.Runtime.xml",
         "ref/netstandard1.2/fr/System.Runtime.xml",
@@ -3928,10 +11093,10 @@
         "ref/netstandard1.2/ja/System.Runtime.xml",
         "ref/netstandard1.2/ko/System.Runtime.xml",
         "ref/netstandard1.2/ru/System.Runtime.xml",
-        "ref/netstandard1.2/System.Runtime.dll",
-        "ref/netstandard1.2/System.Runtime.xml",
         "ref/netstandard1.2/zh-hans/System.Runtime.xml",
         "ref/netstandard1.2/zh-hant/System.Runtime.xml",
+        "ref/netstandard1.3/System.Runtime.dll",
+        "ref/netstandard1.3/System.Runtime.xml",
         "ref/netstandard1.3/de/System.Runtime.xml",
         "ref/netstandard1.3/es/System.Runtime.xml",
         "ref/netstandard1.3/fr/System.Runtime.xml",
@@ -3939,8 +11104,6 @@
         "ref/netstandard1.3/ja/System.Runtime.xml",
         "ref/netstandard1.3/ko/System.Runtime.xml",
         "ref/netstandard1.3/ru/System.Runtime.xml",
-        "ref/netstandard1.3/System.Runtime.dll",
-        "ref/netstandard1.3/System.Runtime.xml",
         "ref/netstandard1.3/zh-hans/System.Runtime.xml",
         "ref/netstandard1.3/zh-hant/System.Runtime.xml",
         "ref/win8/_._",
@@ -3949,15 +11112,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Runtime.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Runtime.Extensions/4.1.0-rc2-23911": {
       "sha512": "/JWPkVgwq2ciYNvok9XEz+YRQSKRbyzrfSu/ESgXH7DUe7esaNhUIquOFQFQ8bWBfe7PG6vJx/0p8SsInud2oA==",
       "type": "Package",
       "files": [
+        "System.Runtime.Extensions.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -3976,6 +11139,8 @@
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net46/System.Runtime.Extensions.dll",
+        "ref/netcore50/System.Runtime.Extensions.dll",
+        "ref/netcore50/System.Runtime.Extensions.xml",
         "ref/netcore50/de/System.Runtime.Extensions.xml",
         "ref/netcore50/es/System.Runtime.Extensions.xml",
         "ref/netcore50/fr/System.Runtime.Extensions.xml",
@@ -3983,10 +11148,10 @@
         "ref/netcore50/ja/System.Runtime.Extensions.xml",
         "ref/netcore50/ko/System.Runtime.Extensions.xml",
         "ref/netcore50/ru/System.Runtime.Extensions.xml",
-        "ref/netcore50/System.Runtime.Extensions.dll",
-        "ref/netcore50/System.Runtime.Extensions.xml",
         "ref/netcore50/zh-hans/System.Runtime.Extensions.xml",
         "ref/netcore50/zh-hant/System.Runtime.Extensions.xml",
+        "ref/netstandard1.0/System.Runtime.Extensions.dll",
+        "ref/netstandard1.0/System.Runtime.Extensions.xml",
         "ref/netstandard1.0/de/System.Runtime.Extensions.xml",
         "ref/netstandard1.0/es/System.Runtime.Extensions.xml",
         "ref/netstandard1.0/fr/System.Runtime.Extensions.xml",
@@ -3994,10 +11159,10 @@
         "ref/netstandard1.0/ja/System.Runtime.Extensions.xml",
         "ref/netstandard1.0/ko/System.Runtime.Extensions.xml",
         "ref/netstandard1.0/ru/System.Runtime.Extensions.xml",
-        "ref/netstandard1.0/System.Runtime.Extensions.dll",
-        "ref/netstandard1.0/System.Runtime.Extensions.xml",
         "ref/netstandard1.0/zh-hans/System.Runtime.Extensions.xml",
         "ref/netstandard1.0/zh-hant/System.Runtime.Extensions.xml",
+        "ref/netstandard1.3/System.Runtime.Extensions.dll",
+        "ref/netstandard1.3/System.Runtime.Extensions.xml",
         "ref/netstandard1.3/de/System.Runtime.Extensions.xml",
         "ref/netstandard1.3/es/System.Runtime.Extensions.xml",
         "ref/netstandard1.3/fr/System.Runtime.Extensions.xml",
@@ -4005,8 +11170,6 @@
         "ref/netstandard1.3/ja/System.Runtime.Extensions.xml",
         "ref/netstandard1.3/ko/System.Runtime.Extensions.xml",
         "ref/netstandard1.3/ru/System.Runtime.Extensions.xml",
-        "ref/netstandard1.3/System.Runtime.Extensions.dll",
-        "ref/netstandard1.3/System.Runtime.Extensions.xml",
         "ref/netstandard1.3/zh-hans/System.Runtime.Extensions.xml",
         "ref/netstandard1.3/zh-hant/System.Runtime.Extensions.xml",
         "ref/win8/_._",
@@ -4015,15 +11178,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Runtime.Extensions.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Runtime.Handles/4.0.1-rc2-23911": {
       "sha512": "dARvcYmozbtYuMFk5i69pxX+MkF3sQbFmAxzz3EVLvMj7D1uhw0is0lI6IbFfrcCSadygwnh8ocfDSlXOsQWXg==",
       "type": "Package",
       "files": [
+        "System.Runtime.Handles.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4037,6 +11200,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
+        "ref/netstandard1.3/System.Runtime.Handles.dll",
+        "ref/netstandard1.3/System.Runtime.Handles.xml",
         "ref/netstandard1.3/de/System.Runtime.Handles.xml",
         "ref/netstandard1.3/es/System.Runtime.Handles.xml",
         "ref/netstandard1.3/fr/System.Runtime.Handles.xml",
@@ -4044,22 +11209,20 @@
         "ref/netstandard1.3/ja/System.Runtime.Handles.xml",
         "ref/netstandard1.3/ko/System.Runtime.Handles.xml",
         "ref/netstandard1.3/ru/System.Runtime.Handles.xml",
-        "ref/netstandard1.3/System.Runtime.Handles.dll",
-        "ref/netstandard1.3/System.Runtime.Handles.xml",
         "ref/netstandard1.3/zh-hans/System.Runtime.Handles.xml",
         "ref/netstandard1.3/zh-hant/System.Runtime.Handles.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Runtime.Handles.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Runtime.InteropServices/4.1.0-rc2-23911": {
       "sha512": "XmW1MYoO9ZncxUQ8a8P4mbHyfQ3MZDipuX7C46/oRH9fDCvN+TBotme8jm6g2wgfPu04SMMgRNolqf2zXfKg3g==",
       "type": "Package",
       "files": [
+        "System.Runtime.InteropServices.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4077,6 +11240,8 @@
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/net46/System.Runtime.InteropServices.dll",
+        "ref/netcore50/System.Runtime.InteropServices.dll",
+        "ref/netcore50/System.Runtime.InteropServices.xml",
         "ref/netcore50/de/System.Runtime.InteropServices.xml",
         "ref/netcore50/es/System.Runtime.InteropServices.xml",
         "ref/netcore50/fr/System.Runtime.InteropServices.xml",
@@ -4084,10 +11249,10 @@
         "ref/netcore50/ja/System.Runtime.InteropServices.xml",
         "ref/netcore50/ko/System.Runtime.InteropServices.xml",
         "ref/netcore50/ru/System.Runtime.InteropServices.xml",
-        "ref/netcore50/System.Runtime.InteropServices.dll",
-        "ref/netcore50/System.Runtime.InteropServices.xml",
         "ref/netcore50/zh-hans/System.Runtime.InteropServices.xml",
         "ref/netcore50/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/netstandard1.1/System.Runtime.InteropServices.dll",
+        "ref/netstandard1.1/System.Runtime.InteropServices.xml",
         "ref/netstandard1.1/de/System.Runtime.InteropServices.xml",
         "ref/netstandard1.1/es/System.Runtime.InteropServices.xml",
         "ref/netstandard1.1/fr/System.Runtime.InteropServices.xml",
@@ -4095,10 +11260,10 @@
         "ref/netstandard1.1/ja/System.Runtime.InteropServices.xml",
         "ref/netstandard1.1/ko/System.Runtime.InteropServices.xml",
         "ref/netstandard1.1/ru/System.Runtime.InteropServices.xml",
-        "ref/netstandard1.1/System.Runtime.InteropServices.dll",
-        "ref/netstandard1.1/System.Runtime.InteropServices.xml",
         "ref/netstandard1.1/zh-hans/System.Runtime.InteropServices.xml",
         "ref/netstandard1.1/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/netstandard1.2/System.Runtime.InteropServices.dll",
+        "ref/netstandard1.2/System.Runtime.InteropServices.xml",
         "ref/netstandard1.2/de/System.Runtime.InteropServices.xml",
         "ref/netstandard1.2/es/System.Runtime.InteropServices.xml",
         "ref/netstandard1.2/fr/System.Runtime.InteropServices.xml",
@@ -4106,10 +11271,10 @@
         "ref/netstandard1.2/ja/System.Runtime.InteropServices.xml",
         "ref/netstandard1.2/ko/System.Runtime.InteropServices.xml",
         "ref/netstandard1.2/ru/System.Runtime.InteropServices.xml",
-        "ref/netstandard1.2/System.Runtime.InteropServices.dll",
-        "ref/netstandard1.2/System.Runtime.InteropServices.xml",
         "ref/netstandard1.2/zh-hans/System.Runtime.InteropServices.xml",
         "ref/netstandard1.2/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/netstandard1.3/System.Runtime.InteropServices.dll",
+        "ref/netstandard1.3/System.Runtime.InteropServices.xml",
         "ref/netstandard1.3/de/System.Runtime.InteropServices.xml",
         "ref/netstandard1.3/es/System.Runtime.InteropServices.xml",
         "ref/netstandard1.3/fr/System.Runtime.InteropServices.xml",
@@ -4117,8 +11282,6 @@
         "ref/netstandard1.3/ja/System.Runtime.InteropServices.xml",
         "ref/netstandard1.3/ko/System.Runtime.InteropServices.xml",
         "ref/netstandard1.3/ru/System.Runtime.InteropServices.xml",
-        "ref/netstandard1.3/System.Runtime.InteropServices.dll",
-        "ref/netstandard1.3/System.Runtime.InteropServices.xml",
         "ref/netstandard1.3/zh-hans/System.Runtime.InteropServices.xml",
         "ref/netstandard1.3/zh-hant/System.Runtime.InteropServices.xml",
         "ref/win8/_._",
@@ -4126,15 +11289,38 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Runtime.InteropServices.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Runtime.InteropServices.PInvoke/4.0.0-rc2-23911": {
+      "sha512": "QpI/lMEkojgpNu88kDP8IfFCaRaugjwKTI71vXKSBI0GtF3bFJ9MeMPwB6MSnF+nEU5us3qLFgJuOgUjbgInkg==",
+      "type": "package",
+      "files": [
+        "System.Runtime.InteropServices.PInvoke.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Runtime.InteropServices.PInvoke.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Runtime.InteropServices.PInvoke.dll",
+        "lib/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Runtime.InteropServices.PInvoke.dll",
+        "ref/netstandard1.3/System.Runtime.InteropServices.PInvoke.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/aot/lib/netcore50/System.Runtime.InteropServices.PInvoke.dll"
       ]
     },
     "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23911": {
       "sha512": "Waycb2JZScjcc6FzcCxVibnsiTkoyGWW6G+jrhwaaE4CuOfXG51Oo6IG58J14UHwQupWMo7Yi2pPbCL/EDY9ZQ==",
       "type": "Package",
       "files": [
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4150,21 +11336,23 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Runtime.Loader/4.0.0-rc2-23911": {
       "sha512": "4zc5OPUW3tCjfOFqVf44b/OtDyP9RSHwYjSXYxPIKBhR3gEvdxaSLkvvZwuKO326nFWAyd3ybhzXluN13h4UcQ==",
       "type": "Package",
       "files": [
+        "System.Runtime.Loader.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
         "lib/net462/_._",
         "lib/netcore50/_._",
         "lib/netstandard1.5/System.Runtime.Loader.dll",
+        "ref/netstandard1.5/System.Runtime.Loader.dll",
+        "ref/netstandard1.5/System.Runtime.Loader.xml",
         "ref/netstandard1.5/de/System.Runtime.Loader.xml",
         "ref/netstandard1.5/es/System.Runtime.Loader.xml",
         "ref/netstandard1.5/fr/System.Runtime.Loader.xml",
@@ -4172,18 +11360,16 @@
         "ref/netstandard1.5/ja/System.Runtime.Loader.xml",
         "ref/netstandard1.5/ko/System.Runtime.Loader.xml",
         "ref/netstandard1.5/ru/System.Runtime.Loader.xml",
-        "ref/netstandard1.5/System.Runtime.Loader.dll",
-        "ref/netstandard1.5/System.Runtime.Loader.xml",
         "ref/netstandard1.5/zh-hans/System.Runtime.Loader.xml",
-        "ref/netstandard1.5/zh-hant/System.Runtime.Loader.xml",
-        "System.Runtime.Loader.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/netstandard1.5/zh-hant/System.Runtime.Loader.xml"
       ]
     },
     "System.Runtime.Numerics/4.0.1-rc2-23911": {
       "sha512": "MNER6YxAgqqLmmrfagkLACUdMh9X+B0DRiCito+noGN6yyQKV28fppPATdVleFhuoz76bDwHApnJlmBA3TQcvQ==",
       "type": "Package",
       "files": [
+        "System.Runtime.Numerics.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4201,6 +11387,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Runtime.Numerics.dll",
+        "ref/netcore50/System.Runtime.Numerics.xml",
         "ref/netcore50/de/System.Runtime.Numerics.xml",
         "ref/netcore50/es/System.Runtime.Numerics.xml",
         "ref/netcore50/fr/System.Runtime.Numerics.xml",
@@ -4208,10 +11396,10 @@
         "ref/netcore50/ja/System.Runtime.Numerics.xml",
         "ref/netcore50/ko/System.Runtime.Numerics.xml",
         "ref/netcore50/ru/System.Runtime.Numerics.xml",
-        "ref/netcore50/System.Runtime.Numerics.dll",
-        "ref/netcore50/System.Runtime.Numerics.xml",
         "ref/netcore50/zh-hans/System.Runtime.Numerics.xml",
         "ref/netcore50/zh-hant/System.Runtime.Numerics.xml",
+        "ref/netstandard1.1/System.Runtime.Numerics.dll",
+        "ref/netstandard1.1/System.Runtime.Numerics.xml",
         "ref/netstandard1.1/de/System.Runtime.Numerics.xml",
         "ref/netstandard1.1/es/System.Runtime.Numerics.xml",
         "ref/netstandard1.1/fr/System.Runtime.Numerics.xml",
@@ -4219,8 +11407,6 @@
         "ref/netstandard1.1/ja/System.Runtime.Numerics.xml",
         "ref/netstandard1.1/ko/System.Runtime.Numerics.xml",
         "ref/netstandard1.1/ru/System.Runtime.Numerics.xml",
-        "ref/netstandard1.1/System.Runtime.Numerics.dll",
-        "ref/netstandard1.1/System.Runtime.Numerics.xml",
         "ref/netstandard1.1/zh-hans/System.Runtime.Numerics.xml",
         "ref/netstandard1.1/zh-hant/System.Runtime.Numerics.xml",
         "ref/win8/_._",
@@ -4228,15 +11414,324 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Security.Claims/4.0.1-rc2-23911": {
+      "sha512": "s2W7sqEESeaxI8kDlT0KkCDsuz2X46UeEB5T45s4yr7kTqNzfSWBCPkEaf2Ey4OPzqJTJFdu7qdt3GTbPmgZMg==",
+      "type": "package",
+      "files": [
+        "System.Security.Claims.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Security.Claims.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
+        "lib/netstandard1.3/System.Security.Claims.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
+        "ref/netstandard1.3/System.Security.Claims.dll",
+        "ref/netstandard1.3/System.Security.Claims.xml",
+        "ref/netstandard1.3/de/System.Security.Claims.xml",
+        "ref/netstandard1.3/es/System.Security.Claims.xml",
+        "ref/netstandard1.3/fr/System.Security.Claims.xml",
+        "ref/netstandard1.3/it/System.Security.Claims.xml",
+        "ref/netstandard1.3/ja/System.Security.Claims.xml",
+        "ref/netstandard1.3/ko/System.Security.Claims.xml",
+        "ref/netstandard1.3/ru/System.Security.Claims.xml",
+        "ref/netstandard1.3/zh-hans/System.Security.Claims.xml",
+        "ref/netstandard1.3/zh-hant/System.Security.Claims.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Security.Cryptography.Algorithms/4.1.0-rc2-23911": {
+      "sha512": "fcY0eV194G1N1Cqh/Sf4c3fq9ytPcDUNedjXuzBd0FoOWOrXq781vsUi6sDANU2F0l0ONjXLxkY6fj4h8JxZ3w==",
+      "type": "package",
+      "files": [
+        "System.Security.Cryptography.Algorithms.4.1.0-rc2-23911.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Algorithms.dll",
+        "lib/net461/System.Security.Cryptography.Algorithms.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Algorithms.dll",
+        "ref/net461/System.Security.Cryptography.Algorithms.dll",
+        "ref/netstandard1.3/System.Security.Cryptography.Algorithms.dll",
+        "ref/netstandard1.4/System.Security.Cryptography.Algorithms.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Security.Cryptography.Cng/4.1.0-rc2-23911": {
+      "sha512": "0uaYXQlykNUf9NzBNneTlOxI1kkHo7ghGgymza0BJs4l+7agBQag+tKl5Msb0se4xYtJz8yU6dOX91zCWJQc6w==",
+      "type": "package",
+      "files": [
+        "System.Security.Cryptography.Cng.4.1.0-rc2-23911.nupkg.sha512",
+        "System.Security.Cryptography.Cng.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/net46/System.Security.Cryptography.Cng.dll",
+        "lib/net461/System.Security.Cryptography.Cng.dll",
+        "lib/netstandard1.4/System.Security.Cryptography.Cng.dll",
+        "ref/net46/System.Security.Cryptography.Cng.dll",
+        "ref/net461/System.Security.Cryptography.Cng.dll",
+        "ref/netstandard1.3/System.Security.Cryptography.Cng.dll",
+        "ref/netstandard1.4/System.Security.Cryptography.Cng.dll"
+      ]
+    },
+    "System.Security.Cryptography.Csp/4.0.0-rc2-23911": {
+      "sha512": "hXK1uJA4tA1hqwpks2a/45uGmOGAQDdSCC0hRkaR1MBzvkrdqZ5psH+B3hTPmytDSRK+JNfwKB0XWp1r8HyppQ==",
+      "type": "package",
+      "files": [
+        "System.Security.Cryptography.Csp.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Security.Cryptography.Csp.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Csp.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Csp.dll",
+        "ref/netstandard1.3/System.Security.Cryptography.Csp.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "System.Runtime.Numerics.nuspec",
-        "ThirdPartyNotices.txt"
+        "runtimes/win/lib/netcore50/_._",
+        "runtimes/win/lib/netstandard1.3/System.Security.Cryptography.Csp.dll"
+      ]
+    },
+    "System.Security.Cryptography.Encoding/4.0.0-rc2-23911": {
+      "sha512": "xGyigjSB2QlcVCNdLk4W1Al5s8KHIf76lyvEG2v8hAD1iAnKX2Tkhu5LD85I/LGk9WZpG9YiYnhX6tShnpSsoQ==",
+      "type": "package",
+      "files": [
+        "System.Security.Cryptography.Encoding.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encoding.dll",
+        "ref/netstandard1.3/System.Security.Cryptography.Encoding.dll",
+        "ref/netstandard1.3/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/de/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/es/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/it/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/ru/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/netstandard1.3/zh-hant/System.Security.Cryptography.Encoding.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23911": {
+      "sha512": "e0PLYovv0lcsB7SrLQZtB3LBGFtPGE/UJd4YYzjRGBoRXjSzrGzStEwz0R9oLyEXd/p3RTUT247kF5/hXYkBKg==",
+      "type": "package",
+      "files": [
+        "System.Security.Cryptography.OpenSsl.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Security.Cryptography.OpenSsl.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/net461/_._",
+        "lib/netcore50/_._",
+        "lib/netstandard1.4/System.Security.Cryptography.OpenSsl.dll",
+        "ref/netstandard1.4/System.Security.Cryptography.OpenSsl.dll"
+      ]
+    },
+    "System.Security.Cryptography.Primitives/4.0.0-rc2-23911": {
+      "sha512": "gdeaS2j1VRGIZNaBTwnABjlXxQydqDb2sqRt1bSqbjFQCTFdEVq9w62A7ProJWVxzRxtcT1i8fPr/j86bmvyWw==",
+      "type": "package",
+      "files": [
+        "System.Security.Cryptography.Primitives.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Primitives.dll",
+        "lib/netstandard1.3/System.Security.Cryptography.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Primitives.dll",
+        "ref/netstandard1.3/System.Security.Cryptography.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Security.Cryptography.X509Certificates/4.1.0-rc2-23911": {
+      "sha512": "rp3TiR0tkL5NqEB338N+XD9xh3plxfZQHGOe4JPOyF6UOIm3jZr/UWe1V/v2ub8uLP3rZcjzX8N488yemm3JIw==",
+      "type": "package",
+      "files": [
+        "System.Security.Cryptography.X509Certificates.4.1.0-rc2-23911.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
+        "lib/net461/System.Security.Cryptography.X509Certificates.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
+        "ref/net461/System.Security.Cryptography.X509Certificates.dll",
+        "ref/netstandard1.3/System.Security.Cryptography.X509Certificates.dll",
+        "ref/netstandard1.3/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/ru/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.3/zh-hant/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.dll",
+        "ref/netstandard1.4/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/ru/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/netstandard1.4/zh-hant/System.Security.Cryptography.X509Certificates.xml",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Security.Principal/4.0.1-rc2-23911": {
+      "sha512": "rZ74e9vQdN0uruHaw/ZM1xjICTtjWZPMYl7zMH70tfq1LwjzVOAu+1q7NNV3yePsVoXn9zcErNJ0yXC/2QAxCg==",
+      "type": "package",
+      "files": [
+        "System.Security.Principal.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Security.Principal.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Security.Principal.dll",
+        "lib/netstandard1.0/System.Security.Principal.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "lib/xamarintvos10/_._",
+        "lib/xamarinwatchos10/_._",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.Security.Principal.dll",
+        "ref/netcore50/System.Security.Principal.xml",
+        "ref/netcore50/de/System.Security.Principal.xml",
+        "ref/netcore50/es/System.Security.Principal.xml",
+        "ref/netcore50/fr/System.Security.Principal.xml",
+        "ref/netcore50/it/System.Security.Principal.xml",
+        "ref/netcore50/ja/System.Security.Principal.xml",
+        "ref/netcore50/ko/System.Security.Principal.xml",
+        "ref/netcore50/ru/System.Security.Principal.xml",
+        "ref/netcore50/zh-hans/System.Security.Principal.xml",
+        "ref/netcore50/zh-hant/System.Security.Principal.xml",
+        "ref/netstandard1.0/System.Security.Principal.dll",
+        "ref/netstandard1.0/System.Security.Principal.xml",
+        "ref/netstandard1.0/de/System.Security.Principal.xml",
+        "ref/netstandard1.0/es/System.Security.Principal.xml",
+        "ref/netstandard1.0/fr/System.Security.Principal.xml",
+        "ref/netstandard1.0/it/System.Security.Principal.xml",
+        "ref/netstandard1.0/ja/System.Security.Principal.xml",
+        "ref/netstandard1.0/ko/System.Security.Principal.xml",
+        "ref/netstandard1.0/ru/System.Security.Principal.xml",
+        "ref/netstandard1.0/zh-hans/System.Security.Principal.xml",
+        "ref/netstandard1.0/zh-hant/System.Security.Principal.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ref/xamarintvos10/_._",
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Security.Principal.Windows/4.0.0-rc2-23911": {
+      "sha512": "AgjwmFIvv2fQLak80rd8/+DyvzsEg1FdzqVeE7nYYstXgFyR4PInpb7P5o4/ZfN1tN3d83o2DJMMEvea4lroeQ==",
+      "type": "package",
+      "files": [
+        "System.Security.Principal.Windows.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Security.Principal.Windows.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/net46/System.Security.Principal.Windows.dll",
+        "lib/netstandard1.3/System.Security.Principal.Windows.dll",
+        "ref/net46/System.Security.Principal.Windows.dll",
+        "ref/netstandard1.3/System.Security.Principal.Windows.dll",
+        "ref/netstandard1.3/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/de/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/es/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/fr/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/it/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/ja/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/ko/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/ru/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/netstandard1.3/zh-hant/System.Security.Principal.Windows.xml"
       ]
     },
     "System.Text.Encoding/4.0.11-rc2-23911": {
       "sha512": "s4ZlY7obnrhAVGwkbbsCFsfeH/4exPrK7hbjVd4eRt9I2otLpXCAft4+S8BSkqFgncIaMLisb1Z1v7vyQYFvBA==",
       "type": "Package",
       "files": [
+        "System.Text.Encoding.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4253,6 +11748,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Text.Encoding.dll",
+        "ref/netcore50/System.Text.Encoding.xml",
         "ref/netcore50/de/System.Text.Encoding.xml",
         "ref/netcore50/es/System.Text.Encoding.xml",
         "ref/netcore50/fr/System.Text.Encoding.xml",
@@ -4260,10 +11757,10 @@
         "ref/netcore50/ja/System.Text.Encoding.xml",
         "ref/netcore50/ko/System.Text.Encoding.xml",
         "ref/netcore50/ru/System.Text.Encoding.xml",
-        "ref/netcore50/System.Text.Encoding.dll",
-        "ref/netcore50/System.Text.Encoding.xml",
         "ref/netcore50/zh-hans/System.Text.Encoding.xml",
         "ref/netcore50/zh-hant/System.Text.Encoding.xml",
+        "ref/netstandard1.0/System.Text.Encoding.dll",
+        "ref/netstandard1.0/System.Text.Encoding.xml",
         "ref/netstandard1.0/de/System.Text.Encoding.xml",
         "ref/netstandard1.0/es/System.Text.Encoding.xml",
         "ref/netstandard1.0/fr/System.Text.Encoding.xml",
@@ -4271,10 +11768,10 @@
         "ref/netstandard1.0/ja/System.Text.Encoding.xml",
         "ref/netstandard1.0/ko/System.Text.Encoding.xml",
         "ref/netstandard1.0/ru/System.Text.Encoding.xml",
-        "ref/netstandard1.0/System.Text.Encoding.dll",
-        "ref/netstandard1.0/System.Text.Encoding.xml",
         "ref/netstandard1.0/zh-hans/System.Text.Encoding.xml",
         "ref/netstandard1.0/zh-hant/System.Text.Encoding.xml",
+        "ref/netstandard1.3/System.Text.Encoding.dll",
+        "ref/netstandard1.3/System.Text.Encoding.xml",
         "ref/netstandard1.3/de/System.Text.Encoding.xml",
         "ref/netstandard1.3/es/System.Text.Encoding.xml",
         "ref/netstandard1.3/fr/System.Text.Encoding.xml",
@@ -4282,8 +11779,6 @@
         "ref/netstandard1.3/ja/System.Text.Encoding.xml",
         "ref/netstandard1.3/ko/System.Text.Encoding.xml",
         "ref/netstandard1.3/ru/System.Text.Encoding.xml",
-        "ref/netstandard1.3/System.Text.Encoding.dll",
-        "ref/netstandard1.3/System.Text.Encoding.xml",
         "ref/netstandard1.3/zh-hans/System.Text.Encoding.xml",
         "ref/netstandard1.3/zh-hant/System.Text.Encoding.xml",
         "ref/win8/_._",
@@ -4292,15 +11787,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Text.Encoding.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.11-rc2-23911": {
       "sha512": "Kw062/7RIoqkrQi1N55QrEAQOd2ihxoEBBVHKZxPxI+ndgX1M2gTUz5IftYq3cHpPwvdM86Wynl1NeqkwZQsxw==",
       "type": "Package",
       "files": [
+        "System.Text.Encoding.Extensions.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4317,6 +11812,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/netcore50/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/de/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/es/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/fr/System.Text.Encoding.Extensions.xml",
@@ -4324,10 +11821,10 @@
         "ref/netcore50/ja/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/ko/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/ru/System.Text.Encoding.Extensions.xml",
-        "ref/netcore50/System.Text.Encoding.Extensions.dll",
-        "ref/netcore50/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/netcore50/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/netstandard1.0/System.Text.Encoding.Extensions.dll",
+        "ref/netstandard1.0/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.0/de/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.0/es/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.0/fr/System.Text.Encoding.Extensions.xml",
@@ -4335,10 +11832,10 @@
         "ref/netstandard1.0/ja/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.0/ko/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.0/ru/System.Text.Encoding.Extensions.xml",
-        "ref/netstandard1.0/System.Text.Encoding.Extensions.dll",
-        "ref/netstandard1.0/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.0/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.0/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/netstandard1.3/System.Text.Encoding.Extensions.dll",
+        "ref/netstandard1.3/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.3/de/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.3/es/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.3/fr/System.Text.Encoding.Extensions.xml",
@@ -4346,8 +11843,6 @@
         "ref/netstandard1.3/ja/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.3/ko/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.3/ru/System.Text.Encoding.Extensions.xml",
-        "ref/netstandard1.3/System.Text.Encoding.Extensions.dll",
-        "ref/netstandard1.3/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.3/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/netstandard1.3/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/win8/_._",
@@ -4356,15 +11851,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Text.Encoding.Extensions.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Text.RegularExpressions/4.0.12-rc2-23911": {
       "sha512": "XPKxaSfEbvnKtrCNFJrvGPsRu2Um4z2YhFGwLGVEUnaMqQcZUGwrR4XCru8I35cRVrwCV54tP9cDAYK0c9MGDA==",
       "type": "Package",
       "files": [
+        "System.Text.RegularExpressions.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4383,6 +11878,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Text.RegularExpressions.dll",
+        "ref/netcore50/System.Text.RegularExpressions.xml",
         "ref/netcore50/de/System.Text.RegularExpressions.xml",
         "ref/netcore50/es/System.Text.RegularExpressions.xml",
         "ref/netcore50/fr/System.Text.RegularExpressions.xml",
@@ -4390,10 +11887,10 @@
         "ref/netcore50/ja/System.Text.RegularExpressions.xml",
         "ref/netcore50/ko/System.Text.RegularExpressions.xml",
         "ref/netcore50/ru/System.Text.RegularExpressions.xml",
-        "ref/netcore50/System.Text.RegularExpressions.dll",
-        "ref/netcore50/System.Text.RegularExpressions.xml",
         "ref/netcore50/zh-hans/System.Text.RegularExpressions.xml",
         "ref/netcore50/zh-hant/System.Text.RegularExpressions.xml",
+        "ref/netstandard1.0/System.Text.RegularExpressions.dll",
+        "ref/netstandard1.0/System.Text.RegularExpressions.xml",
         "ref/netstandard1.0/de/System.Text.RegularExpressions.xml",
         "ref/netstandard1.0/es/System.Text.RegularExpressions.xml",
         "ref/netstandard1.0/fr/System.Text.RegularExpressions.xml",
@@ -4401,10 +11898,10 @@
         "ref/netstandard1.0/ja/System.Text.RegularExpressions.xml",
         "ref/netstandard1.0/ko/System.Text.RegularExpressions.xml",
         "ref/netstandard1.0/ru/System.Text.RegularExpressions.xml",
-        "ref/netstandard1.0/System.Text.RegularExpressions.dll",
-        "ref/netstandard1.0/System.Text.RegularExpressions.xml",
         "ref/netstandard1.0/zh-hans/System.Text.RegularExpressions.xml",
         "ref/netstandard1.0/zh-hant/System.Text.RegularExpressions.xml",
+        "ref/netstandard1.3/System.Text.RegularExpressions.dll",
+        "ref/netstandard1.3/System.Text.RegularExpressions.xml",
         "ref/netstandard1.3/de/System.Text.RegularExpressions.xml",
         "ref/netstandard1.3/es/System.Text.RegularExpressions.xml",
         "ref/netstandard1.3/fr/System.Text.RegularExpressions.xml",
@@ -4412,8 +11909,6 @@
         "ref/netstandard1.3/ja/System.Text.RegularExpressions.xml",
         "ref/netstandard1.3/ko/System.Text.RegularExpressions.xml",
         "ref/netstandard1.3/ru/System.Text.RegularExpressions.xml",
-        "ref/netstandard1.3/System.Text.RegularExpressions.dll",
-        "ref/netstandard1.3/System.Text.RegularExpressions.xml",
         "ref/netstandard1.3/zh-hans/System.Text.RegularExpressions.xml",
         "ref/netstandard1.3/zh-hant/System.Text.RegularExpressions.xml",
         "ref/win8/_._",
@@ -4422,15 +11917,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Text.RegularExpressions.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Threading/4.0.11-rc2-23911": {
       "sha512": "qcw7giuxnTl8HIHNBFWdbu6vgCoQz386HPTrR19rRoRtOEVrKFyE3f9+cgF+GdbTIcAKiduXUTf9U1TEWpL2PQ==",
       "type": "Package",
       "files": [
+        "System.Threading.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4449,6 +11944,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Threading.dll",
+        "ref/netcore50/System.Threading.xml",
         "ref/netcore50/de/System.Threading.xml",
         "ref/netcore50/es/System.Threading.xml",
         "ref/netcore50/fr/System.Threading.xml",
@@ -4456,10 +11953,10 @@
         "ref/netcore50/ja/System.Threading.xml",
         "ref/netcore50/ko/System.Threading.xml",
         "ref/netcore50/ru/System.Threading.xml",
-        "ref/netcore50/System.Threading.dll",
-        "ref/netcore50/System.Threading.xml",
         "ref/netcore50/zh-hans/System.Threading.xml",
         "ref/netcore50/zh-hant/System.Threading.xml",
+        "ref/netstandard1.0/System.Threading.dll",
+        "ref/netstandard1.0/System.Threading.xml",
         "ref/netstandard1.0/de/System.Threading.xml",
         "ref/netstandard1.0/es/System.Threading.xml",
         "ref/netstandard1.0/fr/System.Threading.xml",
@@ -4467,10 +11964,10 @@
         "ref/netstandard1.0/ja/System.Threading.xml",
         "ref/netstandard1.0/ko/System.Threading.xml",
         "ref/netstandard1.0/ru/System.Threading.xml",
-        "ref/netstandard1.0/System.Threading.dll",
-        "ref/netstandard1.0/System.Threading.xml",
         "ref/netstandard1.0/zh-hans/System.Threading.xml",
         "ref/netstandard1.0/zh-hant/System.Threading.xml",
+        "ref/netstandard1.3/System.Threading.dll",
+        "ref/netstandard1.3/System.Threading.xml",
         "ref/netstandard1.3/de/System.Threading.xml",
         "ref/netstandard1.3/es/System.Threading.xml",
         "ref/netstandard1.3/fr/System.Threading.xml",
@@ -4478,8 +11975,6 @@
         "ref/netstandard1.3/ja/System.Threading.xml",
         "ref/netstandard1.3/ko/System.Threading.xml",
         "ref/netstandard1.3/ru/System.Threading.xml",
-        "ref/netstandard1.3/System.Threading.dll",
-        "ref/netstandard1.3/System.Threading.xml",
         "ref/netstandard1.3/zh-hans/System.Threading.xml",
         "ref/netstandard1.3/zh-hant/System.Threading.xml",
         "ref/win8/_._",
@@ -4489,15 +11984,40 @@
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
         "ref/xamarinwatchos10/_._",
-        "runtimes/aot/lib/netcore50/System.Threading.dll",
-        "System.Threading.nuspec",
-        "ThirdPartyNotices.txt"
+        "runtimes/aot/lib/netcore50/System.Threading.dll"
+      ]
+    },
+    "System.Threading.Overlapped/4.0.1-rc2-23911": {
+      "sha512": "LLnhOZODPYDG2RrC+ibfsEiVAA9VXEnnG4InlYLmQ4H8IWsMPPi90GvhVfA8VdSCZawoPVrrzLt4tvKUxKxs6A==",
+      "type": "package",
+      "files": [
+        "System.Threading.Overlapped.4.0.1-rc2-23911.nupkg.sha512",
+        "System.Threading.Overlapped.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/net46/System.Threading.Overlapped.dll",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "ref/net46/System.Threading.Overlapped.dll",
+        "ref/netstandard1.3/System.Threading.Overlapped.dll",
+        "ref/netstandard1.3/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/de/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/es/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/fr/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/it/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/ja/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/ko/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/ru/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/zh-hans/System.Threading.Overlapped.xml",
+        "ref/netstandard1.3/zh-hant/System.Threading.Overlapped.xml",
+        "runtimes/win/lib/netstandard1.3/System.Threading.Overlapped.dll"
       ]
     },
     "System.Threading.Tasks/4.0.11-rc2-23911": {
       "sha512": "5599rvzULAH/aSpcGEc042i8UXKgYcQD5PC6/VHRl+dNpNeMiKUYmtpv0XLJlU5AfR2I3yPXo5SLbmvWC4iRfg==",
       "type": "Package",
       "files": [
+        "System.Threading.Tasks.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4514,6 +12034,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "ref/netcore50/System.Threading.Tasks.xml",
         "ref/netcore50/de/System.Threading.Tasks.xml",
         "ref/netcore50/es/System.Threading.Tasks.xml",
         "ref/netcore50/fr/System.Threading.Tasks.xml",
@@ -4521,10 +12043,10 @@
         "ref/netcore50/ja/System.Threading.Tasks.xml",
         "ref/netcore50/ko/System.Threading.Tasks.xml",
         "ref/netcore50/ru/System.Threading.Tasks.xml",
-        "ref/netcore50/System.Threading.Tasks.dll",
-        "ref/netcore50/System.Threading.Tasks.xml",
         "ref/netcore50/zh-hans/System.Threading.Tasks.xml",
         "ref/netcore50/zh-hant/System.Threading.Tasks.xml",
+        "ref/netstandard1.0/System.Threading.Tasks.dll",
+        "ref/netstandard1.0/System.Threading.Tasks.xml",
         "ref/netstandard1.0/de/System.Threading.Tasks.xml",
         "ref/netstandard1.0/es/System.Threading.Tasks.xml",
         "ref/netstandard1.0/fr/System.Threading.Tasks.xml",
@@ -4532,10 +12054,10 @@
         "ref/netstandard1.0/ja/System.Threading.Tasks.xml",
         "ref/netstandard1.0/ko/System.Threading.Tasks.xml",
         "ref/netstandard1.0/ru/System.Threading.Tasks.xml",
-        "ref/netstandard1.0/System.Threading.Tasks.dll",
-        "ref/netstandard1.0/System.Threading.Tasks.xml",
         "ref/netstandard1.0/zh-hans/System.Threading.Tasks.xml",
         "ref/netstandard1.0/zh-hant/System.Threading.Tasks.xml",
+        "ref/netstandard1.3/System.Threading.Tasks.dll",
+        "ref/netstandard1.3/System.Threading.Tasks.xml",
         "ref/netstandard1.3/de/System.Threading.Tasks.xml",
         "ref/netstandard1.3/es/System.Threading.Tasks.xml",
         "ref/netstandard1.3/fr/System.Threading.Tasks.xml",
@@ -4543,8 +12065,6 @@
         "ref/netstandard1.3/ja/System.Threading.Tasks.xml",
         "ref/netstandard1.3/ko/System.Threading.Tasks.xml",
         "ref/netstandard1.3/ru/System.Threading.Tasks.xml",
-        "ref/netstandard1.3/System.Threading.Tasks.dll",
-        "ref/netstandard1.3/System.Threading.Tasks.xml",
         "ref/netstandard1.3/zh-hans/System.Threading.Tasks.xml",
         "ref/netstandard1.3/zh-hant/System.Threading.Tasks.xml",
         "ref/win8/_._",
@@ -4553,15 +12073,29 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Threading.Tasks.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
+      ]
+    },
+    "System.Threading.Tasks.Extensions/4.0.0-rc2-23911": {
+      "sha512": "0Nbrt+rDc6vTBY/adCvJlIQojuIQTeChCak0lN3JCN+FxD0azgDplZL0cDZHOF6foyY0TpijB+EIdhLiV9tibA==",
+      "type": "package",
+      "files": [
+        "System.Threading.Tasks.Extensions.4.0.0-rc2-23911.nupkg.sha512",
+        "System.Threading.Tasks.Extensions.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "lib/netstandard1.0/System.Threading.Tasks.Extensions.dll",
+        "lib/netstandard1.0/System.Threading.Tasks.Extensions.xml",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Extensions.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Extensions.xml"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.1-rc2-23911": {
       "sha512": "OmfR89tWe4xvE0120SxzYAY0ZnGKYL15QajQfOoSia6josfd/1ZHtl5RdITdeUwvHIthd4VxfT+nQnaEjZMneA==",
       "type": "Package",
       "files": [
+        "System.Threading.Tasks.Parallel.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4579,6 +12113,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Threading.Tasks.Parallel.dll",
+        "ref/netcore50/System.Threading.Tasks.Parallel.xml",
         "ref/netcore50/de/System.Threading.Tasks.Parallel.xml",
         "ref/netcore50/es/System.Threading.Tasks.Parallel.xml",
         "ref/netcore50/fr/System.Threading.Tasks.Parallel.xml",
@@ -4586,10 +12122,10 @@
         "ref/netcore50/ja/System.Threading.Tasks.Parallel.xml",
         "ref/netcore50/ko/System.Threading.Tasks.Parallel.xml",
         "ref/netcore50/ru/System.Threading.Tasks.Parallel.xml",
-        "ref/netcore50/System.Threading.Tasks.Parallel.dll",
-        "ref/netcore50/System.Threading.Tasks.Parallel.xml",
         "ref/netcore50/zh-hans/System.Threading.Tasks.Parallel.xml",
         "ref/netcore50/zh-hant/System.Threading.Tasks.Parallel.xml",
+        "ref/netstandard1.1/System.Threading.Tasks.Parallel.dll",
+        "ref/netstandard1.1/System.Threading.Tasks.Parallel.xml",
         "ref/netstandard1.1/de/System.Threading.Tasks.Parallel.xml",
         "ref/netstandard1.1/es/System.Threading.Tasks.Parallel.xml",
         "ref/netstandard1.1/fr/System.Threading.Tasks.Parallel.xml",
@@ -4597,8 +12133,6 @@
         "ref/netstandard1.1/ja/System.Threading.Tasks.Parallel.xml",
         "ref/netstandard1.1/ko/System.Threading.Tasks.Parallel.xml",
         "ref/netstandard1.1/ru/System.Threading.Tasks.Parallel.xml",
-        "ref/netstandard1.1/System.Threading.Tasks.Parallel.dll",
-        "ref/netstandard1.1/System.Threading.Tasks.Parallel.xml",
         "ref/netstandard1.1/zh-hans/System.Threading.Tasks.Parallel.xml",
         "ref/netstandard1.1/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/win8/_._",
@@ -4606,15 +12140,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Threading.Tasks.Parallel.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Threading.Thread/4.0.0-rc2-23911": {
       "sha512": "x8yaPh+WCffXVDd70mOK73siQ+GAdyKdEJMiX44N6B1e6OlNg5n1NZHSG0wryyvT/XIh3o8pjNmKokxRMZXwDA==",
       "type": "Package",
       "files": [
+        "System.Threading.Thread.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4630,6 +12164,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.Thread.dll",
+        "ref/netstandard1.3/System.Threading.Thread.dll",
+        "ref/netstandard1.3/System.Threading.Thread.xml",
         "ref/netstandard1.3/de/System.Threading.Thread.xml",
         "ref/netstandard1.3/es/System.Threading.Thread.xml",
         "ref/netstandard1.3/fr/System.Threading.Thread.xml",
@@ -4637,22 +12173,20 @@
         "ref/netstandard1.3/ja/System.Threading.Thread.xml",
         "ref/netstandard1.3/ko/System.Threading.Thread.xml",
         "ref/netstandard1.3/ru/System.Threading.Thread.xml",
-        "ref/netstandard1.3/System.Threading.Thread.dll",
-        "ref/netstandard1.3/System.Threading.Thread.xml",
         "ref/netstandard1.3/zh-hans/System.Threading.Thread.xml",
         "ref/netstandard1.3/zh-hant/System.Threading.Thread.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Threading.Thread.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Threading.ThreadPool/4.0.10-rc2-23911": {
       "sha512": "NAlkWCenRhG90Q8Wln7i1qwWB5LRFEbL8svvhVOqFx3eHwxMnDc7ghtIrXgafi5Qu+uhf1VQVqm6Y86g/Z7xjQ==",
       "type": "Package",
       "files": [
+        "System.Threading.ThreadPool.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4668,6 +12202,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/netstandard1.3/System.Threading.ThreadPool.dll",
+        "ref/netstandard1.3/System.Threading.ThreadPool.xml",
         "ref/netstandard1.3/de/System.Threading.ThreadPool.xml",
         "ref/netstandard1.3/es/System.Threading.ThreadPool.xml",
         "ref/netstandard1.3/fr/System.Threading.ThreadPool.xml",
@@ -4675,22 +12211,20 @@
         "ref/netstandard1.3/ja/System.Threading.ThreadPool.xml",
         "ref/netstandard1.3/ko/System.Threading.ThreadPool.xml",
         "ref/netstandard1.3/ru/System.Threading.ThreadPool.xml",
-        "ref/netstandard1.3/System.Threading.ThreadPool.dll",
-        "ref/netstandard1.3/System.Threading.ThreadPool.xml",
         "ref/netstandard1.3/zh-hans/System.Threading.ThreadPool.xml",
         "ref/netstandard1.3/zh-hant/System.Threading.ThreadPool.xml",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Threading.ThreadPool.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Threading.Timer/4.0.1-rc2-23911": {
       "sha512": "Io8x/wZ+Oh/x93b4rdg6AQVJo6vn9QGJ5fIsdh5vgnX0JEKGW/m16vj/wAGGnZDmxsRpCRZp+ug/d65Lu1lzcw==",
       "type": "Package",
       "files": [
+        "System.Threading.Timer.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4706,6 +12240,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net451/_._",
+        "ref/netcore50/System.Threading.Timer.dll",
+        "ref/netcore50/System.Threading.Timer.xml",
         "ref/netcore50/de/System.Threading.Timer.xml",
         "ref/netcore50/es/System.Threading.Timer.xml",
         "ref/netcore50/fr/System.Threading.Timer.xml",
@@ -4713,10 +12249,10 @@
         "ref/netcore50/ja/System.Threading.Timer.xml",
         "ref/netcore50/ko/System.Threading.Timer.xml",
         "ref/netcore50/ru/System.Threading.Timer.xml",
-        "ref/netcore50/System.Threading.Timer.dll",
-        "ref/netcore50/System.Threading.Timer.xml",
         "ref/netcore50/zh-hans/System.Threading.Timer.xml",
         "ref/netcore50/zh-hant/System.Threading.Timer.xml",
+        "ref/netstandard1.2/System.Threading.Timer.dll",
+        "ref/netstandard1.2/System.Threading.Timer.xml",
         "ref/netstandard1.2/de/System.Threading.Timer.xml",
         "ref/netstandard1.2/es/System.Threading.Timer.xml",
         "ref/netstandard1.2/fr/System.Threading.Timer.xml",
@@ -4724,8 +12260,6 @@
         "ref/netstandard1.2/ja/System.Threading.Timer.xml",
         "ref/netstandard1.2/ko/System.Threading.Timer.xml",
         "ref/netstandard1.2/ru/System.Threading.Timer.xml",
-        "ref/netstandard1.2/System.Threading.Timer.dll",
-        "ref/netstandard1.2/System.Threading.Timer.xml",
         "ref/netstandard1.2/zh-hans/System.Threading.Timer.xml",
         "ref/netstandard1.2/zh-hant/System.Threading.Timer.xml",
         "ref/win81/_._",
@@ -4733,15 +12267,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Threading.Timer.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Xml.ReaderWriter/4.0.11-rc2-23911": {
       "sha512": "/ICm9EcvRr6yv5oznqJp8VmbU2z0OB6m9g/QqMYw66+7ApTe0Bc4YaRHHIkEjhTdEyFzLyRci47zTKOxOYpnhw==",
       "type": "Package",
       "files": [
+        "System.Xml.ReaderWriter.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4760,6 +12294,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Xml.ReaderWriter.dll",
+        "ref/netcore50/System.Xml.ReaderWriter.xml",
         "ref/netcore50/de/System.Xml.ReaderWriter.xml",
         "ref/netcore50/es/System.Xml.ReaderWriter.xml",
         "ref/netcore50/fr/System.Xml.ReaderWriter.xml",
@@ -4767,10 +12303,10 @@
         "ref/netcore50/ja/System.Xml.ReaderWriter.xml",
         "ref/netcore50/ko/System.Xml.ReaderWriter.xml",
         "ref/netcore50/ru/System.Xml.ReaderWriter.xml",
-        "ref/netcore50/System.Xml.ReaderWriter.dll",
-        "ref/netcore50/System.Xml.ReaderWriter.xml",
         "ref/netcore50/zh-hans/System.Xml.ReaderWriter.xml",
         "ref/netcore50/zh-hant/System.Xml.ReaderWriter.xml",
+        "ref/netstandard1.0/System.Xml.ReaderWriter.dll",
+        "ref/netstandard1.0/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.0/de/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.0/es/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.0/fr/System.Xml.ReaderWriter.xml",
@@ -4778,10 +12314,10 @@
         "ref/netstandard1.0/ja/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.0/ko/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.0/ru/System.Xml.ReaderWriter.xml",
-        "ref/netstandard1.0/System.Xml.ReaderWriter.dll",
-        "ref/netstandard1.0/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.0/zh-hans/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.0/zh-hant/System.Xml.ReaderWriter.xml",
+        "ref/netstandard1.3/System.Xml.ReaderWriter.dll",
+        "ref/netstandard1.3/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.3/de/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.3/es/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.3/fr/System.Xml.ReaderWriter.xml",
@@ -4789,8 +12325,6 @@
         "ref/netstandard1.3/ja/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.3/ko/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.3/ru/System.Xml.ReaderWriter.xml",
-        "ref/netstandard1.3/System.Xml.ReaderWriter.dll",
-        "ref/netstandard1.3/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.3/zh-hans/System.Xml.ReaderWriter.xml",
         "ref/netstandard1.3/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/win8/_._",
@@ -4799,15 +12333,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Xml.ReaderWriter.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     },
     "System.Xml.XDocument/4.0.11-rc2-23911": {
       "sha512": "+4nE9DK7vwMruPWd7tLsJbpa3NBJfFroj3wi2ZrCGv6JIFLIvAcW4dlHyWwWS3E6UdqfsDZiGG2HKpyAomG+gw==",
       "type": "Package",
       "files": [
+        "System.Xml.XDocument.nuspec",
+        "ThirdPartyNotices.txt",
         "[Content_Types].xml",
         "_rels/.rels",
         "dotnet_library_license.txt",
@@ -4826,6 +12360,8 @@
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
+        "ref/netcore50/System.Xml.XDocument.dll",
+        "ref/netcore50/System.Xml.XDocument.xml",
         "ref/netcore50/de/System.Xml.XDocument.xml",
         "ref/netcore50/es/System.Xml.XDocument.xml",
         "ref/netcore50/fr/System.Xml.XDocument.xml",
@@ -4833,10 +12369,10 @@
         "ref/netcore50/ja/System.Xml.XDocument.xml",
         "ref/netcore50/ko/System.Xml.XDocument.xml",
         "ref/netcore50/ru/System.Xml.XDocument.xml",
-        "ref/netcore50/System.Xml.XDocument.dll",
-        "ref/netcore50/System.Xml.XDocument.xml",
         "ref/netcore50/zh-hans/System.Xml.XDocument.xml",
         "ref/netcore50/zh-hant/System.Xml.XDocument.xml",
+        "ref/netstandard1.0/System.Xml.XDocument.dll",
+        "ref/netstandard1.0/System.Xml.XDocument.xml",
         "ref/netstandard1.0/de/System.Xml.XDocument.xml",
         "ref/netstandard1.0/es/System.Xml.XDocument.xml",
         "ref/netstandard1.0/fr/System.Xml.XDocument.xml",
@@ -4844,10 +12380,10 @@
         "ref/netstandard1.0/ja/System.Xml.XDocument.xml",
         "ref/netstandard1.0/ko/System.Xml.XDocument.xml",
         "ref/netstandard1.0/ru/System.Xml.XDocument.xml",
-        "ref/netstandard1.0/System.Xml.XDocument.dll",
-        "ref/netstandard1.0/System.Xml.XDocument.xml",
         "ref/netstandard1.0/zh-hans/System.Xml.XDocument.xml",
         "ref/netstandard1.0/zh-hant/System.Xml.XDocument.xml",
+        "ref/netstandard1.3/System.Xml.XDocument.dll",
+        "ref/netstandard1.3/System.Xml.XDocument.xml",
         "ref/netstandard1.3/de/System.Xml.XDocument.xml",
         "ref/netstandard1.3/es/System.Xml.XDocument.xml",
         "ref/netstandard1.3/fr/System.Xml.XDocument.xml",
@@ -4855,8 +12391,6 @@
         "ref/netstandard1.3/ja/System.Xml.XDocument.xml",
         "ref/netstandard1.3/ko/System.Xml.XDocument.xml",
         "ref/netstandard1.3/ru/System.Xml.XDocument.xml",
-        "ref/netstandard1.3/System.Xml.XDocument.dll",
-        "ref/netstandard1.3/System.Xml.XDocument.xml",
         "ref/netstandard1.3/zh-hans/System.Xml.XDocument.xml",
         "ref/netstandard1.3/zh-hant/System.Xml.XDocument.xml",
         "ref/win8/_._",
@@ -4865,9 +12399,7 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "System.Xml.XDocument.nuspec",
-        "ThirdPartyNotices.txt"
+        "ref/xamarinwatchos10/_._"
       ]
     }
   },


### PR DESCRIPTION
With the coreclr merge Jenkins stopped working.  This converts Jenkins to use the 
build.cmd script.

This checkin only builds the product.

Todo: 
1.fix build to not require admin permissions for running tests.