### PR TITLE
Systematically eliminate foldMap/mapFold duplication

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -121,19 +121,6 @@ module Array =
             acc <- s'
         res, acc
 
-
-    // REVIEW: systematically eliminate foldMap/mapFold duplication. 
-    // They only differ by the tuple returned by the function.
-    let foldMap f s l = 
-        let mutable acc = s
-        let n = Array.length l
-        let mutable res = Array.zeroCreate n
-        for i = 0 to n - 1 do
-            let s',h' = f acc l.[i]
-            res.[i] <- h'
-            acc <- s'
-        acc, res
-
     let order (eltOrder: IComparer<'T>) = 
         { new IComparer<array<'T>> with 
               member __.Compare(xs,ys) = 
@@ -192,13 +179,6 @@ module Option =
         match opt with 
         | None -> dflt()
         | res -> res
-
-    // REVIEW: systematically eliminate foldMap/mapFold duplication
-    let foldMap f z l = 
-        match l with 
-        | None   -> z,None
-        | Some x -> let z,x = f z x
-                    z,Some x
 
     let fold f z x = 
         match x with 
@@ -420,18 +400,7 @@ module List =
       let l, s = mapFold f s l
       List.concat l, s
 
-    let singleton x = [x]
-
-    // NOTE: must be tail-recursive 
-    let rec private foldMapAux f z l acc =
-      match l with
-      | []    -> z,List.rev acc
-      | x::xs -> let z,x = f z x
-                 foldMapAux f z xs (x::acc)
-                 
-    // NOTE: must be tail-recursive 
-    // REVIEW: systematically eliminate foldMap/mapFold duplication
-    let foldMap f z l = foldMapAux f z l []
+    let singleton x = [x]              
 
     let collect2 f xs ys = List.concat (List.map2 f xs ys)
 
@@ -602,14 +571,6 @@ module FlatList =
             let  arr,acc = Array.mapFold f acc x.array
             FlatList(arr),acc
 
-    // REVIEW: systematically eliminate foldMap/mapFold duplication
-    let foldMap f acc (x:FlatList<_>) = 
-        match x.array with
-        | null -> 
-            acc,FlatList.Empty
-        | arr -> 
-            let  acc,arr = Array.foldMap f acc x.array
-            acc,FlatList(arr)
 #endif
 #if FLAT_LIST_AS_LIST
 
@@ -621,7 +582,6 @@ module FlatList =
     let order eltOrder = List.order eltOrder 
     let mapq f (x:FlatList<_>) = List.mapq f x
     let mapFold f acc (x:FlatList<_>) =  List.mapFold f acc x
-    let foldMap f acc (x:FlatList<_>) =  List.foldMap f acc x
 
 #endif
 
@@ -631,7 +591,6 @@ module FlatList =
     let order eltOrder = Array.order eltOrder 
     let mapq f x = Array.mapq f x
     let mapFold f acc x =  Array.mapFold f acc x
-    let foldMap f acc x =  Array.foldMap f acc x
 #endif
 
 

--- a/src/absil/zmap.fsi
+++ b/src/absil/zmap.fsi
@@ -26,7 +26,7 @@ module internal Zmap =
     val map      : mapping:('T -> 'U) -> Zmap<'Key,'T> -> Zmap<'Key,'U>
     val mapi     : ('Key -> 'T -> 'U) -> Zmap<'Key,'T> -> Zmap<'Key,'U>
     val fold     : ('Key -> 'T -> 'U -> 'U) -> Zmap<'Key,'T> -> 'U -> 'U
-    val foldMap     : ('State -> 'Key -> 'T -> 'State * 'U) -> 'State -> Zmap<'Key,'T> -> 'State * Zmap<'Key,'U>
+    val foldMap  : ('State -> 'Key -> 'T -> 'State * 'U) -> 'State -> Zmap<'Key,'T> -> 'State * Zmap<'Key,'U>
     val iter     : action:('T -> 'U -> unit) -> Zmap<'T, 'U>  -> unit
 
     val foldSection: 'Key -> 'Key -> ('Key -> 'T -> 'U -> 'U) -> Zmap<'Key,'T> -> 'U -> 'U  

--- a/src/fsharp/DetupleArgs.fs
+++ b/src/fsharp/DetupleArgs.fs
@@ -383,16 +383,16 @@ let rebuildTS g m ts vs =
     let rec rebuild vs ts = 
       match vs,ts with
       | []   ,UnknownTS   -> internalError "rebuildTS: not enough fringe to build tuple"
-      | v::vs,UnknownTS   -> vs,(exprForVal m v,v.Type)
+      | v::vs,UnknownTS   -> (exprForVal m v,v.Type),vs
       | vs   ,TupleTS tss -> 
-          let vs,xtys = List.foldMap rebuild vs tss
+          let xtys,vs = List.mapFold rebuild vs tss
           let xs,tys  = List.unzip xtys
           let x  = mkTupled g m xs tys
           let ty = mkTupledTy g tys
-          vs,(x,ty)
+          (x,ty),vs
    
-    let vs,(x,_ty) = rebuild vs ts
-    if vs.Length <> 0 then internalError "rebuildTS: had move fringe vars than fringe. REPORT BUG" else ();
+    let (x,_ty),vs = rebuild vs ts
+    if vs.Length <> 0 then internalError "rebuildTS: had more fringe vars than fringe. REPORT BUG" else ();
     x
 
 /// CallPattern is tuple-structure for each argument position.

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -94,9 +94,10 @@ let ChooseFreeVarNames takenNames ts =
           chooseName names (t,Some(match nOpt with None ->  0 | Some n -> (n+1)))
         else
           let names = Zset.add tn names
-          names,tn
+          tn,names
+
     let names    = Zset.empty String.order |> Zset.addList takenNames
-    let _names,ts = List.foldMap chooseName names tns
+    let ts,_names = List.mapFold chooseName names tns
     ts
 
 let ilxgenGlobalNng = NiceNameGenerator ()

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -4111,7 +4111,6 @@ let arityOfVal (v:Val) = (match v.ValReprInfo with None -> ValReprInfo.emptyValD
 //---------------------------------------------------------------------------
 
 let mapTImplFile   f   (TImplFile(fragName,pragmas,moduleExpr,hasExplicitEntryPoint,isScript)) = TImplFile(fragName, pragmas,f moduleExpr,hasExplicitEntryPoint,isScript)
-let fmapTImplFile  f z (TImplFile(fragName,pragmas,moduleExpr,hasExplicitEntryPoint,isScript)) = let z,moduleExpr = f z moduleExpr in z,TImplFile(fragName,pragmas,moduleExpr,hasExplicitEntryPoint,isScript)
 let mapAccImplFile f z (TImplFile(fragName,pragmas,moduleExpr,hasExplicitEntryPoint,isScript)) = let moduleExpr,z = f z moduleExpr in TImplFile(fragName,pragmas,moduleExpr,hasExplicitEntryPoint,isScript), z
 let foldTImplFile  f z (TImplFile(_,_,moduleExpr,_,_)) = f z moduleExpr
 


### PR DESCRIPTION
based on comment:

    // REVIEW: systematically eliminate foldMap/mapFold duplication. 
    // They only differ by the tuple returned by the function.

this replaces all occurences of foldMap with mapFold.