### PR TITLE
ILX cleanup 7

### DIFF
--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -2,112 +2,48 @@
 
 module internal Microsoft.FSharp.Compiler.AbstractIL.Morphs 
 
+open System.Collections.Generic
 open Internal.Utilities
 open Microsoft.FSharp.Compiler.AbstractIL 
 open Microsoft.FSharp.Compiler.AbstractIL.Internal 
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library 
 open Microsoft.FSharp.Compiler.AbstractIL.Diagnostics 
-open Microsoft.FSharp.Compiler.AbstractIL.Extensions.ILX.Types 
 open Microsoft.FSharp.Compiler.AbstractIL.IL 
-
-type 'T morph = 'T -> 'T
-
-type EnclosingTypeDefs = ILTypeDef list * ILTypeDef
-
-let checking = false 
-let notlazy v = Lazy.CreateFromValue v
 
 let mutable morphCustomAttributeData = false
 
-let enablemorphCustomAttributeData() = 
+let enableMorphCustomAttributeData() = 
     morphCustomAttributeData <- true
 
-let disablemorphCustomAttributeData() =
+let disableMorphCustomAttributeData() =
     morphCustomAttributeData <- false
 
-let mdef_code2code f md  =
-    let code = 
-        match md.mdBody.Contents with 
-        | MethodBody.IL il-> il 
-        | _ -> failwith "mdef_code2code - method not IL"  
-    let code' = MethodBody.IL {code with Code = f code.Code} 
-    {md with mdBody=  mkMethBodyAux code'}  
+let code_instr2instr f (code: ILCode) = {code with Instrs= Array.map f code.Instrs}
 
-let code_block2block f (c:ILCode) = checkILCode (f c)
-
-let bblock_instr2instr f bb = 
-    let instrs = bb.Instructions 
-    let len = Array.length instrs 
-    let res = Array.zeroCreate len 
-    for i = 0 to len - 1 do 
-        res.[i] <- f instrs.[i]
-    {bb with Instructions=res}
-
-// This is quite performance critical 
-let bblock_instr2instrs f bb = 
-    let instrs = bb.Instructions 
-    let mutable codebuf = Array.zeroCreate (Array.length instrs) 
-    let mutable codebuf_size = 0 
+let code_instr2instrs f (code: ILCode) = 
+    let instrs = code.Instrs
+    let codebuf = ResizeArray()
+    let adjust = Dictionary()
+    let mutable old = 0
+    let mutable nw = 0
     for instr in instrs do 
+        adjust.[old] <- nw
         let instrs : list<_> = f instr
         for instr2 in instrs do
-            let sz = codebuf_size 
-            let old_buf_size = Array.length codebuf 
-            let new_size = sz + 1
-            if new_size > old_buf_size then
-              let old = codebuf 
-              let new' = Array.zeroCreate (max new_size (old_buf_size * 4)) 
-              Array.blit old 0 new' 0 sz
-              codebuf <- new'
-              
-            codebuf.[sz] <- instr2
-            codebuf_size <- codebuf_size + 1 
-          
-    {bb with Instructions = Array.sub codebuf 0 codebuf_size}
+            codebuf.Add instr2
+            nw <- nw + 1
+        old <- old + 1
+    adjust.[old] <- nw          
+    { code with 
+         Instrs = codebuf.ToArray()
+         Labels = Dictionary.ofList [ for kvp in code.Labels -> kvp.Key, adjust.[kvp.Value] ] }
 
-let rec block_bblock2code_typ2typ ((fbb,fty) as f) x =
-    match x with
-    | ILBasicBlock bblock -> fbb bblock
-    | GroupBlock (locs,l) -> GroupBlock(locs,List.map (code_bblock2code_typ2typ f) l)
-    | TryBlock (tryb,seh) ->
-        let seh = 
-            match seh with 
-            | FaultBlock b -> FaultBlock (code_bblock2code_typ2typ f  b)
-            | FinallyBlock b -> FinallyBlock (code_bblock2code_typ2typ f  b)
-            | FilterCatchBlock clsl -> 
-                FilterCatchBlock 
-                  (List.map (fun (flt,ctch) -> 
-                    (match flt with 
-                      CodeFilter fltcode -> CodeFilter (code_bblock2code_typ2typ f fltcode)
-                    | TypeFilter ty -> TypeFilter (fty ty)), 
-                    code_bblock2code_typ2typ f ctch) clsl)
-        TryBlock (code_bblock2code_typ2typ f tryb,seh)
-    | RestrictBlock (ls,c) -> RestrictBlock (ls,code_bblock2code_typ2typ f c)
 
-and code_bblock2code_typ2typ f (c:ILCode) = checkILCode (block_bblock2code_typ2typ f c)
-let topcode_bblock2code_typ2typ f (c:ILCode) = code_bblock2code_typ2typ f c
 
-let rec block_bblock2code f x =
-    match x with
-    | ILBasicBlock bblock -> f bblock
-    | GroupBlock (locs,l) -> GroupBlock(locs,List.map (code_bblock2code f) l)
-    | TryBlock (tryb,seh) ->
-        TryBlock (code_bblock2code f tryb,
-                  begin match seh with 
-                  | FaultBlock b -> FaultBlock (code_bblock2code f  b)
-                  | FinallyBlock b -> FinallyBlock (code_bblock2code f  b)
-                  | FilterCatchBlock clsl -> 
-                      FilterCatchBlock 
-                        (List.map (fun (flt,ctch) -> 
-                          (match flt with 
-                           |CodeFilter fltcode -> CodeFilter (code_bblock2code f fltcode)
-                           | TypeFilter _ty -> flt), 
-                          code_bblock2code f ctch) clsl)
-                  end)
-    | RestrictBlock (ls,c) -> RestrictBlock (ls,code_bblock2code f c)
-
-and code_bblock2code f (c:ILCode) = checkILCode (block_bblock2code f c)
-let topcode_bblock2code f (c:ILCode) = code_bblock2code f c
+let code_instr2instr_typ2typ  (finstr,fty) (c:ILCode) = 
+    let c = code_instr2instr finstr c
+    { c with 
+           Exceptions = c.Exceptions |> List.map (fun e -> { e with Clause = e.Clause |> (function ILExceptionClause.TypeCatch (ilty, b) -> ILExceptionClause.TypeCatch (fty ilty, b) | cl -> cl) }) } 
 
 // --------------------------------------------------------------------
 // Standard morphisms - mapping types etc.
@@ -171,10 +107,10 @@ let mref_typ2typ (f: ILType -> ILType) (x:ILMethodRef) =
                        returnType= f x.ReturnType)
 
 
-type formal_scopeCtxt =  Choice<ILMethodSpec, ILFieldSpec, IlxUnionSpec>
+type formal_scopeCtxt =  Choice<ILMethodSpec, ILFieldSpec>
 
 let mspec_typ2typ (((factualty : ILType -> ILType) , (fformalty: formal_scopeCtxt -> ILType -> ILType))) (x: ILMethodSpec) = 
-    mkILMethSpecForMethRefInTyRaw(mref_typ2typ (fformalty (Choice1Of3 x)) x.MethodRef,
+    mkILMethSpecForMethRefInTyRaw(mref_typ2typ (fformalty (Choice1Of2 x)) x.MethodRef,
                                   factualty x.EnclosingType, 
                                   typs_typ2typ factualty  x.GenericArgs)
 
@@ -183,7 +119,7 @@ let fref_typ2typ (f: ILType -> ILType) x =
              Type= f x.Type }
 
 let fspec_typ2typ ((factualty,(fformalty : formal_scopeCtxt -> ILType -> ILType))) x = 
-    { FieldRef=fref_typ2typ (fformalty (Choice2Of3 x)) x.FieldRef;
+    { FieldRef=fref_typ2typ (fformalty (Choice2Of2 x)) x.FieldRef;
       EnclosingType= factualty x.EnclosingType }
 
 let rec celem_typ2typ f celem =
@@ -217,18 +153,8 @@ let cattrs_typ2typ ilg f (cs: ILAttributes) =
 let fdef_typ2typ ilg ftype (fd: ILFieldDef) = 
     {fd with Type=ftype fd.Type; 
              CustomAttrs=cattrs_typ2typ ilg ftype fd.CustomAttrs}
-let altfdef_typ2typ ilg ftype (fd: IlxUnionField) = 
-    IlxUnionField( fdef_typ2typ ilg ftype fd.ILField)
-
-let alts_typ2typ ilg f alts = 
-  Array.map (fun alt -> { alt with altFields = Array.map (altfdef_typ2typ ilg f)  alt.altFields;
-                                   altCustomAttrs = cattrs_typ2typ ilg f alt.altCustomAttrs }) alts
-
-let curef_typ2typ ilg f (IlxUnionRef(s,alts,nullPermitted,helpers)) =
-  IlxUnionRef(s,alts_typ2typ ilg f alts,nullPermitted,helpers)
 
 let local_typ2typ f (l: ILLocal) = {l with Type = f l.Type}
-let freevar_typ2typ f l = {l with fvType = f l.fvType}
 let varargs_typ2typ f (varargs: ILVarArgs) = Option.map (ILList.map f) varargs
 (* REVIEW: convert varargs *)
 let morphILTypesInILInstr ((factualty,fformalty)) i = 
@@ -280,13 +206,11 @@ let fdefs_fdef2fdef f (m:ILFieldDefs) = mkILFields (List.map f m.AsList)
 let morphILTypeDefs f (m: ILTypeDefs) = mkILTypeDefsFromArray (Array.map f m.AsArray)
 
 let locals_typ2typ f ls = ILList.map (local_typ2typ f) ls
-let freevars_typ2typ f ls = Array.map (freevar_typ2typ f) ls
 
-let ilmbody_bblock2code_typ2typ_maxstack2maxstack fs il = 
-    let (finstr,ftype,fmaxstack) = fs 
-    {il with Code=topcode_bblock2code_typ2typ (finstr,ftype) il.Code;
-             Locals = locals_typ2typ ftype il.Locals;
-             MaxStack = fmaxstack il.MaxStack }
+let ilmbody_instr2instr_typ2typ fs (il: ILMethodBody) = 
+    let (finstr,ftype) = fs 
+    {il with Code=code_instr2instr_typ2typ (finstr,ftype) il.Code;
+             Locals = locals_typ2typ ftype il.Locals }
 
 let morphILMethodBody (filmbody) (x: ILLazyMethodBody) = 
     let c = 
@@ -311,9 +235,6 @@ let mdef_typ2typ_ilmbody2ilmbody ilg fs md  =
 let fdefs_typ2typ ilg f x = fdefs_fdef2fdef (fdef_typ2typ ilg f) x
 
 let mdefs_typ2typ_ilmbody2ilmbody ilg fs x = morphILMethodDefs (mdef_typ2typ_ilmbody2ilmbody ilg fs) x
-
-let cuinfo_typ2typ ilg ftype cud = 
-    { cud with cudAlternatives = alts_typ2typ ilg ftype cud.cudAlternatives; } 
 
 let mimpl_typ2typ f e =
     { Overrides = ospec_typ2typ f e.Overrides;
@@ -368,31 +289,24 @@ and tdefs_typ2typ_ilmbody2ilmbody_mdefs2mdefs ilg enc fs tdefs =
 let manifest_typ2typ ilg f (m : ILAssemblyManifest) =
     { m with CustomAttrs = cattrs_typ2typ ilg f m.CustomAttrs }
 
-let morphILTypeInILModule_ilmbody2ilmbody_mdefs2mdefs ilg
-    ((ftype: ILModuleDef -> (ILTypeDef list * ILTypeDef) option -> ILMethodDef option -> ILType -> ILType),
-     fmdefs) m = 
+let morphILTypeInILModule_ilmbody2ilmbody_mdefs2mdefs ilg ((ftype: ILModuleDef -> (ILTypeDef list * ILTypeDef) option -> ILMethodDef option -> ILType -> ILType),fmdefs) m = 
 
-    let ftdefs = 
-      tdefs_typ2typ_ilmbody2ilmbody_mdefs2mdefs ilg []
-        (ftype m,
-         fmdefs m) 
+    let ftdefs = tdefs_typ2typ_ilmbody2ilmbody_mdefs2mdefs ilg [] (ftype m,fmdefs m) 
 
     { m with TypeDefs=ftdefs m.TypeDefs;
              CustomAttrs=cattrs_typ2typ ilg (ftype m None None) m.CustomAttrs;
              Manifest=Option.map (manifest_typ2typ ilg (ftype m None None)) m.Manifest  }
     
-let module_bblock2code_typ2typ_maxstack2maxstack ilg fs x = 
-    let (fbblock,ftype,fmaxstack) = fs 
-    let filmbody modCtxt tdefCtxt mdefCtxt = ilmbody_bblock2code_typ2typ_maxstack2maxstack (fbblock modCtxt tdefCtxt mdefCtxt, ftype modCtxt (Some tdefCtxt) mdefCtxt, fmaxstack modCtxt tdefCtxt mdefCtxt) 
+let module_instr2instr_typ2typ ilg fs x = 
+    let (fcode,ftype) = fs 
+    let filmbody modCtxt tdefCtxt mdefCtxt = ilmbody_instr2instr_typ2typ (fcode modCtxt tdefCtxt mdefCtxt, ftype modCtxt (Some tdefCtxt) mdefCtxt) 
     let fmdefs modCtxt tdefCtxt = mdefs_typ2typ_ilmbody2ilmbody ilg (ftype modCtxt (Some tdefCtxt), filmbody modCtxt tdefCtxt) 
     morphILTypeInILModule_ilmbody2ilmbody_mdefs2mdefs ilg (ftype, fmdefs) x 
 
-let module_bblock2code_typ2typ ilg (f1,f2) x = 
-  module_bblock2code_typ2typ_maxstack2maxstack ilg (f1, f2, (fun _modCtxt _tdefCtxt _mdefCtxt x -> x)) x
 let morphILInstrsAndILTypesInILModule ilg (f1,f2) x = 
-  module_bblock2code_typ2typ ilg ((fun modCtxt tdefCtxt mdefCtxt  i -> mkBasicBlock (bblock_instr2instr (f1 modCtxt tdefCtxt mdefCtxt) i)), f2) x
+  module_instr2instr_typ2typ ilg (f1, f2) x
 
-let morphILInstrsInILCode f x = topcode_bblock2code (fun i -> mkBasicBlock (bblock_instr2instrs f i)) x
+let morphILInstrsInILCode f x = code_instr2instrs f x
 
 let morphILTypeInILModule ilg ftype y = 
     let finstr modCtxt tdefCtxt mdefCtxt =

--- a/src/absil/ilmorph.fsi
+++ b/src/absil/ilmorph.fsi
@@ -21,5 +21,5 @@ val morphILScopeRefsInILModuleMemoized: ILGlobals -> (ILScopeRef -> ILScopeRef) 
 
 val morphILInstrsInILCode: (ILInstr -> ILInstr list) -> ILCode -> ILCode
 
-val enablemorphCustomAttributeData : unit -> unit
-val disablemorphCustomAttributeData : unit -> unit
+val enableMorphCustomAttributeData : unit -> unit
+val disableMorphCustomAttributeData : unit -> unit

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -483,10 +483,10 @@ type ILInstrDecoder =
     | I_method_instr of (ILInstrPrefixesRegister -> ILMethodSpec * ILVarArgs -> ILInstr)
     | I_unconditional_i32_instr of (ILInstrPrefixesRegister -> ILCodeLabel  -> ILInstr)
     | I_unconditional_i8_instr of (ILInstrPrefixesRegister -> ILCodeLabel  -> ILInstr)
-    | I_conditional_i32_instr of (ILInstrPrefixesRegister -> ILCodeLabel * ILCodeLabel -> ILInstr)
-    | I_conditional_i8_instr of (ILInstrPrefixesRegister -> ILCodeLabel * ILCodeLabel -> ILInstr)
+    | I_conditional_i32_instr of (ILInstrPrefixesRegister -> ILCodeLabel -> ILInstr)
+    | I_conditional_i8_instr of (ILInstrPrefixesRegister -> ILCodeLabel -> ILInstr)
     | I_string_instr of (ILInstrPrefixesRegister -> string -> ILInstr)
-    | I_switch_instr of (ILInstrPrefixesRegister -> ILCodeLabel list * ILCodeLabel -> ILInstr)
+    | I_switch_instr of (ILInstrPrefixesRegister -> ILCodeLabel list -> ILInstr)
     | I_tok_instr of (ILInstrPrefixesRegister -> ILToken -> ILInstr)
     | I_sig_instr of (ILInstrPrefixesRegister -> ILCallingSignature * ILVarArgs -> ILInstr)
     | I_type_instr of (ILInstrPrefixesRegister -> ILType -> ILInstr)
@@ -549,30 +549,30 @@ let instrs () =
    i_br_s, I_unconditional_i8_instr (noPrefixes I_br); 
    i_leave, I_unconditional_i32_instr (noPrefixes (fun x -> I_leave x));
    i_br, I_unconditional_i32_instr (noPrefixes I_br); 
-   i_brtrue_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_brtrue,x,y)));
-   i_brfalse_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_brfalse,x,y)));
-   i_beq_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_beq,x,y)));
-   i_blt_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_blt,x,y)));
-   i_blt_un_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_blt_un,x,y)));
-   i_ble_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_ble,x,y)));
-   i_ble_un_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_ble_un,x,y)));
-   i_bgt_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bgt,x,y)));
-   i_bgt_un_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bgt_un,x,y)));
-   i_bge_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bge,x,y)));
-   i_bge_un_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bge_un,x,y)));
-   i_bne_un_s, I_conditional_i8_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bne_un,x,y)));   
-   i_brtrue, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_brtrue,x,y)));
-   i_brfalse, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_brfalse,x,y)));
-   i_beq, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_beq,x,y)));
-   i_blt, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_blt,x,y)));
-   i_blt_un, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_blt_un,x,y)));
-   i_ble, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_ble,x,y)));
-   i_ble_un, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_ble_un,x,y)));
-   i_bgt, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bgt,x,y)));
-   i_bgt_un, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bgt_un,x,y)));
-   i_bge, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bge,x,y)));
-   i_bge_un, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bge_un,x,y)));
-   i_bne_un, I_conditional_i32_instr (noPrefixes (fun (x,y) -> I_brcmp (BI_bne_un,x,y))); 
+   i_brtrue_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_brtrue,x)));
+   i_brfalse_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_brfalse,x)));
+   i_beq_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_beq,x)));
+   i_blt_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_blt,x)));
+   i_blt_un_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_blt_un,x)));
+   i_ble_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_ble,x)));
+   i_ble_un_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_ble_un,x)));
+   i_bgt_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_bgt,x)));
+   i_bgt_un_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_bgt_un,x)));
+   i_bge_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_bge,x)));
+   i_bge_un_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_bge_un,x)));
+   i_bne_un_s, I_conditional_i8_instr (noPrefixes (fun x -> I_brcmp (BI_bne_un,x)));   
+   i_brtrue, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_brtrue,x)));
+   i_brfalse, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_brfalse,x)));
+   i_beq, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_beq,x)));
+   i_blt, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_blt,x)));
+   i_blt_un, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_blt_un,x)));
+   i_ble, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_ble,x)));
+   i_ble_un, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_ble_un,x)));
+   i_bgt, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_bgt,x)));
+   i_bgt_un, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_bgt_un,x)));
+   i_bge, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_bge,x)));
+   i_bge_un, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_bge_un,x)));
+   i_bne_un, I_conditional_i32_instr (noPrefixes (fun x -> I_brcmp (BI_bne_un,x))); 
    i_ldstr, I_string_instr (noPrefixes I_ldstr); 
    i_switch, I_switch_instr (noPrefixes I_switch);
    i_ldtoken, I_tok_instr (noPrefixes I_ldtoken);
