### PR TITLE
Put union erasure in IlxGen phase

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -3446,8 +3446,6 @@ type ILExceptionSpec =
     { exnRange: (ILCodeLabel * ILCodeLabel);
       exnClauses: ILExceptionClause list }
 
-type exceptions = ILExceptionSpec list
-
 //-----------------------------------------------------------------------
 // [instructions_to_code] makes the basic block structure of code from
 // a primitive array of instructions.  We

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -98,9 +98,6 @@ type ILSourceMarker =
     member EndLine: int
     member EndColumn: int
 
-/// Represents an extension to the algebra of instructions
-type IlxExtensionInstr 
-
 [<StructuralEquality; StructuralComparison>]
 type PublicKey = 
     | PublicKey of byte[]
@@ -669,15 +666,6 @@ type ILInstr =
     // EXTENSIONS, e.g. MS-ILX 
     | EI_ilzero of ILType
     | EI_ldlen_multi      of int32 * int32
-    | I_other    of IlxExtensionInstr
-
-// REVIEW: remove this open-ended way of extending the IL and just combine with ILX
-type ILInstrSetExtension<'Extension> = 
-    { instrExtDests: ('Extension -> ILCodeLabel list);
-      instrExtFallthrough: ('Extension -> ILCodeLabel option);
-      instrExtRelabel: (ILCodeLabel -> ILCodeLabel) -> 'Extension -> 'Extension; }
-
-val RegisterInstructionSetExtension: ILInstrSetExtension<'Extension> -> ('Extension -> IlxExtensionInstr) * (IlxExtensionInstr -> bool) * (IlxExtensionInstr -> 'Extension)
 
 /// A list of instructions ending in an unconditionally
 /// branching instruction. A basic block has a label which must be unique

--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -65,90 +65,6 @@ let bblock_instr2instrs f bb =
           
     {bb with Instructions = Array.sub codebuf 0 codebuf_size}
 
-// Map each instruction in a basic block to a more complicated block that 
-// may involve internal branching, but which will still have one entry 
-// label and one exit label. This is used, for example, when macro-expanding 
-// complicated high-level ILX instructions. 
-// The morphing function is told the name of the input and output labels 
-// that must be used for the generated block. 
-// Optimize the case where an instruction gets mapped to a 
-// straightline sequence of instructions by allowing the morphing 
-// function to return a special result for this case. 
-// 
-// Let [i] be the instruction being morphed.  If [i] is a control-flow 
-// then instruction then [f] must return either a control-flow terminated 
-// sequence of instructions or a block both of which must targets the same labels 
-// (or a subset of the labels) targeted in [i].  If [i] 
-// is not a if not a control-flow instruction then [f] 
-// must return a block targeting the given output label. 
-
-let rec countAccInstrs (xss:ILInstr list list) acc = 
-    match xss with 
-    | [] -> acc
-    | xs :: rest -> countAccInstrs rest (acc + List.length xs)
-
-let rec commitAccInstrsAux (xs:ILInstr list) (arr:ILInstr[]) i = 
-    match xs with 
-    | [] -> ()
-    | x :: rest -> arr.[i] <- x; commitAccInstrsAux rest arr (i+1)
-    
-// Fill in the array chunk by chunk from the end and work backwards
-let rec commitAccInstrs xss arr i = 
-    match xss with 
-    | [] -> assert (i = 0)
-    | xs :: rest -> 
-        let n = List.length xs
-        commitAccInstrsAux xs arr (i - n)
-        commitAccInstrs rest arr (i - n)
-    
-// Write the accumulated instructions into an array. The fragments come in in reverse order.
-let commitAccBasicBlock (sofar: ILInstr list list) = 
-    let n = countAccInstrs sofar 0
-    let arr = Array.zeroCreate n 
-    commitAccInstrs sofar arr n
-    arr
-
-[<Struct; NoComparison; NoEquality>]
-type InstrMorph(isInstrs:bool, instrs:ILInstr list, code: ILCode) = 
-    new (instrs:ILInstr list) = InstrMorph(true,instrs,Unchecked.defaultof<_>)
-    new (code:ILCode) = InstrMorph(false,Unchecked.defaultof<_>,code)
-    member x.IsInstrs = isInstrs
-    member x.Instrs = instrs
-    member x.Code = code
-    
-let rec bblockLoop f bb currBBlockInpLabel currInpLabel currOutLabel sofar instrs = 
-    match instrs with 
-    | (i::rest) -> 
-        let res : InstrMorph = f currInpLabel currOutLabel i 
-        if res.IsInstrs then
-          // First possibility: return a list of instructions.  No addresses get consumed. 
-            bblockLoop f bb currBBlockInpLabel currInpLabel currOutLabel (res.Instrs :: sofar) rest
-        else
-          let middle_bblock = res.Code
-          let before_bblock = 
-            let instrs = commitAccBasicBlock ([I_br currInpLabel] :: sofar) 
-            mkBasicBlock {Label=currBBlockInpLabel;Instructions=instrs} 
-          if checking && uniqueEntryOfCode middle_bblock <> currInpLabel then 
-            dprintn ("*** warning when transforming bblock "^formatCodeLabel bb.Label^": bblock2code_instr2code: input label of returned block does not match the expected label while converting an instruction to a block.");
-          let afterBlocks = 
-              match rest with 
-              | [] -> [] // the bblock has already been transformed 
-              | _ -> 
-                  let newInLab = generateCodeLabel () 
-                  let newOutLab = generateCodeLabel () 
-                  [ bblockLoop f bb currOutLabel newInLab newOutLab [] rest ]
-           
-          checkILCode 
-              (mkGroupBlock 
-                 ( currInpLabel :: (match rest with [] -> [] | _ -> [ currOutLabel ]),
-                  before_bblock ::  middle_bblock :: afterBlocks))
-    | [] -> 
-       let instrs = commitAccBasicBlock sofar 
-       mkBasicBlock {Label=currBBlockInpLabel;Instructions=instrs} 
-
-let bblock2code_instr2code (f:ILCodeLabel -> ILCodeLabel -> ILInstr -> InstrMorph) bb = 
-    bblockLoop f bb bb.Label (generateCodeLabel ()) (generateCodeLabel ()) [] (Array.toList bb.Instructions)
-
 let rec block_bblock2code_typ2typ ((fbb,fty) as f) x =
     match x with
     | ILBasicBlock bblock -> fbb bblock
@@ -363,12 +279,6 @@ let fdefs_fdef2fdef f (m:ILFieldDefs) = mkILFields (List.map f m.AsList)
 (* use this when the conversion produces just one type... *)
 let morphILTypeDefs f (m: ILTypeDefs) = mkILTypeDefsFromArray (Array.map f m.AsArray)
 
-let morphExpandILTypeDefs f (m:ILTypeDefs) = 
-  mkILTypeDefs (List.collect f m.AsList)
-
-let morphILTypeDefsInILModule typesf m = 
-    {m with TypeDefs=typesf m.TypeDefs}
-
 let locals_typ2typ f ls = ILList.map (local_typ2typ f) ls
 let freevars_typ2typ f ls = Array.map (freevar_typ2typ f) ls
 
@@ -483,7 +393,6 @@ let morphILInstrsAndILTypesInILModule ilg (f1,f2) x =
   module_bblock2code_typ2typ ilg ((fun modCtxt tdefCtxt mdefCtxt  i -> mkBasicBlock (bblock_instr2instr (f1 modCtxt tdefCtxt mdefCtxt) i)), f2) x
 
 let morphILInstrsInILCode f x = topcode_bblock2code (fun i -> mkBasicBlock (bblock_instr2instrs f i)) x
-let morphExpandILInstrsInILCode f x = topcode_bblock2code (bblock2code_instr2code f) x
 
 let morphILTypeInILModule ilg ftype y = 
     let finstr modCtxt tdefCtxt mdefCtxt =

--- a/src/absil/ilmorph.fsi
+++ b/src/absil/ilmorph.fsi
@@ -8,40 +8,18 @@
 /// the ILMethodDef (if any) where the item occurs. etc.
 module internal Microsoft.FSharp.Compiler.AbstractIL.Morphs 
 
-open Internal.Utilities
 open Microsoft.FSharp.Compiler.AbstractIL 
-open Microsoft.FSharp.Compiler.AbstractIL.Internal 
-open Microsoft.FSharp.Compiler.AbstractIL.Extensions.ILX.Types 
 open Microsoft.FSharp.Compiler.AbstractIL.IL 
 
-type 'T morph = 'T -> 'T
-
 /// Morph each scope reference inside a type signature.
-val morphILScopeRefsInILTypeRef: ILScopeRef morph -> ILTypeRef -> ILTypeRef 
-
-val morphILMethodDefs: ILMethodDef morph -> ILMethodDefs -> ILMethodDefs
-/// nb. does not do nested tdefs.
-val morphILTypeDefs: ILTypeDef morph -> ILTypeDefs -> ILTypeDefs 
-
-val morphExpandILTypeDefs: (ILTypeDef -> ILTypeDef list) -> ILTypeDefs -> ILTypeDefs
-
-/// Morph all tables of ILTypeDefs in "ILModuleDef".
-val morphILTypeDefsInILModule: ILTypeDefs morph -> ILModuleDef -> ILModuleDef
+val morphILScopeRefsInILTypeRef: (ILScopeRef -> ILScopeRef) -> ILTypeRef -> ILTypeRef 
 
 /// Morph all type references throughout an entire module.
-val morphILTypeRefsInILModuleMemoized:  ILGlobals -> ILTypeRef morph ->  ILModuleDef ->  ILModuleDef
+val morphILTypeRefsInILModuleMemoized:  ILGlobals -> (ILTypeRef -> ILTypeRef) ->  ILModuleDef ->  ILModuleDef
 
-val morphILScopeRefsInILModuleMemoized: ILGlobals -> ILScopeRef morph ->  ILModuleDef ->  ILModuleDef
+val morphILScopeRefsInILModuleMemoized: ILGlobals -> (ILScopeRef -> ILScopeRef) ->  ILModuleDef ->  ILModuleDef
 
-val morphILMethodBody: ILMethodBody morph -> ILLazyMethodBody -> ILLazyMethodBody
 val morphILInstrsInILCode: (ILInstr -> ILInstr list) -> ILCode -> ILCode
-
-[<Struct; NoComparison; NoEquality>]
-type InstrMorph = 
-    new : ILInstr list -> InstrMorph
-    new : ILCode -> InstrMorph
-
-val morphExpandILInstrsInILCode: (ILCodeLabel -> ILCodeLabel -> ILInstr -> InstrMorph) -> ILCode -> ILCode
 
 val enablemorphCustomAttributeData : unit -> unit
 val disablemorphCustomAttributeData : unit -> unit

--- a/src/absil/ilprint.fs
+++ b/src/absil/ilprint.fs
@@ -754,24 +754,7 @@ let rec goutput_instr env os inst =
   | I_cpobj tok -> output_string os "cpobj "; goutput_typ env os tok
   | I_sizeof  tok -> output_string os "sizeof "; goutput_typ env os tok
   | I_seqpoint  s -> output_source os s
-  |  (EI_ilzero ty) -> output_string os "ilzero "; goutput_typ env os ty
-  | I_other e when isIlxExtInstr e -> 
-      match (destIlxExtInstr e) with 
-      | EI_castdata (check,ty,n)     ->
-          if not check then output_string os "/* unchecked. */ ";
-          output_string os "castdata ";
-          goutput_cuspec env os ty;
-          output_string os ",";
-          output_int os n
-      | (EI_lddatatag (_,ty)) -> 
-          output_string os "lddatatag "; 
-          goutput_cuspec env os ty
-      |  (EI_datacase (_,ty,l,_))  -> 
-          output_string os "datacase";
-          output_string os " ";  
-          goutput_cuspec env os ty;
-          output_string os ",";  
-          output_parens (output_seq "," (fun os (x,y) -> output_int os x;  output_string os ",";  output_code_label os y)) os l
+  | EI_ilzero ty -> output_string os "ilzero "; goutput_typ env os ty
   | _ -> 
       output_string os "<printing for this instruction is not implemented>"
 

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1200,7 +1200,6 @@ let rec emitInstr cenv (modB : ModuleBuilder) emEnv (ilG:ILGenerator) instr =
     | EI_ldlen_multi (_,m) -> 
         emitInstr cenv modB emEnv ilG (mkLdcInt32 m);
         emitInstr cenv modB emEnv ilG (mkNormalCall(mkILNonGenericMethSpecInTy(cenv.ilg.typ_Array, ILCallingConv.Instance, "GetLength", [cenv.ilg.typ_int32], cenv.ilg.typ_int32)))
-    | I_other e when isIlxExtInstr e -> Printf.failwithf "the ILX instruction %s cannot be emitted" (e.ToString())
     | i -> Printf.failwithf "the IL instruction %s cannot be emitted" (i.ToString())
 
 //----------------------------------------------------------------------------

--- a/src/absil/ilx.fs
+++ b/src/absil/ilx.fs
@@ -115,41 +115,6 @@ type IlxClosureSpec =
         mkILCtorMethSpecForTy (cloTy,fields |> Array.map (fun fv -> fv.fvType) |> Array.toList)
 
 
-type IlxInstr = 
-  // Discriminated unions
-  | EI_castdata of bool * IlxUnionSpec * int
-  | EI_datacase of avoidHelpers:bool * IlxUnionSpec * (int * ILCodeLabel) list * ILCodeLabel
-  | EI_lddatatag of avoidHelpers:bool * IlxUnionSpec
-  
-
-let destinations i =
-  match i with 
-  |  (EI_datacase (_,_,ls,l)) -> 
-        let hashSet = System.Collections.Generic.HashSet<_>(HashIdentity.Structural)
-        [yield l
-         for (_,l) in ls do
-            if hashSet.Add l then
-                yield l]
-  | _ -> []
-
-let fallthrough i = 
-  match i with 
-  |  (EI_datacase (_,_,_,l)) -> Some l
-  | _ -> None
-
-let remapIlxLabels lab2cl i = 
-  match i with 
-    | EI_datacase (z,x,ls,l) -> EI_datacase (z,x,List.map (fun (y,l) -> (y,lab2cl l)) ls, lab2cl l)
-    | _ -> i
-
-let (mkIlxExtInstr,isIlxExtInstr,destIlxExtInstr) = 
-  RegisterInstructionSetExtension  
-    { instrExtDests=destinations
-      instrExtFallthrough=fallthrough
-      instrExtRelabel=remapIlxLabels }
-
-let mkIlxInstr i = I_other (mkIlxExtInstr i)
-
 // Define an extension of the IL algebra of type definitions
 type IlxClosureInfo = 
     { cloStructure: IlxClosureLambdas;
@@ -157,7 +122,7 @@ type IlxClosureInfo =
       cloCode: Lazy<ILMethodBody>;
       cloSource: ILSourceMarker option}
 
-and IlxUnionInfo = 
+type IlxUnionInfo = 
     { /// is the representation public? 
       cudReprAccess: ILMemberAccess; 
       /// are the representation public? 

--- a/src/absil/ilx.fsi
+++ b/src/absil/ilx.fsi
@@ -89,18 +89,6 @@ type IlxClosureApps =
     | Apps_app of ILType * IlxClosureApps 
     | Apps_done of ILType
 
-/// ILX extensions to the instruction set.
-type IlxInstr = 
-    | EI_castdata of bool * IlxUnionSpec * int
-    | EI_datacase of avoidHelpers:bool * IlxUnionSpec * (int * ILCodeLabel) list * ILCodeLabel
-    | EI_lddatatag of avoidHelpers:bool * IlxUnionSpec
-
-val mkIlxExtInstr: (IlxInstr -> IlxExtensionInstr)
-val isIlxExtInstr: (IlxExtensionInstr -> bool)
-val destIlxExtInstr: (IlxExtensionInstr -> IlxInstr)
-
-val mkIlxInstr: IlxInstr -> ILInstr
-
 // -------------------------------------------------------------------- 
 // ILX extensions to the kinds of type definitions available
 // -------------------------------------------------------------------- 
@@ -111,7 +99,7 @@ type IlxClosureInfo =
       cloCode: Lazy<ILMethodBody>;
       cloSource: ILSourceMarker option}
 
-and IlxUnionInfo = 
+type IlxUnionInfo = 
     { /// Is the representation public? 
       cudReprAccess: ILMemberAccess; 
       /// Are the representation helpers public? 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -2028,18 +2028,7 @@ let main2b(Args(tcConfig: TcConfig, tcImports, tcGlobals, errorLogger, generated
     
     Args (tcConfig,errorLogger,staticLinker,ilGlobals,outfile,pdbfile,ilxMainModule,signingInfo,exiter)
 
-let main2c(Args(tcConfig, errorLogger, staticLinker, ilGlobals, outfile, pdbfile, ilxMainModule, signingInfo, exiter: Exiter)) = 
-      
-    use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind (BuildPhase.IlGen)
-    
-    ReportTime tcConfig "ILX -> IL (Unions)"; 
-    let ilxMainModule = EraseUnions.ConvModule ilGlobals ilxMainModule
-
-    AbortOnError(errorLogger,tcConfig,exiter)
-    Args(tcConfig,errorLogger,staticLinker,ilGlobals,ilxMainModule,outfile,pdbfile,signingInfo,exiter)
-  
-
-let main3(Args(tcConfig, errorLogger: ErrorLogger, staticLinker, ilGlobals, ilxMainModule, outfile, pdbfile, signingInfo, exiter:Exiter)) = 
+let main3(Args(tcConfig, errorLogger: ErrorLogger, staticLinker, ilGlobals, outfile, pdbfile, ilxMainModule, signingInfo, exiter:Exiter)) = 
         
     let ilxMainModule =  
         try  staticLinker ilxMainModule
@@ -2077,7 +2066,6 @@ let typecheckAndCompile(argv,bannerAlreadyPrinted,exiter:Exiter, errorLoggerProv
     |> main1
     |> main2
     |> main2b
-    |> main2c
     |> main3 
     |> main4
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -856,11 +856,6 @@ type internal FsiDynamicCompiler
 
         errorLogger.AbortOnError();
             
-        ReportTime tcConfig "ILX -> IL (Unions)"; 
-        let ilxMainModule = EraseUnions.ConvModule ilGlobals ilxMainModule
-
-        errorLogger.AbortOnError();   
-              
         ReportTime tcConfig "Assembly refs Normalised"; 
         let mainmod3 = Morphs.morphILScopeRefsInILModuleMemoized ilGlobals (NormalizeAssemblyRefs tcImports) ilxMainModule
         errorLogger.AbortOnError();

--- a/src/ilx/EraseClosures.fs
+++ b/src/ilx/EraseClosures.fs
@@ -282,10 +282,10 @@ let mkCallFunc cenv allocLocal numThisGenParams tl apps =
             buildApp true [] apps 
 
 // Fix up I_ret instruction. Generalise to selected instr.
-let convReturnInstr ty _inplab _outlab instr = 
+let convReturnInstr ty instr = 
     match instr with 
-    | I_ret -> InstrMorph [I_box ty;I_ret]
-    | _     -> InstrMorph [instr]
+    | I_ret -> [I_box ty;I_ret]
+    | _     -> [instr]
         
 let convILMethodBody (thisClo,boxReturnTy) il = 
     let tmps = ILLocalsAllocator il.Locals.Length
@@ -303,7 +303,7 @@ let convILMethodBody (thisClo,boxReturnTy) il =
     let code = 
         match boxReturnTy with
         | None    -> code
-        | Some ty -> morphExpandILInstrsInILCode (convReturnInstr ty) code
+        | Some ty -> morphILInstrsInILCode (convReturnInstr ty) code
     {il with MaxStack=newMax;  
              IsZeroInit=true;
              Code= code ;

--- a/src/ilx/EraseUnions.fsi
+++ b/src/ilx/EraseUnions.fsi
@@ -15,5 +15,16 @@ val mkLdData : bool * IlxUnionSpec * int * int -> ILInstr list
 val mkStData : IlxUnionSpec * int * int -> ILInstr list
 val mkBrIsData : ILGlobals -> avoidHelpers:bool * IlxUnionSpec * int * ILCodeLabel * ILCodeLabel -> ILInstr list
 val mkClassUnionDef : ILGlobals -> ILTypeRef -> ILTypeDef -> IlxUnionInfo -> ILTypeDef
-val ConvModule: ILGlobals -> ILModuleDef -> ILModuleDef 
 val GetILTypeForAlternative : IlxUnionSpec -> int -> ILType
+
+type ICodeGen<'Mark> = 
+    abstract CodeLabel: 'Mark -> ILCodeLabel
+    abstract GenerateDelayMark: unit -> 'Mark
+    abstract GenLocal: ILType -> uint16
+    abstract SetMarkToHere: 'Mark  -> unit
+    abstract EmitInstr : ILInstr -> unit
+    abstract EmitInstrs : ILInstr list -> unit
+
+val emitCastData : ILGlobals -> ICodeGen<'Mark> -> canfail: bool * IlxUnionSpec * int -> unit
+val emitLdDataTag : ILGlobals -> ICodeGen<'Mark> -> avoidHelpers:bool * IlxUnionSpec -> unit
+val emitDataSwitch : ILGlobals -> ICodeGen<'Mark> -> avoidHelpers:bool * IlxUnionSpec * (int * ILCodeLabel) list * ILCodeLabel -> unit

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/ComputationExpressions/keep.lst
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/ComputationExpressions/keep.lst
@@ -1,1 +1,1 @@
-ComputationExprLibrary.dll
+*

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Misc/EqualsOnUnions01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Misc/EqualsOnUnions01.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.1
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly EqualsOnUnions01
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.EqualsOnUnions01
 {
-  // Offset: 0x00000000 Length: 0x00000657
+  // Offset: 0x00000000 Length: 0x0000064B
 }
 .mresource public FSharpOptimizationData.EqualsOnUnions01
 {
-  // Offset: 0x00000660 Length: 0x000001C7
+  // Offset: 0x00000650 Length: 0x000001C7
 }
 .module EqualsOnUnions01.exe
-// MVID: {4BEB2859-BBFB-14A0-A745-03835928EB4B}
+// MVID: {57570CD9-BBFB-14A0-A745-0383D90C5757}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x001E0000
+// Image base: 0x01410000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -83,7 +83,7 @@
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
-        .maxstack  2
+        .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  call       instance void EqualsOnUnions01/U::.ctor()
         IL_0006:  ret
@@ -109,7 +109,7 @@
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
-        .maxstack  2
+        .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  call       instance void EqualsOnUnions01/U::.ctor()
         IL_0006:  ldarg.0
@@ -118,12 +118,13 @@
         IL_000d:  ret
       } // end of method B::.ctor
 
-      .method public instance int32  get_Item() cil managed
+      .method public hidebysig instance int32 
+              get_Item() cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       7 (0x7)
-        .maxstack  4
+        .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldfld      int32 EqualsOnUnions01/U/B::item
         IL_0006:  ret
@@ -153,7 +154,7 @@
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
-        .maxstack  3
+        .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
@@ -177,7 +178,7 @@
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       14 (0xe)
-        .maxstack  3
+        .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
         IL_0006:  ldarg.0
@@ -186,12 +187,13 @@
         IL_000d:  ret
       } // end of method B@DebugTypeProxy::.ctor
 
-      .method public instance int32  get_Item() cil managed
+      .method public hidebysig instance int32 
+              get_Item() cil managed
       {
         .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
         // Code size       12 (0xc)
-        .maxstack  4
+        .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldfld      class EqualsOnUnions01/U/B EqualsOnUnions01/U/B@DebugTypeProxy::_obj
         IL_0006:  ldfld      int32 EqualsOnUnions01/U/B::item
@@ -217,7 +219,7 @@
             void  .cctor() cil managed
     {
       // Code size       11 (0xb)
-      .maxstack  1
+      .maxstack  8
       IL_0000:  newobj     instance void EqualsOnUnions01/U/_A::.ctor()
       IL_0005:  stsfld     class EqualsOnUnions01/U EqualsOnUnions01/U::_unique_A
       IL_000a:  ret
@@ -229,36 +231,11 @@
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       7 (0x7)
-      .maxstack  2
+      .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ret
     } // end of method U::.ctor
-
-    .method public static class EqualsOnUnions01/U 
-            NewB(int32 item) cil managed
-    {
-      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
-                                                                                                  int32) = ( 01 00 08 00 00 00 01 00 00 00 00 00 ) 
-      // Code size       7 (0x7)
-      .maxstack  3
-      IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void EqualsOnUnions01/U/B::.ctor(int32)
-      IL_0006:  ret
-    } // end of method U::NewB
-
-    .method public instance bool  get_IsB() cil managed
-    {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      // Code size       10 (0xa)
-      .maxstack  4
-      IL_0000:  ldarg.0
-      IL_0001:  isinst     EqualsOnUnions01/U/B
-      IL_0006:  ldnull
-      IL_0007:  cgt.un
-      IL_0009:  ret
-    } // end of method U::get_IsB
 
     .method public static class EqualsOnUnions01/U 
             get_A() cil managed
@@ -266,17 +243,18 @@
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
       // Code size       6 (0x6)
-      .maxstack  2
+      .maxstack  8
       IL_0000:  ldsfld     class EqualsOnUnions01/U EqualsOnUnions01/U::_unique_A
       IL_0005:  ret
     } // end of method U::get_A
 
-    .method public instance bool  get_IsA() cil managed
+    .method public hidebysig instance bool 
+            get_IsA() cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       10 (0xa)
-      .maxstack  4
+      .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  isinst     EqualsOnUnions01/U/_A
       IL_0006:  ldnull
@@ -284,33 +262,57 @@
       IL_0009:  ret
     } // end of method U::get_IsA
 
-    .method public instance int32  get_Tag() cil managed
+    .method public static class EqualsOnUnions01/U 
+            NewB(int32 item) cil managed
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
+                                                                                                  int32) = ( 01 00 08 00 00 00 01 00 00 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  newobj     instance void EqualsOnUnions01/U/B::.ctor(int32)
+      IL_0006:  ret
+    } // end of method U::NewB
+
+    .method public hidebysig instance bool 
+            get_IsB() cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      // Code size       15 (0xf)
-      .maxstack  4
-      .locals init (class EqualsOnUnions01/U V_0)
+      // Code size       10 (0xa)
+      .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  stloc.0
-      IL_0002:  ldloc.0
-      IL_0003:  isinst     EqualsOnUnions01/U/B
-      IL_0008:  brfalse.s  IL_000d
+      IL_0001:  isinst     EqualsOnUnions01/U/B
+      IL_0006:  ldnull
+      IL_0007:  cgt.un
+      IL_0009:  ret
+    } // end of method U::get_IsB
 
