### PR TITLE
Update System.ValueTuple in templates to the official public pre-release. 

### DIFF
--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
@@ -46,7 +46,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.0.1-beta-24423-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System"/>

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.0.1-beta-24423-01" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
 </packages>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
@@ -42,7 +42,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.0.1-beta-24423-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System"/>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.0.1-beta-24423-01" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
 </packages>

--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
@@ -41,7 +41,7 @@
       <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.0.1-beta-24423-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/packages.config
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.0.1-beta-24423-01" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
 </packages>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
@@ -41,7 +41,7 @@
       <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.0.1-beta-24423-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/packages.config
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.0.1-beta-24423-01" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
 </packages>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
@@ -41,7 +41,7 @@
       <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.0.1-beta-24423-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.0.1-beta-24423-01" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
 </packages>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
@@ -40,7 +40,7 @@
       <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETPortable\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.0.1-beta-24423-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.0.1-beta-24423-01" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
 </packages>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Drawing"/>
     <Reference Include="System.Windows.Forms"/>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.0.1-beta-24423-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.ValueTuple" version="4.0.1-beta-24423-01" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
 </packages>

--- a/vsintegration/tests/unittests/Tests.LanguageService.Script.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.Script.fs
@@ -569,27 +569,6 @@ type UsingMSBuild() as this =
 
     [<Test>]
     [<Category("fsx closure")>]
-
-    // 'Microsoft.VisualStudio.QualityTools.Common.dll' is resolved via AssemblyFoldersEx over recent VS releases
-    member public this.``Fsx.NoError.HashR.ResolveFromAssemblyFoldersEx``() =  
-        let fileContent = """
-            #light
-            #r "Microsoft.VisualStudio.QualityTools.Common.dll"
-            """
-        this.VerifyFSXNoErrorList(fileContent)
-
-    [<Test>]
-    [<Category("fsx closure")>]
-    // Can be any assembly that is in AssemblyFolders but not AssemblyFoldersEx
-    member public this.``Fsx.NoError.HashR.ResolveFromAssemblyFolders``() = 
-        let fileContent = """
-            #light
-            #r "Microsoft.SqlServer.SString"
-            """
-        this.VerifyFSXNoErrorList(fileContent) 
-
-    [<Test>]
-    [<Category("fsx closure")>]
     member public this.``Fsx.NoError.HashR.ResolveFromFullyQualifiedPath``() =         
         let fullyqualifiepathtoddll = System.IO.Path.Combine( System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(), "System.configuration.dll" )
         let code = ["#light";"#r @\"" + fullyqualifiepathtoddll + "\""]

--- a/vsintegration/tests/unittests/Tests.ProjectSystem.Miscellaneous.fs
+++ b/vsintegration/tests/unittests/Tests.ProjectSystem.Miscellaneous.fs
@@ -516,8 +516,6 @@ type Miscellaneous() =
     member public this.TestBuildActions () =
         DoWithTempFile "Test.fsproj" (fun file ->
             let text = TheTests.FsprojTextWithProjectReferences(["foo.fs";"Bar.resx"; "Bar.de.resx"; "Xyz\Baz.ru.resx"; "Abc.resources"],[],[],"<Import Project=\"My.targets\" />")
-            // Use toolsversion 2.0 project to have predictable default set of BuildActions
-            let text = text.Replace("ToolsVersion='4.0'", "ToolsVersion='2.0'") 
             
             File.AppendAllText(file, text)
             let dirName = Path.GetDirectoryName(file)


### PR DESCRIPTION
1. Update System.ValueTuple in templates to the official public pre-release.  
2. remove a couple of reference tests that were flaky on many platforms due to a dependence on specific VS installation options.  
3. Update a test that was relient on an installation of .Net 2.0