### PR TITLE
minimize nuget deps for FSharp.Core

### DIFF
--- a/src/fsharp/fsharp.core.netcore.nuget/Microsoft.FSharp.Core.netcore.nuspec
+++ b/src/fsharp/fsharp.core.netcore.nuget/Microsoft.FSharp.Core.netcore.nuspec
@@ -1,42 +1,56 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
-    <metadata>
-        <id>Microsoft.FSharp.Core.netcore</id>
-        <description>
-            .NET Core compatible version of the fsharp core library fsharp.core.dll
-            Supported Platforms: - .NET Core (netstandard1.6)
-        </description>
-        <language>en-US</language>
-        <requireLicenseAcceptance>true</requireLicenseAcceptance>
-        <version>$version$</version>
-        <authors>$authors$</authors>
-        <licenseUrl>$licenseUrl$</licenseUrl>
-        <projectUrl>$projectUrl$</projectUrl>
-        <tags>$tags$</tags>
-        <dependencies>
-            <group targetFramework=".NETStandard1.6">
-                <dependency id="Microsoft.NETCore.Platforms" version="1.0.1" />
-                <dependency id="NETStandard.Library" version="1.6.0" />
-                <dependency id="System.Linq.Expressions" version="4.1.0" />
-                <dependency id="System.Linq.Queryable" version="4.0.1" />
-                <dependency id="System.Reflection.Emit" version="4.0.1" />
-                <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
-                <dependency id="System.Runtime.Loader" version="4.0.0" />
-                <dependency id="System.Net.Requests" version= "4.0.11" />
-                <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
-                <dependency id="System.Threading.Thread" version="4.0.0" />
-                <dependency id="System.Threading.ThreadPool" version="4.0.10" />
-            </group>
-        </dependencies>
-    </metadata>
-    <files>
-        <file src="FSharp.Core.dll"     target="lib/netstandard1.6" />
-        <file src="FSharp.Core.sigdata" target="lib/netstandard1.6" />
-        <file src="FSharp.Core.optdata" target="lib/netstandard1.6" />
-        <file src="FSharp.Core.runtimeconfig.json" target="lib/netstandard1.6" />
-        <file src="FSharp.Core.sigdata" target="content/any/netstandard1.6" />
-        <file src="FSharp.Core.optdata" target="content/any/netstandard1.6" />
-        <file src="FSharp.Core.sigdata" target="runtimes/any/native/" />
-        <file src="FSharp.Core.optdata" target="runtimes/any/native/" />
-    </files>
+	<metadata>
+		<id>Microsoft.FSharp.Core.netcore</id>
+		<description>
+			.NET Core compatible version of the fsharp core library fsharp.core.dll
+			Supported Platforms: - .NET Core (netstandard1.6)
+		</description>
+		<language>en-US</language>
+		<requireLicenseAcceptance>true</requireLicenseAcceptance>
+		<version>$version$</version>
+		<authors>$authors$</authors>
+		<licenseUrl>$licenseUrl$</licenseUrl>
+		<projectUrl>$projectUrl$</projectUrl>
+		<tags>$tags$</tags>
+		<dependencies>
+			<group targetFramework=".NETStandard1.6">
+				<dependency id="Microsoft.NETCore.Platforms" version="1.0.1" />
+				<dependency id="Microsoft.NETCore.Runtime.CoreCLR" version="1.0.2" />
+				<dependency id="System.Collections" version="4.0.11" />
+				<dependency id="System.Console" version="4.0.0" />
+				<dependency id="System.Diagnostics.Debug" version="4.0.11" />
+				<dependency id="System.Diagnostics.Tools" version="4.0.1" />
+				<dependency id="System.Globalization" version="4.0.11" />
+				<dependency id="System.IO" version="4.1.0" />
+				<dependency id="System.Linq" version="4.1.0" />
+				<dependency id="System.Linq.Expressions" version="4.1.0" />
+				<dependency id="System.Linq.Queryable" version="4.0.1" />
+				<dependency id="System.Net.Requests" version="4.0.11" />
+				<dependency id="System.Reflection" version="4.1.0" />
+				<dependency id="System.Reflection.Extensions" version="4.0.1" />
+				<dependency id="System.Resources.ResourceManager" version="4.0.1" />
+				<dependency id="System.Runtime" version="4.1.0" />
+				<dependency id="System.Runtime.Extensions" version="4.1.0" />
+				<dependency id="System.Runtime.Numerics" version="4.0.1" />
+				<dependency id="System.Text.RegularExpressions" version="4.1.0" />
+				<dependency id="System.Threading" version="4.0.11" />
+				<dependency id="System.Threading.Tasks" version="4.0.11" />
+				<dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
+				<dependency id="System.Threading.Thread" version="4.0.0" />
+				<dependency id="System.Threading.ThreadPool" version="4.0.10" />
+				<dependency id="System.Threading.Timer" version="4.0.1"/>
+			</group>
+		</dependencies>
+	</metadata>
+	<files>
+		<file src="FSharp.Core.dll"     target="lib/netstandard1.6" />
+		<file src="FSharp.Core.sigdata" target="lib/netstandard1.6" />
+		<file src="FSharp.Core.optdata" target="lib/netstandard1.6" />
+		<file src="FSharp.Core.runtimeconfig.json" target="lib/netstandard1.6" />
+		<file src="FSharp.Core.sigdata" target="content/any/netstandard1.6" />
+		<file src="FSharp.Core.optdata" target="content/any/netstandard1.6" />
+		<file src="FSharp.Core.sigdata" target="runtimes/any/native/" />
+		<file src="FSharp.Core.optdata" target="runtimes/any/native/" />
+	</files>
 </package>


### PR DESCRIPTION
This is an attempt to minimize the dependencies in the FSharp.Core nuget package so it doesn't induce a dependency on the whole .NETStandard library

See https://github.com/Microsoft/visualfsharp/issues/1357