### PR TITLE
WIP: BulkInsert into eUnqualifiedItems should not create new arrays

### DIFF
--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -106,9 +106,6 @@ type FullyQualifiedFlag =
   | FullyQualified
   | OpenQualified
 
-[<RequireQualifiedAccess>]
-type BulkAdd = Yes | No
-
 /// Lookup patterns in name resolution environment
 val internal TryFindPatternByName : string -> NameResolutionEnv -> Item option
 
@@ -125,10 +122,10 @@ val internal AddValRefToNameEnv                    : NameResolutionEnv -> ValRef
 val internal AddActivePatternResultTagsToNameEnv   : ActivePatternInfo -> NameResolutionEnv -> TType -> range -> NameResolutionEnv
 
 /// Add a list of type definitions to the name resolution environment 
-val internal AddTyconRefsToNameEnv                 : BulkAdd -> bool -> TcGlobals -> ImportMap -> range -> bool -> NameResolutionEnv -> TyconRef list -> NameResolutionEnv
+val internal AddTyconRefsToNameEnv                 : bool -> TcGlobals -> ImportMap -> range -> bool -> NameResolutionEnv -> TyconRef list -> NameResolutionEnv
 
 /// Add an F# exception definition to the name resolution environment 
-val internal AddExceptionDeclsToNameEnv            : BulkAdd -> NameResolutionEnv -> TyconRef -> NameResolutionEnv
+val internal AddExceptionDeclsToNameEnv            : NameResolutionEnv -> TyconRef -> NameResolutionEnv
 
 /// Add a module abbreviation to the name resolution environment 
 val internal AddModuleAbbrevToNameEnv              : Ident -> NameResolutionEnv -> ModuleOrNamespaceRef list -> NameResolutionEnv

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -394,14 +394,14 @@ let AddLocalVal tcSink scopem v env =
     env
 
 let AddLocalExnDefn tcSink scopem (exnc:Tycon) env =
-    let env = ModifyNameResEnv (fun nenv -> AddExceptionDeclsToNameEnv BulkAdd.No nenv (mkLocalEntityRef exnc)) env
+    let env = ModifyNameResEnv (fun nenv -> AddExceptionDeclsToNameEnv nenv (mkLocalEntityRef exnc)) env
     (* Also make VisualStudio think there is an identifier in scope at the range of the identifier text of its binding location *)
     CallEnvSink tcSink (exnc.Range,env.NameEnv,env.eAccessRights)
     CallEnvSink tcSink (scopem,env.NameEnv,env.eAccessRights)
     env
  
 let AddLocalTyconRefs ownDefinition g amap m tcrefs env = 
-     ModifyNameResEnv (fun nenv -> AddTyconRefsToNameEnv BulkAdd.No ownDefinition g amap m false nenv tcrefs) env 
+     ModifyNameResEnv (fun nenv -> AddTyconRefsToNameEnv ownDefinition g amap m false nenv tcrefs) env 
 
 let AddLocalTycons g amap m (tycons: Tycon list) env = 
      AddLocalTyconRefs false g amap m (List.map mkLocalTyconRef tycons) env 
@@ -439,7 +439,7 @@ let AddNonLocalCcu g amap scopem env assemblyName  (ccu:CcuThunk, internalsVisib
     // Compute the top-rooted type definitions
     let tcrefs = ccu.RootTypeAndExceptionDefinitions |> List.map (mkNonLocalCcuRootEntityRef ccu) 
     let env = AddRootModuleOrNamespaceRefs g amap scopem env modrefs
-    let env = ModifyNameResEnv (fun nenv -> AddTyconRefsToNameEnv BulkAdd.Yes false g amap scopem true nenv tcrefs) env
+    let env = ModifyNameResEnv (fun nenv -> AddTyconRefsToNameEnv false g amap scopem true nenv tcrefs) env
     //CallEnvSink tcSink (scopem,env.NameEnv,env.eAccessRights)
     env
 
@@ -449,7 +449,7 @@ let AddLocalRootModuleOrNamespace tcSink g amap scopem env (mtyp:ModuleOrNamespa
     // Compute the top-rooted type definitions
     let tcrefs = mtyp.TypeAndExceptionDefinitions |> List.map mkLocalTyconRef
     let env = AddRootModuleOrNamespaceRefs g amap scopem env modrefs
-    let env = ModifyNameResEnv (fun nenv -> AddTyconRefsToNameEnv BulkAdd.No false g amap scopem true nenv tcrefs) env
+    let env = ModifyNameResEnv (fun nenv -> AddTyconRefsToNameEnv false g amap scopem true nenv tcrefs) env
     let env = {env with eUngeneralizableItems = addFreeItemOfModuleTy mtyp env.eUngeneralizableItems}
     CallEnvSink tcSink (scopem,env.NameEnv,env.eAccessRights)
     env


### PR DESCRIPTION
We create a lot of intermediate arrays and KeyValuePairs to put values into maps.

I removed the bulkinsert distinction since we don't use "real" LayeredMaps.