### PR TITLE
List.scan/mapi2/map3 algorithm improvements

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -97,6 +97,13 @@ type ListModule02() =
         let resultStr = List.map3 funcStr ["A";"B";"C";"D"] ["a";"b";"c";"d"] ["1";"2";"3";"4"]        
         Assert.AreEqual(["Aa1";"Bb2";"Cc3";"Dd4"], resultStr)
         
+        // lists of different length
+        let shortList = [1]
+        let longerList = [1; 2]
+        CheckThrowsArgumentNullException (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)
+        CheckThrowsArgumentNullException (fun () -> List.map3 funcInt shortList longerList shortList |> ignore)
+        CheckThrowsArgumentNullException (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)  
+
         // empty List
         let resultEpt = List.map3 funcInt List.empty List.empty List.empty
         Assert.AreEqual(List.empty<int>, resultEpt)
@@ -176,6 +183,12 @@ type ListModule02() =
         let resultStr = List.mapi2 funcStr [3;6;9;11] ["a";"b";"c";"d"]        
         Assert.AreEqual([4;8;12;15], resultStr)
         
+        // lists of different length
+        let shortList = [1]
+        let longerList = [1; 2]       
+        CheckThrowsArgumentNullException (fun () -> List.mapi2 funcInt shortList longerList |> ignore)
+        CheckThrowsArgumentNullException (fun () -> List.mapi2 funcInt longerList shortList |> ignore)
+
         // empty List
         let emptyArr:int list = [ ]
         let resultEpt = List.mapi2 funcInt emptyArr emptyArr        

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -100,9 +100,9 @@ type ListModule02() =
         // lists of different length
         let shortList = [1]
         let longerList = [1; 2]
-        CheckThrowsArgumentNullException (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)
-        CheckThrowsArgumentNullException (fun () -> List.map3 funcInt shortList longerList shortList |> ignore)
-        CheckThrowsArgumentNullException (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)  
+        CheckThrowsArgumentException  (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)
+        CheckThrowsArgumentException  (fun () -> List.map3 funcInt shortList longerList shortList |> ignore)
+        CheckThrowsArgumentException  (fun () -> List.map3 funcInt shortList shortList longerList |> ignore)  
 
         // empty List
         let resultEpt = List.map3 funcInt List.empty List.empty List.empty
@@ -186,8 +186,8 @@ type ListModule02() =
         // lists of different length
         let shortList = [1]
         let longerList = [1; 2]       
-        CheckThrowsArgumentNullException (fun () -> List.mapi2 funcInt shortList longerList |> ignore)
-        CheckThrowsArgumentNullException (fun () -> List.mapi2 funcInt longerList shortList |> ignore)
+        CheckThrowsArgumentException  (fun () -> List.mapi2 funcInt shortList longerList |> ignore)
+        CheckThrowsArgumentException  (fun () -> List.mapi2 funcInt longerList shortList |> ignore)
 
         // empty List
         let emptyArr:int list = [ ]

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -191,7 +191,7 @@ namespace Microsoft.FSharp.Collections
             let rec loop list1 list2 = 
                 match list1,list2 with
                 | [],[] -> () 
-                | (h1::t1), (h2::t2) -> f.Invoke(h1,h2); loop t1 t2 
+                | h1::t1, h2::t2 -> f.Invoke(h1,h2); loop t1 t2 
                 | _ -> invalidArg "list2" (SR.GetString(SR.listsHadDifferentLengths))
             loop list1 list2
 

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -257,12 +257,7 @@ namespace Microsoft.FSharp.Collections
 
         [<CompiledName("Scan")>]
         let scan<'T,'State> f (s:'State) (list:'T list) = 
-            let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
-            let rec loop s xs acc = 
-                match xs with 
-                | [] -> rev acc
-                | (h::t) -> let s = f.Invoke(s,h) in loop s t (s :: acc)
-            loop s list [s]
+            Microsoft.FSharp.Primitives.Basics.List.scan f s list
 
         [<CompiledName("Singleton")>]
         let inline singleton value = [value]

--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -204,28 +204,14 @@ namespace Microsoft.FSharp.Collections
                 | (h1::t1), (h2::t2) -> f.Invoke(n,h1,h2); loop (n+1) t1 t2 
                 | _ -> invalidArg "list2" (SR.GetString(SR.listsHadDifferentLengths))
             loop 0 list1 list2
