### PR TITLE
enable neg92, neg93, neg94 tests

### DIFF
--- a/tests/fsharp/typecheck/tests_typecheck.fs
+++ b/tests/fsharp/typecheck/tests_typecheck.fs
@@ -55,9 +55,6 @@ module Sigs =
         let singleNegTest = SingleNegTest.singleNegTest cfg dir
 
 
-        // call ..\..\single-neg-test.bat neg91
-        do! singleNegTest "neg91"
-            
         // "%FSC%" %fsc_flags% --target:exe -o:pos23.exe  pos23.fs 
         do! fsc "%s --target:exe -o:pos23.exe" fsc_flags ["pos23.fs"]
         // "%PEVERIFY%" pos23.exe
@@ -139,7 +136,8 @@ module Sigs =
         // "%PEVERIFY%" pos09.dll
         do! peverify "pos09.dll"
 
-        do! attempt.For (["neg90"; "neg89"; "neg88";
+        do! attempt.For (["neg94"; "neg93"; "neg92"; "neg91"; 
+                          "neg90"; "neg89"; "neg88";
                           "neg87"; "neg86"; "neg85"; "neg84"; "neg83"; "neg82"; "neg81"; "neg80"; "neg79"; "neg78"; "neg77"; "neg76"; "neg75"; 
                           "neg74"; "neg73"; "neg72"; "neg71"; "neg70"; "neg69"; "neg68"; "neg67"; "neg66"; "neg65"; "neg64"; "neg61"; "neg63"; 
                           "neg62"; "neg20"; "neg24"; "neg32"; "neg37"; "neg37_a"; "neg60"; "neg59"; "neg58"; "neg57"; "neg56"; "neg56_a"; "neg56_b"; 


### PR DESCRIPTION
Some tests were not enabled in the F# test driver code

cc @enricosada 