@@ -2090,9 +2090,8 @@ and sigptrGetLocal ctxt numtypars bytes sigptr =
         else 
             false, sigptr
     let typ, sigptr = sigptrGetTy ctxt numtypars bytes sigptr
-    { IsPinned = pinned;
-      Type = typ;
-      DebugInfo = None }, sigptr
+    let loc : ILLocal = { IsPinned = pinned; Type = typ; DebugInfo = None }
+    loc, sigptr
          
 and readBlobHeapAsMethodSig ctxt numtypars blobIdx  =
     ctxt.readBlobHeapAsMethodSig (BlobAsMethodSigIdx (numtypars,blobIdx))
@@ -2362,7 +2361,7 @@ and seekReadMethod ctxt numtypars (idx:int) =
      
 and seekReadParams ctxt (retty,argtys) pidx1 pidx2 =
     let retRes : ILReturn ref =  ref { Marshal=None; Type=retty; CustomAttrs=emptyILCustomAttrs }
-    let paramsRes = 
+    let paramsRes : ILParameter [] = 
         argtys 
         |> ILList.toArray 
         |> Array.map (fun ty ->  
@@ -2803,14 +2802,12 @@ and seekReadTopCode ctxt numtypars (sz:int) start seqpoints =
              let offsDest =  (seekReadInt32 ctxt.is (start + (!curr)))
              curr := !curr + 4;
              let dest = !curr + offsDest
-             let next = !curr
-             f prefixes (rawToLabel dest, rawToLabel next)
+             f prefixes (rawToLabel dest)
          | I_conditional_i8_instr f ->
              let offsDest = int (seekReadSByte ctxt.is (start + (!curr)))
              curr := !curr + 1;
              let dest = !curr + offsDest
-             let next = !curr
-             f prefixes (rawToLabel dest, rawToLabel next)
+             f prefixes (rawToLabel dest)
          | I_unconditional_i32_instr f ->
              let offsDest =  (seekReadInt32 ctxt.is (start + (!curr)))
              curr := !curr + 4;
@@ -2852,18 +2849,13 @@ and seekReadTopCode ctxt numtypars (sz:int) start seqpoints =
                    curr := !curr + 4; 
                    i) 
              let dests = List.map (fun offs -> rawToLabel (!curr + offs)) offsets
-             let next = rawToLabel !curr
-             f prefixes (dests,next)
+             f prefixes dests
        ibuf.Add instr
    done;
    // Finished reading instructions - mark the end of the instruction stream in case the PDB information refers to it. 
    markAsInstructionStart !curr ibuf.Count;
    // Build the function that maps from raw labels (offsets into the bytecode stream) to indexes in the AbsIL instruction stream 
-   let lab2pc lab = 
-       try
-          ilOffsetsOfLabels.[lab]
-       with :? KeyNotFoundException-> 
-          failwith ("branch destination "+formatCodeLabel lab+" not found in code")
+   let lab2pc = ilOffsetsOfLabels
 
    // Some offsets used in debug info refer to the end of an instruction, rather than the 
    // start of the subsequent instruction.  But all labels refer to instruction starts, 
@@ -2933,7 +2925,7 @@ and seekReadMethodRVA ctxt (idx,nm,_internalcall,noinline,numtypars) rva =
                          |> List.filter (fun l -> 
                              let k,_idx = pdbVariableGetAddressAttributes l
                              k = 1 (* ADDR_IL_OFFSET *)) 
-                       let ilinfos =
+                       let ilinfos : ILLocalDebugMapping list =
                          ilvs |> List.map (fun ilv -> 
                              let _k,idx = pdbVariableGetAddressAttributes ilv
                              let n = pdbVariableGetName ilv
@@ -2942,9 +2934,8 @@ and seekReadMethodRVA ctxt (idx,nm,_internalcall,noinline,numtypars) rva =
                            
                        let thisOne = 
                          (fun raw2nextLab ->
-                           { locRange= (raw2nextLab a,raw2nextLab b); 
-                             locInfos = ilinfos })
-                       //  this scope covers IL range: "+string a+"-"+string b)
+                           { Range= (raw2nextLab a,raw2nextLab b); 
+                             DebugMappings = ilinfos } : ILLocalDebugInfo )
                        let others = List.foldBack (scopes >> (@)) (Array.toList (pdbScopeGetChildren scp)) []
                        thisOne :: others
                  let localPdbInfos = [] (* <REVIEW> scopes fail for mscorlib </REVIEW> scopes rootScope  *)
@@ -2965,7 +2956,7 @@ and seekReadMethodRVA ctxt (idx,nm,_internalcall,noinline,numtypars) rva =
            let instrs,_,lab2pc,raw2nextLab = seekReadTopCode ctxt numtypars codeSize codeBase seqpoints
            (* Convert the linear code format to the nested code format *)
            let localPdbInfos2 = List.map (fun f -> f raw2nextLab) localPdbInfos
-           let code = checkILCode (buildILCode nm lab2pc instrs [] localPdbInfos2)
+           let code = buildILCode nm lab2pc instrs [] localPdbInfos2
            MethodBody.IL
              { IsZeroInit=false;
                MaxStack= 8;
@@ -3079,7 +3070,7 @@ and seekReadMethodRVA ctxt (idx,nm,_internalcall,noinline,numtypars) rva =
                     else 
                         sehMap.[key] <- [clause])
                   clauses;
-                Seq.fold  (fun acc (KeyValue(key,bs)) -> {exnRange=key; exnClauses=bs} :: acc)  [] sehMap
+                ([],sehMap) ||> Seq.fold  (fun acc (KeyValue(key,bs)) -> [ for b in bs -> {Range=key; Clause=b} : ILExceptionSpec ] @ acc)  
              seh := sehClauses;
              moreSections := (sectionFlag &&& e_CorILMethod_Sect_MoreSects) <> 0x0uy;
              nextSectionBase := sectionBase + sectionSize;
@@ -3089,7 +3080,7 @@ and seekReadMethodRVA ctxt (idx,nm,_internalcall,noinline,numtypars) rva =
            if logging then dprintn ("doing localPdbInfos2"); 
            let localPdbInfos2 = List.map (fun f -> f raw2nextLab) localPdbInfos
            if logging then dprintn ("done localPdbInfos2, checking code..."); 
-           let code = checkILCode (buildILCode nm lab2pc instrs !seh localPdbInfos2)
+           let code = buildILCode nm lab2pc instrs !seh localPdbInfos2
            if logging then dprintn ("done checking code."); 
            MethodBody.IL
              { IsZeroInit=initlocals;

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -79,7 +79,7 @@ type System.Reflection.Emit.ModuleBuilder with
 #else
     member modB.DefineDocumentAndLog(file,lang,vendor,doctype) =
         let symDoc = modB.DefineDocument(file,lang,vendor,doctype)
-        if logRefEmitCalls then printfn "let docWriter%d = moduleBuilder%d.DefineDocument(%A,System.Guid(\"%A\"),System.Guid(\"%A\"),System.Guid(\"%A\"))" (abs <| hash symDoc)  (abs <| hash modB) file lang vendor doctype
+        if logRefEmitCalls then printfn "let docWriter%d = moduleBuilder%d.DefineDocument(@%A,System.Guid(\"%A\"),System.Guid(\"%A\"),System.Guid(\"%A\"))" (abs <| hash symDoc)  (abs <| hash modB) file lang vendor doctype
         symDoc
 #endif
     member modB.GetTypeAndLog(nameInModule,flag1,flag2) =
@@ -170,19 +170,20 @@ type System.Reflection.Emit.TypeBuilder with
 
     member typB.DefineConstructorAndLog(attrs,cconv,parms) = 
         let consB = typB.DefineConstructor(attrs,cconv,parms)
-        if logRefEmitCalls then printfn "let constructorBuilder%d = typeBuilder%d.DefineConstructor(enum %d,%A,%A)" (abs <| hash consB) (abs <| hash typB) (LanguagePrimitives.EnumToValue attrs) cconv parms
+        if logRefEmitCalls then printfn "let constructorBuilder%d = typeBuilder%d.DefineConstructor(enum %d,CallingConventions.%A,%A)" (abs <| hash consB) (abs <| hash typB) (LanguagePrimitives.EnumToValue attrs) cconv parms
         consB
 
     member typB.DefineFieldAndLog(nm,ty:System.Type,attrs) = 
-        if logRefEmitCalls then printfn "typeBuilder%d.DefineField(\"%s\",typeof<%s>,enum %d)" (abs <| hash typB) nm ty.FullName (LanguagePrimitives.EnumToValue attrs)
-        typB.DefineField(nm,ty,attrs)
+        let fieldB = typB.DefineField(nm,ty,attrs)
+        if logRefEmitCalls then printfn "let fieldBuilder%d = typeBuilder%d.DefineField(\"%s\",typeof<%s>,enum %d)" (abs <| hash fieldB) (abs <| hash typB) nm ty.FullName (LanguagePrimitives.EnumToValue attrs)
+        fieldB
 
-    member typB.DefinePropertyAndLog(nm,attrs,ty,args) = 
-        if logRefEmitCalls then printfn "typeBuilder%d.DefineProperty(\"%A\",enum %d,%A,%A)" (abs <| hash typB) nm (LanguagePrimitives.EnumToValue attrs) ty args
+    member typB.DefinePropertyAndLog(nm,attrs,ty:System.Type,args) = 
+        if logRefEmitCalls then printfn "typeBuilder%d.DefineProperty(\"%A\",enum %d,typeof<%s>,%A)" (abs <| hash typB) nm (LanguagePrimitives.EnumToValue attrs) ty.FullName args
         typB.DefineProperty(nm,attrs,ty,args)
 
-    member typB.DefineEventAndLog(nm,attrs,ty) = 
-        if logRefEmitCalls then printfn "typeBuilder%d.DefineEvent(\"%A\",enum %d,%A)" (abs <| hash typB) nm (LanguagePrimitives.EnumToValue attrs) ty
+    member typB.DefineEventAndLog(nm,attrs,ty:System.Type) = 
+        if logRefEmitCalls then printfn "typeBuilder%d.DefineEvent(\"%A\",enum %d,typeof<%A>)" (abs <| hash typB) nm (LanguagePrimitives.EnumToValue attrs) ty.FullName
         typB.DefineEvent(nm,attrs,ty)
 
     member typB.SetParentAndLog(ty:System.Type) = 
@@ -271,16 +272,16 @@ type System.Reflection.Emit.ILGenerator with
         if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s, %d)" (abs <| hash x) op.RefEmitName v; 
         x.Emit(op,v)
     member x.EmitAndLog (op:OpCode,v:MethodInfo) = 
-        if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s, meth_%s)" (abs <| hash x) op.RefEmitName v.Name; 
+        if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s, methodBuilder%d) // method %s" (abs <| hash x) op.RefEmitName (abs <| hash v) v.Name; 
         x.Emit(op,v)
     member x.EmitAndLog (op:OpCode,v:string) = 
-        if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s,\"%s\")" (abs <| hash x) op.RefEmitName v; 
+        if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s,\"@%s\")" (abs <| hash x) op.RefEmitName v; 
         x.Emit(op,v)
     member x.EmitAndLog (op:OpCode,v:Type) = 
         if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s, typeof<%s>)" (abs <| hash x) op.RefEmitName v.FullName; 
         x.Emit(op,v)
     member x.EmitAndLog (op:OpCode,v:FieldInfo) = 
-        if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s, field_%s)" (abs <| hash x) op.RefEmitName v.Name; 
+        if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s, fieldBuilder%d) // field %s" (abs <| hash x) op.RefEmitName (abs <| hash v) v.Name; 
         x.Emit(op,v)
     member x.EmitAndLog (op:OpCode,v:ConstructorInfo) = 
         if logRefEmitCalls then printfn "ilg%d.Emit(OpCodes.%s,constructor_%s)" (abs <| hash x) op.RefEmitName v.DeclaringType.Name; 
@@ -803,19 +804,13 @@ let convConstructorSpec cenv emEnv (mspec:ILMethodSpec) =
             queryableTypeGetConstructor cenv emEnv parentTI mref 
 
 //----------------------------------------------------------------------------
-// emitLabelMark, defineLabel
+// emitLabelMark
 //----------------------------------------------------------------------------
 
 let emitLabelMark emEnv (ilG:ILGenerator) (label:ILCodeLabel) =
     let lab = envGetLabel emEnv label
     ilG.MarkLabelAndLog(lab)
     
