### PR TITLE
Fix for this error message in type provider code

### DIFF
--- a/tests/fsharpqa/Source/TypeProviders/ProvidedTypes.fs
+++ b/tests/fsharpqa/Source/TypeProviders/ProvidedTypes.fs
@@ -1734,7 +1734,7 @@ type AssemblyGenerator(assemblyFileName) =
             and nestedType (tb:TypeBuilder)  (ntd : Type) = 
                 match ntd with 
                 | :? ProvidedTypeDefinition as pntd -> 
-                    if pntd.IsErased then invalidOp ("The nested provided type "+pntd.Name+"is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
+                    if pntd.IsErased then invalidOp ("The nested provided type "+pntd.Name+" is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
                     // Adjust the attributes - we're codegen'ing this type as nested
                     let attributes = adjustTypeAttributes ntd.Attributes true
                     let ntb = tb.DefineNestedType(pntd.Name,attr=attributes)

--- a/tests/fsharpqa/Source/TypeProviders/TypeProviderEmitAPI/TypeProviderEmit.fs
+++ b/tests/fsharpqa/Source/TypeProviders/TypeProviderEmitAPI/TypeProviderEmit.fs
@@ -808,7 +808,7 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
     /// Emit the given provided type definitions into an assembly and adjust 'Assembly' property of all type definitions to return that
     /// assembly.
     member this.ConvertToGenerated (assemblyFileName: string, ?reportAssemblyElements) = 
-        if this.IsErased then invalidOp ("The provided type "+this.Name+"is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
+        if this.IsErased then invalidOp ("The provided type "+this.Name+" is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
         let typeDefinitions = [this]
         let theElementsLazy = 
            lazy 

--- a/vsintegration/tests/unittests/Resources.MockTypeProviders/DummyProviderForLanguageServiceTesting/ProvidedTypes.fs
+++ b/vsintegration/tests/unittests/Resources.MockTypeProviders/DummyProviderForLanguageServiceTesting/ProvidedTypes.fs
@@ -1922,7 +1922,7 @@ type AssemblyGenerator(assemblyFileName) =
             and nestedType (tb:TypeBuilder)  (ntd : Type) = 
                 match ntd with 
                 | :? ProvidedTypeDefinition as pntd -> 
-                    if pntd.IsErased then invalidOp ("The nested provided type "+pntd.Name+"is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
+                    if pntd.IsErased then invalidOp ("The nested provided type "+pntd.Name+" is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
                     // Adjust the attributes - we're codegen'ing this type as nested
                     let attributes = adjustTypeAttributes ntd.Attributes true
                     let ntb = tb.DefineNestedType(pntd.Name,attr=attributes)


### PR DESCRIPTION
"The nested provided type {typename} is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition"

it was missing a space between typename and is.

I'll contribute a fix to the starter pack too.