### PR TITLE
Fix helloWorldCSharp on jenins

### DIFF
--- a/tests/fsharp/typeProviders/helloWorldCSharp/build.bat
+++ b/tests/fsharp/typeProviders/helloWorldCSharp/build.bat
@@ -10,18 +10,11 @@ if errorlevel 1 goto :Error
 "%FSC%" --out:magic.dll -a magic.fs --keyfile:magic.snk
 if errorlevel 1 goto :Error
 
-REM == If we are running this test on a lab machine, we may not be running from an elev cmd prompt
-REM == In that case, ADMIN_PIPE is set to the tool to invoke the command elevated.
-IF DEFINED ADMIN_PIPE %ADMIN_PIPE% %GACUTIL% /if magic.dll
-if errorlevel 1 goto :Error
-
 if EXIST provider.dll del provider.dll
 if ERRORLEVEL 1 goto :Error
 
 %CSC% /out:provider.dll /target:library "/r:%FSCOREDLLPATH%" /r:magic.dll provider.cs
 if ERRORLEVEL 1 goto :Error
-
-"%GACUTIL%" /if magic.dll
 
 "%FSC%" %fsc_flags% /debug+ /r:provider.dll /optimize- test.fsx
 if ERRORLEVEL 1 goto Error

--- a/tests/fsharp/typeProviders/tests_typeProviders.fs
+++ b/tests/fsharp/typeProviders/tests_typeProviders.fs
@@ -261,7 +261,6 @@ module HelloWorldCSharp =
         let fsc = Printf.ksprintf (Commands.fsc exec cfg.FSC)
         let csc = Printf.ksprintf (Commands.csc exec cfg.CSC)
         let del = Commands.rm dir
-        let gacutil = Commands.gacutil exec cfg.GACUTIL
 
         // if EXIST magic.dll del magic.dll
         del "magic.dll"
@@ -269,21 +268,11 @@ module HelloWorldCSharp =
         // "%FSC%" --out:magic.dll -a magic.fs --keyfile:magic.snk
         do! fsc "%s" "--out:magic.dll -a --keyfile:magic.snk" ["magic.fs "]
 
-        // REM == If we are running this test on a lab machine, we may not be running from an elev cmd prompt
-        // REM == In that case, ADMIN_PIPE is set to the tool to invoke the command elevated.
-        // IF DEFINED ADMIN_PIPE %ADMIN_PIPE% %GACUTIL% /if magic.dll
-        
-        //REVIEW check ADMIN_PIPE and elevated gac
-        ignore "useless ADMIN_PIPE, test are run as administrator"
-
         // if EXIST provider.dll del provider.dll
         del "provider.dll"
 
         // %CSC% /out:provider.dll /target:library "/r:%FSCOREDLLPATH%" /r:magic.dll provider.cs
         do! csc """/out:provider.dll /target:library "/r:%s" /r:magic.dll""" cfg.FSCOREDLLPATH ["provider.cs"]
-
-        // "%GACUTIL%" /if magic.dll
-        do! gacutil "/if" "magic.dll"
 
         // "%FSC%" %fsc_flags% /debug+ /r:provider.dll /optimize- test.fsx
         do! fsc "%s /debug+ /r:provider.dll /optimize-" cfg.fsc_flags ["test.fsx"]


### PR DESCRIPTION
magic.dll has no need to go in the gac ... so don't put it there.