### PR TITLE
Give nice explanation when else case is missing

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -116,7 +116,7 @@ let GetRangeOfError(err:PhasedError) =
 #endif
       | ReservedKeyword(_,m)
       | IndentationProblem(_,m)
-      | ErrorFromAddingTypeEquation(_,_,_,_,_,m) 
+      | ErrorFromAddingTypeEquation(_,_,_,_,_,_,m) 
       | ErrorFromApplyingDefault(_,_,_,_,_,m) 
       | ErrorsFromAddingSubsumptionConstraint(_,_,_,_,_,m) 
       | FunctionExpected(_,_,m)
@@ -202,7 +202,7 @@ let GetRangeOfError(err:PhasedError) =
       | ConstraintSolverTupleDiffLengths(_,_,_,m,_) 
       | ConstraintSolverInfiniteTypes(_,_,_,m,_) 
       | ConstraintSolverMissingConstraint(_,_,_,m,_) 
-      | ConstraintSolverTypesNotInEqualityRelation(_,_,_,m,_) 
+      | ConstraintSolverTypesNotInEqualityRelation(_,_,_,m,_)
       | ConstraintSolverError(_,m,_) 
       | ConstraintSolverTypesNotInSubsumptionRelation(_,_,_,m,_) 
       | ConstraintSolverRelatedInformation(_,m,_) 
@@ -407,9 +407,9 @@ let SplitRelatedErrors(err:PhasedError) =
       | ConstraintSolverRelatedInformation(fopt,m2,e) -> 
           let e,related = SplitRelatedException e
           ConstraintSolverRelatedInformation(fopt,m2,e.Exception)|>ToPhased, related
-      | ErrorFromAddingTypeEquation(g,denv,t1,t2,e,m) ->
+      | ErrorFromAddingTypeEquation(g,denv,t1,t2,e,specializedMessageF,m) ->
           let e,related = SplitRelatedException e
-          ErrorFromAddingTypeEquation(g,denv,t1,t2,e.Exception,m)|>ToPhased, related
+          ErrorFromAddingTypeEquation(g,denv,t1,t2,e.Exception,specializedMessageF,m)|>ToPhased, related
       | ErrorFromApplyingDefault(g,denv,tp,defaultType,e,m) ->  
           let e,related = SplitRelatedException e
           ErrorFromApplyingDefault(g,denv,tp,defaultType,e.Exception,m)|>ToPhased, related
@@ -614,7 +614,7 @@ let OutputPhasedErrorR (os:System.Text.StringBuilder) (err:PhasedError) =
       | ConstraintSolverTypesNotInEqualityRelation(denv,(TType_measure _ as t1),(TType_measure _ as t2),m,m2) -> 
           // REVIEW: consider if we need to show _cxs (the type parameter constrants)
           let t1, t2, _cxs = NicePrint.minimalStringsOfTwoTypes denv t1 t2
-          os.Append(ConstraintSolverTypesNotInEqualityRelation1E().Format t1 t2)  |> ignore
+          os.Append(ConstraintSolverTypesNotInEqualityRelation1E().Format t1 t2 )  |> ignore
           (if m.StartLine <> m2.StartLine then 
              os.Append(SeeAlsoE().Format (stringOfRange m))  |> ignore)
       | ConstraintSolverTypesNotInEqualityRelation(denv,t1,t2,m,m2) -> 
@@ -638,14 +638,18 @@ let OutputPhasedErrorR (os:System.Text.StringBuilder) (err:PhasedError) =
           | ConstraintSolverError _ -> OutputExceptionR os e
           | _ -> ()
           fopt |> Option.iter (Printf.bprintf os " %s")
-      | ErrorFromAddingTypeEquation(g,denv,t1,t2,ConstraintSolverTypesNotInEqualityRelation(_, t1', t2',_ ,_ ),_) 
+      | ErrorFromAddingTypeEquation(g,denv,t1,t2,ConstraintSolverTypesNotInEqualityRelation(_, t1', t2',_ ,_ ),contextInfo,_) 
          when typeEquiv g t1 t1'
-         &&   typeEquiv g t2 t2' ->  
+         &&   typeEquiv g t2 t2' ->
           let t1,t2,tpcs = NicePrint.minimalStringsOfTwoTypes denv t1 t2
