### PR TITLE
More Efficient algorithm for List.groupBy 

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
@@ -777,7 +777,7 @@ type ListModule() =
         let group_byEmpty = List.groupBy funcInt emptyList
         let expectedEmptyList = []
 
-        Assert.AreEqual(expectedEmptyList, emptyList)
+        Assert.AreEqual(expectedEmptyList, group_byEmpty)
 
         ()
 

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -419,28 +419,7 @@ namespace Microsoft.FSharp.Collections
         let where f x = List.filter f x
 
         let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (list: 'T list) =
-            let dict = Dictionary<_,ResizeArray<_>> comparer
-
-            // Build the groupings
-            let rec loop list =
-                match list with
-                | v :: t -> 
-                    let safeKey = keyf v
-                    let mutable prev = Unchecked.defaultof<_>
-                    if dict.TryGetValue(safeKey, &prev) then
-                        prev.Add v
-                    else 
-                        let prev = ResizeArray ()
-                        dict.[safeKey] <- prev
-                        prev.Add v
-                    loop t
-                | _ -> ()
-            loop list
-
-            // Return the list-of-lists.
-            dict
-            |> Seq.map (fun group -> (getKey group.Key, Seq.toList group.Value))
-            |> Seq.toList
+            Microsoft.FSharp.Primitives.Basics.List.groupBy comparer keyf getKey list
 
         // We avoid wrapping a StructBox, because under 64 JIT we get some "hard" tailcalls which affect performance
         let groupByValueType (keyf:'T->'Key) (list:'T list) = groupByImpl HashIdentity.Structural<'Key> keyf id list

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -419,7 +419,7 @@ namespace Microsoft.FSharp.Collections
         let where f x = List.filter f x
 
         let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (list: 'T list) =
-            Microsoft.FSharp.Primitives.Basics.List.groupBy comparer keyf getKey list
+            List.groupBy comparer keyf getKey list
 
         // We avoid wrapping a StructBox, because under 64 JIT we get some "hard" tailcalls which affect performance
         let groupByValueType (keyf:'T->'Key) (list:'T list) = groupByImpl HashIdentity.Structural<'Key> keyf id list

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -126,7 +126,7 @@ module internal List =
                 chooseToFreshConsTail cons f t
                 cons
                   
-    let inline groupBy (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (list: 'T list) =
+    let groupBy (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (list: 'T list) =
         let dict = Dictionary<_, _ list []> comparer
 
         // Build the groupings

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -149,12 +149,14 @@ module internal List =
         let mutable ie = dict.GetEnumerator()
         if not (ie.MoveNext()) then []
         else
-            setFreshConsTail ie.Current.Value.[1] []
-            let res = freshConsNoTail (getKey ie.Current.Key, ie.Current.Value.[0])
+            let mutable curr = ie.Current
+            setFreshConsTail curr.Value.[1] []
+            let res = freshConsNoTail (getKey curr.Key, curr.Value.[0])
             let mutable cons = res
             while ie.MoveNext() do
-                setFreshConsTail ie.Current.Value.[1] []
-                let cons2 = freshConsNoTail (getKey ie.Current.Key, ie.Current.Value.[0])
+                curr <- ie.Current
+                setFreshConsTail curr.Value.[1] []
+                let cons2 = freshConsNoTail (getKey curr.Key, curr.Value.[0])
                 setFreshConsTail cons cons2
                 cons <- cons2
             setFreshConsTail cons []

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -11,7 +11,7 @@ module internal List =
     val choose: ('T -> 'U option) -> 'T list -> 'U list
     val countBy : System.Collections.Generic.Dictionary<'T1, int> -> ('T1 -> 'T2) -> ('T2 * int) list
     val pairwise : 'T list -> ('T * 'T) list
-    val inline groupBy : System.Collections.Generic.IEqualityComparer<'SafeKey> -> ('T->'SafeKey) -> ('SafeKey->'Key) -> 'T list -> ('Key*'T list) list
+    val groupBy : System.Collections.Generic.IEqualityComparer<'SafeKey> -> ('T->'SafeKey) -> ('SafeKey->'Key) -> 'T list -> ('Key*'T list) list
     val distinctWithComparer : System.Collections.Generic.IEqualityComparer<'T> -> 'T list -> 'T list
     val distinctByWithComparer : System.Collections.Generic.IEqualityComparer<'Key> -> ('T -> 'Key) -> list:'T list -> 'T list when 'Key : equality
     val init : int -> (int -> 'T) -> 'T list

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -11,6 +11,7 @@ module internal List =
     val choose: ('T -> 'U option) -> 'T list -> 'U list
     val countBy : System.Collections.Generic.Dictionary<'T1, int> -> ('T1 -> 'T2) -> ('T2 * int) list
     val pairwise : 'T list -> ('T * 'T) list
+    val inline groupBy : System.Collections.Generic.IEqualityComparer<'SafeKey> -> ('T->'SafeKey) -> ('SafeKey->'Key) -> 'T list -> ('Key*'T list) list
     val distinctWithComparer : System.Collections.Generic.IEqualityComparer<'T> -> 'T list -> 'T list
     val distinctByWithComparer : System.Collections.Generic.IEqualityComparer<'Key> -> ('T -> 'Key) -> list:'T list -> 'T list when 'Key : equality
     val init : int -> (int -> 'T) -> 'T list


### PR DESCRIPTION
Also fixes a related unit test.

Here's a gist showing the difference: https://gist.github.com/liboz/d1f2ef35c9c46a5019127bd3b4f99d17
Note that I just made a clone of the original List.groupBy called List.groupBy2 for the purposes of the test

There seems to be inconsistent inlining in the List module, but I inlined the stuff I did here because the original was inlined.

Will edit in a benchmark with BenchmarkDotNet in a couple hours.

EDIT:

Here's the source code for the BenchmarkDotNet: https://gist.github.com/liboz/d1d513c378aefbc78889f2db27f2800f
and I pasted the results:. It's mostly the same test suite as the fsi gist I have above.

CLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1080.0

Type=groupBy  Mode=Throughput  GarbageCollection=Concurrent Workstation  

                 Method |    count |                 Median |              StdDev |     Gen 0 |    Gen 1 |  Gen 2 | Bytes Allocated/Op |
----------------------- |--------- |----------------------- |-------------------- |---------- |--------- |------- |------------------- |
         groupByModulus |       10 |            705.8428 ns |          42.6993 ns |      0.03 |        - |      - |             469.55 |
 groupByOriginalModulus |       10 |          1,839.0410 ns |          93.7306 ns |      0.04 |        - |      - |             763.10 |
                groupBy |       10 |          1,255.7102 ns |          61.1925 ns |      0.07 |        - |      - |           1,232.88 |
        groupByOriginal |       10 |          3,987.1858 ns |         160.5903 ns |      0.09 |        - |      - |           1,610.93 |
           groupByMixed |       10 |        582,407.5966 ns |      30,728.3895 ns |      6.92 |     4.30 |      - |         337,104.46 |
   groupByOriginalMixed |       10 |        736,841.4709 ns |      37,799.7629 ns |      8.59 |     5.55 |      - |         379,064.74 |
         groupByModulus |      100 |          4,406.7663 ns |         169.0106 ns |      0.15 |        - |      - |           2,729.34 |
 groupByOriginalModulus |      100 |          7,344.0738 ns |         255.2806 ns |      0.20 |        - |      - |           3,557.86 |
                groupBy |      100 |         10,367.8809 ns |         381.3533 ns |      0.62 |        - |      - |          11,856.14 |
        groupByOriginal |      100 |         32,412.6751 ns |       1,597.1644 ns |      0.85 |        - |      - |          16,286.61 |
           groupByMixed |      100 |        572,375.6532 ns |      22,456.2116 ns |      6.59 |     4.49 |      - |         332,997.24 |
   groupByOriginalMixed |      100 |        741,901.9452 ns |      35,264.1825 ns |      5.69 |     4.86 |      - |         288,494.12 |
         groupByModulus |    10000 |        525,283.8138 ns |      28,838.6492 ns |      5.29 |     3.39 |      - |         254,351.92 |
 groupByOriginalModulus |    10000 |        664,096.0494 ns |      26,908.3865 ns |      7.44 |     4.89 |      - |         328,690.80 |
                groupBy |    10000 |      2,761,663.8746 ns |      64,557.9006 ns |     17.59 |        - |  17.50 |       1,213,041.70 |
        groupByOriginal |    10000 |      5,317,136.8731 ns |     254,277.2331 ns |     20.54 |     4.88 |  16.69 |       1,516,082.90 |
           groupByMixed |    10000 |      1,300,531.4866 ns |      61,808.7686 ns |     11.74 |    11.40 |      - |         794,595.49 |
   groupByOriginalMixed |    10000 |      1,630,609.7672 ns |      73,949.6140 ns |     16.05 |    11.84 |      - |         896,730.53 |
         groupByModulus |  1000000 |    231,907,137.1163 ns |   4,046,452.1418 ns |    301.91 |   225.42 | 108.98 |      19,284,699.38 |
 groupByOriginalModulus |  1000000 |    231,722,288.2738 ns |   2,443,656.7017 ns |    274.10 |   188.98 | 119.02 |      19,670,409.44 |
                groupBy |  1000000 |    804,278,639.9725 ns |  22,017,307.4191 ns |    656.45 |   578.39 | 118.52 |      64,999,778.71 |
        groupByOriginal |  1000000 |  1,191,626,049.8725 ns |  13,775,845.9996 ns |  1,125.25 |   736.46 | 136.33 |      87,812,227.41 |
           groupByMixed |  1000000 |    688,763,766.6713 ns |  21,067,158.4101 ns |    781.33 |   661.33 | 146.00 |      52,232,920.00 |
   groupByOriginalMixed |  1000000 |    635,669,734.7538 ns |  22,632,039.2767 ns |    964.44 |   775.56 | 209.78 |      69,421,290.06 |
         groupByModulus | 10000000 |  2,536,577,746.9513 ns |  62,383,748.7772 ns |  1,919.75 | 3,452.31 | 148.25 |     192,795,744.98 |
 groupByOriginalModulus | 10000000 |  2,696,990,104.5825 ns |  58,256,910.0715 ns |  3,744.00 | 3,749.00 | 358.00 |     326,685,879.41 |
                groupBy | 10000000 |  7,250,552,647.7425 ns | 245,053,956.2612 ns |  7,797.71 | 8,358.86 | 212.00 |     808,063,523.82 |
        groupByOriginal | 10000000 | 11,373,338,310.5325 ns | 255,350,492.3006 ns | 11,926.00 | 8,566.67 | 192.00 |     931,257,868.36 |
           groupByMixed | 10000000 |  6,623,608,707.1300 ns | 212,181,053.7540 ns |  6,827.45 | 7,176.06 | 180.74 |     503,127,305.38 |
   groupByOriginalMixed | 10000000 |  6,849,243,043.4850 ns | 134,781,808.1311 ns |  7,022.13 | 7,195.38 | 198.00 |     588,532,280.50 |
