### PR TITLE
reduce allocations

### DIFF
--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -293,7 +293,7 @@ module DispatchSlotChecking =
                     match  overrides |> List.filter (IsPartialMatch g amap m dispatchSlot)  with 
                     | [] -> 
                         match overrides |> List.filter (fun overrideBy -> IsNameMatch dispatchSlot overrideBy && 
-                                                                            IsImplMatch g dispatchSlot overrideBy)  with 
+                                                                          IsImplMatch g dispatchSlot overrideBy)  with 
                         | [] -> 
                             noimpl()
                         | [ Override(_,_,_,(mtps,_),argTys,_,_,_) as overrideBy ] -> 
@@ -307,12 +307,10 @@ module DispatchSlotChecking =
                             errorR(Error(FSComp.SR.typrelOverloadNotFound(FormatMethInfoSig g amap m denv dispatchSlot, FormatMethInfoSig g amap m denv dispatchSlot),overrideBy.Range))
 
                     | [ overrideBy ] -> 
-
-                        match dispatchSlots  |> List.filter (fun (RequiredSlot(dispatchSlot,_)) -> OverrideImplementsDispatchSlot g amap m dispatchSlot overrideBy) with 
-                        | [] -> 
+                        if dispatchSlots |> List.exists (fun (RequiredSlot(dispatchSlot,_)) -> OverrideImplementsDispatchSlot g amap m dispatchSlot overrideBy) then
                             // Error will be reported below in CheckOverridesAreAllUsedOnce 
                             ()
-                        | _ -> 
+                        else
                             noimpl()
                         
                     | _ -> 

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -265,17 +265,21 @@ module DispatchSlotChecking =
 
         let isReqdTyInterface = isInterfaceTy g reqdTy 
         let showMissingMethodsAndRaiseErrors = (isReqdTyInterface || not isOverallTyAbstract)
-        let res = ref true
-        let fail exn = (res := false ; if showMissingMethodsAndRaiseErrors then errorR exn)
+        let mutable res = true
+        let fail exn = (res <- false; if showMissingMethodsAndRaiseErrors then errorR exn)
         
         // Index the availPriorOverrides and overrides by name
         let availPriorOverridesKeyed = availPriorOverrides |> NameMultiMap.initBy (fun ov -> ov.LogicalName)
         let overridesKeyed = overrides |> NameMultiMap.initBy (fun ov -> ov.LogicalName)
         