-
-let defineLabel (ilG:ILGenerator) emEnv (label:ILCodeLabel) =
-    let lab = ilG.DefineLabelAndLog()
-    envSetLabel emEnv label lab
-
-
 //----------------------------------------------------------------------------
 // emitInstr cenv - I_arith
 //----------------------------------------------------------------------------
@@ -1033,10 +1028,10 @@ let rec emitInstr cenv (modB : ModuleBuilder) emEnv (ilG:ILGenerator) instr =
                                       | DT_U8  -> ilG.EmitAndLog(OpCodes.Stind_I8)   // NOTE: unsigned -> int conversion
                                       | DT_REF -> ilG.EmitAndLog(OpCodes.Stind_Ref)) 
     | I_stloc  u16                -> ilG.EmitAndLog(OpCodes.Stloc,int16 u16)
-    | I_br  _                 -> () 
+    | I_br  targ                  -> ilG.EmitAndLog(OpCodes.Br,envGetLabel emEnv targ)
     | I_jmp mspec                 -> ilG.EmitAndLog(OpCodes.Jmp,convMethodSpec cenv emEnv mspec)
-    | I_brcmp (comp,targ,_)    -> emitInstrCompare emEnv ilG comp targ 
-    | I_switch (labels,_)      -> ilG.Emit(OpCodes.Switch,Array.ofList (List.map (envGetLabel emEnv) labels));
+    | I_brcmp (comp,targ)    -> emitInstrCompare emEnv ilG comp targ 
+    | I_switch labels      -> ilG.Emit(OpCodes.Switch,Array.ofList (List.map (envGetLabel emEnv) labels));
     | I_ret                       -> ilG.EmitAndLog(OpCodes.Ret)
     | I_call           (tail,mspec,varargs)   -> emitSilverlightCheck ilG
                                                  emitInstrCall cenv emEnv ilG OpCodes.Call     tail mspec varargs
@@ -1059,14 +1054,14 @@ let rec emitInstr cenv (modB : ModuleBuilder) emEnv (ilG:ILGenerator) instr =
     | I_ldftn mspec                           -> ilG.EmitAndLog(OpCodes.Ldftn,convMethodSpec cenv emEnv mspec)
     | I_newobj (mspec,varargs)                -> emitInstrNewobj cenv emEnv ilG mspec varargs
     | I_throw                        -> ilG.EmitAndLog(OpCodes.Throw)
-    | I_endfinally                   -> ilG.EmitAndLog(OpCodes.Endfinally) (* capitalization! *)
-    | I_endfilter                    -> () (* ilG.EmitAndLog(OpCodes.Endfilter) *)
+    | I_endfinally                   -> ilG.EmitAndLog(OpCodes.Endfinally)
+    | I_endfilter                    -> ilG.EmitAndLog(OpCodes.Endfilter) 
     | I_leave label                  -> ilG.EmitAndLog(OpCodes.Leave,envGetLabel emEnv label)
-    | I_ldsfld (vol,fspec)           ->                           emitInstrVolatile ilG vol; ilG.EmitAndLog(OpCodes.Ldsfld ,convFieldSpec cenv emEnv fspec)
+    | I_ldsfld (vol,fspec)           -> emitInstrVolatile ilG vol; ilG.EmitAndLog(OpCodes.Ldsfld ,convFieldSpec cenv emEnv fspec)
     | I_ldfld (align,vol,fspec)      -> emitInstrAlign ilG align; emitInstrVolatile ilG vol; ilG.EmitAndLog(OpCodes.Ldfld  ,convFieldSpec cenv emEnv fspec)
-    | I_ldsflda fspec                ->                                                      ilG.EmitAndLog(OpCodes.Ldsflda,convFieldSpec cenv emEnv fspec)
-    | I_ldflda fspec                 ->                                                      ilG.EmitAndLog(OpCodes.Ldflda ,convFieldSpec cenv emEnv fspec)
-    | I_stsfld (vol,fspec)           ->                           emitInstrVolatile ilG vol; ilG.EmitAndLog(OpCodes.Stsfld ,convFieldSpec cenv emEnv fspec)
+    | I_ldsflda fspec                -> ilG.EmitAndLog(OpCodes.Ldsflda,convFieldSpec cenv emEnv fspec)
+    | I_ldflda fspec                 -> ilG.EmitAndLog(OpCodes.Ldflda ,convFieldSpec cenv emEnv fspec)
+    | I_stsfld (vol,fspec)           -> emitInstrVolatile ilG vol; ilG.EmitAndLog(OpCodes.Stsfld ,convFieldSpec cenv emEnv fspec)
     | I_stfld (align,vol,fspec)      -> emitInstrAlign ilG align; emitInstrVolatile ilG vol; ilG.EmitAndLog(OpCodes.Stfld  ,convFieldSpec cenv emEnv fspec)
     | I_ldstr     s                  -> ilG.EmitAndLog(OpCodes.Ldstr    ,s)
     | I_isinst    typ                -> ilG.EmitAndLog(OpCodes.Isinst   ,convType cenv emEnv  typ)
@@ -1202,74 +1197,58 @@ let rec emitInstr cenv (modB : ModuleBuilder) emEnv (ilG:ILGenerator) instr =
         emitInstr cenv modB emEnv ilG (mkNormalCall(mkILNonGenericMethSpecInTy(cenv.ilg.typ_Array, ILCallingConv.Instance, "GetLength", [cenv.ilg.typ_int32], cenv.ilg.typ_int32)))
     | i -> Printf.failwithf "the IL instruction %s cannot be emitted" (i.ToString())
 
-//----------------------------------------------------------------------------
-// emitCode 
-//----------------------------------------------------------------------------
 
-let emitBasicBlock cenv  modB emEnv (ilG:ILGenerator) bblock =
-    emitLabelMark emEnv ilG bblock.Label;
-    Array.iter (emitInstr cenv modB emEnv ilG) bblock.Instructions;
-
-let emitCode cenv modB emEnv (ilG:ILGenerator) code =
-    // pre define labels pending determining their actual marks
-    let labels = labelsOfCode code
-    let emEnv  = List.fold (defineLabel ilG) emEnv labels
+let emitCode cenv modB emEnv (ilG:ILGenerator) (code: ILCode) =
+    // Pre-define the labels pending determining their actual marks
+    let pc2lab = Dictionary()
+    let emEnv  = 
+        (emEnv, code.Labels) ||> Seq.fold (fun emEnv (KeyValue(label,pc)) -> 
+            let lab = ilG.DefineLabelAndLog()
+            pc2lab.[pc] <- (if pc2lab.ContainsKey pc then lab :: pc2lab.[pc] else [lab])
+            envSetLabel emEnv label lab)
               
-    let emitSusp susp = 
-        match susp with 
-        | Some dest -> ilG.EmitAndLog(OpCodes.Br, envGetLabel emEnv dest)
-        | _ -> ()
-     
-    let commitSusp susp lab = 
-        match susp with 
-        | Some dest when dest <> lab -> emitSusp susp 
-        | _ -> ()
+    // Build a table that contains the operations that define where exception handlers are
+    let pc2action = Dictionary()
+    let lab2pc = code.Labels
+    let add lab action = 
+        let pc = lab2pc.[lab]
+        pc2action.[pc] <- (if pc2action.ContainsKey pc then pc2action.[pc] @ [ action ] else [ action ])
 
-    let rec emitter susp code = 
-        match code with
-        | ILBasicBlock bblock                  -> 
-            commitSusp susp bblock.Label;
-            emitBasicBlock cenv modB emEnv ilG bblock
-            bblock.Fallthrough
-        | GroupBlock (_localDebugInfos,codes)-> 
-            List.fold emitter susp codes
-        | RestrictBlock (_labels,code)       -> 
-            code |> emitter susp (* restrictions ignorable: code_labels unique *)
-        | TryBlock (code,seh)                -> 
-            commitSusp susp (uniqueEntryOfCode code);
-            let _endExBlockL = ilG.BeginExceptionBlockAndLog()
-            code |> emitter None |> emitSusp
-            //ilG.MarkLabel endExBlockL;
-            emitHandler seh;
-            ilG.EndExceptionBlockAndLog();
-            None
-    and emitHandler seh =
-        match seh with      
-        | FaultBlock code         -> 
-            ilG.BeginFaultBlockAndLog();   
-            emitter None code |> emitSusp 
-        | FinallyBlock code       -> 
-            ilG.BeginFinallyBlockAndLog(); 
-            emitter None code |> emitSusp 
-        | FilterCatchBlock fcodes -> 
-            let emitFilter (filter,code) =
-                match filter with
-                | TypeFilter typ  -> 
-                    ilG.BeginCatchBlockAndLog (convType cenv emEnv  typ); 
-                    emitter None code |> emitSusp 
-                    
-                | CodeFilter test -> 
-                    ilG.BeginExceptFilterBlockAndLog(); 
-                    emitter None test |> emitSusp 
-                    ilG.BeginCatchBlockAndLog null; 
-                    emitter None code |> emitSusp 
-            fcodes |> List.iter emitFilter 
-    let initialSusp = Some (uniqueEntryOfCode code)
-    emitter initialSusp code |> emitSusp
+    for e in code.Exceptions do
+        let (startTry,_endTry) = e.Range
 
-//----------------------------------------------------------------------------
-// emitILMethodBody 
-//----------------------------------------------------------------------------
+        add startTry (fun () -> ilG.BeginExceptionBlockAndLog() |> ignore)
+
+        match e.Clause with 
+        | ILExceptionClause.Finally(startHandler,endHandler) -> 
+            add startHandler ilG.BeginFinallyBlockAndLog
+            add endHandler ilG.EndExceptionBlockAndLog
+        | ILExceptionClause.Fault(startHandler,endHandler) -> 
+            add startHandler ilG.BeginFaultBlockAndLog
+            add endHandler ilG.EndExceptionBlockAndLog
+        | ILExceptionClause.FilterCatch((startFilter,_),(startHandler,endHandler)) -> 
+            add startFilter ilG.BeginExceptFilterBlockAndLog
+            add startHandler (fun () -> ilG.BeginCatchBlockAndLog null)
+            add endHandler ilG.EndExceptionBlockAndLog
+        | ILExceptionClause.TypeCatch(typ, (startHandler,endHandler)) -> 
+            add startHandler (fun () -> ilG.BeginCatchBlockAndLog (convType cenv emEnv  typ))
+            add endHandler ilG.EndExceptionBlockAndLog
+
+    // Emit the instructions
+    let instrs = code.Instrs
+
+    for pc = 0 to instrs.Length do
+        if pc2action.ContainsKey pc then  
+            for action in pc2action.[pc] do 
+                action()
+        if pc2lab.ContainsKey pc then  
+            for lab in pc2lab.[pc] do
+                ilG.MarkLabelAndLog lab
+        if pc < instrs.Length then 
+            match instrs.[pc] with 
+            | I_br l when code.Labels.[l] = pc + 1 -> () // compress I_br to next instruction
+            | i -> emitInstr cenv modB emEnv ilG i
+
 
 let emitLocal cenv emEnv (ilG : ILGenerator) (local: ILLocal) =
     let ty = convType cenv emEnv  local.Type
@@ -1282,19 +1261,11 @@ let emitLocal cenv emEnv (ilG : ILGenerator) (local: ILLocal) =
 #endif
     locBuilder
 
-let emitILMethodBody cenv modB emEnv (ilG:ILGenerator) ilmbody =
-    // XXX - REVIEW:
-    //      NoInlining: bool;
-    //      SourceMarker: source option }
-    // emit locals and record emEnv
+let emitILMethodBody cenv modB emEnv (ilG:ILGenerator) (ilmbody: ILMethodBody) =
     let localBs = Array.map (emitLocal cenv emEnv ilG) (ILList.toArray ilmbody.Locals)
     let emEnv = envSetLocals emEnv localBs
     emitCode cenv modB emEnv ilG ilmbody.Code 
 
-
-//----------------------------------------------------------------------------
-// emitMethodBody 
-//----------------------------------------------------------------------------
 
 let emitMethodBody cenv modB emEnv ilG _name (mbody: ILLazyMethodBody) =
     match mbody.Contents with
@@ -1302,11 +1273,6 @@ let emitMethodBody cenv modB emEnv ilG _name (mbody: ILLazyMethodBody) =
     | MethodBody.PInvoke  _pinvoke -> () (* printf "EMIT: pinvoke method %s\n" name *) (* XXX - check *)
     | MethodBody.Abstract         -> () (* printf "EMIT: abstract method %s\n" name *) (* XXX - check *)
     | MethodBody.Native           -> failwith "emitMethodBody cenv: native"               (* XXX - gap *)
-
-
-//----------------------------------------------------------------------------
-// emitCustomAttrs
-//----------------------------------------------------------------------------
 
 let convCustomAttr cenv emEnv cattr =
     let methInfo = 
