### PR TITLE
added optimization when doing set difference from an empty set

### DIFF
--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -285,6 +285,9 @@ namespace Microsoft.FSharp.Collections
         let filter comparer f s = filterAux comparer f s SetEmpty
 
         let rec diffAux comparer m acc = 
+            match acc with
+            | SetEmpty -> acc
+            | _ ->
             match m with 
             | SetNode(k,l,r,_) -> diffAux comparer l (diffAux comparer r (remove comparer k acc))
             | SetOne(k) -> remove comparer k acc


### PR DESCRIPTION
Optimization by returning early in `A - B` when `A` is an empty set and `B` is a large set. A trivial modification in the existing code. Addresses issue #324 