### PR TITLE
More efficient Algorithm for List.countBy

### DIFF
--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -53,10 +53,7 @@ namespace Microsoft.FSharp.Collections
                     if dict.TryGetValue(safeKey, &prev) then dict.[safeKey] <- prev + 1 else dict.[safeKey] <- 1
                     loop t
             loop list
-            let mutable result = []
-            for group in dict do
-                result <- (getKey group.Key, group.Value) :: result
-            result |> rev
+            Microsoft.FSharp.Primitives.Basics.List.countBy dict getKey
 
         // We avoid wrapping a StructBox, because under 64 JIT we get some "hard" tailcalls which affect performance
         let countByValueType (projection:'T->'Key) (list:'T list) = countByImpl HashIdentity.Structural<'Key> projection id list

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -72,6 +72,19 @@ module internal List =
             let cons = freshConsNoTail x
             distinctByToFreshConsTail cons hashSet keyf rest
             cons
+    
+    let countBy (dict:Dictionary<_, int>) (keyf:'T -> 'Key) = 
+        use mutable ie = dict.GetEnumerator()
+        if not (ie.MoveNext()) then []
+        else
+            let res = freshConsNoTail (keyf ie.Current.Key, ie.Current.Value)
+            let mutable cons = res
+            while ie.MoveNext() do
+                let cons2 = freshConsNoTail (keyf ie.Current.Key, ie.Current.Value)
+                setFreshConsTail cons cons2
+                cons <- cons2
+            setFreshConsTail cons []
+            res
 
     let rec mapToFreshConsTail cons f x = 
         match x with

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -74,7 +74,7 @@ module internal List =
             cons
     
     let countBy (dict:Dictionary<_, int>) (keyf:'T -> 'Key) = 
-        use mutable ie = dict.GetEnumerator()
+        let mutable ie = dict.GetEnumerator()
         if not (ie.MoveNext()) then []
         else
             let res = freshConsNoTail (keyf ie.Current.Key, ie.Current.Value)

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -8,6 +8,7 @@ open Microsoft.FSharp.Collections
 
 module internal List =
     val allPairs : 'T1 list -> 'T2 list -> ('T1 * 'T2) list
+    val countBy : System.Collections.Generic.Dictionary<'T1, int> -> ('T1 -> 'T2) -> ('T2 * int) list
     val distinctWithComparer : System.Collections.Generic.IEqualityComparer<'T> -> 'T list -> 'T list
     val distinctByWithComparer : System.Collections.Generic.IEqualityComparer<'Key> -> ('T -> 'Key) -> list:'T list -> 'T list when 'Key : equality
     val init : int -> (int -> 'T) -> 'T list


### PR DESCRIPTION
As title. I found it strange that in local.fs, I had to use mutable in `use mutable ie = dict.GetEnumerator()` to compile even though the very similar `ofSeq` didn't. Here are some performance numbers: https://gist.github.com/liboz/a6a0cd4ab4a9d8cf585d282193af560c. I had to basically copy the original implementation to do the timings because the new implementation requires access to internal methods in local.fs.

It's significantly faster when there are a decent number of distinct values in the original list. When there are only 2 as in my second example the performance is about the same as before.