-          
-        let rec map3aux (f:OptimizedClosures.FSharpFunc<_,_,_,_>) list1 list2 list3 acc = 
-            match list1,list2,list3 with
-            | [],[],[] -> rev acc
-            | (h1::t1), (h2::t2),(h3::t3) -> let x = f.Invoke(h1,h2,h3) in map3aux f t1 t2 t3 (x :: acc)
-            | _ -> invalidArg "list3" (SR.GetString(SR.listsHadDifferentLengths))
 
         [<CompiledName("Map3")>]
         let map3 f list1 list2 list3 = 
-            let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt(f)
-            map3aux f list1 list2 list3 []
-
-        let rec mapi2aux n (f:OptimizedClosures.FSharpFunc<_,_,_,_>) list1 list2 acc = 
-            match list1,list2 with
-            | [],[] -> rev acc
-            | (h1::t1), (h2::t2) -> let x = f.Invoke(n,h1,h2) in mapi2aux (n+1) f t1 t2 (x :: acc)
-            | _ -> invalidArg "list2" (SR.GetString(SR.listsHadDifferentLengths))
+            Microsoft.FSharp.Primitives.Basics.List.map3 f list1 list2 list3
 
         [<CompiledName("MapIndexed2")>]
         let mapi2 f list1 list2 = 
-            let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt(f)
-            mapi2aux 0 f list1 list2 []
+            Microsoft.FSharp.Primitives.Basics.List.mapi2 f list1 list2
 
         [<CompiledName("Map2")>]
         let map2 f list1 list2 = Microsoft.FSharp.Primitives.Basics.List.map2 f list1 list2

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -142,11 +142,31 @@ module internal List =
             map2ToFreshConsTail cons f t1 t2
             cons
         | _ -> invalidArg "xs2" (SR.GetString(SR.listsHadDifferentLengths))
+    
+    
+    let rec scanToFreshConsTail cons xs s (f: OptimizedClosures.FSharpFunc<_,_,_>) =
+        match xs with
+        | [] ->
+            setFreshConsTail cons []
+        | (h::t) ->
+            let newState = f.Invoke(s,h)
+            let cons2 = freshConsNoTail newState
+            setFreshConsTail cons cons2
+            scanToFreshConsTail cons2 t newState f
+
+    let scan f (s:'State) (list:'T list) = 
+        let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
+        match list with 
+        | [] -> [s]
+        | _ -> 
+            let cons = freshConsNoTail s
+            scanToFreshConsTail cons list s f
+            cons
 
     let rec indexedToFreshConsTail cons xs i =
         match xs with
         | [] ->
-            setFreshConsTail cons [];
+            setFreshConsTail cons []
         | (h::t) ->
             let cons2 = freshConsNoTail (i,h)
             setFreshConsTail cons cons2;

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -142,7 +142,46 @@ module internal List =
             map2ToFreshConsTail cons f t1 t2
             cons
         | _ -> invalidArg "xs2" (SR.GetString(SR.listsHadDifferentLengths))
