### PR TITLE
revert 'use mutable' warning

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1315,7 +1315,6 @@ tcTupleStructMismatch,"One tuple type is a struct tuple, the other is a referenc
 3202,tcUnsupportedMutRecDecl,"This declaration is not supported in recursive declaration groups"
 3203,parsInvalidUseOfRec,"Invalid use of 'rec' keyword"
 3204,tcStructUnionMultiCase,"A union type which is a struct must have only one case."
-3205,tcUseMayNotBeMutable,"This feature is deprecated. A 'use' binding may not be marked 'mutable'."
 3206,CallerMemberNameIsOverriden,"The CallerMemberNameAttribute applied to parameter '%s' will have no effect. It is overridden by the CallerFilePathAttribute."
 3207,tcFixedNotAllowed,"Invalid use of 'fixed'. 'fixed' may only be used in a declaration of the form 'use x = fixed expr' where the expression is an array, the address of a field, the address of an array element or a string'"
 3208,tcCouldNotFindOffsetToStringData,"Could not find method System.Runtime.CompilerServices.OffsetToStringData in references when building 'fixed' expression."

--- a/tests/fsharp/typecheck/sigs/neg96.bsl
+++ b/tests/fsharp/typecheck/sigs/neg96.bsl
@@ -1,8 +1,6 @@
 
 neg96.fs(11,9,11,21): typecheck error FS0039: The value or constructor 'StructRecord' is not defined
 
-neg96.fs(14,17,14,18): typecheck error FS3205: This feature is deprecated. A 'use' binding may not be marked 'mutable'.
-
 neg96.fs(18,10,18,11): typecheck error FS0039: The type 'X' is not defined
 
 neg96.fs(18,10,18,11): typecheck error FS0039: The type 'X' is not defined

--- a/tests/fsharp/typecheck/sigs/neg96.fs
+++ b/tests/fsharp/typecheck/sigs/neg96.fs
@@ -17,3 +17,12 @@ let x = StructRecord ()
 
 type T = X<__SOURCE_DIRECTORY__>
 
+
+open System.Collections.Generic
+
+let f (x: List<'T>) = 
+    use mutable d = x.GetEnumerator() // no warning expected here!
+    while (d.MoveNext() ) do 
+       ()
+    ()
+

--- a/tests/fsharp/typecheck/sigs/neg96.fs
+++ b/tests/fsharp/typecheck/sigs/neg96.fs
@@ -10,9 +10,9 @@ type StructRecord =
 
 let x = StructRecord ()
 
-let invalidUse() = 
-    use mutable x = (null : System.IDisposable)
-    ()
+
+
+
 
 
 type T = X<__SOURCE_DIRECTORY__>


### PR DESCRIPTION
In https://github.com/Microsoft/visualfsharp/pull/1277/ we added a warning for ``use mutable x = ...``

However it turns out that ``use mutable ...`` is useful in F# when the disposable type is a struct.  This occurs when an iterator is a struct type, e.g.

```fsharp

open System.Collections.Generic

let f (x: List<'T>) = 
    use mutable d = x.GetEnumerator()
    while (d.MoveNext() ) do 
       ()
    ()

```

We should revert the warning on ``use mutable`` for this reason

