### PR TITLE
[WIP] ILX callfunc cleanup

### DIFF
--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -684,7 +684,6 @@ type ILInstr =
 type ILInstrSetExtension<'Extension> = 
     { instrExtDests: ('Extension -> ILCodeLabel list);
       instrExtFallthrough: ('Extension -> ILCodeLabel option);
-      instrExtIsTailcall: ('Extension -> bool);
       instrExtRelabel: (ILCodeLabel -> ILCodeLabel) -> 'Extension -> 'Extension; }
 
 val RegisterInstructionSetExtension: ILInstrSetExtension<'Extension> -> ('Extension -> IlxExtensionInstr) * (IlxExtensionInstr -> bool) * (IlxExtensionInstr -> 'Extension)

--- a/src/absil/ilprint.fs
+++ b/src/absil/ilprint.fs
@@ -805,11 +805,6 @@ let rec goutput_instr env os inst =
           goutput_cuspec env os ty;
           output_string os ",";  
           output_parens (output_seq "," (fun os (x,y) -> output_int os x;  output_string os ",";  output_code_label os y)) os l
-      |  (EI_callfunc (tl,cs)) -> 
-          output_tailness os tl; 
-          output_string os "callfunc "; 
-          goutput_apps env os cs;
-          output_after_tailcall os tl;
   | _ -> 
       output_string os "<printing for this instruction is not implemented>"
 

--- a/src/absil/ilx.fsi
+++ b/src/absil/ilx.fsi
@@ -91,15 +91,14 @@ type IlxClosureApps =
 
 /// ILX extensions to the instruction set.
 type IlxInstr = 
-    | EI_lddata of (* avoidHelpers: *) bool * IlxUnionSpec * int * int
-    | EI_isdata of (* avoidHelpers: *) bool * IlxUnionSpec * int
-    | EI_brisdata of (* avoidHelpers: *) bool * IlxUnionSpec * int * ILCodeLabel * ILCodeLabel
+    | EI_lddata of avoidHelpers:bool * IlxUnionSpec * int * int
+    | EI_isdata of avoidHelpers:bool * IlxUnionSpec * int
+    | EI_brisdata of avoidHelpers:bool * IlxUnionSpec * int * ILCodeLabel * ILCodeLabel
     | EI_castdata of bool * IlxUnionSpec * int
     | EI_stdata of IlxUnionSpec * int * int
-    | EI_datacase of (* avoidHelpers: *) bool * IlxUnionSpec * (int * ILCodeLabel) list * ILCodeLabel (* last label is fallthrough *)
-    | EI_lddatatag of (* avoidHelpers: *) bool * IlxUnionSpec
+    | EI_datacase of avoidHelpers:bool * IlxUnionSpec * (int * ILCodeLabel) list * ILCodeLabel
+    | EI_lddatatag of avoidHelpers:bool * IlxUnionSpec
     | EI_newdata of IlxUnionSpec * int
-    | EI_callfunc of ILTailcall * IlxClosureApps
 
 val mkIlxExtInstr: (IlxInstr -> IlxExtensionInstr)
 val isIlxExtInstr: (IlxExtensionInstr -> bool)

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -350,6 +350,8 @@ type TypeReprEnv(reprs : Map<Stamp, uint16>, count: int) =
     member tyenv.Add tps =
         (tyenv,tps) ||> List.fold (fun tyenv tp -> tyenv.AddOne tp)
 
+    member tyenv.Count = count
+
     static member Empty = 
         TypeReprEnv(count = 0, reprs = Map.empty)
 
@@ -2616,10 +2618,9 @@ and GenIndirectCall cenv cgbuf eenv (functy,tyargs,args,m) sequel =
     let isTailCall = CanTailcall(false,None,eenv.withinSEH,hasByrefArg,false,false,false,false,sequel)
     CountCallFuncInstructions();
 
-    // Generate an ILX callfunc instruction
-    // REVIEW: ILX-to-IL generation of callfunc is too complex. It would probably be better
-    // if we just got rid of callfunc and generated the IL code directly in ilxgen.
-    CG.EmitInstr cgbuf (pop (1+args.Length)) (Push [ilActualRetTy]) (mkIlxInstr (EI_callfunc(isTailCall,ilxClosureApps)));
+    // Generate the code code an ILX callfunc operation
+    let instrs = EraseClosures.instrsForCallFunc cenv.g.ilxPubCloEnv (fun ty -> cgbuf.AllocLocal([], ty) |> uint16) eenv.tyenv.Count isTailCall ilxClosureApps
+    CG.EmitInstrs cgbuf (pop (1+args.Length)) (Push [ilActualRetTy]) instrs;
 
     // Done compiling indirect call...
     GenSequel cenv eenv.cloc cgbuf sequel
@@ -6264,15 +6265,15 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                                                    mkMethodBody 
                                                          (true,emptyILLocals,2,
                                                           nonBranchingInstrsToCode 
-                                                             [ // load the hardwired format string
+                                                            ([ // load the hardwired format string
                                                                I_ldstr "%+0.8A";  
                                                                // make the printf format object
                                                                mkNormalNewobj newFormatMethSpec;
                                                                // call sprintf
                                                                mkNormalCall sprintfMethSpec; 
                                                                // call the function returned by sprintf
-                                                               mkLdarg0; 
-                                                               mkIlxInstr (EI_callfunc(Normalcall,Apps_app(ilThisTy, Apps_done cenv.g.ilg.typ_String))) ],
+                                                               mkLdarg0 ] @
+                                                             EraseClosures.instrsForCallFunc cenv.g.ilxPubCloEnv (fun _ -> 0us) eenv.tyenv.Count Normalcall (Apps_app(ilThisTy, Apps_done cenv.g.ilg.typ_String))),
                                                           None))
                       yield ilMethodDef |> AddSpecialNameFlag |> AddNonUserCompilerGeneratedAttribs cenv.g
                   | None,_ ->

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -993,7 +993,7 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
   { ilg=ilg
 #if NO_COMPILER_BACKEND
 #else
-    ilxPubCloEnv=EraseClosures.new_cenv(ilg)
+    ilxPubCloEnv=EraseClosures.newIlxPubCloEnv(ilg)
 #endif
     knownIntrinsics                = knownIntrinsics
     knownFSharpCoreModules         = knownFSharpCoreModules

--- a/src/ilx/EraseClosures.fs
+++ b/src/ilx/EraseClosures.fs
@@ -125,7 +125,7 @@ type cenv =
       tref_Func: ILTypeRef[];
       mkILTyFuncTy: ILType }
   
-let new_cenv(ilg) =
+let newIlxPubCloEnv(ilg) =
     { ilg=ilg;
       tref_Func= Array.init 10 (fun i -> mkFuncTypeRef(i+1));
       mkILTyFuncTy=ILType.Boxed (mkILNonGenericTySpec (mkILTyRef (IlxSettings.ilxFsharpCoreLibScopeRef (), IlxSettings.ilxNamespace () ^ ".FSharpTypeFunc"))) }
@@ -195,7 +195,7 @@ let mkLdFreeVar (clospec: IlxClosureSpec) (fv: IlxClosureFreeVar) =
     [ mkLdarg0; mkNormalLdfld (mkILFieldSpecInTy (clospec.ILType,fv.fvName,fv.fvType) ) ]
 
 
-let instrsForCallFunc cenv allocLocal numThisGenParams tl apps = 
+let mkCallFunc cenv allocLocal numThisGenParams tl apps = 
 
             // "callfunc" and "callclo" instructions become a series of indirect 
             // calls or a single direct call.   
@@ -658,7 +658,7 @@ and convTypeDefs cenv mdefGen encl tdefs =
   morphExpandILTypeDefs (convTypeDef cenv mdefGen encl) tdefs
 
 let ConvModule ilg modul = 
-  let cenv = new_cenv(ilg)
+  let cenv = newIlxPubCloEnv(ilg)
   let mdefGen = ref []
   let newTypes = convTypeDefs cenv mdefGen [] modul.TypeDefs
   {modul with TypeDefs=newTypes}

--- a/src/ilx/EraseClosures.fsi
+++ b/src/ilx/EraseClosures.fsi
@@ -11,9 +11,9 @@ open Microsoft.FSharp.Compiler.AbstractIL.Extensions.ILX.Types
 val ConvModule: ILGlobals -> ILModuleDef -> ILModuleDef 
 
 type cenv
-val instrsForCallFunc : cenv -> allocLocal:(ILType -> uint16) -> numThisGenParams:int -> ILTailcall -> IlxClosureApps -> ILInstr list
+val mkCallFunc : cenv -> allocLocal:(ILType -> uint16) -> numThisGenParams:int -> ILTailcall -> IlxClosureApps -> ILInstr list
 
 val mkILFuncTy : cenv -> ILType -> ILType -> ILType
 val mkILTyFuncTy : cenv -> ILType
-val new_cenv : ILGlobals -> cenv
+val newIlxPubCloEnv : ILGlobals -> cenv
 val mkTyOfLambdas: cenv -> IlxClosureLambdas -> ILType

--- a/src/ilx/EraseClosures.fsi
+++ b/src/ilx/EraseClosures.fsi
@@ -11,6 +11,8 @@ open Microsoft.FSharp.Compiler.AbstractIL.Extensions.ILX.Types
 val ConvModule: ILGlobals -> ILModuleDef -> ILModuleDef 
 
 type cenv
+val instrsForCallFunc : cenv -> allocLocal:(ILType -> uint16) -> numThisGenParams:int -> ILTailcall -> IlxClosureApps -> ILInstr list
+
 val mkILFuncTy : cenv -> ILType -> ILType -> ILType
 val mkILTyFuncTy : cenv -> ILType
 val new_cenv : ILGlobals -> cenv

--- a/src/ilx/EraseUnions.fs
+++ b/src/ilx/EraseUnions.fs
@@ -560,8 +560,6 @@ let rec convInstr cenv (tmps: ILLocalsAllocator) inplab outlab instr =
             | TailOrNull -> 
                 failwith "unexpected: switches on lists should have been eliminated to brisdata tests"
                 
-        | _ -> InstrMorph [instr] 
-
     | _ -> InstrMorph [instr] 
 
 


### PR DESCRIPTION

The F# compiler translates in phases ``TAST --> ILX --> IL --> Binary``.  The ``ILX`` phase is a historical curiosity from a decade ago and we would like to get rid of the whole phase.  The whole ILX representation is cumbersome, silly, allocates a a lot of garbage (though it's all cleaned up quickly so doesn't cost too much) and generally obfuscating.

This is one small step towards eliminating this phase - the ILX "EI_callfunc" operation is immediately eliminated when generating IL from TAST rather than being generated as an instruction.