-    
+
+    let rec map3ToFreshConsTail cons (f:OptimizedClosures.FSharpFunc<_,_,_,_>) xs1 xs2 xs3 = 
+        match xs1,xs2,xs3 with
+        | [],[],[] -> 
+            setFreshConsTail cons [];
+        | (h1::t1), (h2::t2), (h3::t3) -> 
+            let cons2 = freshConsNoTail (f.Invoke(h1,h2,h3))
+            setFreshConsTail cons cons2;
+            map3ToFreshConsTail cons2 f t1 t2 t3
+        | _ -> invalidArg "list3" (SR.GetString(SR.listsHadDifferentLengths))
+
+    let map3 f xs1 xs2 xs3 = 
+        match xs1,xs2,xs3 with
+        | [],[],[] -> []
+        | (h1::t1), (h2::t2), (h3::t3) -> 
+            let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt(f)
+            let cons = freshConsNoTail (f.Invoke(h1,h2,h3))
+            map3ToFreshConsTail cons f t1 t2 t3
+            cons
+        | _ -> invalidArg "list3" (SR.GetString(SR.listsHadDifferentLengths))
+
+    let rec mapi2ToFreshConsTail n cons (f:OptimizedClosures.FSharpFunc<_,_,_,_>) xs1 xs2 = 
+        match xs1,xs2 with
+        | [],[] -> 
+            setFreshConsTail cons [];
+        | (h1::t1),(h2::t2) -> 
+            let cons2 = freshConsNoTail (f.Invoke(n,h1,h2))
+            setFreshConsTail cons cons2;
+            mapi2ToFreshConsTail (n + 1) cons2 f t1 t2
+        | _ -> invalidArg "list2" (SR.GetString(SR.listsHadDifferentLengths))
+
+    let mapi2 f xs1 xs2 = 
+        match xs1,xs2 with
+        | [],[] -> []
+        | (h1::t1),(h2::t2) -> 
+            let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt(f)
+            let cons = freshConsNoTail (f.Invoke(0, h1,h2))
+            mapi2ToFreshConsTail 1 cons f t1 t2
+            cons
+        | _ -> invalidArg "list2" (SR.GetString(SR.listsHadDifferentLengths))
     
     let rec scanToFreshConsTail cons xs s (f: OptimizedClosures.FSharpFunc<_,_,_>) =
         match xs with

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -32,7 +32,7 @@ module internal List =
     let rec distinctToFreshConsTail cons (hashSet:HashSet<_>) list = 
         match list with
         | [] -> setFreshConsTail cons []
-        | (x::rest) ->
+        | x::rest ->
             if hashSet.Add(x) then
                 let cons2 = freshConsNoTail x
                 setFreshConsTail cons cons2
@@ -44,7 +44,7 @@ module internal List =
         match list with
         | [] -> []
         | [h] -> [h]
-        | (x::rest) ->
+        | x::rest ->
             let hashSet =  System.Collections.Generic.HashSet<'T>(comparer)
             hashSet.Add(x) |> ignore
             let cons = freshConsNoTail x
@@ -54,7 +54,7 @@ module internal List =
     let rec distinctByToFreshConsTail cons (hashSet:HashSet<_>) keyf list = 
         match list with
         | [] -> setFreshConsTail cons []
-        | (x::rest) ->
+        | x::rest ->
             if hashSet.Add(keyf x) then
                 let cons2 = freshConsNoTail x
                 setFreshConsTail cons cons2
@@ -66,7 +66,7 @@ module internal List =
         match list with
         | [] -> []
         | [h] -> [h]
-        | (x::rest) ->
+        | x::rest ->
             let hashSet = System.Collections.Generic.HashSet<'Key>(comparer)
             hashSet.Add(keyf x) |> ignore
             let cons = freshConsNoTail x
@@ -89,17 +89,17 @@ module internal List =
     let rec mapToFreshConsTail cons f x = 
         match x with
         | [] -> 
-            setFreshConsTail cons [];
-        | (h::t) -> 
+            setFreshConsTail cons []
+        | h::t -> 
             let cons2 = freshConsNoTail (f h)
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             mapToFreshConsTail cons2 f t
 
     let map f x = 
         match x with
         | [] -> []
         | [h] -> [f h]
-        | (h::t) -> 
+        | h::t -> 
             let cons = freshConsNoTail (f h)
             mapToFreshConsTail cons f t
             cons
@@ -107,17 +107,17 @@ module internal List =
     let rec mapiToFreshConsTail cons (f:OptimizedClosures.FSharpFunc<_,_,_>) x i = 
         match x with
         | [] -> 
-            setFreshConsTail cons [];
+            setFreshConsTail cons []
         | (h::t) -> 
             let cons2 = freshConsNoTail (f.Invoke(i,h))
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             mapiToFreshConsTail cons2 f t (i+1)
 
     let mapi f x = 
         match x with
         | [] -> []
         | [h] -> [f 0 h]
-        | (h::t) -> 
+        | h::t -> 
             let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
             let cons = freshConsNoTail (f.Invoke(0,h))
             mapiToFreshConsTail cons f t 1
@@ -126,17 +126,17 @@ module internal List =
     let rec map2ToFreshConsTail cons (f:OptimizedClosures.FSharpFunc<_,_,_>) xs1 xs2 = 
         match xs1,xs2 with
         | [],[] -> 
