### PR TITLE
Use List.item instead of List.nth

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -3,7 +3,6 @@
 module internal Microsoft.FSharp.Compiler.AbstractIL.IL
 
 #nowarn "49"
-#nowarn "44" // This construct is deprecated. please use List.item
 #nowarn "343" // The type 'ILAssemblyRef' implements 'System.IComparable' explicitly but provides no corresponding override for 'Object.Equals'.
 #nowarn "346" // The struct, record or union type 'IlxExtensionType' has an explicit implementation of 'Object.Equals'. ...
 
@@ -348,7 +347,9 @@ module ILList =
     let inline isEmpty (x:ILList<_>) = x.Length <> 0
     let inline toArray (x:ILList<_>) =  x
     let inline ofArray (x:'T[]) =  x
-    let inline nth n (x:'T[]) =  x.[n]
+    [<System.Obsolete("please use IList.item")>]
+    let inline nth n (x:'T[]) = x.[n]
+    let inline item n (x:'T[]) = x.[n]
     let inline toList (x:ILList<_>) =  Array.toList x
     let inline ofList (x:'T list)  = Array.ofList x
     let inline lengthsEqAndForall2 f x1 x2 = Array.lengthsEqAndForall2 f x1 x2
@@ -372,7 +373,9 @@ module ILList =
     let inline ofArray (x:'T[]) =  List.ofArray x
     let inline iter f (x:'T list) =  List.iter f x
     let inline iteri f (x:'T list) =  List.iteri f x
-    let inline nth (x:'T list) n =  List.nth x n
+    [<System.Obsolete("please use IList.item")>]
+    let inline nth (x:'T list) n =  List.item n x
+    let inline item n (x:'T list) =  List.item n x
     let inline toList (x:ILList<_>) =  x
     let inline ofList (x:'T list)  = x
     let inline lengthsEqAndForall2 f x1 x2 = List.lengthsEqAndForall2 f x1 x2
@@ -395,7 +398,9 @@ module ILList =
     let inline iter f (x:ILList<'T>) =  ThreeList.iter f x
     let inline iteri f (x:ILList<'T>) =  ThreeList.iteri f x
     let inline toList (x:ILList<_>) =  ThreeList.toList x
+    [<System.Obsolete("please use IList.item")>]
     let inline nth (x:ILList<'T>) n =  ThreeList.nth x n
+    let inline item n (x:ILList<'T>) =  ThreeList.nth n x
     let inline ofList (x:'T list)  = ThreeList.ofList x
     let inline lengthsEqAndForall2 f x1 x2 = ThreeList.lengthsEqAndForall2 f x1 x2
     let inline init n f = ThreeList.init n f
@@ -3001,7 +3006,7 @@ and instILTypeAux numFree (inst:ILGenericArgs) typ =
         if v - numFree >= top then 
             ILType.TypeVar (uint16 (v - top)) 
         else 
-            ILList.nth inst (v - numFree)
+            ILList.item (v - numFree) inst
     | x -> x
     
 and instILGenericArgsAux numFree inst i = ILList.map (instILTypeAux numFree inst) i

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -8,7 +8,6 @@
 module internal Microsoft.FSharp.Compiler.AbstractIL.ILBinaryReader 
 
 #nowarn "42" // This construct is deprecated: it is only for use in the F# library
-#nowarn "44" // This construct is deprecated. please use List.item
 
 open System
 open System.IO
@@ -2040,8 +2039,8 @@ and sigptrGetTy ctxt numtypars bytes sigptr =
         let lobounds, sigptr = sigptrFold sigptrGetZInt32 numLoBounded bytes sigptr
         let shape = 
             let dim i =
-              (if i <  numLoBounded then Some (List.nth lobounds i) else None),
-              (if i <  numSized then Some (List.nth sizes i) else None)
+              (if i <  numLoBounded then Some (List.item i lobounds) else None),
+              (if i <  numSized then Some (List.item i sizes) else None)
             ILArrayShape (Array.toList (Array.init rank dim))
         mkILArrTy (typ, shape), sigptr
         

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -281,7 +281,6 @@ namespace Microsoft.FSharp.Control
     #nowarn "40"
     #nowarn "21"
     #nowarn "47"
-    #nowarn "44" // This construct is deprecated. 
     #nowarn "52" // The value has been copied to ensure the original is not mutated by this operation
     #nowarn "67" // This type test or downcast will always hold
     #nowarn "864" // IObservable.Subscribe

--- a/src/fsharp/FSharp.Core/control.fsi
+++ b/src/fsharp/FSharp.Core/control.fsi
@@ -91,8 +91,6 @@ namespace System.Threading
 
 namespace Microsoft.FSharp.Control
 
-    #nowarn "44" // This construct is deprecated. This method will be removed in the next version of F# and may no longer be used. Consider using Async.RunWithContinuations
-
     open System
     open Microsoft.FSharp.Core
     open Microsoft.FSharp.Core.Operators

--- a/src/fsharp/FSharp.Core/nativeptr.fs
+++ b/src/fsharp/FSharp.Core/nativeptr.fs
@@ -2,7 +2,6 @@
 
 namespace Microsoft.FSharp.NativeInterop
 
-#nowarn "44";;
 open Microsoft.FSharp.Core
 open Microsoft.FSharp.Collections
 open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6,8 +6,6 @@
 
 module internal Microsoft.FSharp.Compiler.IlxGen
 
-#nowarn "44" // This construct is deprecated. please use List.item
-
 open System.IO
 open System.Collections.Generic
 open Internal.Utilities
@@ -2143,7 +2141,7 @@ and GenGetExnField cenv cgbuf eenv (e,ecref,fieldNum,m) sequel =
     let typ = GenExnType cenv.amap m cenv.g eenv.tyenv ecref
     CG.EmitInstrs cgbuf (pop 0) Push0 [ I_castclass typ];
 
-    let fld = List.nth (exnc.TrueInstanceFieldsAsList) fieldNum
+    let fld = List.item fieldNum exnc.TrueInstanceFieldsAsList
     let ftyp = GenType cenv.amap m cenv.g eenv.tyenv fld.FormalType
 
     let mspec = mkILNonGenericInstanceMethSpecInTy (typ,"get_" + fld.Name, [], ftyp)
@@ -2156,7 +2154,7 @@ and GenSetExnField cenv cgbuf eenv (e,ecref,fieldNum,e2,m) sequel =
     let exnc = stripExnEqns ecref
     let typ = GenExnType cenv.amap m cenv.g eenv.tyenv ecref
     CG.EmitInstrs cgbuf (pop 0) Push0 [ I_castclass typ ];
-    let fld = List.nth (exnc.TrueInstanceFieldsAsList) fieldNum
+    let fld = List.item fieldNum exnc.TrueInstanceFieldsAsList
     let ftyp = GenType cenv.amap m cenv.g eenv.tyenv fld.FormalType
     let ilFieldName = ComputeFieldName exnc fld
     GenExpr cenv cgbuf eenv SPSuppress e2 Continue;

--- a/src/fsharp/InternalCollections.fs
+++ b/src/fsharp/InternalCollections.fs
@@ -4,8 +4,6 @@ namespace Internal.Utilities.Collections
 open System
 open System.Collections.Generic
 
-#nowarn "44" // This construct is deprecated. This F# library function has been renamed. Use 'isSome' instead
-
 [<StructuralEquality; NoComparison>]
 type internal ValueStrength<'T when 'T : not struct> =
    | Strong of 'T

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -6,8 +6,6 @@
 
 module internal Microsoft.FSharp.Compiler.NicePrint
 
-#nowarn "44" // This construct is deprecated. please use List.item
-
 open Internal.Utilities
 open Microsoft.FSharp.Compiler.AbstractIL 
 open Microsoft.FSharp.Compiler.AbstractIL.Diagnostics
@@ -188,7 +186,7 @@ module private PrintIL =
         | ILType.Ptr t
         | ILType.Byref t            -> layoutILType denv ilTyparSubst t
         | ILType.FunctionPointer t  -> layoutILCallingSignature denv ilTyparSubst None t
-        | ILType.TypeVar n            -> List.nth ilTyparSubst (int n)
+        | ILType.TypeVar n          -> List.item (int n) ilTyparSubst
         | ILType.Modified (_, _, t) -> layoutILType denv ilTyparSubst t // Just recurse through them to the contained ILType
 
     /// Layout a function pointer signature using type-only-F#-style. No argument names are printed.

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 /// Defines derived expression manipulation and construction functions.
-module internal Microsoft.FSharp.Compiler.Tastops 
-
-#nowarn "44" // This construct is deprecated. please use List.item
+module internal Microsoft.FSharp.Compiler.Tastops
 
 open System.Collections.Generic 
 open Internal.Utilities
@@ -5091,7 +5089,7 @@ let rec tyOfExpr g e =
         | TOp.ExnConstr _ -> g.exn_ty
         | TOp.Bytes _ -> mkByteArrayTy g
         | TOp.UInt16s _ -> mkArrayType g g.uint16_ty
-        | TOp.TupleFieldGet(i) -> List.nth tinst i
+        | TOp.TupleFieldGet(i) -> List.item i tinst
         | TOp.Tuple -> mkTupleTy tinst
         | (TOp.For _ | TOp.While _) -> g.unit_ty
         | TOp.Array -> (match tinst with [ty] -> mkArrayType g ty | _ -> failwith "bad TOp.Array node")
@@ -7152,8 +7150,8 @@ type ActivePatternElemRef with
         | None -> error(InternalError("not an active pattern name", vref.Range))
         | Some apinfo -> 
             let nms = apinfo.ActiveTags
-            if n < 0 || n >= List.length nms  then error(InternalError("name_of_apref: index out of range for active pattern refernce", vref.Range));
-            List.nth nms n
+            if n < 0 || n >= List.length nms  then error(InternalError("name_of_apref: index out of range for active pattern reference", vref.Range));
+            List.item n nms
 
 let mkChoiceTyconRef g m n = 
      match n with 

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -6,9 +6,7 @@
 /// into the compiler.  This lets the compiler perform particular optimizations
 /// for these types and values, for example emitting optimized calls for
 /// comparison and hashing functions.  
-module internal Microsoft.FSharp.Compiler.TcGlobals 
-
-#nowarn "44" // This construct is deprecated. please use List.item
+module internal Microsoft.FSharp.Compiler.TcGlobals
 
 open Internal.Utilities
 open Microsoft.FSharp.Compiler 
@@ -1279,7 +1277,7 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
                    let ty = mkNonGenericTy tcr 
                    nm, mkSysTyconRef sys nm, (fun _ -> ty)) 
         let entries2 =
-            [ "FSharpFunc`2",    fastFunc_tcr, (fun tinst -> mkFunTy (List.nth tinst 0) (List.nth tinst 1))
+            [ "FSharpFunc`2",    fastFunc_tcr, (fun tinst -> mkFunTy (List.item 0 tinst) (List.item 1 tinst))
               "Tuple`2",       tuple2_tcr, decodeTupleTy
               "Tuple`3",       tuple3_tcr, decodeTupleTy
               "Tuple`4",       tuple4_tcr, decodeTupleTy

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4,8 +4,6 @@
 /// with generalization at appropriate points.
 module internal Microsoft.FSharp.Compiler.TypeChecker
 
-#nowarn "44" // This construct is deprecated. please use List.item
-
 open System
 open System.Collections.Generic
 
@@ -1938,7 +1936,7 @@ let TcUnionCaseOrExnField cenv (env: TcEnv) ty1 m c n funcs =
       | _ -> error(Error(FSComp.SR.tcUnknownUnion(),m))
     if n >= List.length argtys then 
       error (UnionCaseWrongNumberOfArgs(env.DisplayEnv,List.length argtys,n,m))
-    let ty2 = List.nth argtys n
+    let ty2 = List.item n argtys
     mkf,ty2
 
 //-------------------------------------------------------------------------
@@ -4908,7 +4906,7 @@ and TcPat warnOnUpper cenv env topValInfo vFlags (tpenv,names,takenNames) ty pat
             let activePatExpr, tpenv = PropagateThenTcDelayed cenv activePatType env tpenv m vexp vexpty ExprAtomicFlag.NonAtomic delayed
 
             if idx >= activePatResTys.Length then error(Error(FSComp.SR.tcInvalidIndexIntoActivePatternArray(),m))
-            let argty = List.nth activePatResTys idx 
+            let argty = List.item idx activePatResTys
                 
             let arg',(tpenv,names,takenNames) = TcPat warnOnUpper cenv env None vFlags (tpenv,names,takenNames) argty patarg
             
@@ -6809,7 +6807,7 @@ and TcComputationExpression cenv env overallTy mWhole interpExpr builderTy tpenv
         | None -> false
         | Some argInfos ->
             i < argInfos.Length && 
-            let (_,argInfo) = List.nth argInfos i
+            let (_,argInfo) = List.item i argInfos
             HasFSharpAttribute cenv.g cenv.g.attrib_ProjectionParameterAttribute argInfo.Attribs
 
 
@@ -8054,14 +8052,14 @@ and TcItemThen cenv overallTy env tpenv (item,mItem,rest,afterOverloadResolution
                             let isSpecialCaseForBackwardCompatibility = 
                                 if currentIndex = SEEN_NAMED_ARGUMENT then false
                                 else
-                                match stripTyEqns cenv.g (List.nth argtys currentIndex) with
+                                match stripTyEqns cenv.g (List.item currentIndex argtys) with
                                 | TType_app(tcref, _) -> tyconRefEq cenv.g cenv.g.bool_tcr tcref || tyconRefEq cenv.g cenv.g.system_Bool_tcref tcref
                                 | TType_var(_) -> true
                                 | _ -> false
 
                             if isSpecialCaseForBackwardCompatibility then
                                 assert (box fittedArgs.[currentIndex] = null)
-                                fittedArgs.[currentIndex] <- List.nth args currentIndex // grab original argument, not item from the list of named parametere
+                                fittedArgs.[currentIndex] <- List.item currentIndex args // grab original argument, not item from the list of named parametere
                                 currentIndex <- currentIndex + 1
                             else
                                 let caseName = 

--- a/src/fsharp/import.fs
+++ b/src/fsharp/import.fs
@@ -3,8 +3,6 @@
 /// Functions to import .NET binary metadata as TAST objects
 module internal Microsoft.FSharp.Compiler.Import
 
-#nowarn "44" // This construct is deprecated. please use List.item
-
 open System.Reflection
 open System.Collections.Generic
 open Internal.Utilities
@@ -170,7 +168,7 @@ let rec ImportILType (env:ImportMap) m tinst typ =
          // All custom modifiers are ignored
          ImportILType env m tinst ty
     | ILType.TypeVar u16 -> 
-         try List.nth tinst (int u16) 
+         try List.item (int u16) tinst
          with _ -> 
               error(Error(FSComp.SR.impNotEnoughTypeParamsInScopeWhileImporting(),m))
 


### PR DESCRIPTION
In preparation for the future removement we should remove all usages of List.nth in the compiler.

* I kept the legacy unit tests
* I made IList.nth obsolete as well. If I see this correctly then this is no issue since it's not public