@@ -1369,16 +1335,17 @@ let buildGenParamsPass1b cenv emEnv (genArgs : Type array) (gps : ILGenericParam
 // emitParameter
 //----------------------------------------------------------------------------
 
-let emitParameter cenv emEnv (defineParameter : int * ParameterAttributes * string -> ParameterBuilder) i param =
+let emitParameter cenv emEnv (defineParameter : int * ParameterAttributes * string -> ParameterBuilder) i (param: ILParameter) =
     //  -Type: typ;
     //  -Default: ILFieldInit option;  
     //  -Marshal: NativeType option; (* Marshalling map for parameters. COM Interop only. *)
     let attrs = flagsIf param.IsIn       ParameterAttributes.In ||| 
                 flagsIf param.IsOut      ParameterAttributes.Out |||
                 flagsIf param.IsOptional ParameterAttributes.Optional
-    let name = match param.Name with
-               | Some name -> name
-               | None      -> "X"^string(i+1)
+    let name = 
+        match param.Name with
+        | Some name -> name
+        | None      -> "X" + string(i+1)
    
     let parB = defineParameter(i,attrs,name)
     emitCustomAttrs cenv emEnv (wrapCustomAttr parB.SetCustomAttribute) param.CustomAttrs

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -79,12 +79,8 @@ let ChooseParamNames fieldNamesAndTypes =
 let markup s = s |> Seq.mapi (fun i x -> i,x) 
 
 // Approximation for purposes of optimization and giving a warning when compiling definition-only files as EXEs 
-let rec CheckCodeDoesSomething code = 
-    match code with 
-    | ILBasicBlock bb -> Array.fold (fun x i -> x || match i with (AI_ldnull | AI_nop | AI_pop) | I_ret |  I_seqpoint _ -> false | _ -> true) false bb.Instructions
-    | GroupBlock (_,codes) -> List.exists CheckCodeDoesSomething codes
-    | RestrictBlock (_,code) -> CheckCodeDoesSomething code
-    | TryBlock _ -> true 
+let rec CheckCodeDoesSomething (code: ILCode) = 
+    code.Instrs |> Array.exists (function AI_ldnull | AI_nop | AI_pop | I_ret |  I_seqpoint _ -> false | _ -> true) 
 
 let ChooseFreeVarNames takenNames ts =
     let tns = List.map (fun t -> (t,None)) ts
@@ -1292,10 +1288,10 @@ type CodeGenBuffer(m:range,
     let codeLabelToPC : Dictionary<ILCodeLabel,int> = new Dictionary<_,_>(10)
     let codeLabelToCodeLabel : Dictionary<ILCodeLabel,ILCodeLabel> = new Dictionary<_,_>(10)
     
-    let rec computeCodeLabelToPC n lbl = 
+    let rec lab2pc n lbl = 
         if n = System.Int32.MaxValue then error(InternalError("recursive label graph",m))
         if codeLabelToCodeLabel.ContainsKey lbl then 
-            computeCodeLabelToPC (n+1) codeLabelToCodeLabel.[lbl]
+            lab2pc (n+1) codeLabelToCodeLabel.[lbl]
         else
            codeLabelToPC.[lbl] 
     
@@ -1460,7 +1456,8 @@ type CodeGenBuffer(m:range,
                 instrs
         ResizeArray.toList locals ,
         maxStack,
-        (computeCodeLabelToPC 0),
+        (Dictionary.ofList [ for kvp in codeLabelToPC -> (kvp.Key, lab2pc 0 kvp.Key) 
+                             for kvp in codeLabelToCodeLabel -> (kvp.Key, lab2pc 0 kvp.Key) ] ),
         instrs,
         ResizeArray.toList exnSpecs,
         isSome seqpoint
@@ -1557,15 +1554,15 @@ let CodeGenThen cenv mgbuf (zapFirstSeqPointToStart,entryPointInfo,methodName,ee
                                      liveLocals=IntMap.empty();  
                                      innerVals = innerVals};
 
-    let locals,maxStack,computeCodeLabelToPC,code,exnSpecs,hasSequencePoints = cgbuf.Close()
+    let locals,maxStack,lab2pc,code,exnSpecs,hasSequencePoints = cgbuf.Close()
     
-    let localDebugSpecs = 
+    let localDebugSpecs : ILLocalDebugInfo list = 
         locals
         |> List.mapi (fun i (nms,_) -> List.map (fun nm -> (i,nm)) nms)
         |> List.concat
         |> List.map (fun (i,(nm,(start,finish))) -> 
-            { locRange=(start.CodeLabel, finish.CodeLabel);
-              locInfos= [{ LocalIndex=i; LocalName=nm }] })
+            { Range=(start.CodeLabel, finish.CodeLabel);
+              DebugMappings= [{ LocalIndex=i; LocalName=nm }] })
 
     let ilLocals =
         locals
@@ -1583,27 +1580,19 @@ let CodeGenThen cenv mgbuf (zapFirstSeqPointToStart,entryPointInfo,methodName,ee
 
     (ilLocals, 
      maxStack,
-     computeCodeLabelToPC,
+     lab2pc,
      code,
      exnSpecs,
      localDebugSpecs,
      hasSequencePoints)
 
 let CodeGenMethod cenv mgbuf (zapFirstSeqPointToStart,entryPointInfo,methodName,eenv,alreadyUsedArgs,alreadyUsedLocals,codeGenFunction,m) = 
-    (* Codegen the method. REVIEW: change this to generate the AbsIL code tree directly... *)
 
-    let locals,maxStack,computeCodeLabelToPC,instrs,exns,localDebugSpecs,hasSequencePoints = 
+    let locals,maxStack,lab2pc,instrs,exns,localDebugSpecs,hasSequencePoints = 
       CodeGenThen cenv mgbuf (zapFirstSeqPointToStart,entryPointInfo,methodName,eenv,alreadyUsedArgs,alreadyUsedLocals,codeGenFunction,m)
-
-    let dump() = 
-       instrs |> Array.iteri (fun i instr -> dprintf "%s: %d: %A\n" methodName i instr);
-   
-    let lab2pc lbl = try computeCodeLabelToPC lbl with _ ->  errorR(Error(FSComp.SR.ilLabelNotFound(formatCodeLabel lbl),m)); dump(); 676767
 
     let code =  IL.buildILCode methodName lab2pc instrs exns localDebugSpecs
     
-    let code = IL.checkILCode code
-
     // Attach a source range to the method. Only do this is it has some sequence points, because .NET 2.0/3.5 
     // ILDASM has issues if you emit symbols with a source range but without any sequence points
     let sourceRange = if hasSequencePoints then GenPossibleILSourceMarker cenv m else None
@@ -2756,8 +2745,8 @@ and GenTryCatch cenv cgbuf eenv (e1,vf:Val,ef,vh:Val,eh,m,resty,spTry,spWith) se
                ILExceptionClause.TypeCatch(cenv.g.ilg.typ_Object, handlerMarks)
 
        cgbuf.EmitExceptionClause
-         { exnClauses = [ seh ];
-           exnRange= tryMarks } ;
+         { Clause = seh;
+           Range= tryMarks } ;
 
        CG.SetMarkToHere cgbuf afterHandler;
        CG.SetStack cgbuf [];
@@ -2792,16 +2781,16 @@ and GenTryFinally cenv cgbuf eenv (bodyExpr,handlerExpr,m,resty,spTry,spFinally)
        let endOfHandler = CG.GenerateMark cgbuf "endOfHandler"
        let handlerMarks = (startOfHandler.CodeLabel, endOfHandler.CodeLabel)
        cgbuf.EmitExceptionClause
-         { exnClauses = [ ILExceptionClause.Finally(handlerMarks) ];
-           exnRange   = tryMarks } ;
+         { Clause = ILExceptionClause.Finally(handlerMarks)
+           Range   = tryMarks } 
 
-       CG.SetMarkToHere cgbuf afterHandler;
-       CG.SetStack cgbuf [];
+       CG.SetMarkToHere cgbuf afterHandler
+       CG.SetStack cgbuf []
 
        // Restore the stack and load the result 
-       cgbuf.EmitStartOfHiddenCode();
-       EmitRestoreStack cgbuf stack; 
-       EmitGetLocal cgbuf ilResultTy whereToSave;
+       cgbuf.EmitStartOfHiddenCode()
+       EmitRestoreStack cgbuf stack 
+       EmitGetLocal cgbuf ilResultTy whereToSave
        GenSequel cenv eenv.cloc cgbuf sequel
    ) 
 
@@ -2845,7 +2834,7 @@ and GenForLoop cenv cgbuf eenv (spFor,v,e1,dir,e2,loopBody,m) sequel =
         EmitSetLocal cgbuf finishIdx
         EmitGetLocal cgbuf cenv.g.ilg.typ_int32 finishIdx
         GenGetLocalVal cenv cgbuf eenvinner e2.Range v None;        
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp ((if isUp then BI_blt else BI_bgt),finish.CodeLabel,inner.CodeLabel));
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp ((if isUp then BI_blt else BI_bgt),finish.CodeLabel));
     
     else
         CG.EmitInstr cgbuf (pop 0) Push0 (I_br test.CodeLabel);
@@ -2870,7 +2859,7 @@ and GenForLoop cenv cgbuf eenv (spFor,v,e1,dir,e2,loopBody,m) sequel =
     CG.EmitSeqPoint cgbuf  e2.Range;
     GenGetLocalVal cenv cgbuf eenvinner e2.Range v None;
     let cmp = match dir with FSharpForLoopUp | FSharpForLoopDown -> BI_bne_un | CSharpForLoopUp -> BI_blt
-    let e2Sequel =  (CmpThenBrOrContinue (pop 2, [ I_brcmp(cmp,inner.CodeLabel,finish.CodeLabel) ]));
+    let e2Sequel =  (CmpThenBrOrContinue (pop 2, [ I_brcmp(cmp,inner.CodeLabel) ]));
 
     if isFSharpStyle then 
         EmitGetLocal cgbuf cenv.g.ilg.typ_int32  finishIdx
@@ -2893,7 +2882,6 @@ and GenForLoop cenv cgbuf eenv (spFor,v,e1,dir,e2,loopBody,m) sequel =
     
 and GenWhileLoop cenv cgbuf eenv (spWhile,e1,e2,m) sequel =
     let finish = CG.GenerateDelayMark cgbuf "while_finish" 
-    let inner = CG.GenerateDelayMark cgbuf "while_inner" 
     let startTest = CG.GenerateMark cgbuf "startTest"
     
     match spWhile with 
@@ -2901,8 +2889,7 @@ and GenWhileLoop cenv cgbuf eenv (spWhile,e1,e2,m) sequel =
     | NoSequencePointAtWhileLoop -> ()
 
     // SEQUENCE POINTS: Emit a sequence point to cover all of 'while e do' 
-    GenExpr cenv cgbuf eenv SPSuppress e1 (CmpThenBrOrContinue (pop 1, [ I_brcmp(BI_brfalse,finish.CodeLabel,inner.CodeLabel) ]));
-    CG.SetMarkToHere cgbuf inner; 
+    GenExpr cenv cgbuf eenv SPSuppress e1 (CmpThenBrOrContinue (pop 1, [ I_brcmp(BI_brfalse,finish.CodeLabel) ]));
     
     GenExpr cenv cgbuf eenv SPAlways e2 (DiscardThen (Br startTest));
     CG.SetMarkToHere cgbuf finish; 
@@ -2997,11 +2984,11 @@ and GenAsmCode cenv cgbuf eenv (il,tyargs,args,returnTys,m) sequel =
     // For these we can just generate the argument and change the test (from a brfalse to a brtrue and vice versa) 
     | ([ AI_ceq ],
        [arg1; Expr.Const((Const.Bool false | Const.SByte 0y| Const.Int16 0s | Const.Int32 0 | Const.Int64 0L | Const.Byte 0uy| Const.UInt16 0us | Const.UInt32 0u | Const.UInt64 0UL),_,_) ], 
-       CmpThenBrOrContinue(1, [I_brcmp (((BI_brfalse | BI_brtrue) as bi) , label1,label2) ]),
+       CmpThenBrOrContinue(1, [I_brcmp (((BI_brfalse | BI_brtrue) as bi),label1) ]),
        _) ->
 
             let bi = match bi with BI_brtrue -> BI_brfalse | _ -> BI_brtrue
-            GenExpr cenv cgbuf eenv SPSuppress arg1 (CmpThenBrOrContinue(pop 1, [ I_brcmp (bi, label1,label2) ]))
+            GenExpr cenv cgbuf eenv SPSuppress arg1 (CmpThenBrOrContinue(pop 1, [ I_brcmp (bi,label1) ]))
 
     // Query; when do we get a 'ret' in IL assembly code?
     | [ I_ret ], [arg1],sequel,[_ilRetTy] -> 
@@ -3031,8 +3018,7 @@ and GenAsmCode cenv cgbuf eenv (il,tyargs,args,returnTys,m) sequel =
             let after1 = CG.GenerateDelayMark cgbuf ("fake_join")
             let after2 = CG.GenerateDelayMark cgbuf ("fake_join")
             let after3 = CG.GenerateDelayMark cgbuf ("fake_join")
-            CG.EmitInstrs cgbuf (pop 0) Push0 [mkLdcInt32 0; 
-                                     I_brcmp (BI_brfalse,after2.CodeLabel,after1.CodeLabel); ];
+            CG.EmitInstrs cgbuf (pop 0) Push0 [mkLdcInt32 0; I_brcmp (BI_brfalse,after2.CodeLabel); ];
 
             CG.SetMarkToHere cgbuf after1;
             CG.EmitInstrs cgbuf (pop 0) (Push [ilRetTy]) [AI_ldnull;  I_unbox_any ilRetTy; I_br after3.CodeLabel ];
@@ -3053,29 +3039,29 @@ and GenAsmCode cenv cgbuf eenv (il,tyargs,args,returnTys,m) sequel =
 
       // NOTE: THESE ARE NOT VALID ON FLOATING POINT DUE TO NaN.  Hence INLINE ASM ON FP. MUST BE CAREFULLY WRITTEN  
 
-      | [ AI_clt ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brfalse, label1,label2) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bge,label1,label2));
-      | [ AI_cgt ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brfalse, label1,label2) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_ble,label1, label2));
-      | [ AI_clt_un ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brfalse, label1,label2) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bge_un,label1,label2));
-      | [ AI_cgt_un ], CmpThenBrOrContinue(1, [I_brcmp (BI_brfalse, label1,label2) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_ble_un,label1, label2));
-      | [ AI_ceq ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brfalse, label1,label2) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bne_un,label1, label2));
+      | [ AI_clt ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bge,label1));
+      | [ AI_cgt ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_ble,label1));
+      | [ AI_clt_un ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bge_un,label1));
+      | [ AI_cgt_un ], CmpThenBrOrContinue(1, [I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_ble_un,label1));
+      | [ AI_ceq ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bne_un,label1));
         
       // THESE ARE VALID ON FP w.r.t. NaN 
         
-      | [ AI_clt ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brtrue, label1,label2) ]) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_blt,label1, label2));
-      | [ AI_cgt ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brtrue, label1,label2) ]) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bgt,label1, label2));
-      | [ AI_clt_un ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brtrue, label1,label2) ]) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_blt_un,label1, label2));
-      | [ AI_cgt_un ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brtrue, label1,label2) ]) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bgt_un,label1, label2));
-      | [ AI_ceq ], CmpThenBrOrContinue(1, [ I_brcmp (BI_brtrue, label1,label2) ]) ->
-        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_beq,label1, label2));
+      | [ AI_clt ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brtrue, label1) ]) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_blt,label1));
+      | [ AI_cgt ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brtrue, label1) ]) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bgt,label1));
+      | [ AI_clt_un ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brtrue, label1) ]) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_blt_un,label1));
+      | [ AI_cgt_un ], CmpThenBrOrContinue(1,[ I_brcmp (BI_brtrue, label1) ]) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bgt_un,label1));
+      | [ AI_ceq ], CmpThenBrOrContinue(1, [ I_brcmp (BI_brtrue, label1) ]) ->
+        CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_beq,label1));
       | _ -> 
         // Failing that, generate the real IL leaving value(s) on the stack 
         CG.EmitInstrs cgbuf (pop args.Length) (Push ilReturnTys) ilAfterInst;
@@ -3315,7 +3301,7 @@ and GenGenericParam cenv eenv (tp:Typar) =
 // Generate object expressions as ILX "closures"
 //-------------------------------------------------------------------------- 
 