-            setFreshConsTail cons [];
-        | (h1::t1),(h2::t2) -> 
+            setFreshConsTail cons []
+        | h1::t1, h2::t2 -> 
             let cons2 = freshConsNoTail (f.Invoke(h1,h2))
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             map2ToFreshConsTail cons2 f t1 t2
         | _ -> invalidArg "xs2" (SR.GetString(SR.listsHadDifferentLengths))
 
     let map2 f xs1 xs2 = 
         match xs1,xs2 with
         | [],[] -> []
-        | (h1::t1),(h2::t2) -> 
+        | h1::t1, h2::t2 -> 
             let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
             let cons = freshConsNoTail (f.Invoke(h1,h2))
             map2ToFreshConsTail cons f t1 t2
@@ -145,18 +145,18 @@ module internal List =
 
     let rec map3ToFreshConsTail cons (f:OptimizedClosures.FSharpFunc<_,_,_,_>) xs1 xs2 xs3 = 
         match xs1,xs2,xs3 with
-        | [],[],[] -> 
-            setFreshConsTail cons [];
-        | (h1::t1), (h2::t2), (h3::t3) -> 
+        | [],[],[] ->
+            setFreshConsTail cons []
+        | h1::t1, h2::t2, h3::t3 -> 
             let cons2 = freshConsNoTail (f.Invoke(h1,h2,h3))
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             map3ToFreshConsTail cons2 f t1 t2 t3
         | _ -> invalidArg "list3" (SR.GetString(SR.listsHadDifferentLengths))
 
     let map3 f xs1 xs2 xs3 = 
         match xs1,xs2,xs3 with
         | [],[],[] -> []
-        | (h1::t1), (h2::t2), (h3::t3) -> 
+        | h1::t1, h2::t2, h3::t3 -> 
             let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt(f)
             let cons = freshConsNoTail (f.Invoke(h1,h2,h3))
             map3ToFreshConsTail cons f t1 t2 t3
@@ -166,17 +166,17 @@ module internal List =
     let rec mapi2ToFreshConsTail n cons (f:OptimizedClosures.FSharpFunc<_,_,_,_>) xs1 xs2 = 
         match xs1,xs2 with
         | [],[] -> 
-            setFreshConsTail cons [];
-        | (h1::t1),(h2::t2) -> 
+            setFreshConsTail cons []
+        | h1::t1, h2::t2 -> 
             let cons2 = freshConsNoTail (f.Invoke(n,h1,h2))
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             mapi2ToFreshConsTail (n + 1) cons2 f t1 t2
         | _ -> invalidArg "list2" (SR.GetString(SR.listsHadDifferentLengths))
 
     let mapi2 f xs1 xs2 = 
         match xs1,xs2 with
         | [],[] -> []
-        | (h1::t1),(h2::t2) -> 
+        | h1::t1, h2::t2 -> 
             let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt(f)
             let cons = freshConsNoTail (f.Invoke(0, h1,h2))
             mapi2ToFreshConsTail 1 cons f t1 t2
@@ -187,7 +187,7 @@ module internal List =
         match xs with
         | [] ->
             setFreshConsTail cons []
-        | (h::t) ->
+        | h::t ->
             let newState = f.Invoke(s,h)
             let cons2 = freshConsNoTail newState
             setFreshConsTail cons cons2
@@ -206,16 +206,16 @@ module internal List =
         match xs with
         | [] ->
             setFreshConsTail cons []
-        | (h::t) ->
+        | h::t ->
             let cons2 = freshConsNoTail (i,h)
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             indexedToFreshConsTail cons2 t (i+1)
 
     let indexed xs =
         match xs with
         | [] -> []
         | [h] -> [(0,h)]
-        | (h::t) ->
+        | h::t ->
             let cons = freshConsNoTail (0,h)
             indexedToFreshConsTail cons t 1
             cons
@@ -223,12 +223,12 @@ module internal List =
     let rec mapFoldToFreshConsTail cons (f:OptimizedClosures.FSharpFunc<'State, 'T, 'U * 'State>) acc xs =
         match xs with
         | [] ->
-            setFreshConsTail cons [];
+            setFreshConsTail cons []
             acc
