### PR TITLE
Removing recursion in array.fs where it is may be worthwhile

### DIFF
--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -86,22 +86,21 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("CopyTo")>]
         let inline blit (source : 'T[]) (sourceIndex:int) (target: 'T[]) (targetIndex:int) (count:int) = 
             Array.Copy(source, sourceIndex, target, targetIndex, count)
-
-        let rec concatAddLengths (arrs:'T[][]) i acc =
-            if i >= arrs.Length then acc 
-            else concatAddLengths arrs (i+1) (acc + arrs.[i].Length)
-
-        let rec concatBlit (arrs:'T[][]) i j (tgt:'T[]) =
-            if i < arrs.Length then 
-                let h = arrs.[i]
-                let len = h.Length 
-                Array.Copy(h, 0, tgt, j, len)
-                concatBlit arrs (i+1) (j+len) tgt
+                       
+        let concatArrays (arrs : 'T[][]) : 'T[] =
+            let mutable acc = 0    
+            for h in arrs do
+                acc <- acc + h.Length        
                 
-        let concatArrays (arrs : 'T[][]) =
-            let res = Array.zeroCreateUnchecked (concatAddLengths arrs 0 0) 
-            concatBlit arrs 0 0 res
-            res            
+            let res = Array.zeroCreateUnchecked acc  
+                
+            let mutable j = 0
+            for i = 0 to arrs.Length-1 do     
+                let h = arrs.[i]
+                let len = h.Length
+                Array.Copy(h,0,res,j,len)        
+                j <- j + len
+            res               
 
         [<CompiledName("Concat")>]
         let concat (arrays: seq<'T[]>) = 
@@ -1001,22 +1000,26 @@ namespace Microsoft.FSharp.Collections
         let inline compareWith (comparer:'T -> 'T -> int) (array1: 'T[]) (array2: 'T[]) = 
             checkNonNull "array1" array1
             checkNonNull "array2" array2
-    
+
             let length1 = array1.Length
             let length2 = array2.Length
-            let minLength = Operators.min length1 length2
+            
+            let mutable i = 0
+            let mutable result = 0
+            
+            if length1 < length2 then
+                while i < array1.Length && result = 0 do
+                    result <- comparer array1.[i] array2.[i]
+                    i <- i + 1
+            else
+                while i < array2.Length && result = 0 do
+                    result <- comparer array1.[i] array2.[i]
+                    i <- i + 1
 
-            let rec loop index  =
-                if index = minLength  then
-                    if length1 = length2 then 0
-                    elif length1 < length2 then -1
-                    else 1
-                else  
-                    let result = comparer array1.[index] array2.[index]
-                    if result <> 0 then result else
-                    loop (index+1)
-
-            loop 0
+            if result <> 0 then result
+            elif length1 = length2 then 0            
+            elif length1 < length2 then -1
+            else 1          
 
         [<CompiledName("GetSubArray")>]
         let sub (array:'T[]) (startIndex:int) (count:int) =


### PR DESCRIPTION
I went through testing for opportunities to improve performance when recursive versions could be turned into explicit loops. For many cases it was a very small difference - 1% to 2%.  If that is deemed worthwhile I can roll those into this PR (would include functions like pick, and find, etc)

compareWith got a 20% performance improvement so seems like an clear win.  concat was a very small performance improvement, but I was also able to bring it down from 4 functions to just 2, so it is arguably simpler as well. I could pull this out though if the recursive implementation is preferred.

### compareWith

 Method |  Length |            Median |         StdDev | Scaled | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
------- |-------- |------------------ |--------------- |------- |------ |------ |------ |------------------- |
    **Old** |      **10** |        **23.7544 ns** |      **0.3000 ns** |   **1.00** |     **-** |     **-** |     **-** |               **0.00** |
    New |      10 |        20.6222 ns |      0.2443 ns |   0.87 |     - |     - |     - |               0.00 |
    **Old** |   **10000** |    **16,515.5425 ns** |    **137.0188 ns** |   **1.00** |     **-** |     **-** |     **-** |               **7.08** |
    New |   10000 |    13,171.2588 ns |    194.4002 ns |   0.80 |     - |     - |     - |               7.09 |
    **Old** | **1000000** | **1,741,685.5271 ns** | **46,344.7793 ns** |   **1.00** |     **-** |     **-** |  **2.00** |          **58,857.83** |
    New | 1000000 | 1,430,355.4282 ns | 20,364.5100 ns |   0.82 |     - |     - |  1.00 |          29,901.96 |


### concat (where length is how many arrays are being concatted, each array being 5 elements)

 Method | Length |             Median |          StdDev | Scaled | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
------- |------- |------------------- |---------------- |------- |------ |------ |------ |------------------- |
    **Old** |     **10** |        **313.5194 ns** |       **6.8561 ns** |   **1.00** |  **0.02** |     **-** |     **-** |              **96.07** |
    New |     10 |        303.6155 ns |       3.8994 ns |   0.97 |  0.02 |     - |     - |              92.10 |
    **Old** |   **5000** |    **157,129.6265 ns** |   **2,104.6524 ns** |   **1.00** |     **-** |     **-** |  **8.96** |          **41,074.92** |
    New |   5000 |    156,494.2465 ns |   4,158.5105 ns |   1.00 |     - |     - |  9.05 |          41,470.82 |
    **Old** | **500000** | **17,492,839.3981 ns** | **181,163.9916 ns** |   **1.00** | **75.00** | **75.00** | **96.00** |       **5,711,591.54** |
    New | 500000 | 17,198,734.2853 ns | 146,830.3554 ns |   0.98 | 81.67 | 77.59 | 65.34 |       4,449,222.19 |



### environment for tests

```ini

Host Process Environment Information:
BenchmarkDotNet=v0.9.8.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-4712HQ CPU 2.30GHz, ProcessorCount=8
Frequency=2240908 ticks, Resolution=446.2477 ns, Timer=TSC
CLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1590.0

Type=SIMDBenchmark  Mode=Throughput  Platform=X64  
Jit=RyuJit  GarbageCollection=Concurrent Workstation  

```



