### PR TITLE
[WIP] Removed trailing whitespace from all files referenced in the VS solution.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -14,7 +14,7 @@ echo.
 echo Usage:
 echo.
 echo build.cmd ^<all^|proto^|protofx^|build^|debug^|release^|diag^|compiler^|coreclr^|pcls^|vs^|ci^|ci_part1^|ci_part2^|microbuild^>
-echo           ^<test-coreunit^|test-corecompile^|test-smoke^|test-coreclr^|test-pcls^|test-fsharp^|test-fsharpqa^|test-vs^|publicsign^>
+echo           ^<test-coreunit^|test-corecompile^|test-smoke^|test-coreclr^|test-pcls^|test-fsharp^|test-fsharpqa^|test-vs^|publicsign^|sourceformat^>
 echo.
 echo No arguments default to 'build'
 echo.
@@ -52,6 +52,7 @@ set TEST_FSHARP_SUITE=0
 set TEST_FSHARPQA_SUITE=0
 set TEST_TAGS=
 set SKIP_EXPENSIVE_TESTS=1
+set TEST_SOURCEFORMAT=0
 
 setlocal enableDelayedExpansion
 set /a counter=0
@@ -106,6 +107,7 @@ if /i '%ARG%' == 'all' (
     set TEST_VS=1
 
     set SKIP_EXPENSIVE_TESTS=0
+    set TEST_SOURCEFORMAT=1
 )
 
 if /i '%ARG%' == 'protofx' (
@@ -189,7 +191,6 @@ if /i '%ARG%' == 'ci_part2' (
     set TEST_TAGS=
 )
 
-
 if /i '%ARG%' == 'coreclr' (
     set BUILD_CORECLR=1
     set TEST_CORECLR=1
@@ -265,6 +266,10 @@ if /i '%ARG%' == 'publicsign' (
     set BUILD_PUBLICSIGN=1
 )
 
+if /i '%ARG%' == 'sourceformat' (
+    set TEST_SOURCEFORMAT=1
+)
+
 goto :EOF
 
 :MAIN
@@ -292,6 +297,7 @@ echo TEST_FSHARP_SUITE=%TEST_FSHARP_SUITE%
 echo TEST_FSHARPQA_SUITE=%TEST_FSHARPQA_SUITE%
 echo TEST_TAGS=%TEST_TAGS%
 echo SKIP_EXPENSIVE_TESTS=%SKIP_EXPENSIVE_TESTS%
+echo TEST_SOURCEFORMAT=%TEST_SOURCEFORMAT%
 echo.
 
 if "%RestorePackages%"=="" ( 
@@ -299,6 +305,8 @@ if "%RestorePackages%"=="" (
 )
 
 @echo on
+
+set FSI_TOOL=%~dp0\%BUILD_CONFIG%\net40\bin\Fsi.exe
 
 call src\update.cmd signonly
 
@@ -492,6 +500,11 @@ if '%TEST_CORECLR%' == '1' (
 if '%TEST_VS%' == '1' (
     call RunTests.cmd %BUILD_CONFIG_LOWERCASE% ideunit %TEST_TAGS% 
     @if ERRORLEVEL 1 echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWER% ideunit  %TEST_TAGS%' failed && goto :failed_tests
+)
+
+if '%TEST_SOURCEFORMAT%' == '1' (
+    %FSI_TOOL% %~dp0\tests\scripts\check-whitespace.fsx --exec --nologo
+    @if ERRORLEVEL 1 echo Error: whitespace found && goto :failure
 )
 
 :finished

--- a/tests/scripts/check-whitespace.fsx
+++ b/tests/scripts/check-whitespace.fsx
@@ -1,0 +1,36 @@
+open System.IO
+open System
+
+let root = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..\\..\\"))
+
+// Single * wildcards are permitted.  Where you might use ** to search recursively,
+// use SearchOption.AllDirectories.  To only search a single directory, use
+// SearchOption.TopDirectoryOnly.
+let matches =
+    [|
+        //"*.fs", SearchOption.AllDirectories
+    |]
+
+let files =
+    matches
+    |> Seq.collect(fun (path, searchOption) ->
+        seq { yield! Directory.EnumerateFiles(root, path, searchOption) })
+
+let hasTrailingWhitespace fileName =
+    let lines = File.ReadAllLines(fileName)
+    lines
+    |> Array.exists(fun line -> line.TrimEnd().Length <> line.Length)
+
+let filesWithTrailingWhitespace =
+    files
+    |> Seq.fold(fun filesWithWhitespace file ->
+       match hasTrailingWhitespace file with
+       | true -> file::filesWithWhitespace
+       | false -> filesWithWhitespace) []
+
+filesWithTrailingWhitespace
+|> List.iter(printfn "Whitespace found: %s")
+
+match List.isEmpty filesWithTrailingWhitespace with
+| true -> Environment.Exit(0)
+| false -> Environment.Exit(1)


### PR DESCRIPTION
I used the VS find and replace functionality with the regex "[^\S\r\n]+(?=\r?$)" to remove trailing whitespace.