-and GenSlotParam m cenv eenv (TSlotParam(nm,ty,inFlag,outFlag,optionalFlag,attribs)) = 
+and GenSlotParam m cenv eenv (TSlotParam(nm,ty,inFlag,outFlag,optionalFlag,attribs)) : ILParameter = 
     let inFlag2,outFlag2,optionalFlag2,paramMarshal2,attribs = GenParamAttribs cenv attribs
     
     { Name=nm;
@@ -4136,7 +4122,7 @@ and GenMatch cenv cgbuf eenv (spBind,_exprm,tree,targets,m,ty) sequel =
 
 // Accumulate the decision graph as we go
 and GenDecisionTreeAndTargets cenv cgbuf stackAtTargets eenv tree targets repeatSP sequel = 
-    let targetInfos = GenDecisionTreeAndTargetsInner cenv cgbuf (CG.GenerateDelayMark cgbuf "start_dtree") stackAtTargets eenv tree targets repeatSP (IntMap.empty()) sequel
+    let targetInfos = GenDecisionTreeAndTargetsInner cenv cgbuf None stackAtTargets eenv tree targets repeatSP (IntMap.empty()) sequel
     GenPostponedDecisionTreeTargets cenv cgbuf stackAtTargets targetInfos sequel
     
 and TryFindTargetInfo targetInfos n =  
@@ -4144,11 +4130,15 @@ and TryFindTargetInfo targetInfos n =
     | Some (targetInfo,_) -> Some targetInfo
     | None -> None
 
-and GenDecisionTreeAndTargetsInner cenv cgbuf inplab stackAtTargets eenv tree targets repeatSP targetInfos sequel = 
+/// When inplabOpt is None, we are assuming a branch or fallthrough to the current code location
+///
+/// When inplabOpt is "Some inplab", we are assuming an existing branch to "inplab" and can optionally
+/// set inplab to point to another location if no codegen is required. 
+and GenDecisionTreeAndTargetsInner cenv cgbuf inplabOpt stackAtTargets eenv tree targets repeatSP targetInfos sequel = 
     CG.SetStack cgbuf stackAtTargets;              // Set the expected initial stack.
     match tree with 
     | TDBind(bind,rest) -> 
-       CG.SetMarkToHere cgbuf inplab;
+       match inplabOpt with Some inplab -> CG.SetMarkToHere cgbuf inplab | None -> ()
        let startScope,endScope as scopeMarks = StartDelayedLocalScope "dtreeBind" cgbuf
        let eenv = AllocStorageForBind cenv cgbuf scopeMarks eenv bind
        let sp = GenSequencePointForBind cenv cgbuf eenv bind
@@ -4158,32 +4148,32 @@ and GenDecisionTreeAndTargetsInner cenv cgbuf inplab stackAtTargets eenv tree ta
        // we effectively lose an EndLocalScope for all dtrees that go to the same target 
        // So we just pretend that the variable goes out of scope here. 
        CG.SetMarkToHere cgbuf endScope;
-       let bodyLabel = CG.GenerateDelayMark cgbuf "decisionTreeBindBody"
-       CG.EmitInstr cgbuf (pop 0) Push0 (I_br bodyLabel.CodeLabel); 
-       GenDecisionTreeAndTargetsInner cenv cgbuf bodyLabel stackAtTargets eenv rest targets repeatSP targetInfos sequel
+       GenDecisionTreeAndTargetsInner cenv cgbuf None stackAtTargets eenv rest targets repeatSP targetInfos sequel
 
     | TDSuccess (es,targetIdx) ->  
-       GenDecisionTreeSuccess cenv cgbuf inplab stackAtTargets eenv es targetIdx targets repeatSP targetInfos sequel 
+       GenDecisionTreeSuccess cenv cgbuf inplabOpt stackAtTargets eenv es targetIdx targets repeatSP targetInfos sequel 
 
     | TDSwitch(e, cases, dflt,m)  -> 
-       GenDecisionTreeSwitch cenv cgbuf inplab stackAtTargets eenv e cases dflt m targets repeatSP targetInfos sequel 
+       GenDecisionTreeSwitch cenv cgbuf inplabOpt stackAtTargets eenv e cases dflt m targets repeatSP targetInfos sequel 
 
 and GetTarget (targets:_[]) n =
     if n >= targets.Length then failwith "GetTarget: target not found in decision tree";
     targets.[n]
 
-and GenDecisionTreeSuccess cenv cgbuf inplab stackAtTargets eenv es targetIdx targets repeatSP targetInfos sequel = 
+and GenDecisionTreeSuccess cenv cgbuf inplabOpt stackAtTargets eenv es targetIdx targets repeatSP targetInfos sequel = 
     let (TTarget(vs,successExpr,spTarget)) = GetTarget targets targetIdx
     match TryFindTargetInfo targetInfos targetIdx with
-    | Some (_,targetMarkAfterBinds,eenvAtTarget,_,_,_,_,_,_,_) ->
+    | Some (_,targetMarkAfterBinds:Mark,eenvAtTarget,_,_,_,_,_,_,_) ->
 
         // If not binding anything we can go directly to the targetMarkAfterBinds point 
         // This is useful to avoid lots of branches e.g. in match A | B | C -> e 
         // In this case each case will just go straight to "e" 
         if FlatList.isEmpty vs then 
-            CG.SetMark cgbuf inplab targetMarkAfterBinds;
+            match inplabOpt with 
+            | None -> CG.EmitInstr cgbuf (pop 0) Push0 (I_br targetMarkAfterBinds.CodeLabel); 
+            | Some inplab -> CG.SetMark cgbuf inplab targetMarkAfterBinds;
         else 
-            CG.SetMarkToHere cgbuf inplab;
+            match inplabOpt with None -> () | Some inplab -> CG.SetMarkToHere cgbuf inplab;
             repeatSP();
             // It would be better not to emit any expressions here, and instead push these assignments into the postponed target
             // However not all targets are currently postponed (we only postpone in debug code), pending further testing of the performance
@@ -4196,7 +4186,7 @@ and GenDecisionTreeSuccess cenv cgbuf inplab stackAtTargets eenv es targetIdx ta
 
     | None -> 
 
-        CG.SetMarkToHere cgbuf inplab;
+        match inplabOpt with None -> () | Some inplab -> CG.SetMarkToHere cgbuf inplab;
         let targetMarkBeforeBinds = CG.GenerateDelayMark cgbuf "targetBeforeBinds"
         let targetMarkAfterBinds = CG.GenerateDelayMark cgbuf "targetAfterBinds"
         let startScope,endScope as scopeMarks = StartDelayedLocalScope "targetBinds" cgbuf
@@ -4246,9 +4236,9 @@ and GenDecisionTreeTarget cenv cgbuf stackAtTargets _targetIdx (targetMarkBefore
     GenExpr cenv cgbuf eenvAtTarget spExpr successExpr (EndLocalScope(sequel,endScope));
 
 
-and GenDecisionTreeSwitch cenv cgbuf inplab stackAtTargets eenv e cases defaultTargetOpt switchm targets repeatSP targetInfos sequel = 
+and GenDecisionTreeSwitch cenv cgbuf inplabOpt stackAtTargets eenv e cases defaultTargetOpt switchm targets repeatSP targetInfos sequel = 
     let m = e.Range
-    CG.SetMarkToHere cgbuf inplab;
+    match inplabOpt with None -> () | Some inplab -> CG.SetMarkToHere cgbuf inplab;
 
     repeatSP();
     match cases with 
@@ -4271,10 +4261,6 @@ and GenDecisionTreeSwitch cenv cgbuf inplab stackAtTargets eenv e cases defaultT
 
       | _ ->  
         let caseLabels = List.map (fun _ -> CG.GenerateDelayMark cgbuf "switch_case") cases
-        let defaultLabel = 
-            match defaultTargetOpt with 
-            | None -> List.head caseLabels 
-            | Some _ -> CG.GenerateDelayMark cgbuf "switch_dflt"
         let firstDiscrim =  cases.Head.Discriminator
         match firstDiscrim with 
         // Iterated tests, e.g. exception constructors, nulltests, typetests and active patterns.
@@ -4301,8 +4287,8 @@ and GenDecisionTreeSwitch cenv cgbuf inplab stackAtTargets eenv e cases defaultT
                   GenExpr cenv cgbuf eenv SPSuppress e Continue;
                   BI_brtrue
               | _ -> failwith "internal error: GenDecisionTreeSwitch"
-            CG.EmitInstr cgbuf (pop 1) Push0 (I_brcmp (bi,(List.head caseLabels).CodeLabel,defaultLabel.CodeLabel));
-            GenDecisionTreeCases cenv cgbuf stackAtTargets eenv targets repeatSP targetInfos caseLabels cases defaultTargetOpt defaultLabel sequel
+            CG.EmitInstr cgbuf (pop 1) Push0 (I_brcmp (bi,(List.head caseLabels).CodeLabel));
+            GenDecisionTreeCases cenv cgbuf stackAtTargets eenv targets repeatSP targetInfos defaultTargetOpt caseLabels cases sequel
               
         | Test.ActivePatternCase _ -> error(InternalError("internal error in codegen: Test.ActivePatternCase",switchm))
         | Test.UnionCase (hdc,tyargs) -> 
@@ -4316,9 +4302,9 @@ and GenDecisionTreeSwitch cenv cgbuf inplab stackAtTargets eenv e cases defaultT
                   | _ -> failwith "error: mixed constructor/const test?") 
             
             let avoidHelpers = entityRefInThisAssembly cenv.g.compilingFslib hdc.TyconRef
-            EraseUnions.emitDataSwitch cenv.g.ilg (UnionCodeGen cgbuf) (avoidHelpers,cuspec,dests,defaultLabel.CodeLabel);
+            EraseUnions.emitDataSwitch cenv.g.ilg (UnionCodeGen cgbuf) (avoidHelpers,cuspec,dests);
             CG.EmitInstrs cgbuf (pop 1) Push0 [ ] // push/pop to match the line above
-            GenDecisionTreeCases cenv cgbuf stackAtTargets eenv  targets repeatSP targetInfos caseLabels cases defaultTargetOpt defaultLabel sequel
+            GenDecisionTreeCases cenv cgbuf stackAtTargets eenv  targets repeatSP targetInfos defaultTargetOpt caseLabels cases sequel
               
         | Test.Const c ->
             GenExpr cenv cgbuf eenv SPSuppress e Continue;
@@ -4358,23 +4344,23 @@ and GenDecisionTreeSwitch cenv cgbuf inplab stackAtTargets eenv e cases defaultT
                     if mn <> 0 then 
                       CG.EmitInstrs cgbuf (pop 0) (Push [cenv.g.ilg.typ_int32]) [ mkLdcInt32 mn];
                       CG.EmitInstrs cgbuf (pop 1) Push0 [ AI_sub ];
-                    CG.EmitInstr cgbuf (pop 1) Push0 (I_switch (destinationLabels, defaultLabel.CodeLabel));
+                    CG.EmitInstr cgbuf (pop 1) Push0 (I_switch destinationLabels);
                 else
                   error(InternalError("non-dense integer matches not implemented in codegen - these should have been removed by the pattern match compiler",switchm));
-                GenDecisionTreeCases cenv cgbuf stackAtTargets eenv  targets repeatSP targetInfos caseLabels cases defaultTargetOpt defaultLabel sequel
+                GenDecisionTreeCases cenv cgbuf stackAtTargets eenv  targets repeatSP targetInfos defaultTargetOpt caseLabels cases sequel
             | _ -> error(InternalError("these matches should never be needed",switchm))
 
-and GenDecisionTreeCases cenv cgbuf stackAtTargets eenv targets repeatSP targetInfos caseLabels cases defaultTargetOpt defaultLabel sequel =
+and GenDecisionTreeCases cenv cgbuf stackAtTargets eenv targets repeatSP targetInfos defaultTargetOpt caseLabels cases sequel =
     assert(cgbuf.GetCurrentStack() = stackAtTargets); // cgbuf stack should be unchanged over tests. [bug://1750].
 
     let targetInfos = 
         match defaultTargetOpt with 
-        | Some defaultTarget -> GenDecisionTreeAndTargetsInner cenv cgbuf defaultLabel stackAtTargets eenv defaultTarget targets repeatSP targetInfos sequel
+        | Some defaultTarget -> GenDecisionTreeAndTargetsInner cenv cgbuf None stackAtTargets eenv defaultTarget targets repeatSP targetInfos sequel
         | None -> targetInfos
 
     let targetInfos = 
         (targetInfos, caseLabels, cases) |||> List.fold2 (fun targetInfos caseLabel (TCase(_,caseTree)) -> 
-            GenDecisionTreeAndTargetsInner cenv cgbuf caseLabel stackAtTargets eenv caseTree targets repeatSP targetInfos sequel)
+            GenDecisionTreeAndTargetsInner cenv cgbuf (Some caseLabel) stackAtTargets eenv caseTree targets repeatSP targetInfos sequel)
     targetInfos 
 
 // Used for the peephole optimization below
@@ -4412,27 +4398,26 @@ and GenDecisionTreeTest cenv cloc cgbuf stackAtTargets e tester eenv successTree
              | _ -> failwith "internal error: GenDecisionTreeTest during bool elim"
 
     | _ ->
-        let success = CG.GenerateDelayMark cgbuf "testSuccess"
         let failure = CG.GenerateDelayMark cgbuf "testFailure"
-        (match tester with 
+        match tester with 
         | None -> 
-            (* generate the expression, then test it for "false" *)
-            GenExpr cenv cgbuf eenv SPSuppress e (CmpThenBrOrContinue(pop 1, [ I_brcmp (BI_brfalse, failure.CodeLabel, success.CodeLabel) ]));
+            // generate the expression, then test it for "false" 
+            GenExpr cenv cgbuf eenv SPSuppress e (CmpThenBrOrContinue(pop 1, [ I_brcmp (BI_brfalse, failure.CodeLabel) ]));
 
-        (* Turn 'isdata' tests that branch into EI_brisdata tests *)
+        // Turn 'isdata' tests that branch into EI_brisdata tests 
         | Some (_,_,Choice1Of2 (avoidHelpers,cuspec,idx)) ->
-            GenExpr cenv cgbuf eenv SPSuppress e (CmpThenBrOrContinue(pop 1, EraseUnions.mkBrIsData cenv.g.ilg (avoidHelpers,cuspec, idx, success.CodeLabel, failure.CodeLabel)));
+            GenExpr cenv cgbuf eenv SPSuppress e (CmpThenBrOrContinue(pop 1, EraseUnions.mkBrIsNotData cenv.g.ilg (avoidHelpers,cuspec, idx, failure.CodeLabel)));
 
         | Some (pops,pushes,i) ->
-            GenExpr cenv cgbuf eenv SPSuppress e Continue;
+            GenExpr cenv cgbuf eenv SPSuppress e Continue
             match i with 
             | Choice1Of2 (avoidHelpers,cuspec,idx) -> CG.EmitInstrs cgbuf pops pushes (EraseUnions.mkIsData cenv.g.ilg (avoidHelpers, cuspec, idx))
-            | Choice2Of2 i -> CG.EmitInstr cgbuf pops pushes i;
-            CG.EmitInstr cgbuf (pop 1) Push0  (I_brcmp (BI_brfalse, failure.CodeLabel, success.CodeLabel)));
+            | Choice2Of2 i -> CG.EmitInstr cgbuf pops pushes i
+            CG.EmitInstr cgbuf (pop 1) Push0  (I_brcmp (BI_brfalse, failure.CodeLabel))
 
-        let targetInfos = GenDecisionTreeAndTargetsInner cenv cgbuf success stackAtTargets eenv successTree targets repeatSP targetInfos sequel
+        let targetInfos = GenDecisionTreeAndTargetsInner cenv cgbuf None stackAtTargets eenv successTree targets repeatSP targetInfos sequel
 
-        GenDecisionTreeAndTargetsInner cenv cgbuf failure stackAtTargets eenv failureTree targets repeatSP targetInfos sequel 
+        GenDecisionTreeAndTargetsInner cenv cgbuf (Some failure) stackAtTargets eenv failureTree targets repeatSP targetInfos sequel 
 
 //-------------------------------------------------------------------------
 // Generate letrec bindings
@@ -4881,7 +4866,7 @@ and GenParams cenv eenv (mspec:ILMethodSpec) (attribs:ArgReprInfo list) (implVal
             | None -> 
                 None, takenNames
             
-        let param = 
+        let param : ILParameter = 
             { Name=nmOpt;
               Type= ilArgTy;  
               Default=None; (* REVIEW: support "default" attributes *)   

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1570,7 +1570,7 @@ module StaticLinker =
               ReportTime tcConfig "Static link";
 
 #if EXTENSIONTYPING
-              Morphs.enablemorphCustomAttributeData()
+              Morphs.enableMorphCustomAttributeData()
               let providerGeneratedILModules =  FindProviderGeneratedILModules (tcImports, providerGeneratedAssemblies) 
 
               // Transform the ILTypeRefs references in the IL of all provider-generated assemblies so that the references
@@ -1692,7 +1692,7 @@ module StaticLinker =
 
                   providerGeneratedILModules, ilxMainModule
              
-              Morphs.disablemorphCustomAttributeData()
+              Morphs.disableMorphCustomAttributeData()
 #else
               let providerGeneratedILModules = []
 #endif

--- a/src/ilx/EraseUnions.fsi
+++ b/src/ilx/EraseUnions.fsi
@@ -13,7 +13,7 @@ val mkNewData : ILGlobals -> IlxUnionSpec * int -> ILInstr list
 val mkIsData : ILGlobals -> bool * IlxUnionSpec * int -> ILInstr list
 val mkLdData : bool * IlxUnionSpec * int * int -> ILInstr list
 val mkStData : IlxUnionSpec * int * int -> ILInstr list
-val mkBrIsData : ILGlobals -> avoidHelpers:bool * IlxUnionSpec * int * ILCodeLabel * ILCodeLabel -> ILInstr list
+val mkBrIsNotData : ILGlobals -> avoidHelpers:bool * IlxUnionSpec * int * ILCodeLabel -> ILInstr list
 val mkClassUnionDef : ILGlobals -> ILTypeRef -> ILTypeDef -> IlxUnionInfo -> ILTypeDef
 val GetILTypeForAlternative : IlxUnionSpec -> int -> ILType
 
@@ -27,4 +27,4 @@ type ICodeGen<'Mark> =
 
 val emitCastData : ILGlobals -> ICodeGen<'Mark> -> canfail: bool * IlxUnionSpec * int -> unit
 val emitLdDataTag : ILGlobals -> ICodeGen<'Mark> -> avoidHelpers:bool * IlxUnionSpec -> unit
-val emitDataSwitch : ILGlobals -> ICodeGen<'Mark> -> avoidHelpers:bool * IlxUnionSpec * (int * ILCodeLabel) list * ILCodeLabel -> unit
+val emitDataSwitch : ILGlobals -> ICodeGen<'Mark> -> avoidHelpers:bool * IlxUnionSpec * (int * ILCodeLabel) list -> unit

--- a/src/update.cmd
+++ b/src/update.cmd
@@ -98,8 +98,8 @@ if /i not "%2"=="-ngen" goto :donengen
 "%NGEN32%" executeQueuedItems 1
 
 if /i "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
-    "%NGEN64%" install "%BINDIR%\fsiAnyCpu.exe" /queue:1
-    "%NGEN64%" install "%BINDIR%\FSharp.Build.dll" /queue:1
+    "%NGEN64%" install "%BINDIR%\fsiAnyCpu.exe" %NGEN_FLAGS% /queue:1
+    "%NGEN64%" install "%BINDIR%\FSharp.Build.dll" %NGEN_FLAGS% /queue:1
     "%NGEN64%" executeQueuedItems 1
 )
 

--- a/src/update.cmd
+++ b/src/update.cmd
@@ -87,13 +87,14 @@ if /i "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
 )
 
 if /i '%1' == 'signonly' goto :eof
