### PR TITLE
remove nuget.org v2 feed, the v3 (faster) is already defined

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -11,7 +11,6 @@
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />  
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />  
 
   </packageSources>  
 </configuration>

--- a/lkg/NuGet.Config
+++ b/lkg/NuGet.Config
@@ -8,7 +8,6 @@
     <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />  
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />  
 
   </packageSources>  
 </configuration>


### PR DESCRIPTION
this should improve dotnet and nuget restore a bit