### PR TITLE
fix build warnings

### DIFF
--- a/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
+++ b/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
@@ -443,7 +443,7 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="ISymWrapper, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion).0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Utilities.$(MSBuildVersionSuffix), Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Tasks.$(MSBuildVersionSuffix), Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
+++ b/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
@@ -449,7 +449,7 @@
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Engine, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.DiaSymReader.PortablePdb"><HintPath>..\..\..\packages\Microsoft.DiaSymReader.PortablePdb.1.3.20160301.3\lib\portable-net45+win8\Microsoft.DiaSymReader.PortablePdb.dll</HintPath></Reference>
+    <Reference Include="Microsoft.DiaSymReader.PortablePdb"><HintPath>..\..\..\packages\Microsoft.DiaSymReader.PortablePdb.1.0.0-rc-60301\lib\portable-net45+win8\Microsoft.DiaSymReader.PortablePdb.dll</HintPath></Reference>
     <Reference Include="Microsoft.DiaSymReader"><HintPath>..\..\..\packages\Microsoft.DiaSymReader.1.0.7\lib\portable-net45+win8\Microsoft.DiaSymReader.dll</HintPath></Reference>
     <Reference Include="System.Reflection.Metadata"><HintPath>..\..\..\packages\System.Reflection.Metadata.1.3.0-beta-23816\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath></Reference>
     <Reference Include="System.Collections.Immutable"><HintPath>..\..\..\packages\System.Collections.Immutable.1.2.0-rc3-23805\lib\portable-net45+win8+wp8+wpa81</HintPath></Reference>

--- a/tests/fsharp/project.json
+++ b/tests/fsharp/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911",
     "NETStandard.Library": "1.5.0-rc2-23911",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23911", 
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-23911", 
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-23911", 
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23911", 
     "System.Collections.Immutable":"1.2.0-rc2-23911",
@@ -18,7 +18,7 @@
     "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23911",
     "System.Security.Cryptography.Primitives": "4.0.0-rc2-23911",
     "System.Threading.Thread": "4.0.0-rc2-23911",
-    "System.Threading.ThreadPool": "4.0.10-rc2-23911",
+    "System.Threading.ThreadPool": "4.0.10-rc2-23911"
   },
   "runtimes": {
     "win7-x86": { },


### PR DESCRIPTION
- [X] Microsoft.Build version 14.0.0.0.0 not found

```
03:51:50      3>C:\Program Files (x86)\MSBuild\14.0\bin\Microsoft.Common.CurrentVersion.targets(1819,5): warning MSB3106: Assembly strong name "Microsoft.Build, Version=14.0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\). [D:\j\workspace\release_ci_pa---3f142ccc\src\fsharp\FSharp.Compiler-proto\FSharp.Compiler-proto.fsproj]
```

- [X] Microsoft.DiaSymReader.PortablePdb not found

```
3>C:\Program Files (x86)\MSBuild\14.0\bin\Microsoft.Common.CurrentVersion.targets(1820,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "Microsoft.DiaSymReader.PortablePdb". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [C:\projects\visualfsharp-radou\src\fsharp\FSharp.Compiler-proto\FSharp.Compiler-proto.fsproj]
```

- [x] wrong Microsoft.NETCore.Runtime.CoreCLR, rc3 instead of rc2

```
04:08:02   OK https://www.nuget.org/api/v2/FindPackagesById()?id='Microsoft.NETCore.Windows.ApiSets' 85ms
04:08:02 WARNING: Dependency specified was Microsoft.NETCore.Runtime.CoreCLR (>= 1.0.1-rc2-23911) but ended up with Microsoft.NETCore.Runtime.CoreCLR 1.0.1-rc3-23720.
```

the `Microsoft.NETCore.Runtime.CoreCLR` version used in `tests/fsharp` was different than the one used in lkg ( 1.0.1 doesnt have rc2 ), i used the one in lkg (is correct)