+if /i '%1' == 'debug' set NGEN_FLAGS=/Debug
 
 rem NGen fsc, fsi, fsiAnyCpu, and FSharp.Build.dll
 if /i not "%2"=="-ngen" goto :donengen
 
-"%NGEN32%" install "%BINDIR%\fsc.exe" /queue:1
-"%NGEN32%" install "%BINDIR%\fsi.exe" /queue:1
-"%NGEN32%" install "%BINDIR%\FSharp.Build.dll" /queue:1
+"%NGEN32%" install "%BINDIR%\fsc.exe" %NGEN_FLAGS% /queue:1
+"%NGEN32%" install "%BINDIR%\fsi.exe" %NGEN_FLAGS% /queue:1
+"%NGEN32%" install "%BINDIR%\FSharp.Build.dll" %NGEN_FLAGS% /queue:1
 "%NGEN32%" executeQueuedItems 1
 
 if /i "%PROCESSOR_ARCHITECTURE%"=="AMD64" (

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SeqExpressionStepping/SeqExpressionSteppingTest7.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SeqExpressionStepping/SeqExpressionSteppingTest7.il.bsl
@@ -1,19 +1,19 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 3.5.30729.1
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
 
-// Metadata version: v2.0.50727
+// Metadata version: v4.0.30319
 .assembly extern mscorlib
 {
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 2:0:0:0
+  .ver 4:0:0:0
 }
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 2:0:0:0
+  .ver 4:4:1:0
 }
 .assembly SeqExpressionSteppingTest7
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.SeqExpressionSteppingTest7
 {
-  // Offset: 0x00000000 Length: 0x00000254
+  // Offset: 0x00000000 Length: 0x00000272
 }
 .mresource public FSharpOptimizationData.SeqExpressionSteppingTest7
 {
-  // Offset: 0x00000258 Length: 0x00000098
+  // Offset: 0x00000278 Length: 0x00000098
 }
-.module SeqExpressionSteppingTest7.dll
-// MVID: {4D94A874-241E-0855-A745-038374A8944D}
+.module SeqExpressionSteppingTest7.exe
+// MVID: {575BE157-2432-93C3-A745-038357E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x006E0000
+// Image base: 0x00DE0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -51,7 +51,7 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname f@4<a>
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname f@5<a>
          extends class [FSharp.Core]Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase`1<!a>
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
@@ -68,17 +68,17 @@
                                  !a current) cil managed
     {
       // Code size       21 (0x15)
-      .maxstack  6
+      .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldarg.1
-      IL_0002:  stfld      int32 class SeqExpressionSteppingTest7/f@4<!a>::pc
+      IL_0002:  stfld      int32 class SeqExpressionSteppingTest7/f@5<!a>::pc
       IL_0007:  ldarg.0
       IL_0008:  ldarg.2
-      IL_0009:  stfld      !0 class SeqExpressionSteppingTest7/f@4<!a>::current
+      IL_0009:  stfld      !0 class SeqExpressionSteppingTest7/f@5<!a>::current
       IL_000e:  ldarg.0
       IL_000f:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase`1<!a>::.ctor()
       IL_0014:  ret
-    } // end of method f@4::.ctor
+    } // end of method f@5::.ctor
 
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<!a>& next) cil managed
@@ -87,9 +87,9 @@
       .maxstack  6
       .locals init ([0] !a V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SeqExpressionStepping\\SeqExpressionSteppingTest7.fs'
       IL_0000:  ldarg.0
-      IL_0001:  ldfld      int32 class SeqExpressionSteppingTest7/f@4<!a>::pc
+      IL_0001:  ldfld      int32 class SeqExpressionSteppingTest7/f@5<!a>::pc
       IL_0006:  ldc.i4.1
       IL_0007:  sub
       IL_0008:  switch     ( 
@@ -101,26 +101,26 @@
 
       IL_0019:  br.s       IL_001e
 
-      .line 100001,100001 : 0,0 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       IL_001c:  br.s       IL_004e
 
-      .line 100001,100001 : 0,0 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001e:  nop
       IL_001f:  br.s       IL_0059
 
-      .line 100001,100001 : 0,0 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      .line 4,4 : 14,36 
+      .line 5,5 : 14,36 ''
       IL_0022:  nop
-      .line 4,4 : 18,24 
+      .line 5,5 : 18,24 ''
       IL_0023:  call       class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> SeqExpressionSteppingTest7::get_r()
       IL_0028:  call       void [FSharp.Core]Microsoft.FSharp.Core.Operators::Increment(class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32>)
       IL_002d:  nop
-      .line 4,4 : 26,30 
+      .line 5,5 : 26,30 ''
       IL_002e:  ldc.i4.1
       IL_002f:  brfalse.s  IL_0033
 
@@ -130,8 +130,8 @@
 
       IL_0035:  ldarg.0
       IL_0036:  ldc.i4.1
-      IL_0037:  stfld      int32 class SeqExpressionSteppingTest7/f@4<!a>::pc
-      .line 4,4 : 44,55 
+      IL_0037:  stfld      int32 class SeqExpressionSteppingTest7/f@5<!a>::pc
+      .line 5,5 : 44,55 ''
       IL_003c:  ldarg.1
       IL_003d:  ldstr      ""
       IL_0042:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::FailWith<class [mscorlib]System.Collections.Generic.IEnumerable`1<!a>>(string)
@@ -139,45 +139,45 @@
       IL_004c:  ldc.i4.2
       IL_004d:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_004e:  nop
       IL_004f:  br.s       IL_0052
 
-      .line 4,4 : 14,36 
-      .line 100001,100001 : 0,0 
+      .line 5,5 : 14,36 ''
+      .line 100001,100001 : 0,0 ''
       IL_0051:  nop
       IL_0052:  ldarg.0
       IL_0053:  ldc.i4.2
-      IL_0054:  stfld      int32 class SeqExpressionSteppingTest7/f@4<!a>::pc
+      IL_0054:  stfld      int32 class SeqExpressionSteppingTest7/f@5<!a>::pc
       IL_0059:  ldarg.0
       IL_005a:  ldloca.s   V_0
       IL_005c:  initobj    !a
       IL_0062:  ldloc.0
-      IL_0063:  stfld      !0 class SeqExpressionSteppingTest7/f@4<!a>::current
+      IL_0063:  stfld      !0 class SeqExpressionSteppingTest7/f@5<!a>::current
       IL_0068:  ldc.i4.0
       IL_0069:  ret
-    } // end of method f@4::GenerateNext
+    } // end of method f@5::GenerateNext
 
     .method public strict virtual instance void 
             Close() cil managed
     {
       // Code size       9 (0x9)
-      .maxstack  6
+      .maxstack  8
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldc.i4.2
-      IL_0003:  stfld      int32 class SeqExpressionSteppingTest7/f@4<!a>::pc
+      IL_0003:  stfld      int32 class SeqExpressionSteppingTest7/f@5<!a>::pc
       IL_0008:  ret
-    } // end of method f@4::Close
+    } // end of method f@5::Close
 
     .method public strict virtual instance bool 
             get_CheckClose() cil managed
     {
-      // Code size       46 (0x2e)
-      .maxstack  5
+      // Code size       47 (0x2f)
+      .maxstack  8
       IL_0000:  nop
       IL_0001:  ldarg.0
-      IL_0002:  ldfld      int32 class SeqExpressionSteppingTest7/f@4<!a>::pc
+      IL_0002:  ldfld      int32 class SeqExpressionSteppingTest7/f@5<!a>::pc
       IL_0007:  switch     ( 
                             IL_001a,
                             IL_001c,
@@ -191,21 +191,22 @@
       IL_001e:  br.s       IL_0026
 
       IL_0020:  nop
-      IL_0021:  br.s       IL_002c
+      IL_0021:  br.s       IL_002d
 
       IL_0023:  nop
       IL_0024:  br.s       IL_002a
 
       IL_0026:  nop
-      IL_0027:  br.s       IL_002c
+      IL_0027:  br.s       IL_002d
 
       IL_0029:  nop
       IL_002a:  ldc.i4.0
       IL_002b:  ret
 
-      IL_002c:  ldc.i4.0
-      IL_002d:  ret
-    } // end of method f@4::get_CheckClose
+      IL_002c:  nop
+      IL_002d:  ldc.i4.0
+      IL_002e:  ret
+    } // end of method f@5::get_CheckClose
 
     .method public strict virtual instance !a 
             get_LastGenerated() cil managed
@@ -213,12 +214,12 @@
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       8 (0x8)
-      .maxstack  5
+      .maxstack  8
       IL_0000:  nop
       IL_0001:  ldarg.0
-      IL_0002:  ldfld      !0 class SeqExpressionSteppingTest7/f@4<!a>::current
+      IL_0002:  ldfld      !0 class SeqExpressionSteppingTest7/f@5<!a>::current
       IL_0007:  ret
-    } // end of method f@4::get_LastGenerated
+    } // end of method f@5::get_LastGenerated
 
     .method public strict virtual instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!a> 
             GetFreshEnumerator() cil managed
@@ -233,19 +234,19 @@
       IL_0002:  ldloca.s   V_0
       IL_0004:  initobj    !a
       IL_000a:  ldloc.0
-      IL_000b:  newobj     instance void class SeqExpressionSteppingTest7/f@4<!a>::.ctor(int32,
+      IL_000b:  newobj     instance void class SeqExpressionSteppingTest7/f@5<!a>::.ctor(int32,
                                                                                          !0)
       IL_0010:  ret
-    } // end of method f@4::GetFreshEnumerator
+    } // end of method f@5::GetFreshEnumerator
 
-  } // end of class f@4
+  } // end of class f@5
 
   .method public specialname static class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> 
           get_r() cil managed
   {
     // Code size       6 (0x6)
-    .maxstack  4
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> '<StartupCode$SeqExpressionSteppingTest7>'.$SeqExpressionSteppingTest7::r@3
+    .maxstack  8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> '<StartupCode$SeqExpressionSteppingTest7>'.$SeqExpressionSteppingTest7::r@4
     IL_0005:  ret
   } // end of method SeqExpressionSteppingTest7::get_r
 
@@ -255,13 +256,13 @@
     // Code size       24 (0x18)
     .maxstack  4
     .locals init ([0] !!a V_0)
-    .line 4,4 : 12,57 
+    .line 5,5 : 12,57 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.0
     IL_0002:  ldloca.s   V_0
     IL_0004:  initobj    !!a
     IL_000a:  ldloc.0
-    IL_000b:  newobj     instance void class SeqExpressionSteppingTest7/f@4<!!a>::.ctor(int32,
+    IL_000b:  newobj     instance void class SeqExpressionSteppingTest7/f@5<!!a>::.ctor(int32,
                                                                                         !0)
     IL_0010:  tail.
     IL_0012:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<!!0>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
@@ -279,16 +280,16 @@
 .class private abstract auto ansi sealed '<StartupCode$SeqExpressionSteppingTest7>'.$SeqExpressionSteppingTest7
        extends [mscorlib]System.Object
 {
-  .field static assembly initonly class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> r@3
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> r@4
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly int32 init@
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-  .method private specialname rtspecialname static 
-          void  .cctor() cil managed
+  .method public static void  main@() cil managed
   {
-    // Code size       100 (0x64)
+    .entrypoint
+    // Code size       109 (0x6d)
     .maxstack  4
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> r,
              [1] class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit> V_1,
@@ -296,29 +297,29 @@
              [3] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_3,
              [4] class [mscorlib]System.Exception V_4,
              [5] class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string> V_5)
-    .line 3,3 : 1,14 
+    .line 4,4 : 1,14 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.0
     IL_0002:  call       class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<!!0> [FSharp.Core]Microsoft.FSharp.Core.Operators::Ref<int32>(!!0)
     IL_0007:  dup
-    IL_0008:  stsfld     class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> '<StartupCode$SeqExpressionSteppingTest7>'.$SeqExpressionSteppingTest7::r@3
+    IL_0008:  stsfld     class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> '<StartupCode$SeqExpressionSteppingTest7>'.$SeqExpressionSteppingTest7::r@4
     IL_000d:  stloc.0
     IL_000e:  ldstr      "res = %A"
     IL_0013:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
     IL_0018:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_001d:  stloc.1
-    .line 5,5 : 1,53 
+    .line 6,6 : 1,53 ''
     IL_001e:  nop
-    .line 5,5 : 21,24 
+    .line 6,6 : 21,24 ''
     .try
     {
       IL_001f:  nop
-      .line 5,5 : 25,29 
+      .line 6,6 : 25,29 ''
       IL_0020:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> SeqExpressionSteppingTest7::f<int32>()
       IL_0025:  stloc.3
-      IL_0026:  leave.s    IL_0059
+      IL_0026:  leave.s    IL_0062
 
-      .line 5,5 : 30,34 
+      .line 6,6 : 30,34 ''
     }  // end .try
     catch [mscorlib]System.Object 
     {
@@ -334,27 +335,32 @@
 
       IL_003e:  br.s       IL_0057
 
-      .line 5,5 : 48,52 
+      .line 6,6 : 48,52 ''
       IL_0040:  call       class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> SeqExpressionSteppingTest7::get_r()
       IL_0045:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::op_Dereference<int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<!!0>)
       IL_004a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
       IL_004f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
       IL_0054:  stloc.3
-      IL_0055:  leave.s    IL_0059
+      IL_0055:  leave.s    IL_0062
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0057:  rethrow
-      .line 100001,100001 : 0,0 
+      IL_0059:  ldnull
+      IL_005a:  unbox.any  class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>
+      IL_005f:  stloc.3
+      IL_0060:  leave.s    IL_0062
+
+      .line 100001,100001 : 0,0 ''
     }  // end handler
-    IL_0059:  ldloc.3
-    IL_005a:  stloc.2
-    IL_005b:  ldloc.1
-    IL_005c:  ldloc.2
-    IL_005d:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
-    IL_0062:  pop
-    IL_0063:  ret
-  } // end of method $SeqExpressionSteppingTest7::.cctor
+    IL_0062:  ldloc.3
+    IL_0063:  stloc.2
+    IL_0064:  ldloc.1
+    IL_0065:  ldloc.2
+    IL_0066:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
+    IL_006b:  pop
+    IL_006c:  ret
+  } // end of method $SeqExpressionSteppingTest7::main@
 
 } // end of class '<StartupCode$SeqExpressionSteppingTest7>'.$SeqExpressionSteppingTest7
 

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SeqExpressionStepping/SeqExpressionSteppingTest7.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SeqExpressionStepping/SeqExpressionSteppingTest7.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.16774
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly SeqExpressionSteppingTest7
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.SeqExpressionSteppingTest7
 {
-  // Offset: 0x00000000 Length: 0x00000297
+  // Offset: 0x00000000 Length: 0x00000272
 }
 .mresource public FSharpOptimizationData.SeqExpressionSteppingTest7
 {
-  // Offset: 0x000002A0 Length: 0x00000098
+  // Offset: 0x00000278 Length: 0x00000098
 }
 .module SeqExpressionSteppingTest7.exe
-// MVID: {4DAC1467-2432-93C3-A745-03836714AC4D}
+// MVID: {575BE157-2432-93C3-A745-038357E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000000000270000
+// Image base: 0x00DE0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -87,7 +87,7 @@
       .maxstack  6
       .locals init ([0] !a V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SeqExpressionStepping\\SeqExpressionSteppingTest7.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 class SeqExpressionSteppingTest7/f@5<!a>::pc
       IL_0006:  ldc.i4.1
@@ -101,26 +101,26 @@
 
       IL_0019:  br.s       IL_001e
 
-      .line 100001,100001 : 0,0 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       IL_001c:  br.s       IL_004e
 
-      .line 100001,100001 : 0,0 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001e:  nop
       IL_001f:  br.s       IL_0059
 
-      .line 100001,100001 : 0,0 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      .line 5,5 : 14,36 
+      .line 5,5 : 14,36 ''
       IL_0022:  nop
-      .line 5,5 : 18,24 
+      .line 5,5 : 18,24 ''
       IL_0023:  call       class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> SeqExpressionSteppingTest7::get_r()
       IL_0028:  call       void [FSharp.Core]Microsoft.FSharp.Core.Operators::Increment(class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32>)
       IL_002d:  nop
-      .line 5,5 : 26,30 
+      .line 5,5 : 26,30 ''
       IL_002e:  ldc.i4.1
       IL_002f:  brfalse.s  IL_0033
 
@@ -131,7 +131,7 @@
       IL_0035:  ldarg.0
       IL_0036:  ldc.i4.1
       IL_0037:  stfld      int32 class SeqExpressionSteppingTest7/f@5<!a>::pc
-      .line 5,5 : 44,55 
+      .line 5,5 : 44,55 ''
       IL_003c:  ldarg.1
       IL_003d:  ldstr      ""
       IL_0042:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::FailWith<class [mscorlib]System.Collections.Generic.IEnumerable`1<!a>>(string)
@@ -139,12 +139,12 @@
       IL_004c:  ldc.i4.2
       IL_004d:  ret
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_004e:  nop
       IL_004f:  br.s       IL_0052
 
-      .line 5,5 : 14,36 
-      .line 100001,100001 : 0,0 
+      .line 5,5 : 14,36 ''
+      .line 100001,100001 : 0,0 ''
       IL_0051:  nop
       IL_0052:  ldarg.0
       IL_0053:  ldc.i4.2
@@ -173,7 +173,7 @@
     .method public strict virtual instance bool 
             get_CheckClose() cil managed
     {
-      // Code size       46 (0x2e)
+      // Code size       47 (0x2f)
       .maxstack  8
       IL_0000:  nop
       IL_0001:  ldarg.0
@@ -191,20 +191,21 @@
       IL_001e:  br.s       IL_0026
 
       IL_0020:  nop
-      IL_0021:  br.s       IL_002c
+      IL_0021:  br.s       IL_002d
 
       IL_0023:  nop
       IL_0024:  br.s       IL_002a
 
       IL_0026:  nop
-      IL_0027:  br.s       IL_002c
+      IL_0027:  br.s       IL_002d
 
       IL_0029:  nop
       IL_002a:  ldc.i4.0
       IL_002b:  ret
 
-      IL_002c:  ldc.i4.0
-      IL_002d:  ret
+      IL_002c:  nop
+      IL_002d:  ldc.i4.0
+      IL_002e:  ret
     } // end of method f@5::get_CheckClose
 
     .method public strict virtual instance !a 
@@ -255,7 +256,7 @@
     // Code size       24 (0x18)
     .maxstack  4
     .locals init ([0] !!a V_0)
-    .line 5,5 : 12,57 
+    .line 5,5 : 12,57 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.0
     IL_0002:  ldloca.s   V_0
@@ -288,7 +289,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       100 (0x64)
+    // Code size       109 (0x6d)
     .maxstack  4
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> r,
              [1] class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit> V_1,
@@ -296,7 +297,7 @@
              [3] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_3,
              [4] class [mscorlib]System.Exception V_4,
              [5] class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string> V_5)
-    .line 4,4 : 1,14 
+    .line 4,4 : 1,14 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.0
     IL_0002:  call       class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<!!0> [FSharp.Core]Microsoft.FSharp.Core.Operators::Ref<int32>(!!0)
@@ -307,18 +308,18 @@
     IL_0013:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>::.ctor(string)
     IL_0018:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_001d:  stloc.1
-    .line 6,6 : 1,53 
+    .line 6,6 : 1,53 ''
     IL_001e:  nop
-    .line 6,6 : 21,24 
+    .line 6,6 : 21,24 ''
     .try
     {
       IL_001f:  nop
-      .line 6,6 : 25,29 
+      .line 6,6 : 25,29 ''
       IL_0020:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> SeqExpressionSteppingTest7::f<int32>()
       IL_0025:  stloc.3
-      IL_0026:  leave.s    IL_0059
+      IL_0026:  leave.s    IL_0062
 
-      .line 6,6 : 30,34 
+      .line 6,6 : 30,34 ''
     }  // end .try
     catch [mscorlib]System.Object 
     {
@@ -334,26 +335,31 @@
 
       IL_003e:  br.s       IL_0057
 
-      .line 6,6 : 48,52 
+      .line 6,6 : 48,52 ''
       IL_0040:  call       class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> SeqExpressionSteppingTest7::get_r()
       IL_0045:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::op_Dereference<int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<!!0>)
       IL_004a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
       IL_004f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
       IL_0054:  stloc.3
-      IL_0055:  leave.s    IL_0059
+      IL_0055:  leave.s    IL_0062
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0057:  rethrow
-      .line 100001,100001 : 0,0 
+      IL_0059:  ldnull
+      IL_005a:  unbox.any  class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>
+      IL_005f:  stloc.3
+      IL_0060:  leave.s    IL_0062
+
+      .line 100001,100001 : 0,0 ''
     }  // end handler