-      IL_000a:  ldc.i4.1
-      IL_000b:  br.s       IL_000e
+    .method public hidebysig instance int32 
+            get_Tag() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       13 (0xd)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  isinst     EqualsOnUnions01/U/B
+      IL_0006:  brfalse.s  IL_000b
 
-      IL_000d:  ldc.i4.0
-      IL_000e:  ret
+      IL_0008:  ldc.i4.1
+      IL_0009:  br.s       IL_000c
+
+      IL_000b:  ldc.i4.0
+      IL_000c:  ret
     } // end of method U::get_Tag
 
-    .method assembly specialname instance object 
-            __DebugDisplay() cil managed
+    .method assembly hidebysig specialname 
+            instance object  __DebugDisplay() cil managed
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       22 (0x16)
-      .maxstack  4
+      .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
       IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class EqualsOnUnions01/U,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,string>::.ctor(string)
       IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class EqualsOnUnions01/U,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
@@ -326,14 +328,14 @@
       // Code size       159 (0x9f)
       .maxstack  4
       .locals init (int32 V_0,
-               int32 V_1,
-               class EqualsOnUnions01/U/B V_2,
-               class EqualsOnUnions01/U/B V_3,
-               class [mscorlib]System.Collections.IComparer V_4,
-               int32 V_5,
-               int32 V_6,
-               class EqualsOnUnions01/U V_7,
-               class EqualsOnUnions01/U V_8)
+               class EqualsOnUnions01/U V_1,
+               int32 V_2,
+               class EqualsOnUnions01/U V_3,
+               class EqualsOnUnions01/U/B V_4,
+               class EqualsOnUnions01/U/B V_5,
+               class [mscorlib]System.Collections.IComparer V_6,
+               int32 V_7,
+               int32 V_8)
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldnull
@@ -354,59 +356,59 @@
       IL_0016:  br         IL_008f
 
       IL_001b:  ldarg.0
