### PR TITLE
[WIP] fix for .NET Core 1.0 RTM

### DIFF
--- a/src/fsharp/FSharp.Compiler.Host.netcore.nuget/Microsoft.FSharp.Compiler.Host.netcore.nuspec
+++ b/src/fsharp/FSharp.Compiler.Host.netcore.nuget/Microsoft.FSharp.Compiler.Host.netcore.nuspec
@@ -19,7 +19,7 @@
             <group targetFramework=".NETStandard1.6">
                 <dependency id="Microsoft.NETCore.Platforms" version="1.0.1" />
                 <dependency id="Microsoft.NETCore.Runtime.CoreCLR" version="1.0.2" />
-                <dependency id="Microsoft.NETCore" version="5.0.1-rc2-23911" />
+                <dependency id="Microsoft.NETCore" version="5.0.1" />
                 <dependency id="Microsoft.NETCore.ConsoleHost" version="1.0.0-rc2-23911" />
                 <dependency id="Microsoft.FSharp.Compiler.NetCore" version="$version$" />
             </group>

--- a/src/fsharp/FSharp.Compiler.Host.netcore.nuget/Microsoft.FSharp.Compiler.Host.netcore.nuspec
+++ b/src/fsharp/FSharp.Compiler.Host.netcore.nuget/Microsoft.FSharp.Compiler.Host.netcore.nuspec
@@ -20,7 +20,6 @@
                 <dependency id="Microsoft.NETCore.Platforms" version="1.0.1" />
                 <dependency id="Microsoft.NETCore.Runtime.CoreCLR" version="1.0.2" />
                 <dependency id="Microsoft.NETCore" version="5.0.1" />
-                <dependency id="Microsoft.NETCore.ConsoleHost" version="1.0.0-rc2-23911" />
                 <dependency id="Microsoft.FSharp.Compiler.NetCore" version="$version$" />
             </group>
         </dependencies>

--- a/src/fsharp/FSharp.Compiler.netcore.nuget/Microsoft.FSharp.Compiler.netcore.nuspec
+++ b/src/fsharp/FSharp.Compiler.netcore.nuget/Microsoft.FSharp.Compiler.netcore.nuspec
@@ -27,7 +27,6 @@
                 <dependency id="System.Reflection.Emit" version="4.0.1" />
                 <dependency id="System.Reflection.Metadata" version="1.4.1-beta-24227-04" />
                 <dependency id="System.Runtime.InteropServices" version="4.1.0" />
-                <dependency id="System.Runtime.InteropServices.PInvoke" version="4.0.0-rc2-24027" />
                 <dependency id="System.Runtime.Loader" version="4.0.0" />
                 <dependency id="System.Security.Cryptography.Algorithms" version="4.2.0" />
                 <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />

--- a/src/fsharp/FSharp.Compiler/project.json
+++ b/src/fsharp/FSharp.Compiler/project.json
@@ -12,7 +12,6 @@
     "System.Reflection.Metadata": "1.4.1-beta-24227-04",
     "System.Reflection.TypeExtensions": "4.1.0",
     "System.Runtime.InteropServices": "4.1.0",
-    "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-24027",
     "System.Runtime.Loader": "4.0.0",
     "System.Security.Cryptography.Algorithms": "4.2.0",
     "System.Threading.Tasks.Parallel": "4.0.1",

--- a/src/fsharp/FSharp.Core.Unittests/project.json
+++ b/src/fsharp/FSharp.Core.Unittests/project.json
@@ -10,7 +10,7 @@
     "System.Text.RegularExpressions": "4.1.0",
     "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027",
     "System.Threading.Thread": "4.0.0",