-        | (h::t) ->
+        | h::t ->
             let x',s' = f.Invoke(acc,h)
             let cons2 = freshConsNoTail x'
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             mapFoldToFreshConsTail cons2 f s' t
 
     let mapFold f acc xs =
@@ -237,7 +237,7 @@ module internal List =
         | [h] ->
             let x',s' = f acc h
             [x'],s'
-        | (h::t) ->
+        | h::t ->
             let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
             let x',s' = f.Invoke(acc,h)
             let cons = freshConsNoTail x'
@@ -247,12 +247,12 @@ module internal List =
     let rec forall f xs1 = 
         match xs1 with 
         | [] -> true
-        | (h1::t1) -> f h1 && forall f t1
+        | h1::t1 -> f h1 && forall f t1
 
     let rec exists f xs1 = 
         match xs1 with 
         | [] -> false
-        | (h1::t1) -> f h1 || exists f t1
+        | h1::t1 -> f h1 || exists f t1
 
     // optimized mutation-based implementation. This code is only valid in fslib, where mutation of private
     // tail cons cells is permitted in carefully written library code.
@@ -299,7 +299,7 @@ module internal List =
     let rec allPairsToFreshConsTailSingle x ys cons =
         match ys with
         | [] -> cons
-        | (h2::t2) ->
+        | h2::t2 ->
             let cons2 = freshConsNoTail (x,h2)
             setFreshConsTail cons cons2
             allPairsToFreshConsTailSingle x t2 cons2
@@ -307,7 +307,7 @@ module internal List =
     let rec allPairsToFreshConsTail xs ys cons =
         match xs with
         | [] -> setFreshConsTail cons []
-        | (h::t) ->
+        | h::t ->
             let p = allPairsToFreshConsTailSingle h ys cons
             allPairsToFreshConsTail  t ys p
 
@@ -325,11 +325,11 @@ module internal List =
     let rec filterToFreshConsTail cons f l = 
         match l with 
         | [] -> 
-            setFreshConsTail cons l; // note, l = nil
+            setFreshConsTail cons l // note, l = nil
         | h::t -> 
             if f h then 
                 let cons2 = freshConsNoTail h 
-                setFreshConsTail cons cons2;
+                setFreshConsTail cons cons2
                 filterToFreshConsTail cons2 f t
             else 
                 filterToFreshConsTail cons f t
@@ -341,7 +341,7 @@ module internal List =
         | h::t -> 
             if f h then   
                 let cons = freshConsNoTail h 
-                filterToFreshConsTail cons f t; 
+                filterToFreshConsTail cons f t
                 cons
             else 
                 filter f t
@@ -366,7 +366,7 @@ module internal List =
         | []::t -> concatToEmpty t 
         | (h::t1)::tt2 -> 
             let res = freshConsNoTail h
-            concatToFreshConsTail res t1 tt2;
+            concatToFreshConsTail res t1 tt2
             res
 
     let toArray (l:'T list) =
@@ -415,7 +415,7 @@ module internal List =
     let rec initToFreshConsTail cons i n f = 
         if i < n then 
             let cons2 = freshConsNoTail (f i)
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             initToFreshConsTail cons2 (i+1) n f 
         else 
             setFreshConsTail cons []
@@ -477,44 +477,44 @@ module internal List =
     let rec partitionToFreshConsTails consL consR p l = 
         match l with 
         | [] -> 
-            setFreshConsTail consL l; // note, l = nil
-            setFreshConsTail consR l; // note, l = nil
+            setFreshConsTail consL l // note, l = nil
+            setFreshConsTail consR l // note, l = nil
             
         | h::t -> 
             let cons' = freshConsNoTail h
             if p h then 
-                setFreshConsTail consL cons';
+                setFreshConsTail consL cons'
                 partitionToFreshConsTails cons' consR p t
             else 
-                setFreshConsTail consR cons';
+                setFreshConsTail consR cons'
                 partitionToFreshConsTails consL cons' p t
       
     let rec partitionToFreshConsTailLeft consL p l = 
         match l with 
         | [] -> 
-            setFreshConsTail consL l; // note, l = nil
+            setFreshConsTail consL l // note, l = nil
             l // note, l = nil
         | h::t -> 
             let cons' = freshConsNoTail h 
             if p h then 
-                setFreshConsTail consL cons';
+                setFreshConsTail consL cons'
                 partitionToFreshConsTailLeft cons'  p t
             else 
-                partitionToFreshConsTails consL cons' p t; 
+                partitionToFreshConsTails consL cons' p t
                 cons'
 
     let rec partitionToFreshConsTailRight consR p l = 
         match l with 
         | [] -> 
-            setFreshConsTail consR l; // note, l = nil
+            setFreshConsTail consR l // note, l = nil
             l // note, l = nil
         | h::t -> 
             let cons' = freshConsNoTail h 
             if p h then 
-                partitionToFreshConsTails cons' consR p t; 
+                partitionToFreshConsTails cons' consR p t
                 cons'
             else 
-                setFreshConsTail consR cons';
+                setFreshConsTail consR cons'
                 partitionToFreshConsTailRight cons' p t
 
     let partition p l = 
@@ -533,7 +533,7 @@ module internal List =
         | [] -> setFreshConsTail cons []
         | h::t ->
             let cons2 = freshConsNoTail h
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             truncateToFreshConsTail cons2 (count-1) t
 
     let truncate count list =
@@ -573,8 +573,8 @@ module internal List =
         | ((h1,h2)::t) -> 
             let cons2a = freshConsNoTail h1
             let cons2b = freshConsNoTail h2
-            setFreshConsTail cons1a cons2a;
-            setFreshConsTail cons1b cons2b;
+            setFreshConsTail cons1a cons2a
+            setFreshConsTail cons1b cons2b
             unzipToFreshConsTail cons2a cons2b t
 
     // optimized mutation-based implementation. This code is only valid in fslib, where mutation of private
@@ -586,7 +586,7 @@ module internal List =
         | ((h1,h2)::t) -> 
             let res1a = freshConsNoTail h1
             let res1b = freshConsNoTail h2
-            unzipToFreshConsTail res1a res1b t; 
+            unzipToFreshConsTail res1a res1b t
             res1a,res1b
 
     // optimized mutation-based implementation. This code is only valid in fslib, where mutation of private
@@ -594,16 +594,16 @@ module internal List =
     let rec unzip3ToFreshConsTail cons1a cons1b cons1c x = 
         match x with 
         | [] -> 
-            setFreshConsTail cons1a [];
-            setFreshConsTail cons1b [];
-            setFreshConsTail cons1c [];
+            setFreshConsTail cons1a []
+            setFreshConsTail cons1b []
+            setFreshConsTail cons1c []
         | ((h1,h2,h3)::t) -> 
             let cons2a = freshConsNoTail h1
             let cons2b = freshConsNoTail h2
             let cons2c = freshConsNoTail h3
-            setFreshConsTail cons1a cons2a;
-            setFreshConsTail cons1b cons2b;
-            setFreshConsTail cons1c cons2c;
+            setFreshConsTail cons1a cons2a
+            setFreshConsTail cons1b cons2b
+            setFreshConsTail cons1c cons2c
             unzip3ToFreshConsTail cons2a cons2b cons2c t
 
     // optimized mutation-based implementation. This code is only valid in fslib, where mutation of private
@@ -616,7 +616,7 @@ module internal List =
             let res1a = freshConsNoTail h1
             let res1b = freshConsNoTail h2
             let res1c = freshConsNoTail h3 
-            unzip3ToFreshConsTail res1a res1b res1c t; 
+            unzip3ToFreshConsTail res1a res1b res1c t
             res1a,res1b,res1c
 
     let rec windowedToFreshConsTail cons windowSize i list =
@@ -698,19 +698,19 @@ module internal List =
             setFreshConsTail cons []
         | (h1::t1),(h2::t2) -> 
             let cons2 = freshConsNoTail (h1,h2)
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             zipToFreshConsTail cons2 t1 t2
         | _ -> 
             invalidArg "xs2" (SR.GetString(SR.listsHadDifferentLengths))
 
     // optimized mutation-based implementation. This code is only valid in fslib, where mutation of private
     // tail cons cells is permitted in carefully written library code.
-    let zip  xs1 xs2 = 
+    let zip xs1 xs2 = 
         match xs1,xs2 with 
         | [],[] -> []
         | (h1::t1),(h2::t2) -> 
             let res = freshConsNoTail (h1,h2)
-            zipToFreshConsTail res t1 t2; 
+            zipToFreshConsTail res t1 t2
             res
         | _ -> 
             invalidArg "xs2" (SR.GetString(SR.listsHadDifferentLengths))
@@ -720,10 +720,10 @@ module internal List =
     let rec zip3ToFreshConsTail cons xs1 xs2 xs3 = 
         match xs1,xs2,xs3 with 
         | [],[],[] -> 
-            setFreshConsTail cons [];
+            setFreshConsTail cons []
         | (h1::t1),(h2::t2),(h3::t3) -> 
             let cons2 = freshConsNoTail (h1,h2,h3)
-            setFreshConsTail cons cons2;
+            setFreshConsTail cons cons2
             zip3ToFreshConsTail cons2 t1 t2 t3
         | _ -> 
             invalidArg "xs1" (SR.GetString(SR.listsHadDifferentLengths))
@@ -736,7 +736,7 @@ module internal List =
             []
         | (h1::t1),(h2::t2),(h3::t3) -> 
             let res = freshConsNoTail (h1,h2,h3) 
-            zip3ToFreshConsTail res t1 t2 t3; 
+            zip3ToFreshConsTail res t1 t2 t3
             res
         | _ -> 
             invalidArg "xs1" (SR.GetString(SR.listsHadDifferentLengths))
@@ -926,7 +926,7 @@ module internal Array =
         let res = zeroCreateUnchecked (fin-start+2)
         res.[fin - start + 1] <- state
         for i = fin downto start do
-            state <- f.Invoke(array.[i], state);
+            state <- f.Invoke(array.[i], state)
             res.[i - start] <- state
         res
 

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -16,8 +16,9 @@ module internal List =
     val filter : predicate:('T -> bool) -> 'T list -> 'T list
     val collect : ('T -> 'U list) -> 'T list -> 'U list
     val partition : predicate:('T -> bool) -> 'T list -> 'T list * 'T list
-    val map : mapping:('T -> 'U) -> 'T list -> 'U list
-    val map2 : mapping:('T1 -> 'T2 -> 'U) -> 'T1 list -> 'T2 list -> 'U list
+    val map : mapping : ('T -> 'U) -> 'T list -> 'U list
+    val map2 : mapping : ('T1 -> 'T2 -> 'U) -> 'T1 list -> 'T2 list -> 'U list
+    val scan : ('State -> 'T -> 'State) -> 'State -> 'T list -> 'State list
     val mapi : (int -> 'T -> 'U) -> 'T list -> 'U list
     val indexed : 'T list -> (int * 'T) list
     val mapFold : ('State -> 'T -> 'U * 'State) -> 'State -> 'T list -> 'U list * 'State

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -18,8 +18,10 @@ module internal List =
     val partition : predicate:('T -> bool) -> 'T list -> 'T list * 'T list
     val map : mapping : ('T -> 'U) -> 'T list -> 'U list
     val map2 : mapping : ('T1 -> 'T2 -> 'U) -> 'T1 list -> 'T2 list -> 'U list
+    val map3 : mapping : ('T1 -> 'T2 -> 'T3 -> 'U) -> 'T1 list -> 'T2 list -> 'T3 list -> 'U list
     val scan : ('State -> 'T -> 'State) -> 'State -> 'T list -> 'State list
     val mapi : (int -> 'T -> 'U) -> 'T list -> 'U list
+    val mapi2 : (int -> 'T1 -> 'T2 -> 'U) -> 'T1 list -> 'T2 list -> 'U list
     val indexed : 'T list -> (int * 'T) list
     val mapFold : ('State -> 'T -> 'U * 'State) -> 'State -> 'T list -> 'U list * 'State
     val forall : predicate:('T -> bool) -> 'T list -> bool


### PR DESCRIPTION
I updated the unit tests for mapi2 and map3 to deal with lists of different sizes and did some various code cleanups by removing semicolons and unnecessary parenthesis.

Got the benchmarks via BenchmarkDotNet (here's my [script](https://gist.github.com/liboz/718a6477efcc9a9550c24eb8307a9aed)). One thing that was strange is that for map3, and 10000 the median time is significantly slower. I'm not sure why this is. Maybe its a caching issue for my cpu.


       Method |   count |              Median |             StdDev |  Gen 0 |  Gen 1 |  Gen 2 | Bytes Allocated/Op |
------------- |-------- |-------------------- |------------------- |------- |------- |------- |------------------- |
         scan |      10 |         304.5794 ns |         23.1709 ns |   0.03 |      - |      - |             350.03 |
 map3Original |      10 |         341.7830 ns |         16.8830 ns |   0.04 |      - |      - |             484.78 |
         scan |     100 |       2,101.3446 ns |        146.0541 ns |   0.20 |      - |      - |           2,575.35 |
 map3Original |     100 |       2,619.7562 ns |        166.3117 ns |   0.33 |      - |      - |           4,318.09 |
         scan |   10000 |     307,643.1233 ns |     15,477.0630 ns |   9.08 |   5.39 |      - |         299,334.00 |
 map3Original |   10000 |     388,304.6069 ns |     17,862.5471 ns |  11.94 |   6.81 |      - |         372,673.40 |
         scan | 1000000 | 209,831,043.4375 ns |  6,353,605.4655 ns | 414.61 | 327.88 | 148.69 |      19,587,572.91 |
 map3Original | 1000000 | 315,592,189.5875 ns | 10,503,938.3686 ns | 558.84 | 467.34 | 215.47 |      27,217,987.13 |

        Method |   count |              Median |             StdDev |  Gen 0 |  Gen 1 |  Gen 2 | Bytes Allocated/Op |
-------------- |-------- |-------------------- |------------------- |------- |------- |------- |------------------- |
         mapi2 |      10 |         469.7160 ns |         26.0642 ns |   0.04 |      - |      - |             536.93 |
 mapi2Original |      10 |         530.8673 ns |         26.6073 ns |   0.05 |      - |      - |             648.88 |
         mapi2 |     100 |       3,592.7509 ns |        171.6177 ns |   0.33 |      - |      - |           4,281.19 |
 mapi2Original |     100 |       4,060.6522 ns |        151.7855 ns |   0.35 |      - |      - |           4,575.95 |
         mapi2 |   10000 |     500,717.5401 ns |     22,130.9440 ns |  10.33 |   8.93 |      - |         452,556.13 |
 mapi2Original |   10000 |     622,561.0294 ns |     35,048.0503 ns |  11.93 |  11.49 |      - |         554,726.80 |
         mapi2 | 1000000 | 326,453,111.0025 ns | 12,013,955.8763 ns | 525.00 | 449.00 | 133.00 |      26,085,124.39 |
 mapi2Original | 1000000 | 402,292,171.8100 ns |  9,277,239.0437 ns | 732.97 | 607.10 | 169.44 |      35,716,127.78 |


       Method |   count |              Median |             StdDev |    Gen 0 |  Gen 1 |  Gen 2 | Bytes Allocated/Op |
------------- |-------- |-------------------- |------------------- |--------- |------- |------- |------------------- |
         map3 |      10 |         613.4993 ns |         32.6481 ns |     0.06 |      - |      - |             746.24 |
 map3Original |      10 |         714.7689 ns |         45.0829 ns |     0.07 |      - |      - |             805.37 |
         map3 |     100 |       4,568.9905 ns |        225.8320 ns |     0.46 |      - |      - |           5,560.82 |
 map3Original |     100 |       5,278.0294 ns |        279.9612 ns |     0.61 |      - |      - |           7,363.74 |
         map3 |   10000 |     682,773.1369 ns |     27,336.4413 ns |    12.59 |  12.05 |      - |         548,461.39 |
 map3Original |   10000 |     644,494.0281 ns |     31,484.0954 ns |    30.53 |   9.28 |      - |         657,631.84 |
         map3 | 1000000 | 501,848,898.9538 ns | 12,512,666.7946 ns |   777.00 | 692.00 | 171.00 |      36,030,283.15 |
 map3Original | 1000000 | 592,864,013.6563 ns | 15,369,761.5252 ns | 1,058.00 | 906.00 | 200.00 |      47,469,251.94 |