-          os.Append(ErrorFromAddingTypeEquation1E().Format t2 t1 tpcs) |> ignore
-      | ErrorFromAddingTypeEquation(_,_,_,_,((ConstraintSolverTypesNotInSubsumptionRelation _ | ConstraintSolverError _) as e),_)  ->  
+          match contextInfo with
+          | ContextInfo.OmittedElseBranch -> os.Append(FSComp.SR.missingElseBranch(t1,t2)) |> ignore
+          | ContextInfo.ElseBranchWithDifferentType -> os.Append(FSComp.SR.elseBranchHasWrongType(t1,t2)) |> ignore
+          | ContextInfo.NoContext ->
+              os.Append(ErrorFromAddingTypeEquation1E().Format t2 t1 tpcs) |> ignore
+      | ErrorFromAddingTypeEquation(_,_,_,_,((ConstraintSolverTypesNotInSubsumptionRelation _ | ConstraintSolverError _) as e), _, _)  ->  
           OutputExceptionR os e
-      | ErrorFromAddingTypeEquation(g,denv,t1,t2,e,_) ->
+      | ErrorFromAddingTypeEquation(g,denv,t1,t2,e,_,_) ->
           if not (typeEquiv g t1 t2) then (
               let t1,t2,tpcs = NicePrint.minimalStringsOfTwoTypes denv t1 t2
               if t1<>t2 + tpcs then os.Append(ErrorFromAddingTypeEquation2E().Format t1 t2 tpcs) |> ignore

--- a/src/fsharp/ConstraintSolver.fsi
+++ b/src/fsharp/ConstraintSolver.fsi
@@ -47,6 +47,16 @@ val FreshenTypars : range -> Typars -> TType list
 
 val FreshenMethInfo : range -> MethInfo -> TType list
 
+[<RequireQualifiedAccess>] 
+/// Information about the context of a type equation.
+type ContextInfo =
+/// No context was given.
+| NoContext
+/// The type equation comes from an omitted else branch.
+| OmittedElseBranch
+/// The type equation comes from an else branch that might have different type than the corresponding if branch.
+| ElseBranchWithDifferentType
+
 exception ConstraintSolverTupleDiffLengths              of DisplayEnv * TType list * TType list * range * range
 exception ConstraintSolverInfiniteTypes                 of DisplayEnv * TType * TType * range * range
 exception ConstraintSolverTypesNotInEqualityRelation    of DisplayEnv * TType * TType * range * range
@@ -55,7 +65,7 @@ exception ConstraintSolverMissingConstraint             of DisplayEnv * Typar * 
 exception ConstraintSolverError                         of string * range * range
 exception ConstraintSolverRelatedInformation            of string option * range * exn
 exception ErrorFromApplyingDefault                      of TcGlobals * DisplayEnv * Typar * TType * exn * range
-exception ErrorFromAddingTypeEquation                   of TcGlobals * DisplayEnv * TType * TType * exn * range
+exception ErrorFromAddingTypeEquation                   of TcGlobals * DisplayEnv * TType * TType * exn * ContextInfo * range
 exception ErrorsFromAddingSubsumptionConstraint         of TcGlobals * DisplayEnv * TType * TType * exn * range
 exception ErrorFromAddingConstraint                     of DisplayEnv * exn * range
 exception UnresolvedConversionOperator                  of DisplayEnv * TType * TType * range
@@ -93,7 +103,7 @@ val EliminateConstraintsForGeneralizedTypars : ConstraintSolverEnv -> OptionalTr
 val CheckDeclaredTypars                       : DisplayEnv -> ConstraintSolverState -> range -> Typars -> Typars -> unit 
 
 val AddConstraint                             : ConstraintSolverEnv -> int -> Range.range -> OptionalTrace -> Typar -> TyparConstraint -> OperationResult<unit>
-val AddCxTypeEqualsType                       : DisplayEnv -> ConstraintSolverState -> range -> TType -> TType -> unit
+val AddCxTypeEqualsType                       : ContextInfo -> DisplayEnv -> ConstraintSolverState -> range -> TType -> TType -> unit
 val AddCxTypeEqualsTypeUndoIfFailed           : DisplayEnv -> ConstraintSolverState -> range -> TType -> TType -> bool
 val AddCxTypeEqualsTypeMatchingOnlyUndoIfFailed : DisplayEnv -> ConstraintSolverState -> range -> TType -> TType -> bool
 val AddCxTypeMustSubsumeType                  : DisplayEnv -> ConstraintSolverState -> range -> OptionalTrace -> TType -> TType -> unit

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -13,6 +13,8 @@ undefinedNameRecordLabelOrNamespace,"The record label or namespace '%s' is not d
 undefinedNameRecordLabel,"The record label '%s' is not defined"
 undefinedNameTypeParameter,"The type parameter '%s' is not defined"
 undefinedNamePatternDiscriminator,"The pattern discriminator '%s' is not defined"
+missingElseBranch,"You have not supplied the \"else\" case for this expression. If / then is an expression and so it must always return a result of the same type in all cases. This expression was expected to have type '%s' but here has type '%s'."
+elseBranchHasWrongType,"All branches of an if / else expression must return the same type. This expression was expected to have type '%s' but here has type '%s'."
 buildUnexpectedTypeArgs,"The non-generic type '%s' does not expect any type arguments, but here is given %d type argument(s)"
 203,buildInvalidWarningNumber,"Invalid warning number '%s'"
 204,buildInvalidVersionString,"Invalid version string '%s'"

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -609,7 +609,7 @@ type DisplayEnv =
       showConstraintTyparAnnotations:bool;
       abbreviateAdditionalConstraints: bool;
       showTyparDefaultConstraints: bool
-      g: TcGlobals 
+      g: TcGlobals
       contextAccessibility: Accessibility
       generatedValueLayout:(Val -> layout option) }
     member SetOpenPaths: string list list -> DisplayEnv

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -128,10 +128,7 @@ but given a
     B list    
 The type 'A' does not match the type 'B'
 
