### PR TITLE
remove adhoc dictionary that was used as hashset

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -4832,8 +4832,8 @@ type ILReferences =
       ModuleReferences: ILModuleRef list; }
 
 type ILReferencesAccumulator = 
-    { refsA: Hashset<ILAssemblyRef>; 
-      refsM: Hashset<ILModuleRef>; }
+    { refsA: HashSet<ILAssemblyRef>; 
+      refsM: HashSet<ILModuleRef>; }
 
 let emptyILRefs = 
   { AssemblyReferences=[];
@@ -5049,11 +5049,12 @@ and refs_of_manifest s m =
 
 let computeILRefs modul = 
     let s = 
-      { refsA = Hashset.create 10; 
-        refsM = Hashset.create 5; }
+      { refsA = Hashset.create(); 
+        refsM = Hashset.create(); }
+
     refs_of_modul s modul;
-    { AssemblyReferences = Hashset.fold (fun x acc -> x::acc) s.refsA [];
-      ModuleReferences =  Hashset.fold (fun x acc -> x::acc) s.refsM [] }
+    { AssemblyReferences = Seq.fold (fun acc x -> x::acc) [] s.refsA
+      ModuleReferences =  Seq.fold (fun acc x -> x::acc) [] s.refsM }
 
 let tspan = System.TimeSpan(System.DateTime.Now.Ticks - System.DateTime(2000,1,1).Ticks)
 

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -4840,8 +4840,8 @@ let emptyILRefs =
     ModuleReferences = []; }
 
 (* Now find references. *)
-let refs_of_assref s x = Hashset.add s.refsA x
-let refs_of_modref s x = Hashset.add s.refsM x
+let refs_of_assref (s:ILReferencesAccumulator) x = s.refsA.Add x |> ignore
+let refs_of_modref (s:ILReferencesAccumulator) x = s.refsM.Add x |> ignore
     
 let refs_of_scoref s x = 
     match x with 
@@ -5049,8 +5049,8 @@ and refs_of_manifest s m =
 
 let computeILRefs modul = 
     let s = 
-      { refsA = Hashset.create(); 
-        refsM = Hashset.create(); }
+      { refsA = HashSet<_>(HashIdentity.Structural) 
+        refsM = HashSet<_>(HashIdentity.Structural) }
 
     refs_of_modul s modul;
     { AssemblyReferences = Seq.fold (fun acc x -> x::acc) [] s.refsA

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -509,19 +509,11 @@ module Dictionary =
         l |> List.iter (fun (k,v) -> dict.Add(k,v))
         dict
 
-
-// FUTURE CLEANUP: remove this adhoc collection
-type Hashset<'T> = Dictionary<'T,int>
-
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Hashset = 
-    let create (n:int) = new Hashset<'T>(n, HashIdentity.Structural)
-    let add (t: Hashset<'T>) x = if not (t.ContainsKey x) then t.[x] <- 0
-    let fold f (t:Hashset<'T>) acc = Seq.fold (fun z (KeyValue(x,_)) -> f x z) acc t 
-    let ofList l = 
-        let t = new Hashset<'T>(List.length l, HashIdentity.Structural)
-        l |> List.iter (fun x -> t.[x] <- 0)
-        t
+    let create () = new HashSet<'T>(HashIdentity.Structural)
+    let add (t: HashSet<'T>) x = t.Add(x) |> ignore
+    let ofList (l: 'T list) = new HashSet<'T>(l,HashIdentity.Structural)
         
 module Lazy = 
     let force (x: Lazy<'T>) = x.Force()

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -508,12 +508,6 @@ module Dictionary =
         let dict = new System.Collections.Generic.Dictionary<_,_>(List.length l, HashIdentity.Structural)
         l |> List.iter (fun (k,v) -> dict.Add(k,v))
         dict
-
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module Hashset = 
-    let create () = new HashSet<'T>(HashIdentity.Structural)
-    let add (t: HashSet<'T>) x = t.Add(x) |> ignore
-    let ofList (l: 'T list) = new HashSet<'T>(l,HashIdentity.Structural)
         
 module Lazy = 
     let force (x: Lazy<'T>) = x.Force()

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -1231,7 +1231,7 @@ let CompilePatternBasic
         let used = accTargetsOfDecisionTree dtree [] |> Hashset.ofList
 
         clausesL |> List.iteri (fun i c ->  
-            if not (used.ContainsKey i) then warning (RuleNeverMatched c.Range)) 
+            if not (used.Contains i) then warning (RuleNeverMatched c.Range)) 
 
     dtree,targets
   

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -1228,7 +1228,7 @@ let CompilePatternBasic
     
     // Report unused targets 
     if warnOnUnused then 
-        let used = accTargetsOfDecisionTree dtree [] |> Hashset.ofList
+        let used = HashSet<_>(accTargetsOfDecisionTree dtree [],HashIdentity.Structural)
 
         clausesL |> List.iteri (fun i c ->  
             if not (used.Contains i) then warning (RuleNeverMatched c.Range)) 


### PR DESCRIPTION
    // FUTURE CLEANUP: remove this adhoc collection
    type Hashset<'T> = Dictionary<'T,int>

This was replaced with a real System.Collections.HashSet