### PR TITLE
Change task cancellation behaviour on awaited untyped tasks

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -259,7 +259,20 @@ type AsyncType() =
             with :? System.OperationCanceledException -> return true
         }
 
-        Async.RunSynchronously(test()) |> Assert.IsTrue      
+        Async.RunSynchronously(test()) |> Assert.IsTrue   
+        
+    [<Test>]
+    member this.AwaitTaskCancellationUntyped () =
+        let test() = async {
+            let tcs = new System.Threading.Tasks.TaskCompletionSource<unit>()
+            tcs.SetCanceled()
+            try 
+                do! Async.AwaitTask (tcs.Task :> Task)
+                return false
+            with :? System.OperationCanceledException -> return true
+        }
+
+        Async.RunSynchronously(test()) |> Assert.IsTrue    
         
     [<Test>]
     member this.TaskAsyncValueException () =

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1566,7 +1566,7 @@ namespace Microsoft.FSharp.Control
             let continuation (completedTask : Task) : unit =
                 args.aux.trampolineHolder.Protect((fun () ->
                     if completedTask.IsCanceled then
-                        args.aux.ccont (new OperationCanceledException())
+                        args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException()))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1554,7 +1554,7 @@ namespace Microsoft.FSharp.Control
                 args.aux.trampolineHolder.Protect((fun () ->
                     if completedTask.IsCanceled then
                         if useCcontForTaskCancellation then args.aux.ccont(new OperationCanceledException())
-                        else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException()))
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException()))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else
@@ -1568,7 +1568,7 @@ namespace Microsoft.FSharp.Control
                 args.aux.trampolineHolder.Protect((fun () ->
                     if completedTask.IsCanceled then
                         if useCcontForTaskCancellation then args.aux.ccont (new OperationCanceledException())
-                        else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException()))
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException()))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1548,12 +1548,13 @@ namespace Microsoft.FSharp.Control
     // Contains helpers that will attach continuation to the given task.
     // Should be invoked as a part of protectedPrimitive(withResync) call
     module TaskHelpers = 
-        let continueWith (task : Task<'T>, args) = 
+        let continueWith (task : Task<'T>, args, useCcontForTaskCancellation) = 
 
             let continuation (completedTask : Task<_>) : unit =
                 args.aux.trampolineHolder.Protect((fun () ->
                     if completedTask.IsCanceled then
-                        args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException()))
+                        if useCcontForTaskCancellation then args.aux.ccont(new OperationCanceledException())
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException()))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else
@@ -1561,12 +1562,13 @@ namespace Microsoft.FSharp.Control
 
             task.ContinueWith(Action<Task<'T>>(continuation), TaskContinuationOptions.None) |> ignore |> fake
 
-        let continueWithUnit (task : Task, args) = 
+        let continueWithUnit (task : Task, args, useCcontForTaskCancellation) = 
 
             let continuation (completedTask : Task) : unit =
                 args.aux.trampolineHolder.Protect((fun () ->
                     if completedTask.IsCanceled then
-                        args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException()))
+                        if useCcontForTaskCancellation then args.aux.ccont (new OperationCanceledException())
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException()))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else
@@ -1623,7 +1625,7 @@ namespace Microsoft.FSharp.Control
                         null
 
                 match edi with
-                | null -> TaskHelpers.continueWithUnit(task, args)
+                | null -> TaskHelpers.continueWithUnit (task, args, true)
                 | _ -> aux.econt edi
             )
 #else
@@ -2117,12 +2119,12 @@ namespace Microsoft.FSharp.Control
 #else
         static member AwaitTask (task:Task<'T>) : Async<'T> = 
             protectedPrimitiveWithResync (fun args -> 
-                TaskHelpers.continueWith(task, args)
+                TaskHelpers.continueWith(task, args, false)
                 )
 
         static member AwaitTask (task:Task) : Async<unit> = 
             protectedPrimitiveWithResync (fun args -> 
-                TaskHelpers.continueWithUnit(task, args)
+                TaskHelpers.continueWithUnit (task, args, false)
                 )
 #endif
 
@@ -2139,7 +2141,7 @@ namespace Microsoft.FSharp.Control
 #if FX_NO_BEGINEND_READWRITE
                 // use combo protectedPrimitiveWithResync + continueWith instead of AwaitTask so we can pass cancellation token to the ReadAsync task
                 protectedPrimitiveWithResync (fun ({ aux = aux } as args) ->
-                    TaskHelpers.continueWith(stream.ReadAsync(buffer, offset, count, aux.token), args)
+                    TaskHelpers.continueWith(stream.ReadAsync(buffer, offset, count, aux.token), args, false)
                     )
 #else
                 Async.FromBeginEnd (buffer,offset,count,stream.BeginRead,stream.EndRead)
@@ -2163,7 +2165,7 @@ namespace Microsoft.FSharp.Control
 #if FX_NO_BEGINEND_READWRITE
                 // use combo protectedPrimitiveWithResync + continueWith instead of AwaitTask so we can pass cancellation token to the WriteAsync task
                 protectedPrimitiveWithResync ( fun ({ aux = aux} as args) ->
-                    TaskHelpers.continueWithUnit(stream.WriteAsync(buffer, offset, count, aux.token), args)
+                    TaskHelpers.continueWithUnit(stream.WriteAsync(buffer, offset, count, aux.token), args, false)
                     )
 #else
                 Async.FromBeginEnd (buffer,offset,count,stream.BeginWrite,stream.EndWrite)


### PR DESCRIPTION
As observed by @ncave in #1416, the `Async.AwaitTask : Task -> Async<unit>` has inconsistent task cancellation behavior compared to the typed implementation. This PR rectifies the inconsistency.