### PR TITLE
More Efficient algorithm for List.pairwise

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
@@ -1019,6 +1019,6 @@ type ListModule() =
     member this.``pairwise should return pairs of the input list``() =
         Assert.AreEqual(([] : (obj*obj) list), List.pairwise [])
         Assert.AreEqual(([] : (int*int) list), List.pairwise [1])
-        Assert.AreEqual([1,2],List.pairwise [1;2])
-        Assert.AreEqual([1,2; 2,3],List.pairwise [1;2;3])
-        Assert.AreEqual(["H","E"; "E","L"; "L","L"; "L","O"],List.pairwise ["H";"E";"L";"L";"O"])
+        Assert.AreEqual([1,2], List.pairwise [1;2])
+        Assert.AreEqual([1,2; 2,3], List.pairwise [1;2;3])
+        Assert.AreEqual(["H","E"; "E","L"; "L","L"; "L","O"], List.pairwise ["H";"E";"L";"L";"O"])

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -244,10 +244,7 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Pairwise")>]
         let pairwise (list: 'T list) =
-            let array = List.toArray list
-            if array.Length < 2 then [] else
-            List.init (array.Length-1) (fun i -> array.[i],array.[i+1])
-        
+            Microsoft.FSharp.Primitives.Basics.List.pairwise list
 
         [<CompiledName("Reduce")>]
         let reduce f list = 

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -85,6 +85,24 @@ module internal List =
                 cons <- cons2
             setFreshConsTail cons []
             res
+    
+    let rec pairwiseToFreshConsTail cons list lastvalue = 
+        match list with
+        | [] -> setFreshConsTail cons []
+        | [h] -> setFreshConsTail cons [(lastvalue, h)]
+        | h::t ->
+            let cons2 = freshConsNoTail (lastvalue, h)
+            setFreshConsTail cons cons2
+            pairwiseToFreshConsTail cons2 t h
+
+    let pairwise list =       
+        match list with
+        | [] -> []
+        | [_] -> []
+        | x1::x2::t ->
+            let cons = freshConsNoTail (x1, x2)
+            pairwiseToFreshConsTail cons t x2
+            cons
 
     let rec mapToFreshConsTail cons f x = 
         match x with

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -9,6 +9,7 @@ open Microsoft.FSharp.Collections
 module internal List =
     val allPairs : 'T1 list -> 'T2 list -> ('T1 * 'T2) list
     val countBy : System.Collections.Generic.Dictionary<'T1, int> -> ('T1 -> 'T2) -> ('T2 * int) list
+    val pairwise : 'T list -> ('T * 'T) list
     val distinctWithComparer : System.Collections.Generic.IEqualityComparer<'T> -> 'T list -> 'T list
     val distinctByWithComparer : System.Collections.Generic.IEqualityComparer<'Key> -> ('T -> 'Key) -> list:'T list -> 'T list when 'Key : equality
     val init : int -> (int -> 'T) -> 'T list


### PR DESCRIPTION
As title. Here's my benchmark script using BenchmarkDotNet: https://gist.github.com/liboz/c0671b5e0ac855e26eef2a856d0f4547

and here's a copy of the results:

```
BenchmarkDotNet=v0.9.8.0
OS=Microsoft Windows NT 6.2.9200.0
CLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1080.0
```

                 Method |   count |              Median |             StdDev |    Gen 0 |  Gen 1 |  Gen 2 | Bytes Allocated/Op |
----------------------- |-------- |-------------------- |------------------- |--------- |------- |------- |------------------- |
               pairwise |      10 |         327.1238 ns |         13.9871 ns |     0.03 |      - |      - |             347.71 |
       pairwiseOriginal |      10 |         451.8890 ns |         16.9809 ns |     0.04 |      - |      - |             435.91 |
         pairwiseString |      10 |       1,514.4187 ns |         78.5262 ns |     0.05 |      - |      - |             662.03 |
 pairwiseOriginalString |      10 |       1,600.0937 ns |         84.6451 ns |     0.06 |      - |      - |             703.29 |
               pairwise |     100 |       2,714.9367 ns |         92.3309 ns |     0.32 |      - |      - |           3,938.73 |
       pairwiseOriginal |     100 |       3,688.2524 ns |        139.1834 ns |     0.32 |      - |      - |           3,950.25 |
         pairwiseString |     100 |      13,278.4079 ns |        584.3042 ns |     0.49 |      - |      - |           6,098.12 |
 pairwiseOriginalString |     100 |      14,574.3664 ns |        672.0111 ns |     0.48 |      - |      - |           6,081.48 |
               pairwise |   10000 |     454,843.3097 ns |     13,736.0882 ns |     8.79 |   7.97 |      - |         361,562.37 |
       pairwiseOriginal |   10000 |     579,387.0283 ns |     21,741.9021 ns |     9.95 |   8.82 |      - |         391,773.22 |
         pairwiseString |   10000 |   1,843,215.4420 ns |     98,686.8146 ns |    13.27 |  13.15 |      - |         599,281.90 |
 pairwiseOriginalString |   10000 |   2,008,771.7754 ns |     94,775.6581 ns |    14.41 |  13.27 |      - |         643,548.95 |
               pairwise | 1000000 | 329,995,157.5963 ns |  8,002,228.1819 ns |   534.65 | 455.88 | 156.55 |      25,156,179.57 |
       pairwiseOriginal | 1000000 | 345,036,064.5113 ns | 13,168,878.7180 ns |   580.00 | 430.00 | 205.00 |      26,705,087.22 |
         pairwiseString | 1000000 | 685,053,703.6688 ns | 28,268,795.8537 ns |   943.59 | 832.00 | 172.31 |      44,665,904.21 |
 pairwiseOriginalString | 1000000 | 767,084,507.8400 ns | 29,719,202.4054 ns | 1,040.91 | 928.60 | 184.15 |      52,527,595.91 |