-neg20.fs(83,47,83,54): typecheck error FS0001: This expression was expected to have type
-    B    
-but here has type
-    C    
+neg20.fs(83,47,83,54): typecheck error FS0001: All branches of an if / else expression must return the same type. This expression was expected to have type 'B' but here has type 'C'.
 
 neg20.fs(87,54,87,61): typecheck error FS0001: This expression was expected to have type
     B    

--- a/tests/fsharpqa/Source/Diagnostics/async/ReturnBangNonAsync_IfThenElse.fs
+++ b/tests/fsharpqa/Source/Diagnostics/async/ReturnBangNonAsync_IfThenElse.fs
@@ -1,6 +1,6 @@
 // #Regression #Diagnostics #Async 
 // Regression tests for FSHARP1.0:4394
-//<Expects status="error" span="(7,18-7,19)" id="FS0001">This expression was expected to have type.    unit    .but here has type.    int</Expects>
+//<Expects status="error" span="(7,18-7,19)" id="FS0001">All branches of an if / else expression must return the same type. This expression was expected to have type 'unit' but here has type 'int'</Expects>
 async { if true then 
           return ()
         else

--- a/tests/fsharpqa/Source/Warnings/ElseBranchHasWrongType.fs
+++ b/tests/fsharpqa/Source/Warnings/ElseBranchHasWrongType.fs
@@ -1,0 +1,9 @@
+// #Warnings
+//<Expects status="Error" span="(7,10)" id="FS0001">All branches of an if / else expression must return the same type. This expression was expected to have type 'string' but here has type 'int'.</Expects>
+
+let test = 100
+let y =
+    if test > 10 then "test"
+    else 123
+    
+exit 0

--- a/tests/fsharpqa/Source/Warnings/WarnIfMissingElseBranch.fs
+++ b/tests/fsharpqa/Source/Warnings/WarnIfMissingElseBranch.fs
@@ -1,0 +1,8 @@
+// #Warnings
+//<Expects status="Error" span="(6,4)" id="FS0001">You have not supplied the "else" case for this expression. If / then is an expression and so it must always return a result of the same type in all cases.</Expects>
+
+let x = 10
+let y =
+   if x > 10 then "test"
+    
+exit 0

--- a/tests/fsharpqa/Source/Warnings/env.lst
+++ b/tests/fsharpqa/Source/Warnings/env.lst
@@ -1,1 +1,3 @@
 	SOURCE=WrongNumericLiteral.fs # WrongNumericLiteral.fs
+	SOURCE=WarnIfMissingElseBranch.fs # WarnIfMissingElseBranch.fs
+	SOURCE=ElseBranchHasWrongType.fs # ElseBranchHasWrongType.fs


### PR DESCRIPTION
Implements #1104 and #1105

For the following code

    let x = 10
    let y =
       if x > 10 then "test"

we had the following error:

    error FS0001: This expression was expected to have type
        unit    
    but here has type
        string   

Now it's:

![image](https://cloud.githubusercontent.com/assets/57396/14953002/b1b9ea24-1065-11e6-9bc8-be6a83c24d1d.png)


For #1105 we now have:

![image](https://cloud.githubusercontent.com/assets/57396/14958965/7b5c4f80-108d-11e6-93e2-2228d5832e4b.png)