-        dispatchSlots |> List.iter (fun (RequiredSlot(dispatchSlot,isOptional)) -> 
-          
-            match NameMultiMap.find dispatchSlot.LogicalName overridesKeyed 
-                    |> List.filter (OverrideImplementsDispatchSlot g amap m dispatchSlot)  with
+        for RequiredSlot(dispatchSlot,isOptional) in dispatchSlots do
+            let formatMethSig() = FormatMethInfoSig g amap m denv dispatchSlot
+            
+            let overrideInfos = 
+                NameMultiMap.find dispatchSlot.LogicalName overridesKeyed 
+                |> List.filter (OverrideImplementsDispatchSlot g amap m dispatchSlot)
+
+            match overrideInfos with
             | [ovd] -> 
                 if not ovd.IsCompilerGenerated then 
                     let item = Item.MethodGroup(ovd.LogicalName,[dispatchSlot],None)
@@ -286,37 +290,55 @@ module DispatchSlotChecking =
                 if not isOptional && 
                    // Check that no available prior override implements this dispatch slot
                    not (DispatchSlotIsAlreadyImplemented g amap m availPriorOverridesKeyed dispatchSlot) then 
-                    // error reporting path 
-                    let (CompiledSig (vargtys,_vrty,fvmtps,_)) = CompiledSigOfMeth g amap m dispatchSlot
-                    let noimpl() = if isReqdTyInterface then fail(Error(FSComp.SR.typrelNoImplementationGivenWithSuggestion(NicePrint.stringOfMethInfo amap m denv dispatchSlot), m))
-                                   else fail(Error(FSComp.SR.typrelNoImplementationGiven(NicePrint.stringOfMethInfo amap m denv dispatchSlot), m))
-                    match  overrides |> List.filter (IsPartialMatch g amap m dispatchSlot)  with 
-                    | [] -> 
-                        match overrides |> List.filter (fun overrideBy -> IsNameMatch dispatchSlot overrideBy && 
-                                                                          IsImplMatch g dispatchSlot overrideBy)  with 
-                        | [] -> 
-                            noimpl()
-                        | [ Override(_,_,_,(mtps,_),argTys,_,_,_) as overrideBy ] -> 
-                            let error_msg = 
-                                if argTys.Length <> vargtys.Length then FSComp.SR.typrelMemberDoesNotHaveCorrectNumberOfArguments(FormatOverride denv overrideBy, FormatMethInfoSig g amap m denv dispatchSlot)
-                                elif mtps.Length <> fvmtps.Length then FSComp.SR.typrelMemberDoesNotHaveCorrectNumberOfTypeParameters(FormatOverride denv overrideBy, FormatMethInfoSig g amap m denv dispatchSlot)
-                                elif not (IsTyparKindMatch g amap m dispatchSlot overrideBy) then  FSComp.SR.typrelMemberDoesNotHaveCorrectKindsOfGenericParameters(FormatOverride denv overrideBy, FormatMethInfoSig g amap m denv dispatchSlot)
-                                else FSComp.SR.typrelMemberCannotImplement(FormatOverride denv overrideBy, NicePrint.stringOfMethInfo amap m denv dispatchSlot, FormatMethInfoSig g amap m denv dispatchSlot)
-                            fail(Error(error_msg, overrideBy.Range))
-                        | overrideBy :: _ -> 
-                            errorR(Error(FSComp.SR.typrelOverloadNotFound(FormatMethInfoSig g amap m denv dispatchSlot, FormatMethInfoSig g amap m denv dispatchSlot),overrideBy.Range))
-
-                    | [ overrideBy ] -> 
-                        if dispatchSlots |> List.exists (fun (RequiredSlot(dispatchSlot,_)) -> OverrideImplementsDispatchSlot g amap m dispatchSlot overrideBy) then
-                            noimpl()
-                        else
-                            // Error will be reported below in CheckOverridesAreAllUsedOnce 
-                            ()
-                        
-                    | _ -> 
-                        fail(Error(FSComp.SR.typrelOverrideWasAmbiguous(FormatMethInfoSig g amap m denv dispatchSlot),m))
-            | _ -> fail(Error(FSComp.SR.typrelMoreThenOneOverride(FormatMethInfoSig g amap m denv dispatchSlot),m)))
-        !res
+                       // error reporting path 
+                       let (CompiledSig (vargtys,_,fvmtps,_)) = CompiledSigOfMeth g amap m dispatchSlot
+                       
+                       let noimpl() = 
+                           let formattedMethodInfo = NicePrint.stringOfMethInfo amap m denv dispatchSlot
+                           if isReqdTyInterface then 
+                               fail(Error(FSComp.SR.typrelNoImplementationGivenWithSuggestion(formattedMethodInfo), m))
+                           else 
+                               fail(Error(FSComp.SR.typrelNoImplementationGiven(formattedMethodInfo), m))
+                       
+                       match overrides |> List.filter (IsPartialMatch g amap m dispatchSlot)  with 
+                       | [] -> 
+                           let overrides = overrides |> List.filter (fun overrideBy -> 
+                               IsNameMatch dispatchSlot overrideBy && IsImplMatch g dispatchSlot overrideBy)
+                       
+                           match overrides with 
+                           | [] -> noimpl()
+                           | Override(_,_,_,(mtps,_),argTys,_,_,_) as overrideBy :: rest ->
+                               let formatOverride() = FormatOverride denv overrideBy
+                               match rest with
+                               | [] ->
+                                   let error_msg = 
+                                       if argTys.Length <> vargtys.Length then 
+                                           FSComp.SR.typrelMemberDoesNotHaveCorrectNumberOfArguments(formatOverride(), formatMethSig())
+                                       elif mtps.Length <> fvmtps.Length then 
+                                           FSComp.SR.typrelMemberDoesNotHaveCorrectNumberOfTypeParameters(formatOverride(), formatMethSig())
+                                       elif not (IsTyparKindMatch g amap m dispatchSlot overrideBy) then  
+                                           FSComp.SR.typrelMemberDoesNotHaveCorrectKindsOfGenericParameters(formatOverride(), formatMethSig())
+                                       else 
+                                           FSComp.SR.typrelMemberCannotImplement(formatOverride(), NicePrint.stringOfMethInfo amap m denv dispatchSlot, formatMethSig())
+                                   fail(Error(error_msg, overrideBy.Range))
+                               | _ -> 
+                                   errorR(Error(FSComp.SR.typrelOverloadNotFound(formatMethSig(), formatMethSig()),overrideBy.Range))
+                       
+                       | [ overrideBy ] ->
+                           let matchedSlotsFound = 
+                               dispatchSlots 
+                               |> List.exists (fun (RequiredSlot(dispatchSlot,_)) -> 
+                                   OverrideImplementsDispatchSlot g amap m dispatchSlot overrideBy)
+                           if matchedSlotsFound then
+                               // Error will be reported below in CheckOverridesAreAllUsedOnce 
+                               ()
+                           else
+                               noimpl()
+                           
+                       | _ -> 
+                           fail(Error(FSComp.SR.typrelOverrideWasAmbiguous(formatMethSig()),m))
+            | _ -> fail(Error(FSComp.SR.typrelMoreThenOneOverride(formatMethSig()),m))
+        res
 
     /// Check all implementations implement some dispatch slot.
     let CheckOverridesAreAllUsedOnce(denv, g, amap, isObjExpr, reqdTy,

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -308,10 +308,10 @@ module DispatchSlotChecking =
 
                     | [ overrideBy ] -> 
                         if dispatchSlots |> List.exists (fun (RequiredSlot(dispatchSlot,_)) -> OverrideImplementsDispatchSlot g amap m dispatchSlot overrideBy) then
+                            noimpl()
+                        else
                             // Error will be reported below in CheckOverridesAreAllUsedOnce 
                             ()
-                        else
-                            noimpl()
                         
                     | _ -> 
                         fail(Error(FSComp.SR.typrelOverrideWasAmbiguous(FormatMethInfoSig g amap m denv dispatchSlot),m))

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -265,21 +265,17 @@ module DispatchSlotChecking =
 
         let isReqdTyInterface = isInterfaceTy g reqdTy 
         let showMissingMethodsAndRaiseErrors = (isReqdTyInterface || not isOverallTyAbstract)
-        let mutable res = true
-        let fail exn = (res <- false; if showMissingMethodsAndRaiseErrors then errorR exn)
+        let res = ref true
+        let fail exn = (res := false ; if showMissingMethodsAndRaiseErrors then errorR exn)
         
         // Index the availPriorOverrides and overrides by name
         let availPriorOverridesKeyed = availPriorOverrides |> NameMultiMap.initBy (fun ov -> ov.LogicalName)
         let overridesKeyed = overrides |> NameMultiMap.initBy (fun ov -> ov.LogicalName)
         
-        for RequiredSlot(dispatchSlot,isOptional) in dispatchSlots do
-            let formatMethSig() = FormatMethInfoSig g amap m denv dispatchSlot
-            
-            let overrideInfos = 
-                NameMultiMap.find dispatchSlot.LogicalName overridesKeyed 
-                |> List.filter (OverrideImplementsDispatchSlot g amap m dispatchSlot)
-
-            match overrideInfos with
+        dispatchSlots |> List.iter (fun (RequiredSlot(dispatchSlot,isOptional)) -> 
+          
+            match NameMultiMap.find dispatchSlot.LogicalName overridesKeyed 
+                    |> List.filter (OverrideImplementsDispatchSlot g amap m dispatchSlot)  with
             | [ovd] -> 
                 if not ovd.IsCompilerGenerated then 
                     let item = Item.MethodGroup(ovd.LogicalName,[dispatchSlot],None)
@@ -290,55 +286,37 @@ module DispatchSlotChecking =
                 if not isOptional && 
                    // Check that no available prior override implements this dispatch slot
                    not (DispatchSlotIsAlreadyImplemented g amap m availPriorOverridesKeyed dispatchSlot) then 
-                       // error reporting path 
-                       let (CompiledSig (vargtys,_,fvmtps,_)) = CompiledSigOfMeth g amap m dispatchSlot
-                       
-                       let noimpl() = 
-                           let formattedMethodInfo = NicePrint.stringOfMethInfo amap m denv dispatchSlot
-                           if isReqdTyInterface then 
-                               fail(Error(FSComp.SR.typrelNoImplementationGivenWithSuggestion(formattedMethodInfo), m))
-                           else 
-                               fail(Error(FSComp.SR.typrelNoImplementationGiven(formattedMethodInfo), m))
-                       
-                       match overrides |> List.filter (IsPartialMatch g amap m dispatchSlot)  with 
-                       | [] -> 
-                           let overrides = overrides |> List.filter (fun overrideBy -> 
-                               IsNameMatch dispatchSlot overrideBy && IsImplMatch g dispatchSlot overrideBy)
-                       
-                           match overrides with 
-                           | [] -> noimpl()
-                           | Override(_,_,_,(mtps,_),argTys,_,_,_) as overrideBy :: rest ->
-                               let formatOverride() = FormatOverride denv overrideBy
-                               match rest with
-                               | [] ->
-                                   let error_msg = 
-                                       if argTys.Length <> vargtys.Length then 
-                                           FSComp.SR.typrelMemberDoesNotHaveCorrectNumberOfArguments(formatOverride(), formatMethSig())
-                                       elif mtps.Length <> fvmtps.Length then 
-                                           FSComp.SR.typrelMemberDoesNotHaveCorrectNumberOfTypeParameters(formatOverride(), formatMethSig())
-                                       elif not (IsTyparKindMatch g amap m dispatchSlot overrideBy) then  
-                                           FSComp.SR.typrelMemberDoesNotHaveCorrectKindsOfGenericParameters(formatOverride(), formatMethSig())
-                                       else 
-                                           FSComp.SR.typrelMemberCannotImplement(formatOverride(), NicePrint.stringOfMethInfo amap m denv dispatchSlot, formatMethSig())
-                                   fail(Error(error_msg, overrideBy.Range))
-                               | _ -> 
-                                   errorR(Error(FSComp.SR.typrelOverloadNotFound(formatMethSig(), formatMethSig()),overrideBy.Range))
-                       
-                       | [ overrideBy ] ->
-                           let matchedSlotsFound = 
-                               dispatchSlots 
-                               |> List.exists (fun (RequiredSlot(dispatchSlot,_)) -> 
-                                   OverrideImplementsDispatchSlot g amap m dispatchSlot overrideBy)
-                           if matchedSlotsFound then
-                               // Error will be reported below in CheckOverridesAreAllUsedOnce 
-                               ()
-                           else
-                               noimpl()
-                           
-                       | _ -> 
-                           fail(Error(FSComp.SR.typrelOverrideWasAmbiguous(formatMethSig()),m))
-            | _ -> fail(Error(FSComp.SR.typrelMoreThenOneOverride(formatMethSig()),m))
-        res
+                    // error reporting path 
+                    let (CompiledSig (vargtys,_vrty,fvmtps,_)) = CompiledSigOfMeth g amap m dispatchSlot
+                    let noimpl() = if isReqdTyInterface then fail(Error(FSComp.SR.typrelNoImplementationGivenWithSuggestion(NicePrint.stringOfMethInfo amap m denv dispatchSlot), m))
+                                   else fail(Error(FSComp.SR.typrelNoImplementationGiven(NicePrint.stringOfMethInfo amap m denv dispatchSlot), m))
+                    match  overrides |> List.filter (IsPartialMatch g amap m dispatchSlot)  with 
+                    | [] -> 
+                        match overrides |> List.filter (fun overrideBy -> IsNameMatch dispatchSlot overrideBy && 
+                                                                          IsImplMatch g dispatchSlot overrideBy)  with 
+                        | [] -> 
+                            noimpl()
+                        | [ Override(_,_,_,(mtps,_),argTys,_,_,_) as overrideBy ] -> 
+                            let error_msg = 
+                                if argTys.Length <> vargtys.Length then FSComp.SR.typrelMemberDoesNotHaveCorrectNumberOfArguments(FormatOverride denv overrideBy, FormatMethInfoSig g amap m denv dispatchSlot)
+                                elif mtps.Length <> fvmtps.Length then FSComp.SR.typrelMemberDoesNotHaveCorrectNumberOfTypeParameters(FormatOverride denv overrideBy, FormatMethInfoSig g amap m denv dispatchSlot)
+                                elif not (IsTyparKindMatch g amap m dispatchSlot overrideBy) then  FSComp.SR.typrelMemberDoesNotHaveCorrectKindsOfGenericParameters(FormatOverride denv overrideBy, FormatMethInfoSig g amap m denv dispatchSlot)
+                                else FSComp.SR.typrelMemberCannotImplement(FormatOverride denv overrideBy, NicePrint.stringOfMethInfo amap m denv dispatchSlot, FormatMethInfoSig g amap m denv dispatchSlot)
+                            fail(Error(error_msg, overrideBy.Range))
+                        | overrideBy :: _ -> 
+                            errorR(Error(FSComp.SR.typrelOverloadNotFound(FormatMethInfoSig g amap m denv dispatchSlot, FormatMethInfoSig g amap m denv dispatchSlot),overrideBy.Range))
+
+                    | [ overrideBy ] -> 
+                        if dispatchSlots |> List.exists (fun (RequiredSlot(dispatchSlot,_)) -> OverrideImplementsDispatchSlot g amap m dispatchSlot overrideBy) then
+                            // Error will be reported below in CheckOverridesAreAllUsedOnce 
+                            ()
+                        else
+                            noimpl()
+                        
+                    | _ -> 
+                        fail(Error(FSComp.SR.typrelOverrideWasAmbiguous(FormatMethInfoSig g amap m denv dispatchSlot),m))
+            | _ -> fail(Error(FSComp.SR.typrelMoreThenOneOverride(FormatMethInfoSig g amap m denv dispatchSlot),m)))
+        !res
 
     /// Check all implementations implement some dispatch slot.
     let CheckOverridesAreAllUsedOnce(denv, g, amap, isObjExpr, reqdTy,

--- a/src/fsharp/fscmain.fs
+++ b/src/fsharp/fscmain.fs
@@ -315,7 +315,7 @@ do ()
 
 [<EntryPoint>]
 let main(argv) =
-    System.Runtime.GCSettings.LatencyMode <- System.Runtime.GCLatencyMode.Batch
+    System.Runtime.GCSettings.LatencyMode <- System.Runtime.GCLatencyMode.LowLatency
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parameter
 
 #if NO_HEAPTERMINATION

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -4398,19 +4398,18 @@ let fslibValRefEq fslibCcu vref1 vref2 =
 /// This takes into account the possibility that they may have type forwarders
 let primEntityRefEq compilingFslib fslibCcu (x : EntityRef) (y : EntityRef) = 
     x === y ||
-    match x.IsResolved,y.IsResolved with 
-    | true, true when not compilingFslib -> x.ResolvedTarget === y.ResolvedTarget 
-    | _ -> 
-    match x.IsLocalRef,y.IsLocalRef with 
-    | false, false when 
+    
+    if x.IsResolved && y.IsResolved && not compilingFslib then
+        x.ResolvedTarget === y.ResolvedTarget 
+    elif not x.IsLocalRef && not y.IsLocalRef &&
         (// Two tcrefs with identical paths are always equal
          nonLocalRefEq x.nlr y.nlr || 
          // The tcrefs may have forwarders. If they may possibly be equal then resolve them to get their canonical references
          // and compare those using pointer equality.
-         (not (nonLocalRefDefinitelyNotEq x.nlr y.nlr) && x.Deref === y.Deref)) -> 
+         (not (nonLocalRefDefinitelyNotEq x.nlr y.nlr) && x.Deref === y.Deref)) then
         true
-    | _ -> 
-        compilingFslib && fslibEntityRefEq  fslibCcu x y  
+    else
+        compilingFslib && fslibEntityRefEq fslibCcu x y  
 
 /// Primitive routine to compare two UnionCaseRef's for equality
 let primUnionCaseRefEq compilingFslib fslibCcu (UCRef(tcr1,c1) as uc1) (UCRef(tcr2,c2) as uc2) = 

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -184,9 +184,9 @@ namespace Internal.Utilities.Text.Lexing
                     if lexBuffer.IsPastEndOfStream then failwith "End of file on lexing stream";
                     lexBuffer.IsPastEndOfStream <- true;
                     //printf "state %d --> %d on eof\n" state snew;
-                    scanUntilSentinel(lexBuffer,snew)
+                    scanUntilSentinel lexBuffer snew
             else 
-                scanUntilSentinel(lexBuffer, state)
+                scanUntilSentinel lexBuffer state
 
         let onAccept (lexBuffer:LexBuffer<char>,a) = 
             lexBuffer.LexemeLength <- lexBuffer.BufferScanLength;
@@ -201,7 +201,7 @@ namespace Internal.Utilities.Text.Lexing
         let numUnicodeCategories = 30 
         let numLowUnicodeChars = 128 
         let numSpecificUnicodeChars = (trans.[0].Length - 1 - numLowUnicodeChars - numUnicodeCategories)/2
-        let lookupUnicodeCharacters (state,inp) = 
+        let lookupUnicodeCharacters state inp =
             let inpAsInt = int inp
             // Is it a fast ASCII character?
             if inpAsInt < numLowUnicodeChars then 
@@ -235,7 +235,7 @@ namespace Internal.Utilities.Text.Lexing
                 loop 0
         let eofPos    = numLowUnicodeChars + 2*numSpecificUnicodeChars + numUnicodeCategories 
         
-        let rec scanUntilSentinel(lexBuffer,state) =
+        let rec scanUntilSentinel lexBuffer state =
             // Return an endOfScan after consuming the input 
             let a = int accept.[state] 
             if a <> sentinel then 
@@ -251,14 +251,14 @@ namespace Internal.Utilities.Text.Lexing
                 let inp = lexBuffer.Buffer.[lexBuffer.BufferScanPos]
                 
                 // Find the new state
-                let snew = lookupUnicodeCharacters (state,inp)
+                let snew = lookupUnicodeCharacters state inp
 
                 if snew = sentinel then 
                     lexBuffer.EndOfScan()
                 else 
                     lexBuffer.BufferScanLength <- lexBuffer.BufferScanLength + 1;
                     //printf "state %d --> %d on '%c' (%d)\n" s snew (char inp) inp;
-                    scanUntilSentinel(lexBuffer,snew)
+                    scanUntilSentinel lexBuffer snew
                           
         // Each row for the Unicode table has format 
         //      128 entries for ASCII characters
@@ -268,6 +268,6 @@ namespace Internal.Utilities.Text.Lexing
 
         member tables.Interpret(initialState,lexBuffer : LexBuffer<char>) = 
             startInterpret(lexBuffer)
-            scanUntilSentinel(lexBuffer, initialState)
+            scanUntilSentinel lexBuffer initialState
 
         static member Create(trans,accept) = new UnicodeTables(trans,accept)


### PR DESCRIPTION
Compiling FSharp.Configuration project:

Before
![baseline](https://cloud.githubusercontent.com/assets/873919/15404009/456c718c-1e04-11e6-9393-e711bf7f2083.PNG)

After
![detupled lookupunicodecharacters](https://cloud.githubusercontent.com/assets/873919/15404025/50344590-1e04-11e6-80e2-6cce3e9f2a92.PNG)

~8.5% less allocations. Compilation time has not changed.