### PR TITLE
add a warning to mutable use bindings

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1307,3 +1307,4 @@ estApplyStaticArgumentsForMethodNotImplemented,"A type provider implemented GetS
 3201,tcModuleAbbrevFirstInMutRec,"In a recursive declaration group, module abbreviations must come after all 'open' declarations and before other declarations"
 3202,tcUnsupportedMutRecDecl,"This declaration is not supported in recursive declaration groups"
 3203,parsInvalidUseOfRec,"Invalid use of 'rec' keyword"
+3204,tcUseMayNotBeMutable,"This feature is deprecated. A 'use' binding may not be marked 'mutable'."

--- a/tests/fsharp/typecheck/sigs/neg96.bsl
+++ b/tests/fsharp/typecheck/sigs/neg96.bsl
@@ -1,2 +1,4 @@
 
 neg95.fs(11,9,11,21): typecheck error FS0039: The value or constructor 'StructRecord' is not defined
+
+neg96.fs(14,17,14,18): typecheck error FS3204: This feature is deprecated. A 'use' binding may not be marked 'mutable'.

--- a/tests/fsharp/typecheck/sigs/neg96.fs
+++ b/tests/fsharp/typecheck/sigs/neg96.fs
@@ -9,3 +9,7 @@ type StructRecord =
     }
 
 let x = StructRecord ()
+
+let invalidUse() = 
+    use mutable x = (null : System.IDisposable)
+    ()


### PR DESCRIPTION
Addresses the minor language issue identified here: https://fslang.uservoice.com/forums/245727-f-language/status/1225914

This adds a warning for "use mutable x = ..."

Also a little cleanup for the ``immut`` flag in ``CheckedBindingInfo `` that was always ``true``