-      IL_001c:  stloc.s    V_7
-      IL_001e:  ldloc.s    V_7
-      IL_0020:  isinst     EqualsOnUnions01/U/B
-      IL_0025:  brfalse.s  IL_002a
+      IL_001c:  stloc.1
+      IL_001d:  ldloc.1
+      IL_001e:  isinst     EqualsOnUnions01/U/B
+      IL_0023:  brfalse.s  IL_0028
 
-      IL_0027:  ldc.i4.1
-      IL_0028:  br.s       IL_002b
+      IL_0025:  ldc.i4.1
+      IL_0026:  br.s       IL_0029
 
-      IL_002a:  ldc.i4.0
-      IL_002b:  stloc.0
-      IL_002c:  ldarg.1
-      IL_002d:  stloc.s    V_8
-      IL_002f:  ldloc.s    V_8
-      IL_0031:  isinst     EqualsOnUnions01/U/B
-      IL_0036:  brfalse.s  IL_003b
+      IL_0028:  ldc.i4.0
+      IL_0029:  stloc.0
+      IL_002a:  ldarg.1
+      IL_002b:  stloc.3
+      IL_002c:  ldloc.3
+      IL_002d:  isinst     EqualsOnUnions01/U/B
+      IL_0032:  brfalse.s  IL_0037
 
-      IL_0038:  ldc.i4.1
-      IL_0039:  br.s       IL_003c
+      IL_0034:  ldc.i4.1
+      IL_0035:  br.s       IL_0038
 
-      IL_003b:  ldc.i4.0
-      IL_003c:  stloc.1
-      IL_003d:  ldloc.0
-      IL_003e:  ldloc.1
-      IL_003f:  bne.un.s   IL_0043
+      IL_0037:  ldc.i4.0
+      IL_0038:  stloc.2
+      IL_0039:  ldloc.0
+      IL_003a:  ldloc.2
+      IL_003b:  bne.un.s   IL_003f
 
-      IL_0041:  br.s       IL_0045
+      IL_003d:  br.s       IL_0041
 
-      IL_0043:  br.s       IL_008b
+      IL_003f:  br.s       IL_008b
 
-      IL_0045:  ldarg.0
-      IL_0046:  isinst     EqualsOnUnions01/U/B
-      IL_004b:  brfalse.s  IL_004f
+      IL_0041:  ldarg.0
+      IL_0042:  isinst     EqualsOnUnions01/U/B
+      IL_0047:  brfalse.s  IL_004b
 
-      IL_004d:  br.s       IL_0051
+      IL_0049:  br.s       IL_004d
 
-      IL_004f:  br.s       IL_0089
+      IL_004b:  br.s       IL_0089
 
-      IL_0051:  ldarg.0
-      IL_0052:  castclass  EqualsOnUnions01/U/B
-      IL_0057:  stloc.2
-      IL_0058:  ldarg.1
-      IL_0059:  castclass  EqualsOnUnions01/U/B
-      IL_005e:  stloc.3
-      IL_005f:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
-      IL_0064:  stloc.s    V_4
-      IL_0066:  ldloc.2
-      IL_0067:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_006c:  stloc.s    V_5
-      IL_006e:  ldloc.3
+      IL_004d:  ldarg.0
+      IL_004e:  castclass  EqualsOnUnions01/U/B
+      IL_0053:  stloc.s    V_4
+      IL_0055:  ldarg.1
+      IL_0056:  castclass  EqualsOnUnions01/U/B
+      IL_005b:  stloc.s    V_5
+      IL_005d:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0062:  stloc.s    V_6
+      IL_0064:  ldloc.s    V_4
+      IL_0066:  ldfld      int32 EqualsOnUnions01/U/B::item
+      IL_006b:  stloc.s    V_7
+      IL_006d:  ldloc.s    V_5
       IL_006f:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_0074:  stloc.s    V_6
