### PR TITLE
WIP: Avoid to stripTyEqns multiple times

### DIFF
--- a/src/fsharp/AccessibilityLogic.fs
+++ b/src/fsharp/AccessibilityLogic.fs
@@ -182,9 +182,9 @@ let CheckTyconReprAccessible amap m ad tcref =
             
 /// Indicates if a type is accessible (both definition and instantiation)
 let rec IsTypeAccessible g amap m ad ty = 
-    not (isAppTy g ty) ||
-    let tcref,tinst = destAppTy g ty
-    IsEntityAccessible amap m ad tcref && IsTypeInstAccessible g amap m ad tinst
+    match stripTyEqns g ty with
+    | TType_app(tcref,tinst) -> IsEntityAccessible amap m ad tcref && IsTypeInstAccessible g amap m ad tinst
+    | _ -> true
 
 and IsTypeInstAccessible g amap m ad tinst = 
     match tinst with 
@@ -197,9 +197,9 @@ let IsProvidedMemberAccessible (amap:Import.ImportMap) m ad ty access =
     let isTyAccessible = IsTypeAccessible g amap m ad ty
     if not isTyAccessible then false
     else
-        not (isAppTy g ty) ||
-        let tcrefOfViewedItem,_ = destAppTy g ty
-        IsILMemberAccessible g amap m tcrefOfViewedItem ad access
+        match stripTyEqns g ty with
+        | TType_app(tcrefOfViewedItem,_) -> IsILMemberAccessible g amap m tcrefOfViewedItem ad access
+        | _ -> true
 
 /// Compute the accessibility of a provided member
 let ComputeILAccess isPublic isFamily isFamilyOrAssembly isFamilyAndAssembly =

--- a/src/fsharp/AugmentWithHashCompare.fs
+++ b/src/fsharp/AugmentWithHashCompare.fs
@@ -1030,22 +1030,23 @@ let MakeBindingsForEqualsAugmentation g (tycon:Tycon) =
     elif tycon.IsRecordTycon || tycon.IsStructOrEnumTycon then mkEquals mkRecdEquality 
     else []
 
-let rec TypeDefinitelyHasEquality g ty = 
-    if isAppTy g ty && HasFSharpAttribute g g.attrib_NoEqualityAttribute (tcrefOfAppTy g ty).Attribs then
-        false
-    elif isTyparTy g ty &&  (destTyparTy g ty).Constraints |> List.exists (function TyparConstraint.SupportsEquality _ -> true | _ -> false) then
-        true
-    else 
+let rec TypeDefinitelyHasEquality g ty =
+    let stripped = stripTyEqns g ty
+    match stripped with
+    | TType_app(tcref,_) when HasFSharpAttribute g g.attrib_NoEqualityAttribute tcref.Attribs -> false
+    | TType_var v when v.Constraints |> List.exists (function TyparConstraint.SupportsEquality _ -> true | _ -> false) -> true
+    | _ ->
         match ty with 
         | SpecialEquatableHeadType g tinst -> 
             tinst |> List.forall (TypeDefinitelyHasEquality g)
         | SpecialNotEquatableHeadType g _ -> 
             false
-        | _ -> 
+        | _ ->
            // The type is equatable because it has Object.Equals(...)
-           isAppTy g ty &&
-           let tcref,tinst = destAppTy g ty 
-           // Give a good error for structural types excluded from the equality relation because of their fields
-           not (TyconIsCandidateForAugmentationWithEquals g tcref.Deref && isNone tcref.GeneratedHashAndEqualsWithComparerValues) &&
-           // Check the (possibly inferred) structural dependencies
-           (tinst, tcref.TyparsNoRange) ||> List.lengthsEqAndForall2 (fun ty tp -> not tp.EqualityConditionalOn || TypeDefinitelyHasEquality  g ty)
+           match stripped with
+           | TType_app(tcref,tinst) -> 
+               // Give a good error for structural types excluded from the equality relation because of their fields
+               not (TyconIsCandidateForAugmentationWithEquals g tcref.Deref && isNone tcref.GeneratedHashAndEqualsWithComparerValues) &&
+               // Check the (possibly inferred) structural dependencies
+               (tinst, tcref.TyparsNoRange) ||> List.lengthsEqAndForall2 (fun ty tp -> not tp.EqualityConditionalOn || TypeDefinitelyHasEquality  g ty)
+           | _ -> false

--- a/src/fsharp/LowerCallsAndSeqs.fs
+++ b/src/fsharp/LowerCallsAndSeqs.fs
@@ -430,14 +430,22 @@ let LowerSeqExpr g amap overallExpr =
                 // printfn "FAILED - not worth compiling an unrecognized immediate yield! %s " (stringOfRange m)
                 None
             else
