### PR TITLE
disable tests who require en culture, if current culture is not en

### DIFF
--- a/tests/fsharp/FSharp.Tests.fsproj
+++ b/tests/fsharp/FSharp.Tests.fsproj
@@ -67,6 +67,7 @@
     </Compile>
     <Compile Include="..\..\src\fsharp\FSharp.Compiler.Unittests\NunitHelpers.fs" />
     <Compile Include="nunitConf.fs" />
+    <Compile Include="FSharpTestSuiteAsserts.fs" />
     <Compile Include="single-test-build.fs" />
     <Compile Include="single-test-run.fs" />
     <Compile Include="single-neg-test.fs" />

--- a/tests/fsharp/FSharpTestSuiteAsserts.fs
+++ b/tests/fsharp/FSharpTestSuiteAsserts.fs
@@ -1,0 +1,22 @@
+module FSharpTestSuiteAsserts
+
+open PlatformHelpers
+open FSharpTestSuiteTypes
+
+let requireVSUltimate cfg = attempt {
+    do! match cfg.INSTALL_SKU with
+        | Some (Ultimate) -> Success
+        | x ->
+            // IF /I "%INSTALL_SKU%" NEQ "ULTIMATE" (
+            //     echo Test not supported except on Ultimate
+            NUnitConf.skip (sprintf "Test not supported except on Ultimate, was %A" x)
+            //     exit /b 0
+            // )
+    }
+
+let requireENCulture () = attempt {
+    do! match System.Threading.Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName with
+        | "en" -> Success
+        | c ->
+            NUnitConf.skip (sprintf "Test not supported except en Culture, was %s" c)
+    }

--- a/tests/fsharp/core/tests_core.fs
+++ b/tests/fsharp/core/tests_core.fs
@@ -21,6 +21,13 @@ let requireVSUltimate cfg = attempt {
             // )
     }
 
+let requireENCulture () = attempt {
+    do! match System.Threading.Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName with
+        | "en" -> Success
+        | c ->
+            NUnitConf.skip (sprintf "Test not supported except en Culture, was %s" c)
+    }
+
 module Access =
     [<Test; FSharpSuiteScriptPermutations("core/access")>]
     let access p = check (attempt {
@@ -667,7 +674,6 @@ module Printing =
     // if NOT EXIST z.output.test.200.bsl     COPY z.output.test.200.txt     z.output.test.200.bsl
     // %PRDIFF% z.output.test.200.txt     z.output.test.200.bsl     > z.output.test.200.diff
     [<Test>]
-    [<SetCulture("en-US"); SetUICulture("en-US")>] //not enough
     [<FSharpSuiteTestCase("core/printing", "", "z.output.test.default.stdout.txt", "z.output.test.default.stdout.bsl", "z.output.test.default.stderr.txt", "z.output.test.default.stderr.bsl")>]
     [<FSharpSuiteTestCase("core/printing", "--use:preludePrintSize1000.fsx", "z.output.test.1000.stdout.txt", "z.output.test.1000.stdout.bsl", "z.output.test.1000.stderr.txt", "z.output.test.1000.stderr.bsl")>]
     [<FSharpSuiteTestCase("core/printing", "--use:preludePrintSize200.fsx", "z.output.test.200.stdout.txt", "z.output.test.200.stdout.bsl", "z.output.test.200.stderr.txt", "z.output.test.200.stderr.bsl")>]
@@ -675,6 +681,8 @@ module Printing =
     [<FSharpSuiteTestCase("core/printing", "--quiet", "z.output.test.quiet.stdout.txt", "z.output.test.quiet.stdout.bsl", "z.output.test.quiet.stderr.txt", "z.output.test.quiet.stderr.bsl")>]
     let printing flag diffFileOut expectedFileOut diffFileErr expectedFileErr = check (attempt {
         let { Directory = dir; Config = cfg } = testContext ()
+
+        do! requireENCulture ()
 
         let exec p = Command.exec dir cfg.EnvironmentVariables { Output = Inherit; Input = None; } p >> checkResult
         let peverify = Commands.peverify exec cfg.PEVERIFY "/nologo"

--- a/tests/fsharp/core/tests_core.fs
+++ b/tests/fsharp/core/tests_core.fs
@@ -7,26 +7,9 @@ open NUnit.Framework
 open NUnitConf
 open PlatformHelpers
 open FSharpTestSuiteTypes
+open FSharpTestSuiteAsserts
 
 let testContext = FSharpTestSuite.testContext
-
-let requireVSUltimate cfg = attempt {
-    do! match cfg.INSTALL_SKU with
-        | Some (Ultimate) -> Success
-        | x ->
-            // IF /I "%INSTALL_SKU%" NEQ "ULTIMATE" (
-            //     echo Test not supported except on Ultimate
-            NUnitConf.skip (sprintf "Test not supported except on Ultimate, was %A" x)
-            //     exit /b 0
-            // )
-    }
-
-let requireENCulture () = attempt {
-    do! match System.Threading.Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName with
-        | "en" -> Success
-        | c ->
-            NUnitConf.skip (sprintf "Test not supported except en Culture, was %s" c)
-    }
 
 module Access =
     [<Test; FSharpSuiteScriptPermutations("core/access")>]

--- a/tests/fsharp/typeProviders/tests_typeProviders.fs
+++ b/tests/fsharp/typeProviders/tests_typeProviders.fs
@@ -21,6 +21,13 @@ let requireVSUltimate cfg = attempt {
             // )
     }
 
+let requireENCulture () = attempt {
+    do! match System.Threading.Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName with
+        | "en" -> Success
+        | c ->
+            NUnitConf.skip (sprintf "Test not supported except en Culture, was %s" c)
+    }
+
 module DiamondAssembly = 
 
     let build cfg dir = attempt {
@@ -360,6 +367,8 @@ module NegTests =
     [<Test; TestCaseSource("testData")>]
     let negTests name = check (attempt {
         let { Directory = dir; Config = cfg } = testContext ()
+
+        do! requireENCulture ()
 
         let exec p = Command.exec dir cfg.EnvironmentVariables { Output = Inherit; Input = None; } p >> checkResult
         let fsc = Commands.fsc exec cfg.FSC

--- a/tests/fsharp/typeProviders/tests_typeProviders.fs
+++ b/tests/fsharp/typeProviders/tests_typeProviders.fs
@@ -7,26 +7,9 @@ open NUnit.Framework
 open FSharpTestSuiteTypes
 open NUnitConf
 open PlatformHelpers
+open FSharpTestSuiteAsserts
 
 let testContext = FSharpTestSuite.testContext
-
-let requireVSUltimate cfg = attempt {
-    do! match cfg.INSTALL_SKU with
-        | Some (Ultimate) -> Success
-        | x ->
-            // IF /I "%INSTALL_SKU%" NEQ "ULTIMATE" (
-            //     echo Test not supported except on Ultimate
-            NUnitConf.skip (sprintf "Test not supported except on Ultimate, was %A" x)
-            //     exit /b 0
-            // )
-    }
-
-let requireENCulture () = attempt {
-    do! match System.Threading.Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName with
-        | "en" -> Success
-        | c ->
-            NUnitConf.skip (sprintf "Test not supported except en Culture, was %s" c)
-    }
 
 module DiamondAssembly = 
 


### PR DESCRIPTION
fix #1118

tests who require `en` culture are disabled, unless culture is `en`