### PR TITLE
Make fsharp.build.dll build portable

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -238,9 +238,11 @@ if '%VisualStudioVersion%' == '' echo Error: Could not find an installation of V
 if exist "%ProgramFiles(x86)%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe" set _msbuildexe="%ProgramFiles(x86)%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe"
 if exist "%ProgramFiles%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe"      set _msbuildexe="%ProgramFiles%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe"
 if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe. && goto :failure
+set _nrswitch=/nr:false
 
 rem uncomment to use coreclr msbuild not ready yet!!!!
 rem set _msbuildexe=%~dp0Tools\CoreRun.exe %~dp0Tools\MSBuild.exe
+rem set _nrswitch=
           
 :: See <http://www.appveyor.com/docs/environment-variables>
 if defined APPVEYOR (
@@ -250,7 +252,7 @@ if defined APPVEYOR (
    set _msbuildexe=%_msbuildexe% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
    )
 )
-set msbuildflags=/maxcpucount /nr:false
+set msbuildflags=/maxcpucount %_nrswitch%
 set _ngenexe="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ngen.exe"
 if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
 
@@ -318,10 +320,6 @@ call BuildTestTools.cmd %BUILD_CONFIG_LOWERCASE%
 @echo on
 if '%TEST_FSHARP_SUITE%' == '1' (
     set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=true
-
-    %_msbuildexe% %msbuildflags% fsharp\fsharp.tests.fsproj /p:Configuration=%BUILD_CONFIG%
-    @if ERRORLEVEL 1 echo Error: fsharp cambridge tests for nunit failed && goto :failed_tests
-
     call RunTests.cmd %BUILD_CONFIG_LOWERCASE% fsharp %TEST_TAGS% 
     @if ERRORLEVEL 1 (
         type testresults\FSharpNunit_Error.log

--- a/build.cmd
+++ b/build.cmd
@@ -291,6 +291,10 @@ fc fsi.exe corehost.exe >nul
 )
 popd
 
+rem copy targestfile into tools directory ... temporary fix until packaging complete.
+copy src\fsharp\FSharp.Build\Microsoft.FSharp.targets tools\Microsoft.FSharp.targets
+copy src\fsharp\FSharp.Build\Microsoft.Portable.FSharp.targets tools\Microsoft.Portable.FSharp.targets
+
 :: Build Proto
 if NOT EXIST Proto\net40\bin\fsc-proto.exe (set BUILD_PROTO=1)
 

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -15,6 +15,7 @@
     <ToolsDir>$(MSBuildThisFileDirectory)..\Tools\</ToolsDir>
     <BuildToolsTaskDir>$(ToolsDir)net45\</BuildToolsTaskDir>
     <WarningsAsErrors />
+    <FX_NO_LOADER Condition=" '$(FX_NO_LOADER)'==''">false</FX_NO_LOADER>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(ProjectLanguage)' == 'FSharp' ">

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -159,7 +159,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net40'">
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);FSHARP_CORE_4_5</DefineConstants>
     <DefineConstants  Condition="'$(Configuration)'!='Proto'">$(DefineConstants);FX_ATLEAST_45</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_ATLEAST_40</DefineConstants>
@@ -174,12 +173,12 @@
     <DefineConstants>$(DefineConstants);FX_RESX_RESOURCE_READER</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_RESIDENT_COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);SHADOW_COPY_REFERENCES</DefineConstants>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile></TargetFrameworkProfile>
     <!-- MSbuild works out the assembly references -->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='coreclr'">
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);FSHARP_CORE_4_5</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_BEGINEND_READWRITE</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_ATLEAST_45</DefineConstants>
@@ -191,7 +190,7 @@
     <DefineConstants>$(DefineConstants);FX_ATLEAST_LINQ</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_RESHAPED_GLOBALIZATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_RESHAPED_REFLECTION</DefineConstants>
-    <DefineConstants Condition="'$(AssemblyName)'!='FSharp.Core'">$(DefineConstants);FX_RESHAPED_REFLECTION_CORECLR</DefineConstants>
+    <DefineConstants Condition=" '$(FX_NO_LOADER)' != 'true' ">$(DefineConstants);FX_RESHAPED_REFLECTION_CORECLR</DefineConstants>
     <DefineConstants>$(DefineConstants);RESHAPED_MSBUILD</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CONVERTER</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_ARRAY_LONG_LENGTH</DefineConstants>
