### PR TITLE
Don't fail with "impossible" compile error - fixes #1143

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -6761,8 +6761,9 @@ let typarEnc _g (gtpsType,gtpsMethod) typar =
                       "``0" // REVIEW: this should be ERROR not WARNING?
 
 let rec typeEnc g (gtpsType,gtpsMethod) ty = 
-    if verbose then  dprintf "--> typeEnc";
-    match (stripTyEqns g ty) with 
+    if verbose then dprintf "--> typeEnc"
+    let stripped = stripTyEqnsAndMeasureEqns g ty
+    match stripped with 
     | TType_forall _ -> 
         "Microsoft.FSharp.Core.FSharpTypeFunc"
     | _ when isArrayTy g ty   -> 


### PR DESCRIPTION
@dsyme for #1143 we run into a missing pattern match (see diff). I copied the match case from the outer pattern match and the compile error is gone. I'm not sure if this is the correct fix...

/cc @swlaschin 

UPDATE: @dsyme suggested a better fix. PR updated