-      IL_0076:  ldloc.s    V_5
-      IL_0078:  ldloc.s    V_6
+      IL_0074:  stloc.s    V_8
+      IL_0076:  ldloc.s    V_7
+      IL_0078:  ldloc.s    V_8
       IL_007a:  bge.s      IL_007e
 
       IL_007c:  br.s       IL_0080
@@ -416,8 +418,8 @@
       IL_0080:  ldc.i4.m1
       IL_0081:  ret
 
-      IL_0082:  ldloc.s    V_5
-      IL_0084:  ldloc.s    V_6
+      IL_0082:  ldloc.s    V_7
+      IL_0084:  ldloc.s    V_8
       IL_0086:  cgt
       IL_0088:  ret
 
@@ -425,7 +427,7 @@
       IL_008a:  ret
 
       IL_008b:  ldloc.0
-      IL_008c:  ldloc.1
+      IL_008c:  ldloc.2
       IL_008d:  sub
       IL_008e:  ret
 
@@ -453,14 +455,14 @@
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
-      .maxstack  4
+      .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 6,6 : 6,7 
+      .line 6,6 : 6,7 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\Misc\\EqualsOnUnions01.fs'
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldarg.1
       IL_0003:  unbox.any  EqualsOnUnions01/U
-      IL_0008:  call       instance int32 EqualsOnUnions01/U::CompareTo(class EqualsOnUnions01/U)
+      IL_0008:  callvirt   instance int32 EqualsOnUnions01/U::CompareTo(class EqualsOnUnions01/U)
       IL_000d:  ret
     } // end of method U::CompareTo
 
@@ -473,15 +475,15 @@
       .maxstack  4
       .locals init ([0] class EqualsOnUnions01/U V_0,
                [1] int32 V_1,
-               [2] int32 V_2,
-               [3] class EqualsOnUnions01/U/B V_3,
-               [4] class EqualsOnUnions01/U/B V_4,
-               [5] class [mscorlib]System.Collections.IComparer V_5,
-               [6] int32 V_6,
-               [7] int32 V_7,
-               [8] class EqualsOnUnions01/U V_8,
-               [9] class EqualsOnUnions01/U V_9)
-      .line 6,6 : 6,7 
+               [2] class EqualsOnUnions01/U V_2,
+               [3] int32 V_3,
+               [4] class EqualsOnUnions01/U V_4,
+               [5] class EqualsOnUnions01/U/B V_5,
+               [6] class EqualsOnUnions01/U/B V_6,
+               [7] class [mscorlib]System.Collections.IComparer V_7,
+               [8] int32 V_8,
+               [9] int32 V_9)
+      .line 6,6 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  unbox.any  EqualsOnUnions01/U
@@ -495,7 +497,7 @@
 
       IL_0010:  br         IL_009b
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0015:  ldarg.1
       IL_0016:  unbox.any  EqualsOnUnions01/U
       IL_001b:  ldnull
@@ -506,94 +508,94 @@
 
       IL_0022:  br         IL_0099
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0027:  ldarg.0
-      IL_0028:  stloc.s    V_8
-      IL_002a:  ldloc.s    V_8
-      IL_002c:  isinst     EqualsOnUnions01/U/B
-      IL_0031:  brfalse.s  IL_0036
+      IL_0028:  stloc.2
+      IL_0029:  ldloc.2
+      IL_002a:  isinst     EqualsOnUnions01/U/B
+      IL_002f:  brfalse.s  IL_0034
 
-      IL_0033:  ldc.i4.1
-      IL_0034:  br.s       IL_0037
+      IL_0031:  ldc.i4.1
+      IL_0032:  br.s       IL_0035
 
-      IL_0036:  ldc.i4.0
-      IL_0037:  stloc.1
-      IL_0038:  ldloc.0
-      IL_0039:  stloc.s    V_9
-      IL_003b:  ldloc.s    V_9
-      IL_003d:  isinst     EqualsOnUnions01/U/B
-      IL_0042:  brfalse.s  IL_0047
+      IL_0034:  ldc.i4.0
+      IL_0035:  stloc.1
+      IL_0036:  ldloc.0
+      IL_0037:  stloc.s    V_4
+      IL_0039:  ldloc.s    V_4
+      IL_003b:  isinst     EqualsOnUnions01/U/B
+      IL_0040:  brfalse.s  IL_0045
 
-      IL_0044:  ldc.i4.1
-      IL_0045:  br.s       IL_0048
+      IL_0042:  ldc.i4.1
+      IL_0043:  br.s       IL_0046
 
-      IL_0047:  ldc.i4.0
-      IL_0048:  stloc.2
-      IL_0049:  ldloc.1
-      IL_004a:  ldloc.2
-      IL_004b:  bne.un.s   IL_004f
+      IL_0045:  ldc.i4.0
+      IL_0046:  stloc.3
+      IL_0047:  ldloc.1
+      IL_0048:  ldloc.3
+      IL_0049:  bne.un.s   IL_004d
 
-      IL_004d:  br.s       IL_0051
+      IL_004b:  br.s       IL_004f
 
-      IL_004f:  br.s       IL_0095
+      IL_004d:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0 
-      IL_0051:  ldarg.0
-      IL_0052:  isinst     EqualsOnUnions01/U/B
-      IL_0057:  brfalse.s  IL_005b
+      .line 100001,100001 : 0,0 ''
+      IL_004f:  ldarg.0
+      IL_0050:  isinst     EqualsOnUnions01/U/B
+      IL_0055:  brfalse.s  IL_0059
 
-      IL_0059:  br.s       IL_005d
+      IL_0057:  br.s       IL_005b
 
-      IL_005b:  br.s       IL_0093
+      IL_0059:  br.s       IL_0093
 
-      .line 100001,100001 : 0,0 
-      IL_005d:  ldarg.0
-      IL_005e:  castclass  EqualsOnUnions01/U/B
-      IL_0063:  stloc.3
-      IL_0064:  ldloc.0
-      IL_0065:  castclass  EqualsOnUnions01/U/B
-      IL_006a:  stloc.s    V_4
-      IL_006c:  ldarg.2
-      IL_006d:  stloc.s    V_5
-      IL_006f:  ldloc.3
+      .line 100001,100001 : 0,0 ''
+      IL_005b:  ldarg.0
+      IL_005c:  castclass  EqualsOnUnions01/U/B
+      IL_0061:  stloc.s    V_5
+      IL_0063:  ldloc.0
+      IL_0064:  castclass  EqualsOnUnions01/U/B
+      IL_0069:  stloc.s    V_6
+      IL_006b:  ldarg.2
+      IL_006c:  stloc.s    V_7
+      IL_006e:  ldloc.s    V_5
       IL_0070:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_0075:  stloc.s    V_6
-      IL_0077:  ldloc.s    V_4
+      IL_0075:  stloc.s    V_8
+      IL_0077:  ldloc.s    V_6
       IL_0079:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_007e:  stloc.s    V_7
-      IL_0080:  ldloc.s    V_6
-      IL_0082:  ldloc.s    V_7
+      IL_007e:  stloc.s    V_9
+      IL_0080:  ldloc.s    V_8
+      IL_0082:  ldloc.s    V_9
       IL_0084:  bge.s      IL_0088
 
       IL_0086:  br.s       IL_008a
 
       IL_0088:  br.s       IL_008c
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_008a:  ldc.i4.m1
       IL_008b:  ret
 
-      .line 100001,100001 : 0,0 
-      IL_008c:  ldloc.s    V_6
-      IL_008e:  ldloc.s    V_7
+      .line 100001,100001 : 0,0 ''
+      IL_008c:  ldloc.s    V_8
+      IL_008e:  ldloc.s    V_9
       IL_0090:  cgt
       IL_0092:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldc.i4.0
       IL_0094:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ldloc.1
-      IL_0096:  ldloc.2
+      IL_0096:  ldloc.3
       IL_0097:  sub
       IL_0098:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0099:  ldc.i4.1
       IL_009a:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_009b:  ldarg.1
       IL_009c:  unbox.any  EqualsOnUnions01/U
       IL_00a1:  ldnull
@@ -604,11 +606,11 @@
 
       IL_00a8:  br.s       IL_00ac
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_00aa:  ldc.i4.m1
       IL_00ab:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_00ac:  ldc.i4.0
       IL_00ad:  ret
     } // end of method U::CompareTo
@@ -683,12 +685,12 @@
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
-      .maxstack  4
-      .line 6,6 : 6,7 
+      .maxstack  8
+      .line 6,6 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0007:  call       instance int32 EqualsOnUnions01/U::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
+      IL_0007:  callvirt   instance int32 EqualsOnUnions01/U::GetHashCode(class [mscorlib]System.Collections.IEqualityComparer)
       IL_000c:  ret
     } // end of method U::GetHashCode
 
@@ -702,12 +704,12 @@
       .locals init (class EqualsOnUnions01/U V_0,
                class EqualsOnUnions01/U V_1,
                int32 V_2,
-               int32 V_3,
-               class EqualsOnUnions01/U/B V_4,
-               class EqualsOnUnions01/U/B V_5,
-               class [mscorlib]System.Collections.IEqualityComparer V_6,
-               class EqualsOnUnions01/U V_7,
-               class EqualsOnUnions01/U V_8)
+               class EqualsOnUnions01/U V_3,
+               int32 V_4,
+               class EqualsOnUnions01/U V_5,
+               class EqualsOnUnions01/U/B V_6,
+               class EqualsOnUnions01/U/B V_7,
+               class [mscorlib]System.Collections.IEqualityComparer V_8)
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldnull
@@ -731,29 +733,29 @@
       IL_001c:  ldloc.0
       IL_001d:  stloc.1
       IL_001e:  ldarg.0
-      IL_001f:  stloc.s    V_7
-      IL_0021:  ldloc.s    V_7
-      IL_0023:  isinst     EqualsOnUnions01/U/B
-      IL_0028:  brfalse.s  IL_002d
+      IL_001f:  stloc.3
+      IL_0020:  ldloc.3
+      IL_0021:  isinst     EqualsOnUnions01/U/B
+      IL_0026:  brfalse.s  IL_002b
 
-      IL_002a:  ldc.i4.1
-      IL_002b:  br.s       IL_002e
+      IL_0028:  ldc.i4.1
+      IL_0029:  br.s       IL_002c
 
