### PR TITLE
Add F# optional implicit converter runtime tests

### DIFF
--- a/tests/fsharp/core/fsfromfsviacs/lib.fs
+++ b/tests/fsharp/core/fsfromfsviacs/lib.fs
@@ -43,6 +43,7 @@ let tup4 = (2,3,4,5)
 
 
 type OptionalParameterTests =
+    static member MethodWithOptionalParam<'T>(?value : 'T) = value
     static member MethodWithOptionalParams<'T>(?value1 : 'T, ?value2 : int) = (value1, value2)
 
     static member FSharpMethodThatConsumesOptionalParams() = 

--- a/tests/fsharp/core/fsfromfsviacs/lib2.cs
+++ b/tests/fsharp/core/fsfromfsviacs/lib2.cs
@@ -68,7 +68,15 @@ namespace FSharpOptionalTests
     {
         public static Tuple<FSharpOption<T>, FSharpOption<int>> MethodWithOptionalParams<T>(T value1, int value2)
         {
-            return Lib.OptionalParameterTests.MethodWithOptionalParams<T>(value1 = value1, value2 = value2);
+            return Lib.OptionalParameterTests.MethodWithOptionalParams<T>(value1: value1, value2: value2);
+        }
+
+        public static FSharpOption<T> ConsumeOptionalParam<T>(FSharpOption<T> param)
+        {
+            if (param == null)
+                return Lib.OptionalParameterTests.MethodWithOptionalParam<T>(value: null);
+            else
+                return Lib.OptionalParameterTests.MethodWithOptionalParam<T>(value: param.Value);
         }
 
         public static int MethodThatImplicitlyConvertsFSharpOption(int x)

--- a/tests/fsharp/core/fsfromfsviacs/test.fsx
+++ b/tests/fsharp/core/fsfromfsviacs/test.fsx
@@ -1,5 +1,6 @@
 // #Conformance #Interop #Unions 
 open Lib
+open FSharpOptionalTests
 
 let mutable failures = false
 let report_failure () = 
@@ -46,6 +47,25 @@ let _ = test "structunion394b33" (Lib.NestedStructUnionsTests.testPattern3(u2))
 let _ = test "structunion394b14" (Lib.NestedStructUnionsTests.testPattern1mut(u2))
 let _ = test "structunion394b25" (Lib.NestedStructUnionsTests.testPattern2mut(u2))
 let _ = test "structunion394b36" (Lib.NestedStructUnionsTests.testPattern3mut(u2))
+
+
+// F# option implicit converter tests
+
+let testFsOpt() =
+    let testOpt (t : 'T option) =
+        test (sprintf "fsimplicitconv (%A)" t) (ApiWrapper.ConsumeOptionalParam<'T>(t) = t)
+
+    testOpt(Option<int>.None)
+    testOpt(Some 42)
+
+    // check that implicit conversion of optionals does 
+    // differentiate between 'null' and 'Some null'
+    testOpt(Option<string>.None)
+    testOpt(Option<string>.Some null)
+    testOpt(Some "")
+    testOpt(Some "test")
+
+testFsOpt()
 
 
 module NestedStructPatternMatchingAcrossAssemblyBoundaries = 


### PR DESCRIPTION
Related to #1386, this adds some runtime tests as well.