### PR TITLE
Better error message when specializing generic abstract type with unit

### DIFF
--- a/src/fsharp/FSStrings.resx
+++ b/src/fsharp/FSStrings.resx
@@ -867,6 +867,9 @@
   <data name="OverrideDoesntOverride3" xml:space="preserve">
     <value> The required signature is '{0}'.</value>
   </data>
+  <data name="OverrideDoesntOverride4" xml:space="preserve">
+    <value>The member '{0}' is specialized with 'unit' but 'unit' can't be used as return type of an abstract method parameterized on return type.</value>
+  </data>
   <data name="UnionCaseWrongArguments" xml:space="preserve">
     <value>This constructor is applied to {0} argument(s) but expects {1}</value>
   </data>

--- a/tests/fsharpqa/Source/Conformance/TypesAndTypeConstraints/TypeParameterDefinitions/UnitSpecialization.fs
+++ b/tests/fsharpqa/Source/Conformance/TypesAndTypeConstraints/TypeParameterDefinitions/UnitSpecialization.fs
@@ -1,0 +1,9 @@
+// #UnitGenericAbstractType 
+//<Expects status="success"></Expects>
+
+type Foo<'t> =
+  abstract member Bar : 't -> int
+
+type Bar() =
+  interface Foo<unit> with
+    member x.Bar _ = 1

--- a/tests/fsharpqa/Source/Conformance/TypesAndTypeConstraints/TypeParameterDefinitions/env.lst
+++ b/tests/fsharpqa/Source/Conformance/TypesAndTypeConstraints/TypeParameterDefinitions/env.lst
@@ -6,3 +6,4 @@
 	SOURCE=E_LazyInType02.fs SCFLAGS="--test:ErrorRanges"		# E_LazyInType02.fs
 	SOURCE=MultipleConstraints01.fs							# MultipleConstraints01.fs
 	SOURCE=ValueTypesWithConstraints01.fs						# ValueTypesWithConstraints01.fs
+	SOURCE=UnitSpecialization.fs						# UnitSpecialization.fs

--- a/tests/fsharpqa/Source/ErrorMessages/UnitGenericAbstractType/E_UnitGenericAbstractType1.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/UnitGenericAbstractType/E_UnitGenericAbstractType1.fs
@@ -1,0 +1,9 @@
+// #ErrorMessages #UnitGenericAbstractType 
+//<Expects status="error" span="(7,21)" id="FS0017">The member 'Apply : int -> unit' is specialized with 'unit' but 'unit' can't be used as return type of an abstract method parameterized on return type\.</Expects>
+type EDF<'S> =
+    abstract member Apply : int -> 'S
+type SomeEDF () =
+    interface EDF<unit> with
+        member this.Apply d = 
+            // [ERROR] The member 'Apply' does not have the correct type to override the corresponding abstract method.
+            ()

--- a/tests/fsharpqa/Source/ErrorMessages/UnitGenericAbstractType/env.lst
+++ b/tests/fsharpqa/Source/ErrorMessages/UnitGenericAbstractType/env.lst
@@ -1,0 +1,1 @@
+	SOURCE=E_UnitGenericAbstractType1.fs		# E_UnitGenericAbstractType1

--- a/tests/fsharpqa/Source/test.lst
+++ b/tests/fsharpqa/Source/test.lst
@@ -260,6 +260,7 @@ Misc01			Libraries\Core\Reflection
 Misc01			Libraries\Core\Unchecked
 Misc01			Warnings
 Misc01			ErrorMessages\NameResolution
+Misc01			ErrorMessages\UnitGenericAbstractType
 
 Misc02			Libraries\Portable
 Misc02			Misc


### PR DESCRIPTION
Attempt to fix #35

I'll need some guidance in terms of where to add tests and of course if there is anything wrong with the matching I'm doing / assumptions I'm taking.

I'm concerned the matching might yield false positive if there are cases where using `unit` as a generic type argument would be valid, but this is difficult for me to reason about as of now.

Also looking for better ideas for the error message.