-      IL_002d:  ldc.i4.0
-      IL_002e:  stloc.2
-      IL_002f:  ldloc.1
-      IL_0030:  stloc.s    V_8
-      IL_0032:  ldloc.s    V_8
-      IL_0034:  isinst     EqualsOnUnions01/U/B
-      IL_0039:  brfalse.s  IL_003e
+      IL_002b:  ldc.i4.0
+      IL_002c:  stloc.2
+      IL_002d:  ldloc.1
+      IL_002e:  stloc.s    V_5
+      IL_0030:  ldloc.s    V_5
+      IL_0032:  isinst     EqualsOnUnions01/U/B
+      IL_0037:  brfalse.s  IL_003c
 
-      IL_003b:  ldc.i4.1
-      IL_003c:  br.s       IL_003f
+      IL_0039:  ldc.i4.1
+      IL_003a:  br.s       IL_003d
 
-      IL_003e:  ldc.i4.0
-      IL_003f:  stloc.3
-      IL_0040:  ldloc.2
-      IL_0041:  ldloc.3
+      IL_003c:  ldc.i4.0
+      IL_003d:  stloc.s    V_4
+      IL_003f:  ldloc.2
+      IL_0040:  ldloc.s    V_4
       IL_0042:  bne.un.s   IL_0046
 
       IL_0044:  br.s       IL_0048
@@ -770,15 +772,15 @@
 
       IL_0054:  ldarg.0
       IL_0055:  castclass  EqualsOnUnions01/U/B
-      IL_005a:  stloc.s    V_4
+      IL_005a:  stloc.s    V_6
       IL_005c:  ldloc.1
       IL_005d:  castclass  EqualsOnUnions01/U/B
-      IL_0062:  stloc.s    V_5
+      IL_0062:  stloc.s    V_7
       IL_0064:  ldarg.2
-      IL_0065:  stloc.s    V_6
-      IL_0067:  ldloc.s    V_4
+      IL_0065:  stloc.s    V_8
+      IL_0067:  ldloc.s    V_6
       IL_0069:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_006e:  ldloc.s    V_5
+      IL_006e:  ldloc.s    V_7
       IL_0070:  ldfld      int32 EqualsOnUnions01/U/B::item
       IL_0075:  ceq
       IL_0077:  ret
@@ -807,11 +809,11 @@
       // Code size       121 (0x79)
       .maxstack  4
       .locals init (int32 V_0,
-               int32 V_1,
-               class EqualsOnUnions01/U/B V_2,
-               class EqualsOnUnions01/U/B V_3,
-               class EqualsOnUnions01/U V_4,
-               class EqualsOnUnions01/U V_5)
+               class EqualsOnUnions01/U V_1,
+               int32 V_2,
+               class EqualsOnUnions01/U V_3,
+               class EqualsOnUnions01/U/B V_4,
+               class EqualsOnUnions01/U/B V_5)
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldnull
@@ -832,52 +834,52 @@
       IL_0016:  br.s       IL_006f
 
       IL_0018:  ldarg.0
-      IL_0019:  stloc.s    V_4
-      IL_001b:  ldloc.s    V_4
-      IL_001d:  isinst     EqualsOnUnions01/U/B
-      IL_0022:  brfalse.s  IL_0027
+      IL_0019:  stloc.1
+      IL_001a:  ldloc.1
+      IL_001b:  isinst     EqualsOnUnions01/U/B
+      IL_0020:  brfalse.s  IL_0025
 
-      IL_0024:  ldc.i4.1
-      IL_0025:  br.s       IL_0028
+      IL_0022:  ldc.i4.1
+      IL_0023:  br.s       IL_0026
 
-      IL_0027:  ldc.i4.0
-      IL_0028:  stloc.0
-      IL_0029:  ldarg.1
-      IL_002a:  stloc.s    V_5
-      IL_002c:  ldloc.s    V_5
-      IL_002e:  isinst     EqualsOnUnions01/U/B
-      IL_0033:  brfalse.s  IL_0038
+      IL_0025:  ldc.i4.0
+      IL_0026:  stloc.0
+      IL_0027:  ldarg.1
+      IL_0028:  stloc.3
+      IL_0029:  ldloc.3
+      IL_002a:  isinst     EqualsOnUnions01/U/B
+      IL_002f:  brfalse.s  IL_0034
 
-      IL_0035:  ldc.i4.1
-      IL_0036:  br.s       IL_0039
+      IL_0031:  ldc.i4.1
+      IL_0032:  br.s       IL_0035
 
-      IL_0038:  ldc.i4.0
-      IL_0039:  stloc.1
-      IL_003a:  ldloc.0
-      IL_003b:  ldloc.1
-      IL_003c:  bne.un.s   IL_0040
+      IL_0034:  ldc.i4.0
+      IL_0035:  stloc.2
+      IL_0036:  ldloc.0
+      IL_0037:  ldloc.2
+      IL_0038:  bne.un.s   IL_003c
 
-      IL_003e:  br.s       IL_0042
+      IL_003a:  br.s       IL_003e
 
-      IL_0040:  br.s       IL_006d
+      IL_003c:  br.s       IL_006d
 
-      IL_0042:  ldarg.0
-      IL_0043:  isinst     EqualsOnUnions01/U/B
-      IL_0048:  brfalse.s  IL_004c
+      IL_003e:  ldarg.0
+      IL_003f:  isinst     EqualsOnUnions01/U/B
+      IL_0044:  brfalse.s  IL_0048
 
-      IL_004a:  br.s       IL_004e
+      IL_0046:  br.s       IL_004a
 
-      IL_004c:  br.s       IL_006b
+      IL_0048:  br.s       IL_006b
 
-      IL_004e:  ldarg.0
-      IL_004f:  castclass  EqualsOnUnions01/U/B
-      IL_0054:  stloc.2
-      IL_0055:  ldarg.1
-      IL_0056:  castclass  EqualsOnUnions01/U/B
-      IL_005b:  stloc.3
-      IL_005c:  ldloc.2
-      IL_005d:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_0062:  ldloc.3
+      IL_004a:  ldarg.0
+      IL_004b:  castclass  EqualsOnUnions01/U/B
+      IL_0050:  stloc.s    V_4
+      IL_0052:  ldarg.1
+      IL_0053:  castclass  EqualsOnUnions01/U/B
+      IL_0058:  stloc.s    V_5
+      IL_005a:  ldloc.s    V_4
+      IL_005c:  ldfld      int32 EqualsOnUnions01/U/B::item
+      IL_0061:  ldloc.s    V_5
       IL_0063:  ldfld      int32 EqualsOnUnions01/U/B::item
       IL_0068:  ceq
       IL_006a:  ret
@@ -919,7 +921,7 @@
 
       IL_000f:  ldarg.0
       IL_0010:  ldloc.0
-      IL_0011:  call       instance bool EqualsOnUnions01/U::Equals(class EqualsOnUnions01/U)
+      IL_0011:  callvirt   instance bool EqualsOnUnions01/U::Equals(class EqualsOnUnions01/U)
       IL_0016:  ret
 
       IL_0017:  ldc.i4.0
@@ -933,13 +935,6 @@
       .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance int32 EqualsOnUnions01/U::get_Tag()
     } // end of property U::Tag
-    .property instance bool IsB()
-    {
-      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool EqualsOnUnions01/U::get_IsB()
-    } // end of property U::IsB
     .property class EqualsOnUnions01/U A()
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -954,6 +949,13 @@
       .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .get instance bool EqualsOnUnions01/U::get_IsA()
     } // end of property U::IsA
+    .property instance bool IsB()
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+      .get instance bool EqualsOnUnions01/U::get_IsB()
+    } // end of property U::IsB
   } // end of class U
 
 } // end of class EqualsOnUnions01
@@ -965,7 +967,7 @@
   {
     .entrypoint
     // Code size       2 (0x2)
-    .maxstack  2
+    .maxstack  8
     IL_0000:  nop
     IL_0001:  ret
   } // end of method $EqualsOnUnions01::main@

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Misc/EqualsOnUnions01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Misc/EqualsOnUnions01.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.17376
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:3:0:0
+  .ver 4:4:1:0
 }
 .assembly EqualsOnUnions01
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.EqualsOnUnions01
 {
-  // Offset: 0x00000000 Length: 0x00000667
+  // Offset: 0x00000000 Length: 0x0000064B
 }
 .mresource public FSharpOptimizationData.EqualsOnUnions01
 {
-  // Offset: 0x00000670 Length: 0x000001C7
+  // Offset: 0x00000650 Length: 0x000001C7
 }
 .module EqualsOnUnions01.exe
-// MVID: {4F20DEF4-BBFB-14A0-A745-0383F4DE204F}
+// MVID: {57570CD9-BBFB-14A0-A745-0383D90C5757}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000006024A50000
+// Image base: 0x01410000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -293,20 +293,17 @@
     {
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      // Code size       15 (0xf)
-      .maxstack  4
-      .locals init (class EqualsOnUnions01/U V_0)
+      // Code size       13 (0xd)
+      .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  stloc.0
-      IL_0002:  ldloc.0
-      IL_0003:  isinst     EqualsOnUnions01/U/B
-      IL_0008:  brfalse.s  IL_000d
+      IL_0001:  isinst     EqualsOnUnions01/U/B
+      IL_0006:  brfalse.s  IL_000b
 
-      IL_000a:  ldc.i4.1
-      IL_000b:  br.s       IL_000e
+      IL_0008:  ldc.i4.1
+      IL_0009:  br.s       IL_000c
 
-      IL_000d:  ldc.i4.0
-      IL_000e:  ret
+      IL_000b:  ldc.i4.0
+      IL_000c:  ret
     } // end of method U::get_Tag
 
     .method assembly hidebysig specialname 
@@ -331,14 +328,14 @@
       // Code size       159 (0x9f)
       .maxstack  4
       .locals init (int32 V_0,
-               int32 V_1,
-               class EqualsOnUnions01/U/B V_2,
-               class EqualsOnUnions01/U/B V_3,
-               class [mscorlib]System.Collections.IComparer V_4,
-               int32 V_5,
-               int32 V_6,
-               class EqualsOnUnions01/U V_7,
-               class EqualsOnUnions01/U V_8)
+               class EqualsOnUnions01/U V_1,
+               int32 V_2,
+               class EqualsOnUnions01/U V_3,
+               class EqualsOnUnions01/U/B V_4,
+               class EqualsOnUnions01/U/B V_5,
+               class [mscorlib]System.Collections.IComparer V_6,
+               int32 V_7,
+               int32 V_8)
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldnull
@@ -359,59 +356,59 @@
       IL_0016:  br         IL_008f
 
       IL_001b:  ldarg.0
-      IL_001c:  stloc.s    V_7
-      IL_001e:  ldloc.s    V_7
-      IL_0020:  isinst     EqualsOnUnions01/U/B
-      IL_0025:  brfalse.s  IL_002a
+      IL_001c:  stloc.1
+      IL_001d:  ldloc.1
+      IL_001e:  isinst     EqualsOnUnions01/U/B
+      IL_0023:  brfalse.s  IL_0028
 
