### PR TITLE
Fix for loaded script files ignoring #nowarn

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1072,6 +1072,8 @@ type internal FsiDynamicCompiler
               else fsiConsoleOutput.uprintnf " %s %s" (FSIstrings.SR.fsiLoadingFilesPrefixText()) sourceFile)
           fsiConsoleOutput.uprintfn "]"
 
+          closure.NoWarns |> Seq.map (fun (n,ms) -> ms |> Seq.map (fun m -> m,n)) |> Seq.concat |> Seq.iter tcConfigB.TurnWarningOff
+
           // Play errors and warnings from closures of the surface (root) script files.
           closure.RootErrors |> List.iter errorSink
           closure.RootWarnings |> List.iter warnSink

--- a/tests/fsharp/core/load-script/IncludeNoWarn211.fsx
+++ b/tests/fsharp/core/load-script/IncludeNoWarn211.fsx
@@ -1,0 +1,2 @@
+#nowarn "211"
+#I "totally-non-existent-folder"

--- a/tests/fsharp/core/load-script/load-IncludeNoWarn211.fsx
+++ b/tests/fsharp/core/load-script/load-IncludeNoWarn211.fsx
@@ -1,0 +1,1 @@
+#load "IncludeNoWarn211.fsx"

--- a/tests/fsharp/core/load-script/out.stdout.bsl
+++ b/tests/fsharp/core/load-script/out.stdout.bsl
@@ -63,4 +63,5 @@ Type from referenced assembly = System.Web.Mobile.CookielessData
 Test 16=================================================
 Result = 99
 Type from referenced assembly = System.Web.Mobile.CookielessData
+Test 17=================================================
 Done ==================================================

--- a/tests/fsharp/core/load-script/script.bat
+++ b/tests/fsharp/core/load-script/script.bat
@@ -44,4 +44,6 @@ echo Test 16=================================================
 "%FSC%" ProjectDriver.fsx --nologo
 ProjectDriver.exe
 del ProjectDriver.exe
+echo Test 17=================================================
+"%FSI%" load-IncludeNoWarn211.fsx
 echo Done ==================================================

--- a/tests/fsharp/core/tests_core.fs
+++ b/tests/fsharp/core/tests_core.fs
@@ -1186,6 +1186,10 @@ module ``Load-Script`` =
         do! exec ("."/"ProjectDriver.exe") ""
         // del ProjectDriver.exe
         del "ProjectDriver.exe"
+        // echo Test 17=================================================
+        echo "Test 17================================================="
+        // "%FSI%" load-IncludeNoWarn211.fsx
+        do! fsi "" ["load-IncludeNoWarn211.fsx"]
         // echo Done ==================================================
         echo "Done =================================================="
         }


### PR DESCRIPTION
I took a stab at fixing issue #1126. It didn't seem that the loaded script closure's `#nowarn` directives were being applied in `fsi`, like they are in `fsc` here: https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/fsc.fs#L241

I wasn't sure where a test might belong so I stuck one in a convenient place. Here's what it looks like w/o the fix in place:
![fail](https://cloud.githubusercontent.com/assets/1738897/15768667/8684f166-2918-11e6-944e-8ad0a2d1fbdb.png)