-                let tyConfirmsToSeq g ty = isAppTy g ty && tyconRefEq g (tcrefOfAppTy g ty) g.tcref_System_Collections_Generic_IEnumerable
+                let tyConfirmsToSeq g ty = 
+                    match stripTyEqns g ty with
+                    | TType_app(tcref,_) -> tyconRefEq g tcref g.tcref_System_Collections_Generic_IEnumerable
+                    | _ -> false
+
                 match SearchEntireHierarchyOfType (tyConfirmsToSeq g) g amap m (tyOfExpr g arbitrarySeqExpr) with
                 | None -> 
                     // printfn "FAILED - yield! did not yield a sequence! %s" (stringOfRange m)
                     None
                 | Some ty -> 
                     // printfn "found yield!"
-                    let inpElemTy = List.head (argsOfAppTy g ty)
+                    let inpElemTy =  
+                        match stripTyEqns g ty with 
+                        | TType_app(_,tinst) -> List.head tinst 
+                        | _ -> failwith "no appTy"
+
                     if isTailCall then 
                              //this.pc <- NEXT; 
                              //nextEnumerator <- e; 

--- a/src/fsharp/MethodOverrides.fs
+++ b/src/fsharp/MethodOverrides.fs
@@ -430,8 +430,12 @@ module DispatchSlotChecking =
             // Build a set of the implied interface types, for quicker lookup, by nominal type
             let isImpliedInterfaceTable = 
                 impliedTys 
-                |> List.filter (isInterfaceTy g) 
-                |> List.map (fun ty -> tcrefOfAppTy g ty, ()) 
+                |> List.choose (fun ty -> 
+                    if isInterfaceTy g ty then
+                        match stripTyEqns g ty with 
+                        | TType_app(tcref,_) -> Some(tcref, ())
+                        | _ -> failwith "GetSlotImplSets"
+                    else None) 
                 |> TyconRefMap.OfList 
             
             // Is a member an abstract slot of one of the implied interface types?

--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1250,9 +1250,11 @@ module InfoMemberPrinting =
         let retTy = minfo.GetFSharpReturnTy(amap, m, minst)
         if minfo.IsExtensionMember then  
           bprintf os "(%s) " (FSComp.SR.typeInfoExtension())
-        if isAppTy amap.g minfo.EnclosingType then 
-            outputTyconRef denv os (tcrefOfAppTy amap.g minfo.EnclosingType)
-        else
+
+        match stripTyEqns amap.g minfo.EnclosingType with
+        | TType_app(tcref,_) ->
+            outputTyconRef denv os tcref
+        | _ ->
             outputTy denv os minfo.EnclosingType
         if minfo.IsConstructor then  
           bprintf os "("

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -2306,14 +2306,12 @@ and OptimizeVal cenv env expr (v:ValRef,m) =
 // Attempt to replace an application of a value by an alternative value.
 //------------------------------------------------------------------------- 
 
-and StripToNominalTyconRef cenv ty = 
-    if isAppTy cenv.g ty then destAppTy cenv.g ty 
-    elif isTupleTy cenv.g ty then 
-        let tyargs = destTupleTy cenv.g ty
-        mkCompiledTupleTyconRef cenv.g tyargs, tyargs 
-    else failwith "StripToNominalTyconRef: unreachable" 
+and StripToNominalTyconRef cenv ty =
+    match stripTyEqns cenv.g ty with
+    | TType_app(tcref,tinst) -> tcref,tinst
+    | TType_tuple(tyargs) -> mkCompiledTupleTyconRef cenv.g tyargs, tyargs 
+    | _ -> failwith "StripToNominalTyconRef: unreachable" 
       
-
 and CanDevirtualizeApplication cenv v vref ty args  = 
      valRefEq cenv.g v vref
      && not (isUnitTy cenv.g ty)

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -396,7 +396,6 @@ val isProvenUnionCaseTy : TType -> bool
 val isAppTy        : TcGlobals -> TType -> bool
 val destAppTy      : TcGlobals -> TType -> TyconRef * TypeInst
 val tcrefOfAppTy   : TcGlobals -> TType -> TyconRef
-val tyconOfAppTy   : TcGlobals -> TType -> Tycon
 val tryDestAppTy   : TcGlobals -> TType -> TyconRef option
 val argsOfAppTy    : TcGlobals -> TType -> TypeInst
 val mkInstForAppTy  : TcGlobals -> TType -> TyparInst


### PR DESCRIPTION
When compiling Paket.Core with current master I see ~9.8 million calls to stripTyEqns.

After this change (and I think there many more of such "optimizations") it's reduced to 8.3 million calls to stripTyEqns.

Unfortunately I can't measure any perf difference (which seems odd). So my question is: is this something that should be further investigated or do you think it's not worth it?