-      IL_0027:  ldc.i4.1
-      IL_0028:  br.s       IL_002b
+      IL_0025:  ldc.i4.1
+      IL_0026:  br.s       IL_0029
 
-      IL_002a:  ldc.i4.0
-      IL_002b:  stloc.0
-      IL_002c:  ldarg.1
-      IL_002d:  stloc.s    V_8
-      IL_002f:  ldloc.s    V_8
-      IL_0031:  isinst     EqualsOnUnions01/U/B
-      IL_0036:  brfalse.s  IL_003b
+      IL_0028:  ldc.i4.0
+      IL_0029:  stloc.0
+      IL_002a:  ldarg.1
+      IL_002b:  stloc.3
+      IL_002c:  ldloc.3
+      IL_002d:  isinst     EqualsOnUnions01/U/B
+      IL_0032:  brfalse.s  IL_0037
 
-      IL_0038:  ldc.i4.1
-      IL_0039:  br.s       IL_003c
+      IL_0034:  ldc.i4.1
+      IL_0035:  br.s       IL_0038
 
-      IL_003b:  ldc.i4.0
-      IL_003c:  stloc.1
-      IL_003d:  ldloc.0
-      IL_003e:  ldloc.1
-      IL_003f:  bne.un.s   IL_0043
+      IL_0037:  ldc.i4.0
+      IL_0038:  stloc.2
+      IL_0039:  ldloc.0
+      IL_003a:  ldloc.2
+      IL_003b:  bne.un.s   IL_003f
 
-      IL_0041:  br.s       IL_0045
+      IL_003d:  br.s       IL_0041
 
-      IL_0043:  br.s       IL_008b
+      IL_003f:  br.s       IL_008b
 
-      IL_0045:  ldarg.0
-      IL_0046:  isinst     EqualsOnUnions01/U/B
-      IL_004b:  brfalse.s  IL_004f
+      IL_0041:  ldarg.0
+      IL_0042:  isinst     EqualsOnUnions01/U/B
+      IL_0047:  brfalse.s  IL_004b
 
-      IL_004d:  br.s       IL_0051
+      IL_0049:  br.s       IL_004d
 
-      IL_004f:  br.s       IL_0089
+      IL_004b:  br.s       IL_0089
 
-      IL_0051:  ldarg.0
-      IL_0052:  castclass  EqualsOnUnions01/U/B
-      IL_0057:  stloc.2
-      IL_0058:  ldarg.1
-      IL_0059:  castclass  EqualsOnUnions01/U/B
-      IL_005e:  stloc.3
-      IL_005f:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
-      IL_0064:  stloc.s    V_4
-      IL_0066:  ldloc.2
-      IL_0067:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_006c:  stloc.s    V_5
-      IL_006e:  ldloc.3
+      IL_004d:  ldarg.0
+      IL_004e:  castclass  EqualsOnUnions01/U/B
+      IL_0053:  stloc.s    V_4
+      IL_0055:  ldarg.1
+      IL_0056:  castclass  EqualsOnUnions01/U/B
+      IL_005b:  stloc.s    V_5
+      IL_005d:  call       class [mscorlib]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
+      IL_0062:  stloc.s    V_6
+      IL_0064:  ldloc.s    V_4
+      IL_0066:  ldfld      int32 EqualsOnUnions01/U/B::item
+      IL_006b:  stloc.s    V_7
+      IL_006d:  ldloc.s    V_5
       IL_006f:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_0074:  stloc.s    V_6
-      IL_0076:  ldloc.s    V_5
-      IL_0078:  ldloc.s    V_6
+      IL_0074:  stloc.s    V_8
+      IL_0076:  ldloc.s    V_7
+      IL_0078:  ldloc.s    V_8
       IL_007a:  bge.s      IL_007e
 
       IL_007c:  br.s       IL_0080
@@ -421,8 +418,8 @@
       IL_0080:  ldc.i4.m1
       IL_0081:  ret
 
-      IL_0082:  ldloc.s    V_5
-      IL_0084:  ldloc.s    V_6
+      IL_0082:  ldloc.s    V_7
+      IL_0084:  ldloc.s    V_8
       IL_0086:  cgt
       IL_0088:  ret
 
@@ -430,7 +427,7 @@
       IL_008a:  ret
 
       IL_008b:  ldloc.0
-      IL_008c:  ldloc.1
+      IL_008c:  ldloc.2
       IL_008d:  sub
       IL_008e:  ret
 
@@ -460,7 +457,7 @@
       // Code size       14 (0xe)
       .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 6,6 : 6,7 
+      .line 6,6 : 6,7 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\Misc\\EqualsOnUnions01.fs'
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldarg.1
@@ -478,15 +475,15 @@
       .maxstack  4
       .locals init ([0] class EqualsOnUnions01/U V_0,
                [1] int32 V_1,
-               [2] int32 V_2,
-               [3] class EqualsOnUnions01/U/B V_3,
-               [4] class EqualsOnUnions01/U/B V_4,
-               [5] class [mscorlib]System.Collections.IComparer V_5,
-               [6] int32 V_6,
-               [7] int32 V_7,
-               [8] class EqualsOnUnions01/U V_8,
-               [9] class EqualsOnUnions01/U V_9)
-      .line 6,6 : 6,7 
+               [2] class EqualsOnUnions01/U V_2,
+               [3] int32 V_3,
+               [4] class EqualsOnUnions01/U V_4,
+               [5] class EqualsOnUnions01/U/B V_5,
+               [6] class EqualsOnUnions01/U/B V_6,
+               [7] class [mscorlib]System.Collections.IComparer V_7,
+               [8] int32 V_8,
+               [9] int32 V_9)
+      .line 6,6 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  unbox.any  EqualsOnUnions01/U
@@ -500,7 +497,7 @@
 
       IL_0010:  br         IL_009b
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0015:  ldarg.1
       IL_0016:  unbox.any  EqualsOnUnions01/U
       IL_001b:  ldnull
@@ -511,94 +508,94 @@
 
       IL_0022:  br         IL_0099
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0027:  ldarg.0
-      IL_0028:  stloc.s    V_8
-      IL_002a:  ldloc.s    V_8
-      IL_002c:  isinst     EqualsOnUnions01/U/B
-      IL_0031:  brfalse.s  IL_0036
+      IL_0028:  stloc.2
+      IL_0029:  ldloc.2
+      IL_002a:  isinst     EqualsOnUnions01/U/B
+      IL_002f:  brfalse.s  IL_0034
 
-      IL_0033:  ldc.i4.1
-      IL_0034:  br.s       IL_0037
+      IL_0031:  ldc.i4.1
+      IL_0032:  br.s       IL_0035
 
-      IL_0036:  ldc.i4.0
-      IL_0037:  stloc.1
-      IL_0038:  ldloc.0
-      IL_0039:  stloc.s    V_9
-      IL_003b:  ldloc.s    V_9
-      IL_003d:  isinst     EqualsOnUnions01/U/B
-      IL_0042:  brfalse.s  IL_0047
+      IL_0034:  ldc.i4.0
+      IL_0035:  stloc.1
+      IL_0036:  ldloc.0
+      IL_0037:  stloc.s    V_4
+      IL_0039:  ldloc.s    V_4
+      IL_003b:  isinst     EqualsOnUnions01/U/B
+      IL_0040:  brfalse.s  IL_0045
 
-      IL_0044:  ldc.i4.1
-      IL_0045:  br.s       IL_0048
+      IL_0042:  ldc.i4.1
+      IL_0043:  br.s       IL_0046
 
-      IL_0047:  ldc.i4.0
-      IL_0048:  stloc.2
-      IL_0049:  ldloc.1
-      IL_004a:  ldloc.2
-      IL_004b:  bne.un.s   IL_004f
+      IL_0045:  ldc.i4.0
+      IL_0046:  stloc.3
+      IL_0047:  ldloc.1
+      IL_0048:  ldloc.3
+      IL_0049:  bne.un.s   IL_004d
 
-      IL_004d:  br.s       IL_0051
+      IL_004b:  br.s       IL_004f
 
-      IL_004f:  br.s       IL_0095
+      IL_004d:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0 
-      IL_0051:  ldarg.0
-      IL_0052:  isinst     EqualsOnUnions01/U/B
-      IL_0057:  brfalse.s  IL_005b
+      .line 100001,100001 : 0,0 ''
+      IL_004f:  ldarg.0
+      IL_0050:  isinst     EqualsOnUnions01/U/B
+      IL_0055:  brfalse.s  IL_0059
 
-      IL_0059:  br.s       IL_005d
+      IL_0057:  br.s       IL_005b
 
-      IL_005b:  br.s       IL_0093
+      IL_0059:  br.s       IL_0093
 
-      .line 100001,100001 : 0,0 
-      IL_005d:  ldarg.0
-      IL_005e:  castclass  EqualsOnUnions01/U/B
-      IL_0063:  stloc.3
-      IL_0064:  ldloc.0
-      IL_0065:  castclass  EqualsOnUnions01/U/B
-      IL_006a:  stloc.s    V_4
-      IL_006c:  ldarg.2
-      IL_006d:  stloc.s    V_5
-      IL_006f:  ldloc.3
+      .line 100001,100001 : 0,0 ''
+      IL_005b:  ldarg.0
+      IL_005c:  castclass  EqualsOnUnions01/U/B
+      IL_0061:  stloc.s    V_5
+      IL_0063:  ldloc.0
+      IL_0064:  castclass  EqualsOnUnions01/U/B
+      IL_0069:  stloc.s    V_6
+      IL_006b:  ldarg.2
+      IL_006c:  stloc.s    V_7
+      IL_006e:  ldloc.s    V_5
       IL_0070:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_0075:  stloc.s    V_6
-      IL_0077:  ldloc.s    V_4
+      IL_0075:  stloc.s    V_8
+      IL_0077:  ldloc.s    V_6
       IL_0079:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_007e:  stloc.s    V_7
-      IL_0080:  ldloc.s    V_6
-      IL_0082:  ldloc.s    V_7
+      IL_007e:  stloc.s    V_9
+      IL_0080:  ldloc.s    V_8
+      IL_0082:  ldloc.s    V_9
       IL_0084:  bge.s      IL_0088
 
       IL_0086:  br.s       IL_008a
 
       IL_0088:  br.s       IL_008c
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_008a:  ldc.i4.m1
       IL_008b:  ret
 
-      .line 100001,100001 : 0,0 
-      IL_008c:  ldloc.s    V_6
-      IL_008e:  ldloc.s    V_7
+      .line 100001,100001 : 0,0 ''
+      IL_008c:  ldloc.s    V_8
+      IL_008e:  ldloc.s    V_9
       IL_0090:  cgt
       IL_0092:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldc.i4.0
       IL_0094:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ldloc.1
