### PR TITLE
Fix fsharp.core.dll copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For F# 4.1 development
 - [Windows 7 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279)
 - [Windows 8 SDK](http://msdn.microsoft.com/en-us/windows/desktop/hh852363.aspx)
 - [Windows 8.1 SDK](http://msdn.microsoft.com/en-us/library/windows/desktop/bg162891.aspx)
+- [Windows 10 SDK](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)
 
 ####Contributing
 

--- a/src/update.cmd
+++ b/src/update.cmd
@@ -26,6 +26,8 @@ if not "%WindowsSDK_ExecutablePath_x86%" == "" goto :havesdk
 set REGEXE32BIT=reg.exe
 if not "%OSARCH%"=="x86" set REGEXE32BIT=%WINDIR%\syswow64\reg.exe
 
+                                FOR /F "tokens=2* delims=	 " %%A IN ('%REGEXE32BIT% QUERY "HKLM\Software\Microsoft\Microsoft SDKs\NETFXSDK\4.6.2\WinSDK-NetFx40Tools" /v InstallationFolder')  DO SET WINSDKNETFXTOOLS_x86=%%B
+                                FOR /F "tokens=2* delims=	 " %%A IN ('%REGEXE32BIT% QUERY "HKLM\Software\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools" /v InstallationFolder')  DO SET WINSDKNETFXTOOLS_x86=%%B
                                 FOR /F "tokens=2* delims=	 " %%A IN ('%REGEXE32BIT% QUERY "HKLM\Software\Microsoft\Microsoft SDKs\NETFXSDK\4.6\WinSDK-NetFx40Tools" /v InstallationFolder')  DO SET WINSDKNETFXTOOLS_x86=%%B
 if "%WINSDKNETFXTOOLS_x86%"=="" FOR /F "tokens=2* delims=	 " %%A IN ('%REGEXE32BIT% QUERY "HKLM\Software\Microsoft\Microsoft SDKs\Windows\v8.1A\WinSDK-NetFx40Tools" /v InstallationFolder') DO SET WINSDKNETFXTOOLS_x86=%%B
 if "%WINSDKNETFXTOOLS_x86%"=="" FOR /F "tokens=2* delims=	 " %%A IN ('%REGEXE32BIT% QUERY "HKLM\Software\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx40Tools" /v InstallationFolder') DO SET WINSDKNETFXTOOLS_x86=%%B

--- a/src/utils/reshapedmsbuild.fs
+++ b/src/utils/reshapedmsbuild.fs
@@ -743,7 +743,6 @@ module internal ToolLocationHelper =
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion451 visualStudioVersion120     // v4.5.1
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion452 visualStudioVersion150     // v4.5.2
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion46  visualStudioVersion140     // v4.6
-            CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion46  visualStudioVersion150     // v4.6
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion461 visualStudioVersion150     // v4.6.1
         |]
         array.ToDictionary<DotNetFrameworkSpec, Version>(fun spec -> spec.Version)


### PR DESCRIPTION
Correct fsharp.core.dll copying behavior when building.

Since we moved fsharp.core.dll out of the GAC, we added code to drop fsharp.core.dll alongside the built binary.

I noticed several times that we had an issue when an fsharp.core.dll already existed in the output directory.  If the referenced assembly was different we failed to copy it.  The issue manifested as missing method exceptions when new api's were added to fsharp.core.dll.  I previously addressed this by deleting the fsharp.core.dll in the test scripts.  That was, however, not the right fix.

This change does several things.
=====================
1)  It ensures that the compiler copies the referenced dll to the build target directory.
2) It ensures that if the fsharp.core.dll that is there was created at the same time as the referenced dll it doesn't do the copy.
3) When we are building fsharp.core.dll we don't copy the referenced fsharp.core.dll because that would overwrite the dll we had just built.

Note:  referenced in this case means passed on the compiler command line, or the fsharp.core.dll that sits alongside the compiler.


@OmarTawfik 

Thanks

Kevin