@@ -230,9 +229,11 @@
     <DefineConstants>$(DefineConstants);NO_LOADER_OPTIMIZATION</DefineConstants>
     <DefineConstants>$(DefineConstants);SILVERLIGHT_COMPILER_FSHARP_CORE</DefineConstants>
     <DefineConstants>$(DefineConstants);I_DONT_KNOW_HOW_TO_DO_THIS_YET</DefineConstants>
-    <TargetFrameworkProfile>profile7</TargetFrameworkProfile>                            <!-- We are currently directly referencing corefx assemblies, so profile7 is not really true -->
     <OtherFlags>$(OtherFlags) --simpleresolution</OtherFlags>
+    <TargetFrameworkProfile></TargetFrameworkProfile>                                   <!-- We are currently directly referencing corefx assemblies, so profile7 is not really true -->
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>            <!-- To stop msbuild being helpfull and referencing the dlls for the profile -->
+    <PortableNuGetMode>true</PortableNuGetMode>
   </PropertyGroup>
 
   <!-- Target Portable Profile 47 -->

--- a/src/fsharp-compiler-build.proj
+++ b/src/fsharp-compiler-build.proj
@@ -8,8 +8,9 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net20' or 
                          '$(TargetFramework)' == 'net40' or
                          '$(TargetFramework)' == 'coreclr' ">
-    <ProjectFiles Include="fsharp\FSharp.Build\FSharp.Build.fsproj" Condition="'$(TargetFramework)' != 'coreclr'" />
-    <ProjectFiles Include="fsharp\FSharp.Compiler\FSharp.Compiler.fsproj"/>
+
+    <ProjectFiles Include="fsharp\FSharp.Build\FSharp.Build.fsproj" />
+    <ProjectFiles Include="fsharp\FSharp.Compiler\FSharp.Compiler.fsproj" />
     <ProjectFiles Include="fsharp\FSharp.Compiler.Server.Shared\FSharp.Compiler.Server.Shared.fsproj" Condition="'$(TargetFramework)' != 'coreclr'" />
     <ProjectFiles Include="fsharp\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj" />
     <ProjectFiles Include="fsharp\Fsc\Fsc.fsproj" />

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -12,6 +12,8 @@
     <AssemblyName>FSharp.Build</AssemblyName>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <ProjectGuid>{702A7979-BCF9-4C41-853E-3ADFC9897890}</ProjectGuid>
+    <OtherFlags Condition=" '$(TargetFramework)'=='coreclr'">$(OtherFlags) --targetprofile:netcore</OtherFlags>
+    <FX_NOLOADER>true</FX_NOLOADER>
   </PropertyGroup>
   <ItemGroup>
   <FilesToLocalize Include="$(OutDir)$(AssemblyName).dll">
@@ -32,6 +34,7 @@
     <Compile Include="..\..\utils\CompilerLocationUtils.fs">
       <Link>Utilities/CompilerLocationUtils.fs</Link>
     </Compile>
+    <Compile Include="..\..\utils\reshapedreflection.fs" />
     <Compile Include="Fsc.fsi" />
     <Compile Include="Fsc.fs" />
     <Compile Include="CreateFSharpManifestResourceName.fsi" />
@@ -49,7 +52,7 @@
       <SubType>Content</SubType>
     </Content>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'coreclr' ">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
@@ -57,13 +60,14 @@
     <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Utilities.$(MSBuildVersionSuffix), Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Tasks.$(MSBuildVersionSuffix), Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
-  
   <Target Name="GatherBinariesToBeSigned" AfterTargets="Localize">
     <ItemGroup>
       <BinariesToBeSigned Include="$(OutDir)$(AssemblyName).dll" />

--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -17,6 +17,10 @@ open Internal.Utilities
 do()
 
 
+#if FX_RESHAPED_REFLECTION
+open Microsoft.FSharp.Core.ReflectionAdapters
+#endif
+
 type FscCommandLineBuilder() =
     // In addition to generating a command-line that will be handed to cmd.exe, we also generate
     // an array of individual arguments.  The former needs to be quoted (and cmd.exe will strip the
@@ -347,14 +351,10 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
     override fsc.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands) =
         let host = box fsc.HostObject
         match host with
-        | null ->
-            base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
+        | null -> base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
         | _ ->
             let sources = sources|>Array.map(fun i->i.ItemSpec)
