### PR TITLE
Fixes the signature of List.compareWith and Array.compareWith

### DIFF
--- a/src/fsharp/FSharp.Core/array.fsi
+++ b/src/fsharp/FSharp.Core/array.fsi
@@ -72,19 +72,18 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Collect")>]
         val collect : mapping:('T -> 'U[]) -> array:'T[] -> 'U[]
 
-        /// <summary>Compares two arrays using the given comparison function, element by element.
-        /// Returns the first non-zero result from the comparison function. If the first array has 
-        /// a larger element, the return value is always positive. If the second array has a larger 
-        /// element, the return value is always negative. When the elements are equal in the two 
-        /// arrays, 1 is returned if the first array is longer, 0 is returned if they are equal in 
-        /// length, and -1 is returned when the second array is longer.</summary>
+        /// <summary>Compares two arrays using the given comparison function, element by element.</summary>
         ///
         /// <param name="comparer">A function that takes an element from each array and returns an int.
         /// If it evaluates to a non-zero value iteration is stopped and that value is returned.</param>
         /// <param name="array1">The first input array.</param>
         /// <param name="array2">The second input array.</param>
         ///
-        /// <returns>The first non-zero value from the comparison function.</returns>
+        /// <returns>Returns the first non-zero result from the comparison function. If the first array has 
+        /// a larger element, the return value is always positive. If the second array has a larger 
+        /// element, the return value is always negative. When the elements are equal in the two 
+        /// arrays, 1 is returned if the first array is longer, 0 is returned if they are equal in 
+        /// length, and -1 is returned when the second array is longer.</returns>
         ///
         /// <exception cref="System.ArgumentNullException">Thrown when either of the input arrays
         /// is null.</exception>

--- a/src/fsharp/FSharp.Core/array.fsi
+++ b/src/fsharp/FSharp.Core/array.fsi
@@ -73,9 +73,11 @@ namespace Microsoft.FSharp.Collections
         val collect : mapping:('T -> 'U[]) -> array:'T[] -> 'U[]
 
         /// <summary>Compares two arrays using the given comparison function, element by element.
-        /// Returns the first non-zero result from the comparison function.  If the end of an array
-        /// is reached it returns a -1 if the first array is shorter and a 1 if the second array
-        /// is shorter.</summary>
+        /// Returns the first non-zero result from the comparison function. If the first array has 
+        /// a larger element, the return value is always positive. If the second array has a larger 
+        /// element, the return value is always negative. When the elements are equal in the two 
+        /// arrays, 1 is returned if the first array is longer, 0 is returned if they are equal in 
+        /// length, and -1 is returned when the second array is longer.</summary>
         ///
         /// <param name="comparer">A function that takes an element from each array and returns an int.
         /// If it evaluates to a non-zero value iteration is stopped and that value is returned.</param>

--- a/src/fsharp/FSharp.Core/list.fsi
+++ b/src/fsharp/FSharp.Core/list.fsi
@@ -77,9 +77,11 @@ namespace Microsoft.FSharp.Collections
         val collect: mapping:('T -> 'U list) -> list:'T list -> 'U list
 
         /// <summary>Compares two lists using the given comparison function, element by element.
-        /// Returns the first non-zero result from the comparison function.  If the end of a list
-        /// is reached it returns a -1 if the first list is shorter and a 1 if the second list
-        /// is shorter.</summary>
+        /// Returns the first non-zero result from the comparison function. If the first list has a 
+        /// larger element, the return value is always positive. If the second list has a larger 
+        /// element, the return value is always negative. When the elements are equal in the two 
+        /// lists, 1 is returned if the first list is longer, 0 is returned if they are equal in 
+        /// length, and -1 is returned when the second list is longer.</summary>
         ///
         /// <param name="comparer">A function that takes an element from each list and returns an int.
         /// If it evaluates to a non-zero value iteration is stopped and that value is returned.</param>

--- a/src/fsharp/FSharp.Core/list.fsi
+++ b/src/fsharp/FSharp.Core/list.fsi
@@ -76,19 +76,18 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Collect")>]
         val collect: mapping:('T -> 'U list) -> list:'T list -> 'U list
 
-        /// <summary>Compares two lists using the given comparison function, element by element.
-        /// Returns the first non-zero result from the comparison function. If the first list has a 
-        /// larger element, the return value is always positive. If the second list has a larger 
-        /// element, the return value is always negative. When the elements are equal in the two 
-        /// lists, 1 is returned if the first list is longer, 0 is returned if they are equal in 
-        /// length, and -1 is returned when the second list is longer.</summary>
+        /// <summary>Compares two lists using the given comparison function, element by element.</summary>
         ///
         /// <param name="comparer">A function that takes an element from each list and returns an int.
         /// If it evaluates to a non-zero value iteration is stopped and that value is returned.</param>
         /// <param name="list1">The first input list.</param>
         /// <param name="list2">The second input list.</param>
         ///
-        /// <returns>The first non-zero value from the comparison function.</returns>
+        /// <returns>Returns the first non-zero result from the comparison function. If the first list has a 
+        /// larger element, the return value is always positive. If the second list has a larger 
+        /// element, the return value is always negative. When the elements are equal in the two 
+        /// lists, 1 is returned if the first list is longer, 0 is returned if they are equal in 
+        /// length, and -1 is returned when the second list is longer.</returns>
         [<CompiledName("CompareWith")>]
         val inline compareWith: comparer:('T -> 'T -> int) -> list1:'T list -> list2:'T list -> int
 

--- a/src/fsharp/FSharp.Core/seq.fsi
+++ b/src/fsharp/FSharp.Core/seq.fsi
@@ -161,17 +161,16 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Collect")>]
         val collect: mapping:('T -> 'Collection) -> source:seq<'T> -> seq<'U>  when 'Collection :> seq<'U>
 
-        /// <summary>Compares two sequences using the given comparison function, element by element.
-        /// Returns the first non-zero result from the comparison function.  If the end of a sequence
-        /// is reached it returns a -1 if the first sequence is shorter and a 1 if the second sequence
-        /// is shorter.</summary>
+        /// <summary>Compares two sequences using the given comparison function, element by element.</summary>
         ///
         /// <param name="comparer">A function that takes an element from each sequence and returns an int.
         /// If it evaluates to a non-zero value iteration is stopped and that value is returned.</param>
         /// <param name="source1">The first input sequence.</param>
         /// <param name="source2">The second input sequence.</param>
         ///
-        /// <returns>The first non-zero value from the comparison function.</returns>
+        /// <returns>Returns the first non-zero result from the comparison function.  If the end of a sequence
+        /// is reached it returns a -1 if the first sequence is shorter and a 1 if the second sequence
+        /// is shorter.</returns>
         ///
         /// <exception cref="System.ArgumentNullException">Thrown when either of the input sequences
         /// is null.</exception>


### PR DESCRIPTION
Fixes the signature of List.compareWith and Array.compareWith to match the summary in the documentation: 

https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/list.comparewith%5B't%5D-function-%5Bfsharp%5D

Requested by @cartermp [here](https://github.com/Microsoft/visualfsharpdocs/pull/194#discussion_r69171012)