### PR TITLE
Eliminate closure allocations in `checkPathForIllegalChars`

### DIFF
--- a/src/utils/filename.fs
+++ b/src/utils/filename.fs
@@ -7,19 +7,35 @@ open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 
 exception IllegalFileNameChar of string * char
 
-let illegalPathChars = Path.GetInvalidPathChars()
+/// The set of characters which may not be used in a path.
+/// This is saved here because Path.GetInvalidPathChars() allocates and returns
+/// a new array each time it's called (by necessity, for security reasons).
+/// This is only used within `checkPathForIllegalChars`, and is only read from.
+let illegalPathChars =
+    let chars = Path.GetInvalidPathChars ()
+    Array.sortInPlace chars
+    chars
 
-let checkPathForIllegalChars (path:string) = 
-    for c in path do
-        if illegalPathChars |> Array.exists(fun c1->c1=c) then 
-            raise(IllegalFileNameChar(path,c))
+let checkPathForIllegalChars (path:string) =
+    let len = path.Length
+    for i = 0 to len - 1 do
+        // The current character in the string.
+        let c = path.[i]
+        
+        // Determine if this character is disallowed within a path by
+        // attempting to find it in the array of illegal path characters.
+        for badChar in illegalPathChars do
+            if c = badChar then
+                // The character is not allowed to be used within a path, raise an exception.
+                raise(IllegalFileNameChar(path, c))
 
 // Case sensitive (original behaviour preserved).
 let checkSuffix (x:string) (y:string) = x.EndsWith(y,System.StringComparison.Ordinal) 
 
 let hasExtension (s:string) = 
     checkPathForIllegalChars s
-    (s.Length >= 1 && s.[s.Length - 1] = '.' && s <> ".." && s <> ".") 
+    let sLen = s.Length
+    (sLen >= 1 && s.[sLen - 1] = '.' && s <> ".." && s <> ".") 
     || Path.HasExtension(s)
 
 let chopExtension (s:string) =


### PR DESCRIPTION
This a slimmed-down resubmission of fsharp/fsharp#216.

The current implementation of the ``checkPathForIllegalChars`` function allocates a closure for *every* character in a path, each time the function is called. This function is called reasonably often during the compilation process (not directly, but by the other functions in this module), and all of these closure allocations are likely having at least some impact on compilation performance.

I don't have before/after comparison data for allocations / GCs anymore; but, when I originally submitted this (in 2013-2014) I'd done a comparison and found that this small change eliminated a *ton* of memory allocations. There wasn't much effect on overall compilation performance, I suspect because the allocations are so short-lived that the CLR's GC is able to handle them in some optimized way. However, the main argument for accepting this PR is these allocations do have a *significant* impact when running CPU / memory profilers on the compiler to look for other issues, so their presence makes it harder to dig into issues which are meaningfully impacting performance.