### PR TITLE
Removed duplicate key in reshapedmsbuild.fs

### DIFF
--- a/src/utils/reshapedmsbuild.fs
+++ b/src/utils/reshapedmsbuild.fs
@@ -743,7 +743,6 @@ module internal ToolLocationHelper =
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion451 visualStudioVersion120     // v4.5.1
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion452 visualStudioVersion150     // v4.5.2
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion46  visualStudioVersion140     // v4.6
-            CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion46  visualStudioVersion150     // v4.6
             CreateDotNetFrameworkSpecForV4 dotNetFrameworkVersion461 visualStudioVersion150     // v4.6.1
         |]
         array.ToDictionary<DotNetFrameworkSpec, Version>(fun spec -> spec.Version)


### PR DESCRIPTION
Removed duplicate key that was crashing [array.ToDictionary](https://github.com/Microsoft/visualfsharp/blob/master/src/utils/reshapedmsbuild.fs#L749).