-            let baseCall = fun (dummy : int) -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
-            // We are using a Converter<int,int> rather than a "unit->int" because it is too hard to
-            // figure out how to pass an F# function object via reflection.  
-            let baseCallDelegate = new System.Converter<int,int>(baseCall)
+            let baseCallDelegate = Func<int>(fun () -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands) )
             try 
                 let ret = 
                     (host.GetType()).InvokeMember("Compile", BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.InvokeMethod ||| BindingFlags.Instance, null, host, 
@@ -368,7 +368,7 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
             | e ->
                 System.Diagnostics.Debug.Assert(false, "HostObject received by Fsc task did not have a Compile method or the compile method threw an exception. "+(e.ToString()))
                 reraise()
-           
+ 
     override fsc.GenerateCommandLineCommands() =
         let builder = new FscCommandLineBuilder()
         

--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -354,11 +354,11 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
         | null -> base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
         | _ ->
             let sources = sources|>Array.map(fun i->i.ItemSpec)
-            let baseCallDelegate = Func<int>(fun () -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands) )
+            let baseCallDelegate = new Func<int>(fun () -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands) )
             try 
                 let ret = 
                     (host.GetType()).InvokeMember("Compile", BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.InvokeMethod ||| BindingFlags.Instance, null, host, 
-                                                [| box baseCallDelegate; box (capturedArguments |> List.toArray); box (capturedFilenames |> List.toArray) |],
+                                                [| baseCallDelegate; box (capturedArguments |> List.toArray); box (capturedFilenames |> List.toArray) |],
                                                 System.Globalization.CultureInfo.InvariantCulture)
                 unbox ret
             with 

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.targets
@@ -201,14 +201,15 @@ this file.
 
     <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets"/>
 
-  <!--
-      ============================================================
-                                          GenerateTargetFrameworkMonikerAttribute
+        <!--
+            ============================================================
+            GenerateTargetFrameworkMonikerAttribute
 
-      Emit the target framework moniker attribute as  a code fragment into a temporary source file for the compiler.
+            Emit the target framework moniker attribute as  a code 
+            fragment into a temporary source file for the compiler.
 
-      ============================================================
-      -->
+            ============================================================
+        -->
 
     <Target Name="GenerateTargetFrameworkMonikerAttribute" BeforeTargets="BeforeCompile" DependsOnTargets="PrepareForBuild;GetReferenceAssemblyPaths" Inputs="$(MSBuildThisFileFullPath)" Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)" Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
 

--- a/src/fsharp/FSharp.Build/project.json
+++ b/src/fsharp/FSharp.Build/project.json
@@ -1,0 +1,20 @@
+{ 
+   "dependencies": { 
+     "Microsoft.Build": "0.1.0-preview-00022", 
+     "Microsoft.Build.Framework": "0.1.0-preview-00022", 
+     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022", 
+     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022", 
+     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23911", 
+     "Microsoft.Win32.Registry": { 
+      "version": "4.0.0-rc2-23923", 
+      "exclude": "Compile" 
+    }, 
+    "System.AppContext": "4.1.0-rc2-23911",
+    "System.Diagnostics.Tools": "4.0.1-rc2-23911",
+  }, 
+  "frameworks": { 
+    "dnxcore50": {
+        "imports": "portable-net45+win8"
+    } 
+  } 
+} 

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -16,6 +16,7 @@
     <BaseAddress>0x05000000</BaseAddress>
     <CompilingFsLib>true</CompilingFsLib>
     <AllowCrossTargeting>true</AllowCrossTargeting>
+    <FX_NO_LOADER>true</FX_NO_LOADER>
     <OtherFlags>$(OtherFlags) --warnon:1182 --compiling-fslib --optimize --maxerrors:20 --extraoptimizationloops:1 </OtherFlags>
     <OtherFlags Condition=" '$(TargetFramework)'=='net20'">$(OtherFlags) --compiling-fslib-20:"$(SystemRoot)\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll" </OtherFlags>
     <OtherFlags Condition=" '$(TargetFramework)'=='net40'">$(OtherFlags) --compiling-fslib-40</OtherFlags>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -1990,32 +1990,32 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
        | ApplicationDefinition = 4
        | Page = 5
        | Resource  = 6
-       
+
     and public FSharpBuildActionPropertyDescriptor internal (prop : PropertyDescriptor) =
         inherit PropertyDescriptor(prop)
-        
+
         override this.DisplayName = SR.BuildAction
-        
+
         override this.ComponentType = typeof<FSharpFileNodeProperties>
-        
+
         override this.PropertyType = typeof<VSLangProj.prjBuildAction>