-    "System.Threading.ThreadPool": "4.0.10",
+    "System.Threading.ThreadPool": "4.0.10"
   },
   "runtimes": {
     "win7-x86": { },

--- a/src/fsharp/FSharp.Core/project.json
+++ b/src/fsharp/FSharp.Core/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc4-24201-00",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
     "System.Collections": "4.0.11",
     "System.Console": "4.0.0",
     "System.Diagnostics.Debug": "4.0.11",

--- a/tests/fsharp/project.json
+++ b/tests/fsharp/project.json
@@ -41,8 +41,8 @@
 
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-24027", 
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-24027", 
-    "System.Reflection.Emit.ILGeneration": "4.0.2",
-    "System.Security.Cryptography.Primitives": "4.0.1",
+    "System.Reflection.Emit.ILGeneration": "4.0.1",
+    "System.Security.Cryptography.Primitives": "4.0.0"
   },
   "runtimes": {
     "win7-x86": { },

--- a/tests/fsharp/project.json
+++ b/tests/fsharp/project.json
@@ -39,7 +39,7 @@
     "Microsoft.DiaSymReader": "1.0.8",
 
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-24027", 
-    "Microsoft.NETCore.TestHost": "1.0.0-rc2-24027", 
+    "Microsoft.NETCore.TestHost": "1.0.0", 
     "System.Reflection.Emit.ILGeneration": "4.0.1",
     "System.Security.Cryptography.Primitives": "4.0.0"
   },

--- a/tests/fsharp/project.json
+++ b/tests/fsharp/project.json
@@ -24,7 +24,6 @@
     "System.Runtime": "4.1.0",
     "System.Runtime.Extensions": "4.1.0",
     "System.Runtime.InteropServices": "4.1.0",
-    "System.Runtime.InteropServices.PInvoke": "4.0.0-rc2-24027",
     "System.Runtime.Loader": "4.0.0",
     "System.Runtime.Numerics": "4.0.1",
     "System.Security.Cryptography.Algorithms": "4.2.0",

--- a/tests/fsharp/project.json
+++ b/tests/fsharp/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc4-24201-00",
     "NETStandard.Library": "1.6.0",
     "System.Collections": "4.0.11",
     "System.Collections.Immutable":"1.2.0",
@@ -38,7 +37,7 @@
     "Microsoft.DiaSymReader.PortablePdb": "1.1.0",
     "Microsoft.DiaSymReader": "1.0.8",
 
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-24027", 
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2", 
     "Microsoft.NETCore.TestHost": "1.0.0", 
     "System.Reflection.Emit.ILGeneration": "4.0.1",
     "System.Security.Cryptography.Primitives": "4.0.0"

--- a/tests/fsharp/project.json
+++ b/tests/fsharp/project.json
@@ -41,7 +41,6 @@
 
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc2-24027", 
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-24027", 
-    "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-24027", 
     "System.Reflection.Emit.ILGeneration": "4.0.2",
     "System.Security.Cryptography.Primitives": "4.0.1",
   },

--- a/tests/fsharp/single-test-build.bat
+++ b/tests/fsharp/single-test-build.bat
@@ -127,7 +127,7 @@ set platform=win7-x64
 For %%A in ("%cd%") do (Set TestCaseName=%%~nxA)
 set command_line_args=
 set command_line_args=%command_line_args% --exec %~d0%~p0..\fsharpqa\testenv\src\deployProj\CompileProj.fsx
-set command_line_args=%command_line_args% --targetPlatformName:.NETStandard,Version=v1.5/%platform%
+set command_line_args=%command_line_args% --targetPlatformName:.NETStandard,Version=v1.6/%platform%
 set command_line_args=%command_line_args% --source:"%~d0%~p0coreclr_utilities.fs" --source:"%sources%" 
 set command_line_args=%command_line_args% --packagesDir:%~d0%~p0..\..\packages 
 set command_line_args=%command_line_args% --projectJsonLock:%~d0%~p0project.lock.json


### PR DESCRIPTION
- [x] use .NET Core 1.0 RTM and .NET Core sdk `preview2` ( `1.0.0-preview2-003121` )
- fix deps of f# packages, to depend only on 1.0 packages
   - [x] compilers ( but prerelease of `System.Reflection.Metadata` v1.4.1 )
   - [x] fsharp.core
- [x] depends on `.NETStandard.Library` 1.6 instead of 1.5 ( @brthor @piotrpMSFT @blackdwarf that's ok? 1.6 mean is aligned with standard `.NETCoreApp` 1.0 deps )
- [x] depends on `System.Reflection.Metadata` v1.4.1  insteaed of 1.3.0 (metadatabuilder is internal)
- [ ] review declared nuspec dependencies vs project.json