### PR TITLE
Iterate directly over index ranges in EditDistance

### DIFF
--- a/src/fsharp/FSharp.Compiler.Unittests/EditDistance.fs
+++ b/src/fsharp/FSharp.Compiler.Unittests/EditDistance.fs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+namespace FSharp.Compiler.Unittests
+
+open System
+open System.Text
+open NUnit.Framework
+open Microsoft.FSharp.Compiler
+
+[<TestFixture>]
+module EditDistance =
+    open Internal.Utilities.EditDistance
+
+    [<Test>]
+    [<TestCase("CA", "ABC", ExpectedResult = 3)>]
+    let RestrictedEditDistance (str1 : string, str2 : string) : int =
+        CalcEditDistance (str1, str2)

--- a/src/fsharp/FSharp.Compiler.Unittests/FSharp.Compiler.Unittests.fsproj
+++ b/src/fsharp/FSharp.Compiler.Unittests/FSharp.Compiler.Unittests.fsproj
@@ -42,9 +42,9 @@
     <WarningLevel>3</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework" >
-        <Private>True</Private>
-        <HintPath>$(NUnitLibDir)\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework">
+      <Private>True</Private>
+      <HintPath>$(NUnitLibDir)\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('portable'))">
@@ -62,6 +62,7 @@
     <Compile Include="ManglingNameOfProvidedTypes.fs" />
     <Compile Include="HashIfExpression.fs" />
     <Compile Include="ProductVersion.fs" />
+    <Compile Include="EditDistance.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler\FSharp.Compiler.fsproj">

--- a/src/utils/EditDistance.fs
+++ b/src/utils/EditDistance.fs
@@ -3,18 +3,19 @@
 /// Functions to compute the edit distance between two strings
 module internal Internal.Utilities.EditDistance
 
-/// Computes the DamerauLevenstein distance
+/// Computes the restricted Damerau-Levenstein edit distance,
+/// also known as the "optimal string alignment" distance.
 ///  - read more at https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
 ///  - Implementation taken from http://www.navision-blog.de/2008/11/01/damerau-levenshtein-distance-in-fsharp-part-ii/
 let private calcDamerauLevenshtein (a:string, b:string) =
     let m = b.Length + 1
-    let mutable lastLine = Array.init m (fun i -> i)
-    let mutable lastLastLine = Array.create m 0
-    let mutable actLine = Array.create m 0
-      
-    for i in [1..a.Length] do
+    let mutable lastLine = Array.init m id
+    let mutable lastLastLine = Array.zeroCreate m
+    let mutable actLine = Array.zeroCreate m
+
+    for i in 1 .. a.Length do
         actLine.[0] <- i
-        for j in [1..b.Length] do          
+        for j in 1 .. b.Length do
             let cost = if a.[i-1] = b.[j-1] then 0 else 1
             let deletion = lastLine.[j] + 1
             let insertion = actLine.[j-1] + 1


### PR DESCRIPTION
In the ``EditDistance.calcDamerauLevenshtein`` function, modify the `for` loops to iterate directly over the index ranges instead of creating intermediate lists from the ranges and iterating over those lists.

cc @forki