### PR TITLE
Remove references to MS Open Tech

### DIFF
--- a/setup/resources/ThirdPartyNotices.txt
+++ b/setup/resources/ThirdPartyNotices.txt
@@ -10,9 +10,9 @@ Microsoft is offering you a license to use the following components with Microso
 
 %% Visual F# Tools NOTICES AND INFORMATION BEGIN HERE
 =========================================
-Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.
-Microsoft Open Technologies would like to thank its contributors, a list
-of whom are at https://visualfsharp.codeplex.com/wikipage?title=Contributors.
+Copyright (c) Microsoft.  All rights reserved.
+Microsoft would like to thank its contributors, a list
+of whom are at https://github.com/Microsoft/visualfsharp/graphs/contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You may

--- a/src/absil/ilsign.fs
+++ b/src/absil/ilsign.fs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 module internal Microsoft.FSharp.Compiler.AbstractIL.Internal.StrongNameSign
 

--- a/src/buildtools/buildnugets.fsx
+++ b/src/buildtools/buildnugets.fsx
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information,
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information,
 //
 // Build nuget package for the fsharp compiler
 //=========================================================================================

--- a/src/fsharp/FSharp.Compiler.Host.netcore.nuget/layoutfschostnuget.fsx
+++ b/src/fsharp/FSharp.Compiler.Host.netcore.nuget/layoutfschostnuget.fsx
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information,
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information,
 //
 // Layout the nuget host package for the fsharp compiler
 //=========================================================================================

--- a/src/fsharp/FSharp.Compiler.netcore.nuget/layoutfscnuget.fsx
+++ b/src/fsharp/FSharp.Compiler.netcore.nuget/layoutfscnuget.fsx
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information,
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information,
 //
 // Layout the nuget package for the fsharp compiler
 //=========================================================================================

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/RecordTypes.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/RecordTypes.fs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 module FSharp.Core.Unittests.FSharp_Core.Microsoft_FSharp_Core.RecordTypes
 
 #nowarn "9"

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.coreclr.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.coreclr.fs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 namespace FSharp.Core.Unittests.Portable.SurfaceArea
 

--- a/src/fsharp/fsharp.core.netcore.nuget/layoutfscorenuget.fsx
+++ b/src/fsharp/fsharp.core.netcore.nuget/layoutfscorenuget.fsx
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information,
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information,
 //
 // Layout the nuget package for the fsharp compiler
 //=========================================================================================

--- a/src/utils/reshapedmsbuild.fs
+++ b/src/utils/reshapedmsbuild.fs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 namespace Microsoft.Build.Tasks
 namespace Microsoft.Build.Utilities

--- a/src/utils/reshapedreflection.fs
+++ b/src/utils/reshapedreflection.fs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 namespace Microsoft.FSharp.Core
 

--- a/tests/fsharp/core/signedtests/test.fs
+++ b/tests/fsharp/core/signedtests/test.fs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 namespace signingtests
 
 open System

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Overview.xml
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Overview.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../../Common/Overview.xsl" type="text/xsl"?>
-<!-- // Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<!-- // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <VSSDKSample>
   <ImagePath>../../../Common</ImagePath>
   <Status>


### PR DESCRIPTION
Updating remaining references of `Microsoft Open Technologies` to `Microsoft`.

Note that I didn't use `Microsoft Corporation` as `(C) Copyright Microsoft. All Rights Reserved.` is the recommended header in source files (i.e. with no `Corporation`). However I didn't think it was worth the churn to also go update the majority of the headers which currently have `(C) Copyright Microsoft Corporation`.