### PR TITLE
Remove ListSet from compiler and use HashSet instead

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -527,13 +527,6 @@ module Lazy =
     let force (x: Lazy<'T>) = x.Force()
 
 //---------------------------------------------------
-// Lists as sets. This is almost always a bad data structure and should be eliminated from the compiler.  
-
-module ListSet =
-    let insert e l =
-        if List.mem e l then l else e::l
-
-//---------------------------------------------------
 // Misc
 
 /// Get an initialization hole 

--- a/src/absil/ilx.fs
+++ b/src/absil/ilx.fs
@@ -133,7 +133,12 @@ let destinations i =
   match i with 
   |  (EI_brisdata (_,_,_,l1,l2)) ->  [l1; l2]
   |  (EI_callfunc (Tailcall,_)) ->   []
-  |  (EI_datacase (_,_,ls,l)) -> l:: (List.foldBack (fun (_,l) acc -> ListSet.insert l acc) ls [])
+  |  (EI_datacase (_,_,ls,l)) -> 
+        let hashSet = System.Collections.Generic.HashSet<_>(HashIdentity.Structural)
+        [yield l
+         for (_,l) in ls do
+            if hashSet.Add l then
+                yield l]
   | _ -> []
 
 let fallthrough i = 


### PR DESCRIPTION
    // Lists as sets. This is almost always a bad data structure and should be eliminated from the compiler.  

So I did that