-        
+
         override this.IsReadOnly = false
-        
+
         override this.GetEditor(editorBaseType : Type) = this.CreateInstance(editorBaseType)
-        
+
         override this.Converter = null
-        
+
         override this.CanResetValue(o : obj) = prop.CanResetValue(o)
-        
+
         override this.GetValue (o : obj) =
             prop.GetValue(o)
-            
+
         override this.SetValue (o : obj, value : obj) =
             prop.SetValue(o, value)
-        
+
         override this.ResetValue (o : obj) = prop.ResetValue(o)
-        
+
         override this.ShouldSerializeValue(o : obj) = prop.ShouldSerializeValue(o)
 
     and 

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -1353,7 +1353,7 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
                 result
             
             // Fulfill HostObject contract with Fsc task, and enable 'capture' of compiler flags for the project.
-            member x.Compile(compile:System.Converter<int,int>, flags:string[], sources:string[]) = 
+            member x.Compile(compile:Func<int>, flags:string[], sources:string[]) = 
                 // Note: This method may be called from non-UI thread!  The Fsc task in FSharp.Build.dll invokes this method via reflection, and
                 // the Fsc task is typically created by MSBuild on a background thread.  So be careful.
 #if DEBUG
@@ -1370,7 +1370,7 @@ See also ...\SetupAuthoring\FSharp\Registry\FSProjSys_Registration.wxs, e.g.
                     // This is the first time, so set up interface for language service to talk to us
                     projectSite.Open(x.CreateRunningProjectSite())
                 if actuallyBuild then
-                    compile.Invoke(0)
+                    compile.Invoke()
                 else
                     0
             

--- a/vsintegration/tests/Salsa/salsa.fs
+++ b/vsintegration/tests/Salsa/salsa.fs
@@ -44,13 +44,13 @@ module internal Salsa =
             { new System.IDisposable with
                     member this.Dispose() = actuallyBuild <- true }
         member th.Results = capturedFlags, capturedSources
-        member th.Compile(compile:System.Converter<int,int>, flags:string[], sources:string[]) = 
+        member th.Compile(compile:Func<int>, flags:string[], sources:string[]) = 
             use t = Trace.Call("MSBuild", "Compile", fun _ -> "Host compile invoke by Fsc task")
             Trace.PrintLine("MSBuild", fun _ -> sprintf "flags=%A" flags)
             capturedFlags <- flags 
             capturedSources <- sources
             if actuallyBuild then
-                compile.Invoke(0)
+                compile.Invoke()
             else
                 0         
         interface ITaskHost

--- a/vsintegration/tests/unittests/Tests.Build.fs
+++ b/vsintegration/tests/unittests/Tests.Build.fs
@@ -41,7 +41,7 @@ type MyLogger(f : string -> unit) =
 type FauxHostObject() =
     let mutable myFlags : string[] = null
     let mutable mySources : string[] = null
-    member x.Compile(compile:System.Converter<int,int>, flags:string[], sources:string[]) = 
+    member x.Compile(compile:Func<int>, flags:string[], sources:string[]) = 
         myFlags <- flags        
         mySources <- sources
         0

--- a/vsintegration/tests/unittests/Tests.ProjectSystem.MultiTargeting.fs
+++ b/vsintegration/tests/unittests/Tests.ProjectSystem.MultiTargeting.fs
@@ -30,8 +30,8 @@ type MultiTargeting() =
         let dirName = Path.GetDirectoryName(projFile)
         let libDirName = Directory.CreateDirectory(Path.Combine(dirName, "lib")).FullName
         let codeBase = (new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase)).LocalPath |> Path.GetDirectoryName
-        let refLibPath = Path.Combine(libDirName, "FSharp.Core.Unittests.dll")
-        File.Copy(Path.Combine(codeBase, "FSharp.Core.Unittests.dll"), refLibPath)
+        let refLibPath = Path.Combine(libDirName, "VisualFSharp.Unittests.dll")
+        File.Copy(Path.Combine(codeBase, "VisualFSharp.Unittests.dll"), refLibPath)
         File.AppendAllText(projFile, TheTests.FsprojTextWithProjectReferencesAndOtherFlags([], [refLibPath], [], null, "", "v4.0"))
         refLibPath
 


### PR DESCRIPTION
1.  Make FSharp.Build.dll portable
2.  Fix VisualFSharp.Unittests.dll --- a couple of tests had a dependency on FSharp.Unittests.dll
3.  Align build variables for portable with netfx buildtools
