### PR TITLE
Remove ticks when reporting types

### DIFF
--- a/src/fsharp/FSStrings.resx
+++ b/src/fsharp/FSStrings.resx
@@ -145,10 +145,10 @@
     <value> {0}</value>
   </data>
   <data name="ErrorFromAddingTypeEquation1" xml:space="preserve">
-    <value>This expression was expected to have type\n    '{1}'    \nbut here has type\n    '{0}'    {2}</value>
+    <value>This expression was expected to have type\n    {1}    \nbut here has type\n    {0}    {2}</value>
   </data>
   <data name="ErrorFromAddingTypeEquation2" xml:space="preserve">
-    <value>Type mismatch. Expecting a\n    '{0}'    \nbut given a\n    '{1}'    {2}\n</value>
+    <value>Type mismatch. Expecting a\n    {0}    \nbut given a\n    {1}    {2}\n</value>
   </data>
   <data name="ErrorFromApplyingDefault1" xml:space="preserve">
     <value>Type constraint mismatch when applying the default type '{0}' for a type inference variable. </value>
@@ -157,7 +157,7 @@
     <value> Consider adding further type constraints</value>
   </data>
   <data name="ErrorsFromAddingSubsumptionConstraint" xml:space="preserve">
-    <value>Type constraint mismatch. The type \n    '{0}'    \nis not compatible with type\n    '{1}'    {2}\n</value>
+    <value>Type constraint mismatch. The type \n    {0}    \nis not compatible with type\n    {1}    {2}\n</value>
   </data>
   <data name="UpperCaseIdentifierInPattern" xml:space="preserve">
     <value>Uppercase variable identifiers should not generally be used in patterns, and may indicate a misspelt pattern name.</value>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/57396/15215738/57c2e0ba-1854-11e6-8d39-6b5bf23304e7.png)

as you you see above ticks look really bad when we have generic types. I suggest we just use the line breaks whereever possible.

if you think this is the way to go then I will fix all tests.