### PR TITLE
Fixed binary reader error message

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2565,8 +2565,8 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                     clrRoot, (int v1, sprintf "v%d.%d" v1 v2), (v1=5us && v2=0us && v3=5us) // SL5 mscorlib is 5.0.5.0
                 | _ -> 
                     failwith (FSComp.SR.buildCouldNotReadVersionInfoFromMscorlib())
-            with _ -> 
-                error(Error(FSComp.SR.buildCannotReadAssembly(filename),rangeStartup))
+            with e ->
+                error(Error(FSComp.SR.buildErrorOpeningBinaryFile(filename, e.Message), rangeStartup))
         | _ ->
 #if !ENABLE_MONO_SUPPORT
             // TODO:  we have to get msbuild out of this
@@ -2626,8 +2626,8 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                 checkFSharpBinaryCompatWithMscorlib filename ilReader.ILAssemblyRefs ilReader.ILModuleDef.ManifestOfAssembly.Version rangeStartup;
                 let fslibRoot = Path.GetDirectoryName(FileSystem.GetFullPathShim(filename))
                 fslibRoot (* , sprintf "v%d.%d" v1 v2 *)
-            with _ -> 
-                error(Error(FSComp.SR.buildCannotReadAssembly(filename),rangeStartup))
+            with e ->
+                error(Error(FSComp.SR.buildErrorOpeningBinaryFile(filename, e.Message), rangeStartup))
         | _ ->
             data.defaultFSharpBinariesDir
 

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2565,7 +2565,7 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                     clrRoot, (int v1, sprintf "v%d.%d" v1 v2), (v1=5us && v2=0us && v3=5us) // SL5 mscorlib is 5.0.5.0
                 | _ -> 
                     failwith (FSComp.SR.buildCouldNotReadVersionInfoFromMscorlib())
-            with e -> 
+            with e ->
                 error(Error(FSComp.SR.buildErrorOpeningBinaryFile(filename, e.Message), rangeStartup))
         | _ ->
 #if !ENABLE_MONO_SUPPORT

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2565,7 +2565,7 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                     clrRoot, (int v1, sprintf "v%d.%d" v1 v2), (v1=5us && v2=0us && v3=5us) // SL5 mscorlib is 5.0.5.0
                 | _ -> 
                     failwith (FSComp.SR.buildCouldNotReadVersionInfoFromMscorlib())
-            with e ->
+            with e -> 
                 error(Error(FSComp.SR.buildErrorOpeningBinaryFile(filename, e.Message), rangeStartup))
         | _ ->
 #if !ENABLE_MONO_SUPPORT
@@ -2626,7 +2626,7 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                 checkFSharpBinaryCompatWithMscorlib filename ilReader.ILAssemblyRefs ilReader.ILModuleDef.ManifestOfAssembly.Version rangeStartup;
                 let fslibRoot = Path.GetDirectoryName(FileSystem.GetFullPathShim(filename))
                 fslibRoot (* , sprintf "v%d.%d" v1 v2 *)
-            with e ->
+            with e -> 
                 error(Error(FSComp.SR.buildErrorOpeningBinaryFile(filename, e.Message), rangeStartup))
         | _ ->
             data.defaultFSharpBinariesDir

--- a/tests/fsharpqa/Source/MultiTargeting/E_BadPathToFSharpCore.fs
+++ b/tests/fsharpqa/Source/MultiTargeting/E_BadPathToFSharpCore.fs
@@ -1,6 +1,6 @@
 // #Regression #Multitargeting #NoMono #NETFX40Only 
 // Regression test for FSHARP1.0:6026
 // Just a dummy file...
-//<Expects status="error" id="FS0218">Unable to read assembly '.+I_DO_NOT_EXIST\\FSharp\.Core\.dll'$</Expects>
+//<Expects status="error" id="FS0229">Error opening binary file '.+I_DO_NOT_EXIST\\FSharp\.Core\.dll'</Expects>
 
 exit 0

--- a/tests/fsharpqa/Source/MultiTargeting/E_BadPathToFSharpCore.fsx
+++ b/tests/fsharpqa/Source/MultiTargeting/E_BadPathToFSharpCore.fsx
@@ -1,6 +1,6 @@
 // #Regression #Multitargeting #NoMono #NETFX40Only 
 // Regression test for FSHARP1.0:6026
 // Just a dummy file...
-//<Expects status="error" id="FS0218">Unable to read assembly '.+I_DO_NOT_EXIST\\FSharp\.Core\.dll'$</Expects>
+//<Expects status="error" id="FS0229">Error opening binary file '.+I_DO_NOT_EXIST\\FSharp\.Core\.dll'</Expects>
 
 exit 0


### PR DESCRIPTION
Make all binary reader error messages the same (like [this one](https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/CompileOps.fs#L3941)) so they show the actual error, otherwise the actual error is obscured and hidden.