-      IL_0096:  ldloc.2
+      IL_0096:  ldloc.3
       IL_0097:  sub
       IL_0098:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0099:  ldc.i4.1
       IL_009a:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_009b:  ldarg.1
       IL_009c:  unbox.any  EqualsOnUnions01/U
       IL_00a1:  ldnull
@@ -609,11 +606,11 @@
 
       IL_00a8:  br.s       IL_00ac
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_00aa:  ldc.i4.m1
       IL_00ab:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_00ac:  ldc.i4.0
       IL_00ad:  ret
     } // end of method U::CompareTo
@@ -689,7 +686,7 @@
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
-      .line 6,6 : 6,7 
+      .line 6,6 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
@@ -707,12 +704,12 @@
       .locals init (class EqualsOnUnions01/U V_0,
                class EqualsOnUnions01/U V_1,
                int32 V_2,
-               int32 V_3,
-               class EqualsOnUnions01/U/B V_4,
-               class EqualsOnUnions01/U/B V_5,
-               class [mscorlib]System.Collections.IEqualityComparer V_6,
-               class EqualsOnUnions01/U V_7,
-               class EqualsOnUnions01/U V_8)
+               class EqualsOnUnions01/U V_3,
+               int32 V_4,
+               class EqualsOnUnions01/U V_5,
+               class EqualsOnUnions01/U/B V_6,
+               class EqualsOnUnions01/U/B V_7,
+               class [mscorlib]System.Collections.IEqualityComparer V_8)
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldnull
@@ -736,29 +733,29 @@
       IL_001c:  ldloc.0
       IL_001d:  stloc.1
       IL_001e:  ldarg.0
-      IL_001f:  stloc.s    V_7
-      IL_0021:  ldloc.s    V_7
-      IL_0023:  isinst     EqualsOnUnions01/U/B
-      IL_0028:  brfalse.s  IL_002d
+      IL_001f:  stloc.3
+      IL_0020:  ldloc.3
+      IL_0021:  isinst     EqualsOnUnions01/U/B
+      IL_0026:  brfalse.s  IL_002b
 
-      IL_002a:  ldc.i4.1
-      IL_002b:  br.s       IL_002e
+      IL_0028:  ldc.i4.1
+      IL_0029:  br.s       IL_002c
 
-      IL_002d:  ldc.i4.0
-      IL_002e:  stloc.2
-      IL_002f:  ldloc.1
-      IL_0030:  stloc.s    V_8
-      IL_0032:  ldloc.s    V_8
-      IL_0034:  isinst     EqualsOnUnions01/U/B
-      IL_0039:  brfalse.s  IL_003e
+      IL_002b:  ldc.i4.0
+      IL_002c:  stloc.2
+      IL_002d:  ldloc.1
+      IL_002e:  stloc.s    V_5
+      IL_0030:  ldloc.s    V_5
+      IL_0032:  isinst     EqualsOnUnions01/U/B
+      IL_0037:  brfalse.s  IL_003c
 
-      IL_003b:  ldc.i4.1
-      IL_003c:  br.s       IL_003f
+      IL_0039:  ldc.i4.1
+      IL_003a:  br.s       IL_003d
 
-      IL_003e:  ldc.i4.0
-      IL_003f:  stloc.3
-      IL_0040:  ldloc.2
-      IL_0041:  ldloc.3
+      IL_003c:  ldc.i4.0
+      IL_003d:  stloc.s    V_4
+      IL_003f:  ldloc.2
+      IL_0040:  ldloc.s    V_4
       IL_0042:  bne.un.s   IL_0046
 
       IL_0044:  br.s       IL_0048
@@ -775,15 +772,15 @@
 
       IL_0054:  ldarg.0
       IL_0055:  castclass  EqualsOnUnions01/U/B
-      IL_005a:  stloc.s    V_4
+      IL_005a:  stloc.s    V_6
       IL_005c:  ldloc.1
       IL_005d:  castclass  EqualsOnUnions01/U/B
-      IL_0062:  stloc.s    V_5
+      IL_0062:  stloc.s    V_7
       IL_0064:  ldarg.2
-      IL_0065:  stloc.s    V_6
-      IL_0067:  ldloc.s    V_4
+      IL_0065:  stloc.s    V_8
+      IL_0067:  ldloc.s    V_6
       IL_0069:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_006e:  ldloc.s    V_5
+      IL_006e:  ldloc.s    V_7
       IL_0070:  ldfld      int32 EqualsOnUnions01/U/B::item
       IL_0075:  ceq
       IL_0077:  ret
@@ -812,11 +809,11 @@
       // Code size       121 (0x79)
       .maxstack  4
       .locals init (int32 V_0,
-               int32 V_1,
-               class EqualsOnUnions01/U/B V_2,
-               class EqualsOnUnions01/U/B V_3,
-               class EqualsOnUnions01/U V_4,
-               class EqualsOnUnions01/U V_5)
+               class EqualsOnUnions01/U V_1,
+               int32 V_2,
+               class EqualsOnUnions01/U V_3,
+               class EqualsOnUnions01/U/B V_4,
+               class EqualsOnUnions01/U/B V_5)
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldnull
@@ -837,52 +834,52 @@
       IL_0016:  br.s       IL_006f
 
       IL_0018:  ldarg.0
-      IL_0019:  stloc.s    V_4
-      IL_001b:  ldloc.s    V_4
-      IL_001d:  isinst     EqualsOnUnions01/U/B
-      IL_0022:  brfalse.s  IL_0027
+      IL_0019:  stloc.1
+      IL_001a:  ldloc.1
+      IL_001b:  isinst     EqualsOnUnions01/U/B
+      IL_0020:  brfalse.s  IL_0025
 
-      IL_0024:  ldc.i4.1
-      IL_0025:  br.s       IL_0028
+      IL_0022:  ldc.i4.1
+      IL_0023:  br.s       IL_0026
 
-      IL_0027:  ldc.i4.0
-      IL_0028:  stloc.0
-      IL_0029:  ldarg.1
-      IL_002a:  stloc.s    V_5
-      IL_002c:  ldloc.s    V_5
-      IL_002e:  isinst     EqualsOnUnions01/U/B
-      IL_0033:  brfalse.s  IL_0038
+      IL_0025:  ldc.i4.0
+      IL_0026:  stloc.0
+      IL_0027:  ldarg.1
+      IL_0028:  stloc.3
+      IL_0029:  ldloc.3
+      IL_002a:  isinst     EqualsOnUnions01/U/B
+      IL_002f:  brfalse.s  IL_0034
 
-      IL_0035:  ldc.i4.1
-      IL_0036:  br.s       IL_0039
+      IL_0031:  ldc.i4.1
+      IL_0032:  br.s       IL_0035
 
-      IL_0038:  ldc.i4.0
-      IL_0039:  stloc.1
-      IL_003a:  ldloc.0
-      IL_003b:  ldloc.1
-      IL_003c:  bne.un.s   IL_0040
+      IL_0034:  ldc.i4.0
+      IL_0035:  stloc.2
+      IL_0036:  ldloc.0
+      IL_0037:  ldloc.2
+      IL_0038:  bne.un.s   IL_003c
 
-      IL_003e:  br.s       IL_0042
+      IL_003a:  br.s       IL_003e
 
-      IL_0040:  br.s       IL_006d
+      IL_003c:  br.s       IL_006d
 
-      IL_0042:  ldarg.0
-      IL_0043:  isinst     EqualsOnUnions01/U/B
-      IL_0048:  brfalse.s  IL_004c
+      IL_003e:  ldarg.0
+      IL_003f:  isinst     EqualsOnUnions01/U/B
+      IL_0044:  brfalse.s  IL_0048
 
-      IL_004a:  br.s       IL_004e
+      IL_0046:  br.s       IL_004a
 
-      IL_004c:  br.s       IL_006b
+      IL_0048:  br.s       IL_006b
 
-      IL_004e:  ldarg.0
-      IL_004f:  castclass  EqualsOnUnions01/U/B
-      IL_0054:  stloc.2
-      IL_0055:  ldarg.1
-      IL_0056:  castclass  EqualsOnUnions01/U/B
-      IL_005b:  stloc.3
-      IL_005c:  ldloc.2
-      IL_005d:  ldfld      int32 EqualsOnUnions01/U/B::item
-      IL_0062:  ldloc.3
+      IL_004a:  ldarg.0
+      IL_004b:  castclass  EqualsOnUnions01/U/B
+      IL_0050:  stloc.s    V_4
+      IL_0052:  ldarg.1
+      IL_0053:  castclass  EqualsOnUnions01/U/B
+      IL_0058:  stloc.s    V_5
+      IL_005a:  ldloc.s    V_4
+      IL_005c:  ldfld      int32 EqualsOnUnions01/U/B::item
+      IL_0061:  ldloc.s    V_5
       IL_0063:  ldfld      int32 EqualsOnUnions01/U/B::item
       IL_0068:  ceq
       IL_006a:  ret

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/keep.lst
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/keep.lst
@@ -1,1 +1,1 @@
-Utils.dll
+*

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelModule.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelModule.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:9055
+  .ver 4:4:1:0
 }
 .assembly TopLevelModule
 {
@@ -29,22 +29,20 @@
 }
 .mresource public FSharpSignatureData.TopLevelModule
 {
-  // Offset: 0x00000000 Length: 0x0000114B
-  // WARNING: managed resource file FSharpSignatureData.TopLevelModule created
+  // Offset: 0x00000000 Length: 0x0000114D
 }
 .mresource public FSharpOptimizationData.TopLevelModule
 {
-  // Offset: 0x00001150 Length: 0x000003FD
-  // WARNING: managed resource file FSharpOptimizationData.TopLevelModule created
+  // Offset: 0x00001158 Length: 0x000003FD
 }
 .module TopLevelModule.dll
-// MVID: {570620A2-37F5-C118-A745-0383A2200657}
+// MVID: {57570CF0-37F5-C118-A745-0383F00C5757}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00AE0000
+// Image base: 0x01340000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -221,7 +219,7 @@
       // Code size       14 (0xe)
       .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 6,6 : 14,18 'c:\\KevinRansom\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SerializableAttribute\\ToplevelModule.fs'
