### PR TITLE
contribution for #1202 (build.cmd hangs forever on restoring packages behind a proxy)

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -31,9 +31,10 @@ There are various qualifiers:
     build.cmd debug           -- build debug instead of release
 
     build.cmd proto           -- force the rebuild of the Proto bootstrap compiler in addition to other things
+    build.cmd protofx         -- build using a .NET Framework proto (no .NET Core is used)
 
-    build.cmd coreclr         -- build/tests only the coreclr version compiler (not the Visual F# IDE Tools)
-    build.cmd compiler        -- build/tests only the compiler (not the Visual F# IDE Tools)
+    build.cmd net40           -- build/tests for .NET Framework version of the compiler (not the Visual F# IDE Tools or .NET Core)
+    build.cmd coreclr         -- build/tests only the coreclr version compiler (not the Visual F# IDE Tools or .NET Framework)
     build.cmd vs              -- build/tests the Visual F# IDE Tools
     build.cmd pcls            -- build/tests the PCL FSharp.Core libraries
 
@@ -44,7 +45,7 @@ There are various qualifiers:
 
     build.cmd test-smoke      -- build, run smoke tests
     build.cmd test-coreunit   -- build, run FSharp.Core tests
-    build.cmd test-coreclr    -- build, run CoreCLR tests
+    build.cmd test-coreclr    -- build, run .NET Core tests
     build.cmd test-pcls       -- build, run PCL tests
     build.cmd test-fsharp     -- build, run tests\fsharp suite
     build.cmd test-fsharpqa   -- build, run tests\fsharpqa suite

--- a/build.cmd
+++ b/build.cmd
@@ -327,35 +327,37 @@ if '%RestorePackages%' == 'true' (
     .\.nuget\NuGet.exe restore packages.config -PackagesDirectory packages -ConfigFile .nuget\nuget.config
     @if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
 )
+if '%BUILD_CORECLR%' == '1' (
 
-:: Restore the Tools directory
-call %~dp0init-tools.cmd
+    :: Restore the Tools directory
+    call %~dp0init-tools.cmd
 
-set _dotnetexe=%~dp0Tools\dotnetcli\dotnet.exe
-pushd .\lkg & %_dotnetexe% restore &popd
-@if ERRORLEVEL 1 echo Error: dotnet restore failed  && goto :failure
+    set _dotnetexe=%~dp0Tools\dotnetcli\dotnet.exe
+    pushd .\lkg & %_dotnetexe% restore &popd
+    @if ERRORLEVEL 1 echo Error: dotnet restore failed  && goto :failure
 
-pushd .\lkg & %_dotnetexe% publish project.json &popd
-@if ERRORLEVEL 1 echo Error: dotnet publish failed  && goto :failure
+    pushd .\lkg & %_dotnetexe% publish project.json &popd
+    @if ERRORLEVEL 1 echo Error: dotnet publish failed  && goto :failure
 
-rem rename fsc and coreconsole to allow fsc.exe to to start compiler
-pushd .\lkg\bin\debug\netstandard1.6\win7-x64\publish
-fc fsc.exe dotnet.exe >nul
-@if ERRORLEVEL 1 (
-  copy fsc.exe fsc.dll
-  copy dotnet.exe fsc.exe
+    rem rename fsc and coreconsole to allow fsc.exe to to start compiler
+    pushd .\lkg\bin\debug\netstandard1.6\win7-x64\publish
+    fc fsc.exe dotnet.exe >nul
+    @if ERRORLEVEL 1 (
+      copy fsc.exe fsc.dll
+      copy dotnet.exe fsc.exe
+    )
+    popd
+
+    rem rename fsc and coreconsole to allow fsc.exe to to start compiler
+    pushd .\lkg\bin\debug\netstandard1.6\win7-x64\publish
+    fc fsi.exe dotnet.exe >nul
+    @if ERRORLEVEL 1 (
+      copy fsi.exe fsi.dll
+      copy dotnet.exe fsi.exe
+    )
+    popd
+
 )
-popd
-
-rem rename fsc and coreconsole to allow fsc.exe to to start compiler
-pushd .\lkg\bin\debug\netstandard1.6\win7-x64\publish
-fc fsi.exe dotnet.exe >nul
-@if ERRORLEVEL 1 (
-  copy fsi.exe fsi.dll
-  copy dotnet.exe fsi.exe
-)
-popd
-
 rem copy targestfile into tools directory ... temporary fix until packaging complete.
 copy src\fsharp\FSharp.Build\Microsoft.FSharp.targets tools\Microsoft.FSharp.targets
 copy src\fsharp\FSharp.Build\Microsoft.Portable.FSharp.targets tools\Microsoft.Portable.FSharp.targets

--- a/build.cmd
+++ b/build.cmd
@@ -339,8 +339,15 @@ if '%BUILD_PROTO_WITH_CORECLR_LKG%' == '1' (
 
     :: Restore the Tools directory
     call %~dp0init-tools.cmd
+)
 
-    set _dotnetexe=%~dp0Tools\dotnetcli\dotnet.exe
+set _dotnetexe=%~dp0Tools\dotnetcli\dotnet.exe
+
+if '%BUILD_PROTO_WITH_CORECLR_LKG%' == '1' (
+
+    :: Restore the Tools directory
+    call %~dp0init-tools.cmd
+
     pushd .\lkg & %_dotnetexe% restore &popd
     @if ERRORLEVEL 1 echo Error: dotnet restore failed  && goto :failure
 

--- a/build.cmd
+++ b/build.cmd
@@ -26,6 +26,8 @@ exit /b 1
 
 :ARGUMENTS_OK
 
+set BUILD_PROTO_WITH_CORECLR_LKG=1
+
 set BUILD_PROTO=0
 set BUILD_NET40=1
 set BUILD_CORECLR=0
@@ -98,6 +100,11 @@ if /i '%ARG%' == 'all' (
     set TEST_VS=1
 
     set SKIP_EXPENSIVE_TESTS=0
+)
+
+if /i '%ARG%' == 'protofx' (
+    set BUILD_PROTO_WITH_CORECLR_LKG=0
+    set BUILD_PROTO=1
 )
 
 if /i '%ARG%' == 'microbuild' (
@@ -257,6 +264,7 @@ REM after this point, ARG variable should not be used, use only BUILD_* or TEST_
 echo Build/Tests configuration:
 echo.
 echo BUILD_PROTO=%BUILD_PROTO%
+echo BUILD_PROTO_WITH_CORECLR_LKG=%BUILD_PROTO_WITH_CORECLR_LKG%
 echo BUILD_NET40=%BUILD_NET40%
 echo BUILD_CORECLR=%BUILD_CORECLR%
 echo BUILD_PORTABLE=%BUILD_PORTABLE%
@@ -327,7 +335,7 @@ if '%RestorePackages%' == 'true' (
     .\.nuget\NuGet.exe restore packages.config -PackagesDirectory packages -ConfigFile .nuget\nuget.config
     @if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
 )
-if '%BUILD_CORECLR%' == '1' (
+if '%BUILD_PROTO_WITH_CORECLR_LKG%' == '1' (
 
     :: Restore the Tools directory
     call %~dp0init-tools.cmd
@@ -358,6 +366,10 @@ if '%BUILD_CORECLR%' == '1' (
     popd
 
 )
+if '%BUILD_PROTO_WITH_CORECLR_LKG%' == '0' (
+    rmdir /s .\lkg\bin\debug
+)
+
 rem copy targestfile into tools directory ... temporary fix until packaging complete.
 copy src\fsharp\FSharp.Build\Microsoft.FSharp.targets tools\Microsoft.FSharp.targets
 copy src\fsharp\FSharp.Build\Microsoft.Portable.FSharp.targets tools\Microsoft.Portable.FSharp.targets

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -742,7 +742,7 @@
       <Choose>
         <When Condition="Exists('$(FSharpSourcesRoot)\..\lkg\bin\Debug\netstandard1.6\win7-x64\publish\fsc.exe')">
           <PropertyGroup >
-            <FSharpTargetsPath>$(FSharpSourcesRoot)\..\lkg\FSharp-$(LkgVersion)\bin\Microsoft.FSharp.Targets</FSharpTargetsPath>
+            <FSharpTargetsPath>..\lkg\FSharp-$(LkgVersion)\bin\Microsoft.FSharp.Targets</FSharpTargetsPath>
             <FscToolPath>$(FSharpSourcesRoot)\..\lkg\bin\Debug\netstandard1.6\win7-x64\publish</FscToolPath>
             <FSLKGPath>$(FSharpSourcesRoot)\..\lkg\FSharp-$(LkgVersion)\bin</FSLKGPath>
             <FSCoreLKGPath>$(FSLKGPath)\FSharp.Core.dll</FSCoreLKGPath>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -739,12 +739,25 @@
 
   <Choose>
     <When Condition="'$(BuildWith)' == 'LKG'">
-      <PropertyGroup>
-         <FSharpTargetsPath>..\lkg\FSharp-$(LkgVersion)\bin\Microsoft.FSharp.Targets</FSharpTargetsPath>
-         <FscToolPath>$(FSharpSourcesRoot)\..\lkg\bin\Debug\netstandard1.6\win7-x64\publish</FscToolPath>
-         <FSLKGPath>$(FSharpSourcesRoot)\..\lkg\FSharp-$(LkgVersion)\bin</FSLKGPath>
-         <FSCoreLKGPath>$(FSLKGPath)\FSharp.Core.dll</FSCoreLKGPath>
-      </PropertyGroup>
+      <Choose>
+        <When Condition="Exists('$(FSharpSourcesRoot)\..\lkg\bin\Debug\netstandard1.6\win7-x64\publish\fsc.exe')">
+          <PropertyGroup >
+            <FSharpTargetsPath>$(FSharpSourcesRoot)\..\lkg\FSharp-$(LkgVersion)\bin\Microsoft.FSharp.Targets</FSharpTargetsPath>
+            <FscToolPath>$(FSharpSourcesRoot)\..\lkg\bin\Debug\netstandard1.6\win7-x64\publish</FscToolPath>
+            <FSLKGPath>$(FSharpSourcesRoot)\..\lkg\FSharp-$(LkgVersion)\bin</FSLKGPath>
+            <FSCoreLKGPath>$(FSLKGPath)\FSharp.Core.dll</FSCoreLKGPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup >
+            <FSharpTargetsPath>..\lkg\FSharp-$(LkgVersion)\bin\Microsoft.FSharp.Targets</FSharpTargetsPath>
+            <FscToolPath>$(FSharpSourcesRoot)\..\lkg\FSharp-$(LkgVersion)\bin</FscToolPath>
+            <FSLKGPath>$(FSharpSourcesRoot)\..\lkg\FSharp-$(LkgVersion)\bin</FSLKGPath>
+            <FSCoreLKGPath>$(FSLKGPath)\FSharp.Core.dll</FSCoreLKGPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+		
     </When>
     <When Condition="'$(TargetFramework)'=='portable47' OR '$(TargetFramework)'=='portable7' OR '$(TargetFramework)'=='portable78' OR '$(TargetFramework)'=='portable259' OR '$(TargetFramework)'=='coreclr'">
       <PropertyGroup>

--- a/src/update.cmd
+++ b/src/update.cmd
@@ -1,10 +1,9 @@
+@if "%_echo%"=="" echo off
 @rem ===========================================================================================================
 @rem Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, 
 @rem               Version 2.0.  See License.txt in the project root for license information.
 @rem ===========================================================================================================
 
-@echo off
-setlocal
 
 if /i "%1" == "debug" goto :ok
 if /i "%1" == "release" goto :ok


### PR DESCRIPTION
add conditional to build.cmd so that dotnet core stuff only happens if BUILD_CORECLR was set to 1

https://github.com/Microsoft/visualfsharp/issues/1202#issuecomment-220083548

> We really need a developer path that doesn't require CoreCLR, especially for those working on the Visual F# IDE Tools (which don't use CoreCLR). Or we need to split the Visual F# IDE tools into their own repository so the dependencies are clear.