-    IL_0059:  ldloc.3
-    IL_005a:  stloc.2
-    IL_005b:  ldloc.1
-    IL_005c:  ldloc.2
-    IL_005d:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
-    IL_0062:  pop
-    IL_0063:  ret
+    IL_0062:  ldloc.3
+    IL_0063:  stloc.2
+    IL_0064:  ldloc.1
+    IL_0065:  ldloc.2
+    IL_0066:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
+    IL_006b:  pop
+    IL_006c:  ret
   } // end of method $SeqExpressionSteppingTest7::main@
 
 } // end of class '<StartupCode$SeqExpressionSteppingTest7>'.$SeqExpressionSteppingTest7

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelModule.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelModule.il.bsl
@@ -36,13 +36,13 @@
   // Offset: 0x00001158 Length: 0x000003FD
 }
 .module TopLevelModule.dll
-// MVID: {57570CF0-37F5-C118-A745-0383F00C5757}
+// MVID: {575BE147-37F5-C118-A745-038347E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x01340000
+// Image base: 0x00620000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -1720,8 +1720,8 @@
   {
     // Code size       14 (0xe)
     .maxstack  3
-    .locals init ([0] string greeting,
-             [1] string V_1)
+    .locals init ([0] string V_0,
+             [1] string greeting)
     .line 12,12 : 9,31 ''
     IL_0000:  nop
     IL_0001:  call       string ABC::get_greeting()

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelModuleP.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelModuleP.il.bsl
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 3:47:41:9055
+  .ver 3:47:41:0
 }
 .assembly ToplevelModuleP
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.ToplevelModuleP
 {
-  // Offset: 0x00000000 Length: 0x0000114D
+  // Offset: 0x00000000 Length: 0x0000114F
 }
 .mresource public FSharpOptimizationData.ToplevelModuleP
 {
   // Offset: 0x00001158 Length: 0x000003FE
 }
 .module ToplevelModuleP.dll
-// MVID: {5706E103-5A3A-8E4D-A745-038303E10657}
+// MVID: {575BE155-5A3A-8E4D-A745-038355E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x005F0000
+// Image base: 0x009B0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -219,7 +219,7 @@
       // Code size       14 (0xe)
       .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 6,6 : 14,18 'd:\\KevinRansom\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SerializableAttribute\\ToplevelModule.fs'
+      .line 6,6 : 14,18 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SerializableAttribute\\ToplevelModule.fs'
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldarg.1
@@ -1692,8 +1692,8 @@
   {
     // Code size       14 (0xe)
     .maxstack  3
-    .locals init ([0] string greeting,
-             [1] string V_1)
+    .locals init ([0] string V_0,
+             [1] string greeting)
     .line 12,12 : 9,31 ''
     IL_0000:  nop
     IL_0001:  call       string ABC::get_greeting()

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelNamespace.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelNamespace.il.bsl
@@ -36,13 +36,13 @@
   // Offset: 0x00001860 Length: 0x0000055C
 }
 .module ToplevelNamespace.dll
-// MVID: {57570CF5-218B-729A-A745-0383F50C5757}
+// MVID: {575BE14E-218B-729A-A745-03834EE15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00820000
+// Image base: 0x00F30000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -2513,8 +2513,8 @@
   {
     // Code size       14 (0xe)
     .maxstack  3
-    .locals init ([0] string greeting,
-             [1] string V_1)
+    .locals init ([0] string V_0,
+             [1] string greeting)
     .line 19,19 : 9,31 ''
     IL_0000:  nop
     IL_0001:  call       string XYZ.ABC::get_greeting()

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelNamespaceP.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SerializableAttribute/ToplevelNamespaceP.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:4:1:9055
+  .ver 3:47:41:0
 }
 .assembly ToplevelNamespaceP
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.ToplevelNamespaceP
 {
-  // Offset: 0x00000000 Length: 0x00001858
+  // Offset: 0x00000000 Length: 0x0000185A
 }
 .mresource public FSharpOptimizationData.ToplevelNamespaceP
 {
   // Offset: 0x00001860 Length: 0x0000055D
 }
 .module ToplevelNamespaceP.dll
-// MVID: {57061C46-88D9-D7FD-A745-0383461C0657}
+// MVID: {575BE15B-88D9-D7FD-A745-03835BE15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00960000
+// Image base: 0x003C0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -214,7 +214,7 @@
     // Code size       14 (0xe)
     .maxstack  8
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 7,7 : 10,14 'c:\\KevinRansom\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SerializableAttribute\\ToplevelNamespace.fs'
+    .line 7,7 : 10,14 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SerializableAttribute\\ToplevelNamespace.fs'
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  ldarg.1
@@ -2471,8 +2471,8 @@
   {
     // Code size       14 (0xe)
     .maxstack  3
-    .locals init ([0] string greeting,
-             [1] string V_1)
+    .locals init ([0] string V_0,
+             [1] string greeting)
     .line 19,19 : 9,31 ''
     IL_0000:  nop
     IL_0001:  call       string XYZ.ABC::get_greeting()

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/TestFunction3.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/TestFunction3.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.16774
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly TestFunction3
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction3
 {
-  // Offset: 0x00000000 Length: 0x00000221
+  // Offset: 0x00000000 Length: 0x000001FD
 }
 .mresource public FSharpOptimizationData.TestFunction3
 {
-  // Offset: 0x00000228 Length: 0x00000088
+  // Offset: 0x00000208 Length: 0x00000088
 }
 .module TestFunction3.exe
-// MVID: {4DAC30C7-663A-8929-A745-0383C730AC4D}
+// MVID: {575BE191-663A-8929-A745-038391E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000000000270000
+// Image base: 0x003D0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -56,18 +56,18 @@
     // Code size       37 (0x25)
     .maxstack  8
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 5,5 : 5,20 
+    .line 5,5 : 5,20 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\TestFunctions\\TestFunction3.fs'
     IL_0000:  nop
     IL_0001:  ldstr      "Hello"
     IL_0006:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_000b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0010:  pop
-    .line 6,6 : 5,20 
+    .line 6,6 : 5,20 ''
     IL_0011:  ldstr      "World"
     IL_0016:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_001b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0020:  pop
-    .line 7,7 : 5,8 
+    .line 7,7 : 5,8 ''
     IL_0021:  ldc.i4.3
     IL_0022:  ldc.i4.4
     IL_0023:  add
@@ -81,35 +81,35 @@
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_0,
              [1] int32 x,
              [2] class [mscorlib]System.Exception V_2)
-    .line 10,10 : 5,8 
+    .line 10,10 : 5,8 ''
     IL_0000:  nop
     .try
     {
       IL_0001:  nop
-      .line 11,11 : 8,31 
+      .line 11,11 : 8,31 ''
       IL_0002:  call       int32 TestFunction3::TestFunction1()
       IL_0007:  stloc.1
-      .line 12,12 : 8,23 
+      .line 12,12 : 8,23 ''
       IL_0008:  ldstr      "Hello"
       IL_000d:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
       IL_0012:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
       IL_0017:  stloc.0
       IL_0018:  leave.s    IL_0032
 
-      .line 13,13 : 5,9 
+      .line 13,13 : 5,9 ''
     }  // end .try
     catch [mscorlib]System.Object 
     {
       IL_001a:  castclass  [mscorlib]System.Exception
       IL_001f:  stloc.2
-      .line 14,14 : 8,23 
+      .line 14,14 : 8,23 ''
       IL_0020:  ldstr      "World"
       IL_0025:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
       IL_002a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
       IL_002f:  stloc.0
       IL_0030:  leave.s    IL_0032
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
     }  // end handler
     IL_0032:  ldloc.0
     IL_0033:  pop

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/TestFunction3b.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/TestFunction3b.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.16774
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly TestFunction3b
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction3b
 {
-  // Offset: 0x00000000 Length: 0x00000224
+  // Offset: 0x00000000 Length: 0x00000200
 }
 .mresource public FSharpOptimizationData.TestFunction3b
 {
-  // Offset: 0x00000228 Length: 0x0000008A
+  // Offset: 0x00000208 Length: 0x0000008A
 }
 .module TestFunction3b.exe
-// MVID: {4DAC30C9-A662-4FC9-A745-0383C930AC4D}
+// MVID: {575BE194-A662-4FC9-A745-038394E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000000000360000
+// Image base: 0x01040000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -56,18 +56,18 @@
     // Code size       37 (0x25)
     .maxstack  8
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 5,5 : 5,20 
+    .line 5,5 : 5,20 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\TestFunctions\\TestFunction3b.fs'
     IL_0000:  nop
     IL_0001:  ldstr      "Hello"
     IL_0006:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_000b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0010:  pop
-    .line 6,6 : 5,20 
+    .line 6,6 : 5,20 ''
     IL_0011:  ldstr      "World"
     IL_0016:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_001b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0020:  pop
-    .line 7,7 : 5,8 
+    .line 7,7 : 5,8 ''
     IL_0021:  ldc.i4.3
     IL_0022:  ldc.i4.4
     IL_0023:  add
@@ -76,27 +76,27 @@
 
   .method public static void  TestFunction3b() cil managed
   {
-    // Code size       64 (0x40)
+    // Code size       73 (0x49)
     .maxstack  3
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_0,
              [1] int32 x,
              [2] class [mscorlib]System.Exception V_2,
              [3] class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string> V_3)
-    .line 10,10 : 5,8 
+    .line 10,10 : 5,8 ''
     IL_0000:  nop
     .try
     {
       IL_0001:  nop
-      .line 11,11 : 8,31 
+      .line 11,11 : 8,31 ''
       IL_0002:  call       int32 TestFunction3b::TestFunction1()
       IL_0007:  stloc.1
-      .line 12,12 : 8,24 
+      .line 12,12 : 8,24 ''
       IL_0008:  ldstr      "hello"
       IL_000d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::FailWith<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(string)
       IL_0012:  stloc.0
-      IL_0013:  leave.s    IL_003d
+      IL_0013:  leave.s    IL_0046
 
-      .line 13,13 : 5,9 
+      .line 13,13 : 5,9 ''
     }  // end .try
     catch [mscorlib]System.Object 
     {
@@ -112,20 +112,25 @@
 
       IL_0027:  br.s       IL_003b
 
-      .line 14,14 : 8,23 
+      .line 14,14 : 8,23 ''
       IL_0029:  ldstr      "World"
       IL_002e:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
       IL_0033:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
       IL_0038:  stloc.0
-      IL_0039:  leave.s    IL_003d
+      IL_0039:  leave.s    IL_0046
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_003b:  rethrow
-      .line 100001,100001 : 0,0 
+      IL_003d:  ldnull
+      IL_003e:  unbox.any  [FSharp.Core]Microsoft.FSharp.Core.Unit
+      IL_0043:  stloc.0
+      IL_0044:  leave.s    IL_0046
+
+      .line 100001,100001 : 0,0 ''
     }  // end handler