+      .line 6,6 : 14,18 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SerializableAttribute\\ToplevelModule.fs'
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldarg.1
@@ -579,7 +577,7 @@
                                  valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
     {
       // Code size       9 (0x9)
-      .maxstack  10
+      .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
@@ -1377,7 +1375,7 @@
                                    valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
       {
         // Code size       9 (0x9)
-        .maxstack  10
+        .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldarg.1
         IL_0002:  ldarg.2

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelNamespace.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelNamespace.il.bsl
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:9055
+  .ver 4:4:1:0
 }
 .assembly ToplevelNamespace
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.ToplevelNamespace
 {
-  // Offset: 0x00000000 Length: 0x00001856
+  // Offset: 0x00000000 Length: 0x00001858
 }
 .mresource public FSharpOptimizationData.ToplevelNamespace
 {
   // Offset: 0x00001860 Length: 0x0000055C
 }
 .module ToplevelNamespace.dll
-// MVID: {5706E102-218B-729A-A745-038302E10657}
+// MVID: {57570CF5-218B-729A-A745-0383F50C5757}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02520000
+// Image base: 0x00820000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -214,7 +214,7 @@
     // Code size       14 (0xe)
     .maxstack  8
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 7,7 : 10,14 'd:\\KevinRansom\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SerializableAttribute\\ToplevelNamespace.fs'
+    .line 7,7 : 10,14 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SerializableAttribute\\ToplevelNamespace.fs'
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  ldarg.1
@@ -572,7 +572,7 @@
                                valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
   {
     // Code size       9 (0x9)
-    .maxstack  10
+    .maxstack  8
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
     IL_0002:  ldarg.2
@@ -1370,7 +1370,7 @@
                                  valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
     {
       // Code size       9 (0x9)
-      .maxstack  10
+      .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
@@ -2168,7 +2168,7 @@
                                    valuetype [mscorlib]System.Runtime.Serialization.StreamingContext context) cil managed
       {
         // Code size       9 (0x9)
-        .maxstack  10
+        .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldarg.1
         IL_0002:  ldarg.2

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SteppingMatch/SteppingMatch03.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SteppingMatch/SteppingMatch03.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.16774
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly SteppingMatch03
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.SteppingMatch03
 {
-  // Offset: 0x00000000 Length: 0x00000255
+  // Offset: 0x00000000 Length: 0x00000231
 }
 .mresource public FSharpOptimizationData.SteppingMatch03
 {
-  // Offset: 0x00000260 Length: 0x0000007A
+  // Offset: 0x00000238 Length: 0x0000007A
 }
 .module SteppingMatch03.dll
-// MVID: {4DAC14D0-4E87-D110-A745-0383D014AC4D}
+// MVID: {57570D0A-4E87-D110-A745-03830A0D5757}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000000000460000
+// Image base: 0x02A70000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -53,59 +53,59 @@
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .method public static void  funcC<a,b,c>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3<!!a,!!b,!!c> n) cil managed
   {
-    // Code size       84 (0x54)
+    // Code size       82 (0x52)
     .maxstack  3
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3<!!a,!!b,!!c> V_0,
-             [1] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c> V_1,
-             [2] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c> V_2,
-             [3] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c> V_3,
-             [4] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3<!!a,!!b,!!c> V_4)
+             [1] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3<!!a,!!b,!!c> V_1,
+             [2] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c> V_2,
+             [3] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c> V_3,
+             [4] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c> V_4)
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 5,5 : 9,21 
+    .line 5,5 : 9,21 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SteppingMatch\\SteppingMatch03.fs'
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  stloc.0
     IL_0003:  ldloc.0
-    IL_0004:  stloc.s    V_4
-    IL_0006:  ldloc.s    V_4
-    IL_0008:  isinst     class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c>
-    IL_000d:  brtrue.s   IL_001a
+    IL_0004:  stloc.1
+    IL_0005:  ldloc.1
+    IL_0006:  isinst     class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c>
+    IL_000b:  brtrue.s   IL_0017
 
-    IL_000f:  ldloc.s    V_4
-    IL_0011:  isinst     class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c>
-    IL_0016:  brtrue.s   IL_001c
+    IL_000d:  ldloc.1
+    IL_000e:  isinst     class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c>
+    IL_0013:  brtrue.s   IL_0019
 
-    IL_0018:  br.s       IL_001e
+    IL_0015:  br.s       IL_001b
 
-    IL_001a:  br.s       IL_0030
+    IL_0017:  br.s       IL_002d
 
-    IL_001c:  br.s       IL_0042
+    IL_0019:  br.s       IL_003f
 
-    IL_001e:  ldloc.0
-    IL_001f:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c>
-    IL_0024:  stloc.1
-    .line 7,7 : 13,35 
-    IL_0025:  ldstr      "A"
-    IL_002a:  call       void [mscorlib]System.Console::WriteLine(string)
-    IL_002f:  ret
+    IL_001b:  ldloc.0
+    IL_001c:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c>
+    IL_0021:  stloc.2
+    .line 7,7 : 13,35 ''
+    IL_0022:  ldstr      "A"
+    IL_0027:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_002c:  ret
 
-    .line 5,5 : 9,21 
-    IL_0030:  ldloc.0
-    IL_0031:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c>
-    IL_0036:  stloc.2
-    .line 9,9 : 13,35 
-    IL_0037:  ldstr      "B"
-    IL_003c:  call       void [mscorlib]System.Console::WriteLine(string)
-    IL_0041:  ret
+    .line 5,5 : 9,21 ''
+    IL_002d:  ldloc.0
+    IL_002e:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c>
+    IL_0033:  stloc.3
+    .line 9,9 : 13,35 ''
+    IL_0034:  ldstr      "B"
+    IL_0039:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_003e:  ret
 
-    .line 5,5 : 9,21 
-    IL_0042:  ldloc.0
-    IL_0043:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c>
-    IL_0048:  stloc.3
-    .line 11,11 : 13,35 
-    IL_0049:  ldstr      "C"
-    IL_004e:  call       void [mscorlib]System.Console::WriteLine(string)
-    IL_0053:  ret
+    .line 5,5 : 9,21 ''
+    IL_003f:  ldloc.0
+    IL_0040:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c>
+    IL_0045:  stloc.s    V_4
+    .line 11,11 : 13,35 ''
+    IL_0047:  ldstr      "C"
+    IL_004c:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0051:  ret
   } // end of method SteppingMatch03::funcC
 
 } // end of class SteppingMatch03

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SteppingMatch/SteppingMatch04.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SteppingMatch/SteppingMatch04.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.16774
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly SteppingMatch04
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.SteppingMatch04
 {
-  // Offset: 0x00000000 Length: 0x00000256
+  // Offset: 0x00000000 Length: 0x00000232
 }
 .mresource public FSharpOptimizationData.SteppingMatch04
 {
-  // Offset: 0x00000260 Length: 0x0000007B
+  // Offset: 0x00000238 Length: 0x0000007B
 }
 .module SteppingMatch04.dll
-// MVID: {4DAC14D2-6D4C-8357-A745-0383D214AC4D}
+// MVID: {57570D0D-6D4C-8357-A745-03830D0D5757}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000000000360000
+// Image base: 0x00E40000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -53,59 +53,59 @@
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .method public static void  funcC2<a,b,c>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3<!!a,!!b,!!c> n) cil managed
   {
-    // Code size       84 (0x54)
+    // Code size       82 (0x52)
     .maxstack  3
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3<!!a,!!b,!!c> V_0,
-             [1] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c> V_1,
-             [2] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c> V_2,
-             [3] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c> V_3,
-             [4] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3<!!a,!!b,!!c> V_4)
+             [1] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3<!!a,!!b,!!c> V_1,
+             [2] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c> V_2,
+             [3] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c> V_3,
+             [4] class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c> V_4)
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 5,5 : 9,21 
+    .line 5,5 : 9,21 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SteppingMatch\\SteppingMatch04.fs'
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  stloc.0
     IL_0003:  ldloc.0
-    IL_0004:  stloc.s    V_4
-    IL_0006:  ldloc.s    V_4
-    IL_0008:  isinst     class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c>
-    IL_000d:  brtrue.s   IL_001a
+    IL_0004:  stloc.1
+    IL_0005:  ldloc.1
+    IL_0006:  isinst     class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c>
+    IL_000b:  brtrue.s   IL_0017
 
-    IL_000f:  ldloc.s    V_4
-    IL_0011:  isinst     class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c>
-    IL_0016:  brtrue.s   IL_001c
+    IL_000d:  ldloc.1
+    IL_000e:  isinst     class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c>
+    IL_0013:  brtrue.s   IL_0019
 
-    IL_0018:  br.s       IL_001e
+    IL_0015:  br.s       IL_001b
 
-    IL_001a:  br.s       IL_0030
+    IL_0017:  br.s       IL_002d
 
-    IL_001c:  br.s       IL_0042
+    IL_0019:  br.s       IL_003f
 
-    IL_001e:  ldloc.0
-    IL_001f:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c>
-    IL_0024:  stloc.1
-    .line 7,7 : 13,35 
-    IL_0025:  ldstr      "B"
-    IL_002a:  call       void [mscorlib]System.Console::WriteLine(string)
-    IL_002f:  ret
+    IL_001b:  ldloc.0
+    IL_001c:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice2Of3<!!a,!!b,!!c>
+    IL_0021:  stloc.2
+    .line 7,7 : 13,35 ''
+    IL_0022:  ldstr      "B"
+    IL_0027:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_002c:  ret
 
-    .line 5,5 : 9,21 
-    IL_0030:  ldloc.0
-    IL_0031:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c>
-    IL_0036:  stloc.2
-    .line 9,9 : 13,35 
-    IL_0037:  ldstr      "C"
-    IL_003c:  call       void [mscorlib]System.Console::WriteLine(string)
-    IL_0041:  ret
+    .line 5,5 : 9,21 ''
+    IL_002d:  ldloc.0
+    IL_002e:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice3Of3<!!a,!!b,!!c>
+    IL_0033:  stloc.3
+    .line 9,9 : 13,35 ''
+    IL_0034:  ldstr      "C"
+    IL_0039:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_003e:  ret
 
-    .line 5,5 : 9,21 
-    IL_0042:  ldloc.0
-    IL_0043:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c>
-    IL_0048:  stloc.3
-    .line 11,11 : 13,35 
-    IL_0049:  ldstr      "A"
-    IL_004e:  call       void [mscorlib]System.Console::WriteLine(string)
-    IL_0053:  ret
+    .line 5,5 : 9,21 ''
+    IL_003f:  ldloc.0
+    IL_0040:  castclass  class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`3/Choice1Of3<!!a,!!b,!!c>
+    IL_0045:  stloc.s    V_4
+    .line 11,11 : 13,35 ''
+    IL_0047:  ldstr      "A"
+    IL_004c:  call       void [mscorlib]System.Console::WriteLine(string)
+    IL_0051:  ret
   } // end of method SteppingMatch04::funcC2
 
 } // end of class SteppingMatch04


### PR DESCRIPTION
This eliminates the "Union" rewrite phase and means IlxGen now directly generates IL.

This PR changes IL code generation and a bunch of baselines will need to be updated because the order in which locals are generated changes.  

Next? There is still a very awkward, expensive and complexifying code transformation done as part of IlxGen from 

    "list of instructions" --> "structured code" --> "list of instructions" 

which I believe can be eliminated next.

