### PR TITLE
Fix type declaration order when merging namespace fragments

### DIFF
--- a/tests/fsharp/core/fileorder/libfile1.fs
+++ b/tests/fsharp/core/fileorder/libfile1.fs
@@ -1,0 +1,15 @@
+
+// Repro for https://github.com/Microsoft/visualfsharp/issues/1298
+namespace Ploeh.Weird.Repro
+
+type Foo = {
+    Value : string
+    Text : string }
+
+type Bar = {
+    Value : string
+    Number : int }
+
+type Baz = {
+    Value : int
+    Text : string }

--- a/tests/fsharp/core/fileorder/libfile2.fs
+++ b/tests/fsharp/core/fileorder/libfile2.fs
@@ -1,0 +1,4 @@
+namespace Ploeh.Weird.Repro
+
+
+// deliberately empty

--- a/tests/fsharp/core/fileorder/test.fsx
+++ b/tests/fsharp/core/fileorder/test.fsx
@@ -1,0 +1,23 @@
+// #Conformance #Regression 
+#if Portable
+module Core_fileorder
+#endif
+
+
+open Ploeh.Weird.Repro
+
+let failures = ref false
+let report_failure s  = 
+  stderr.WriteLine ("NO: test "+s+" failed"); failures := true
+
+
+let b = {
+    Value = 42
+    Text = "Ploeh" }
+    
+let aa =
+  if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
+
+do (stdout.WriteLine "Test Passed"; 
+    System.IO.File.WriteAllText("test.ok","ok"); 
+    exit 0)


### PR DESCRIPTION
This fixes the problem of https://github.com/Microsoft/visualfsharp/issues/1298

Basically we were sorting type declarations by their name when merging the types inferred for namespaces, rather than maintaining the original declaration order.  This caused an inconsistency when the introduction of an empty file caused a merge to be introduced.

Because of the nature of this fix, it's possible that in some pathological cases it will change the behavior of name resolution in cases where there are multiple record types sharing the same labels.  However it seems important to make the fix, though some users may then have to adjust their code.  Because of this we may want to also list it as an RFC.