-    IL_003d:  ldloc.0
-    IL_003e:  pop
-    IL_003f:  ret
+    IL_0046:  ldloc.0
+    IL_0047:  pop
+    IL_0048:  ret
   } // end of method TestFunction3b::TestFunction3b
 
 } // end of class TestFunction3b

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/TestFunction3c.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/TestFunction3c.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.16774
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly TestFunction3c
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction3c
 {
-  // Offset: 0x00000000 Length: 0x00000224
+  // Offset: 0x00000000 Length: 0x00000200
 }
 .mresource public FSharpOptimizationData.TestFunction3c
 {
-  // Offset: 0x00000228 Length: 0x0000008A
+  // Offset: 0x00000208 Length: 0x0000008A
 }
 .module TestFunction3c.exe
-// MVID: {4DAC30CC-A662-4FAC-A745-0383CC30AC4D}
+// MVID: {575BE197-A662-4FAC-A745-038397E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000000000160000
+// Image base: 0x00520000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -56,18 +56,18 @@
     // Code size       37 (0x25)
     .maxstack  8
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 5,5 : 5,20 
+    .line 5,5 : 5,20 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\TestFunctions\\TestFunction3c.fs'
     IL_0000:  nop
     IL_0001:  ldstr      "Hello"
     IL_0006:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_000b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0010:  pop
-    .line 6,6 : 5,20 
+    .line 6,6 : 5,20 ''
     IL_0011:  ldstr      "World"
     IL_0016:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_001b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0020:  pop
-    .line 7,7 : 5,8 
+    .line 7,7 : 5,8 ''
     IL_0021:  ldc.i4.3
     IL_0022:  ldc.i4.4
     IL_0023:  add
@@ -76,7 +76,7 @@
 
   .method public static void  TestFunction3c() cil managed
   {
-    // Code size       94 (0x5e)
+    // Code size       103 (0x67)
     .maxstack  4
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_0,
              [1] int32 x,
@@ -84,21 +84,21 @@
              [3] class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string> V_3,
              [4] string msg,
              [5] string V_5)
-    .line 10,10 : 5,8 
+    .line 10,10 : 5,8 ''
     IL_0000:  nop
     .try
     {
       IL_0001:  nop
-      .line 11,11 : 8,31 
+      .line 11,11 : 8,31 ''
       IL_0002:  call       int32 TestFunction3c::TestFunction1()
       IL_0007:  stloc.1
-      .line 12,12 : 8,24 
+      .line 12,12 : 8,24 ''
       IL_0008:  ldstr      "hello"
       IL_000d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::FailWith<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(string)
       IL_0012:  stloc.0
-      IL_0013:  leave.s    IL_005b
+      IL_0013:  leave.s    IL_0064
 
-      .line 13,13 : 5,9 
+      .line 13,13 : 5,9 ''
     }  // end .try
     catch [mscorlib]System.Object 
     {
@@ -126,20 +126,25 @@
       IL_003f:  ldloc.3
       IL_0040:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string>::get_Value()
       IL_0045:  stloc.s    V_5
-      .line 14,14 : 8,23 
+      .line 14,14 : 8,23 ''
       IL_0047:  ldstr      "World"
       IL_004c:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
       IL_0051:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
       IL_0056:  stloc.0
-      IL_0057:  leave.s    IL_005b
+      IL_0057:  leave.s    IL_0064
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0059:  rethrow
-      .line 100001,100001 : 0,0 
+      IL_005b:  ldnull
+      IL_005c:  unbox.any  [FSharp.Core]Microsoft.FSharp.Core.Unit
+      IL_0061:  stloc.0
+      IL_0062:  leave.s    IL_0064
+
+      .line 100001,100001 : 0,0 ''
     }  // end handler
-    IL_005b:  ldloc.0
-    IL_005c:  pop
-    IL_005d:  ret
+    IL_0064:  ldloc.0
+    IL_0065:  pop
+    IL_0066:  ret
   } // end of method TestFunction3c::TestFunction3c
 
 } // end of class TestFunction3c

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/Testfunction3.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/Testfunction3.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.1
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly TestFunction3
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction3
 {
-  // Offset: 0x00000000 Length: 0x00000211
+  // Offset: 0x00000000 Length: 0x000001FD
 }
 .mresource public FSharpOptimizationData.TestFunction3
 {
-  // Offset: 0x00000218 Length: 0x00000088
+  // Offset: 0x00000208 Length: 0x00000088
 }
 .module TestFunction3.exe
-// MVID: {4BEB2912-663A-8929-A745-03831229EB4B}
+// MVID: {575BE191-663A-8929-A745-038391E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x006C0000
+// Image base: 0x003D0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -54,20 +54,20 @@
   .method public static int32  TestFunction1() cil managed
   {
     // Code size       37 (0x25)
-    .maxstack  4
+    .maxstack  8
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 5,5 : 5,20 
+    .line 5,5 : 5,20 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\TestFunctions\\TestFunction3.fs'
     IL_0000:  nop
     IL_0001:  ldstr      "Hello"
     IL_0006:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_000b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0010:  pop
-    .line 6,6 : 5,20 
+    .line 6,6 : 5,20 ''
     IL_0011:  ldstr      "World"
     IL_0016:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_001b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0020:  pop
-    .line 7,7 : 5,8 
+    .line 7,7 : 5,8 ''
     IL_0021:  ldc.i4.3
     IL_0022:  ldc.i4.4
     IL_0023:  add
@@ -81,35 +81,35 @@
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_0,
              [1] int32 x,
              [2] class [mscorlib]System.Exception V_2)
-    .line 10,10 : 5,8 
+    .line 10,10 : 5,8 ''
     IL_0000:  nop
     .try
     {
       IL_0001:  nop
-      .line 11,11 : 8,31 
+      .line 11,11 : 8,31 ''
       IL_0002:  call       int32 TestFunction3::TestFunction1()
       IL_0007:  stloc.1
-      .line 12,12 : 8,23 
+      .line 12,12 : 8,23 ''
       IL_0008:  ldstr      "Hello"
       IL_000d:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
       IL_0012:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
       IL_0017:  stloc.0
       IL_0018:  leave.s    IL_0032
 
-      .line 13,13 : 5,9 
+      .line 13,13 : 5,9 ''
     }  // end .try
     catch [mscorlib]System.Object 
     {
       IL_001a:  castclass  [mscorlib]System.Exception
       IL_001f:  stloc.2
-      .line 14,14 : 8,23 
+      .line 14,14 : 8,23 ''
       IL_0020:  ldstr      "World"
       IL_0025:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
       IL_002a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
       IL_002f:  stloc.0
       IL_0030:  leave.s    IL_0032
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
     }  // end handler
     IL_0032:  ldloc.0
     IL_0033:  pop
@@ -125,7 +125,7 @@
   {
     .entrypoint
     // Code size       2 (0x2)
-    .maxstack  2
+    .maxstack  8
     IL_0000:  nop
     IL_0001:  ret
   } // end of method $TestFunction3::main@

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/Testfunction3b.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/Testfunction3b.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.1
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly TestFunction3b
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction3b
 {
-  // Offset: 0x00000000 Length: 0x00000214
+  // Offset: 0x00000000 Length: 0x00000200
 }
 .mresource public FSharpOptimizationData.TestFunction3b
 {
-  // Offset: 0x00000218 Length: 0x0000008A
+  // Offset: 0x00000208 Length: 0x0000008A
 }
 .module TestFunction3b.exe
-// MVID: {4BEB2917-A662-4FC9-A745-03831729EB4B}
+// MVID: {575BE194-A662-4FC9-A745-038394E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x004B0000
+// Image base: 0x01040000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -54,20 +54,20 @@
   .method public static int32  TestFunction1() cil managed
   {
     // Code size       37 (0x25)
-    .maxstack  4
+    .maxstack  8
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 5,5 : 5,20 
+    .line 5,5 : 5,20 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\TestFunctions\\TestFunction3b.fs'
     IL_0000:  nop
     IL_0001:  ldstr      "Hello"
     IL_0006:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_000b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0010:  pop
-    .line 6,6 : 5,20 
+    .line 6,6 : 5,20 ''
     IL_0011:  ldstr      "World"
     IL_0016:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_001b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0020:  pop
-    .line 7,7 : 5,8 
+    .line 7,7 : 5,8 ''
     IL_0021:  ldc.i4.3
     IL_0022:  ldc.i4.4
     IL_0023:  add
@@ -76,27 +76,27 @@
 
   .method public static void  TestFunction3b() cil managed
   {
-    // Code size       64 (0x40)
+    // Code size       73 (0x49)
     .maxstack  3
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_0,
              [1] int32 x,
              [2] class [mscorlib]System.Exception V_2,
              [3] class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string> V_3)
-    .line 10,10 : 5,8 
+    .line 10,10 : 5,8 ''
     IL_0000:  nop
     .try
     {
       IL_0001:  nop
-      .line 11,11 : 8,31 
+      .line 11,11 : 8,31 ''
       IL_0002:  call       int32 TestFunction3b::TestFunction1()
       IL_0007:  stloc.1
-      .line 12,12 : 8,24 
+      .line 12,12 : 8,24 ''
       IL_0008:  ldstr      "hello"
       IL_000d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::FailWith<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(string)
       IL_0012:  stloc.0
-      IL_0013:  leave.s    IL_003d
+      IL_0013:  leave.s    IL_0046
 
-      .line 13,13 : 5,9 
+      .line 13,13 : 5,9 ''
     }  // end .try
     catch [mscorlib]System.Object 
     {
@@ -112,20 +112,25 @@
 
       IL_0027:  br.s       IL_003b
 
-      .line 14,14 : 8,23 
+      .line 14,14 : 8,23 ''
       IL_0029:  ldstr      "World"
       IL_002e:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
       IL_0033:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
       IL_0038:  stloc.0
-      IL_0039:  leave.s    IL_003d
+      IL_0039:  leave.s    IL_0046
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_003b:  rethrow
-      .line 100001,100001 : 0,0 
+      IL_003d:  ldnull
+      IL_003e:  unbox.any  [FSharp.Core]Microsoft.FSharp.Core.Unit
+      IL_0043:  stloc.0
+      IL_0044:  leave.s    IL_0046
+
+      .line 100001,100001 : 0,0 ''
     }  // end handler
-    IL_003d:  ldloc.0
-    IL_003e:  pop
-    IL_003f:  ret
+    IL_0046:  ldloc.0
+    IL_0047:  pop
+    IL_0048:  ret
   } // end of method TestFunction3b::TestFunction3b
 
 } // end of class TestFunction3b
@@ -137,7 +142,7 @@
   {
     .entrypoint
     // Code size       2 (0x2)
-    .maxstack  2
+    .maxstack  8
     IL_0000:  nop
     IL_0001:  ret
   } // end of method $TestFunction3b::main@

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/Testfunction3c.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/TestFunctions/Testfunction3c.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.1
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly TestFunction3c
 {
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.TestFunction3c
 {
-  // Offset: 0x00000000 Length: 0x00000214
+  // Offset: 0x00000000 Length: 0x00000200
 }
 .mresource public FSharpOptimizationData.TestFunction3c
 {
-  // Offset: 0x00000218 Length: 0x0000008A
+  // Offset: 0x00000208 Length: 0x0000008A
 }
 .module TestFunction3c.exe
-// MVID: {4BEB291C-A662-4FAC-A745-03831C29EB4B}
+// MVID: {575BE197-A662-4FAC-A745-038397E15B57}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00460000
+// Image base: 0x00520000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -54,20 +54,20 @@
   .method public static int32  TestFunction1() cil managed
   {
     // Code size       37 (0x25)
-    .maxstack  4
+    .maxstack  8
     .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-    .line 5,5 : 5,20 
+    .line 5,5 : 5,20 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\TestFunctions\\TestFunction3c.fs'
     IL_0000:  nop
     IL_0001:  ldstr      "Hello"
     IL_0006:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_000b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0010:  pop
-    .line 6,6 : 5,20 
+    .line 6,6 : 5,20 ''
     IL_0011:  ldstr      "World"
     IL_0016:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
     IL_001b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_0020:  pop
-    .line 7,7 : 5,8 
+    .line 7,7 : 5,8 ''
     IL_0021:  ldc.i4.3
     IL_0022:  ldc.i4.4
     IL_0023:  add
@@ -76,7 +76,7 @@
 
   .method public static void  TestFunction3c() cil managed
   {
-    // Code size       94 (0x5e)
+    // Code size       103 (0x67)
     .maxstack  4
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_0,
              [1] int32 x,
@@ -84,21 +84,21 @@
              [3] class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string> V_3,
              [4] string msg,
              [5] string V_5)
-    .line 10,10 : 5,8 
+    .line 10,10 : 5,8 ''
     IL_0000:  nop
     .try
     {
       IL_0001:  nop
-      .line 11,11 : 8,31 
+      .line 11,11 : 8,31 ''
       IL_0002:  call       int32 TestFunction3c::TestFunction1()
       IL_0007:  stloc.1
-      .line 12,12 : 8,24 
+      .line 12,12 : 8,24 ''
       IL_0008:  ldstr      "hello"
       IL_000d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::FailWith<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(string)
       IL_0012:  stloc.0
-      IL_0013:  leave.s    IL_005b
+      IL_0013:  leave.s    IL_0064
 
-      .line 13,13 : 5,9 
+      .line 13,13 : 5,9 ''
     }  // end .try
     catch [mscorlib]System.Object 
     {
@@ -126,20 +126,25 @@
       IL_003f:  ldloc.3
       IL_0040:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string>::get_Value()
       IL_0045:  stloc.s    V_5
-      .line 14,14 : 8,23 
+      .line 14,14 : 8,23 ''
       IL_0047:  ldstr      "World"
       IL_004c:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
       IL_0051:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
       IL_0056:  stloc.0
-      IL_0057:  leave.s    IL_005b
+      IL_0057:  leave.s    IL_0064
 
-      .line 100001,100001 : 0,0 
+      .line 100001,100001 : 0,0 ''
       IL_0059:  rethrow
-      .line 100001,100001 : 0,0 
+      IL_005b:  ldnull
+      IL_005c:  unbox.any  [FSharp.Core]Microsoft.FSharp.Core.Unit
+      IL_0061:  stloc.0
+      IL_0062:  leave.s    IL_0064
+
+      .line 100001,100001 : 0,0 ''
     }  // end handler
-    IL_005b:  ldloc.0
-    IL_005c:  pop
-    IL_005d:  ret
+    IL_0064:  ldloc.0
+    IL_0065:  pop
+    IL_0066:  ret
   } // end of method TestFunction3c::TestFunction3c
 
 } // end of class TestFunction3c
@@ -151,7 +156,7 @@
   {
     .entrypoint
     // Code size       2 (0x2)
-    .maxstack  2
+    .maxstack  8
     IL_0000:  nop
     IL_0001:  ret
   } // end of method $TestFunction3c::main@


### PR DESCRIPTION
This is the last piece of work to remove the "ILX-to-IL" phase from the compiler

Historically, the AbstractIL code representation has long been an overly complicated "basic block" form.  This form was suitable when we needed to do rewriting transformations over the structure that might need to replace instructions with further code.  However, it was expensive and complex to get the generated code into this representation, and then to get it back out again.

Now that the ILX phase has been removed, we can use a much simpler code representation which is just an array of instructions, a dictionary of labels plus information about exceptions and locals.

As part of this, the "branch" instructions now "fall through" to the next instruction, rather than specifying a branch target for the fallthrough case.  This corresponds to the shift to a linear sequence of instructions.

I believe - though do not yet have proof - that this should give better performance for the TAST - to - IL phase of the compiler.  Certainly it reduces the overall code complexity, since this PR removes about 1000 lines from the compiler.  

It's not totally trivial to get the exception and locals information in ilwrite.fs into the form desired, so that part took a while to complete.

