### PR TITLE
More Efficient algorithm for List.choose

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
@@ -224,11 +224,11 @@ type ListModule() =
     member this.Choose() = 
         // int List
         let intSrc:int list = [ 1..100 ]    
-        let funcInt x = if (x%5=0) then Some x else None       
+        let funcInt x = if (x%5=0) then Some (x*x) else None       
         let intChosen = List.choose funcInt intSrc        
-        Assert.AreEqual(5, intChosen.[0])
-        Assert.AreEqual(10, intChosen.[1])
-        Assert.AreEqual(15, intChosen.[2])
+        Assert.AreEqual(25, intChosen.[0])
+        Assert.AreEqual(100, intChosen.[1])
+        Assert.AreEqual(225, intChosen.[2])
         
         // string List
         let stringSrc: string list = [ "List"; "this"; "is" ;"str"; "list" ]
@@ -240,6 +240,11 @@ type ListModule() =
         Assert.AreEqual("list", strChosen.[0].ToLower())
         Assert.AreEqual("list", strChosen.[1].ToLower())
         
+        // always None 
+        let emptySrc :int list = [ ]
+        let emptyChosen = List.choose (fun i -> Option<int>.None) intSrc        
+        Assert.AreEqual(emptySrc, emptyChosen)
+
         // empty List
         let emptySrc :int list = [ ]
         let emptyChosen = List.choose funcInt emptySrc        

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -151,16 +151,8 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Get")>]
         let nth list index = item index list
 
-        let rec chooseAllAcc f xs acc =
-            match xs with 
-            | [] -> rev acc
-            | h :: t -> 
-                 match f h with 
-                 | None -> chooseAllAcc f t acc 
-                 | Some x -> chooseAllAcc f t (x::acc)
-
         [<CompiledName("Choose")>]
-        let choose f xs = chooseAllAcc f xs []
+        let choose f xs = Microsoft.FSharp.Primitives.Basics.List.choose f xs
     
         [<CompiledName("SplitAt")>]
         let splitAt index (list:'T list) = Microsoft.FSharp.Primitives.Basics.List.splitAt index list

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -86,13 +86,36 @@ module internal List =
             setFreshConsTail cons []
             res
 
+    let rec chooseToFreshConsTail cons f xs =
+        match xs with 
+        | [] -> setFreshConsTail cons []
+        | h::t -> 
+            match f h with 
+            | None -> chooseToFreshConsTail cons f t 
+            | Some x -> 
+                let cons2 = freshConsNoTail x
+                setFreshConsTail cons cons2
+                chooseToFreshConsTail cons2 f t
+
+    let rec choose f xs =
+        match xs with 
+        | [] -> []
+        | h::t -> 
+            match f h with
+            | None -> choose f t
+            | Some x -> 
+                let cons = freshConsNoTail x
+                chooseToFreshConsTail cons f t
+                cons
+            
+
     let rec mapToFreshConsTail cons f x = 
         match x with
         | [] -> 
             setFreshConsTail cons [];
         | (h::t) -> 
             let cons2 = freshConsNoTail (f h)
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             mapToFreshConsTail cons2 f t
 
     let map f x = 

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -8,6 +8,7 @@ open Microsoft.FSharp.Collections
 
 module internal List =
     val allPairs : 'T1 list -> 'T2 list -> ('T1 * 'T2) list
+    val choose: ('T -> 'U option) -> 'T list -> 'U list
     val countBy : System.Collections.Generic.Dictionary<'T1, int> -> ('T1 -> 'T2) -> ('T2 * int) list
     val distinctWithComparer : System.Collections.Generic.IEqualityComparer<'T> -> 'T list -> 'T list
     val distinctByWithComparer : System.Collections.Generic.IEqualityComparer<'Key> -> ('T -> 'Key) -> list:'T list -> 'T list when 'Key : equality


### PR DESCRIPTION
Here's my benchmark script: https://gist.github.com/liboz/f992c00393cce1b79c0ec85330e79176

and some results:

CLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1080.0

Type=choose  Mode=Throughput  GarbageCollection=Concurrent Workstation  

         Method |   count |              Median |            StdDev |  Gen 0 |  Gen 1 |  Gen 2 | Bytes Allocated/Op |
--------------- |-------- |-------------------- |------------------ |------- |------- |------- |------------------- |
         choose |      10 |         302.7255 ns |        23.0145 ns |   0.02 |      - |      - |             304.93 |
 chooseOriginal |      10 |         374.1193 ns |        23.8762 ns |   0.02 |      - |      - |             412.92 |
         choose |     100 |       2,503.1982 ns |       234.6705 ns |   0.17 |      - |      - |           2,953.99 |
 chooseOriginal |     100 |       3,082.9388 ns |       267.0670 ns |   0.19 |      - |      - |           3,364.25 |
         choose |   10000 |     361,230.1470 ns |    25,578.0325 ns |   7.62 |   3.88 |      - |         282,999.61 |
 chooseOriginal |   10000 |     434,685.6065 ns |    38,492.8310 ns |  12.72 |   3.70 |      - |         364,244.25 |
         choose | 1000000 | 289,144,230.9500 ns | 8,040,926.5965 ns | 455.00 | 266.00 | 130.00 |      26,114,722.18 |
 chooseOriginal | 1000000 | 326,453,778.1425 ns | 8,388,233.8730 ns | 391.85 | 242.31 | 108.00 |      22,898,812.98 |
