### PR TITLE
Deploy correct dependencies for the compiler

### DIFF
--- a/setup/FSharp.SDK/Common.Wix.Properties.wxs
+++ b/setup/FSharp.SDK/Common.Wix.Properties.wxs
@@ -2,96 +2,96 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
-	<!-- Common Folders -->
-	<Fragment>	
-		<Directory Id="TARGETDIR" Name="SourceDir">
-			<Directory Id="ProgramFilesFolder" Name="Program Files">
-				<Directory Id="ReferenceAssemblies" Name="Reference Assemblies">
-					<Directory Id="ReferenceAssemblies_Microsoft" Name="Microsoft">
-						<Directory Id="ReferenceAssemblies_Microsoft_FSharp" Name="FSharp">
-							<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework" Name=".NETFramework">
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0" Name="v4.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.1.0" Name="4.4.1.0">
-										<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.1.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-									</Directory>
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.0.0" Name="4.4.0.0">
-										<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.0.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-									</Directory>
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.1.0" Name="4.3.1.0">
-										<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.1.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-									</Directory>
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.0.0" Name="4.3.0.0">
-										<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.0.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-									</Directory>
-								</Directory>
-							</Directory>
-							
-							<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable" Name=".NETPortable">
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.41.0" Name="3.47.41.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.41.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.4.0" Name="3.47.4.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.1" Name="2.3.5.1">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.1_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.0" Name="2.3.5.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-							</Directory>
-							
-							<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore" Name=".NETCore">
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.41.0" Name="3.7.41.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.41.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.4.0" Name="3.7.4.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.3.1.0" Name="3.3.1.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.3.1.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
+  <!-- Common Folders -->
+  <Fragment>  
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder" Name="Program Files">
+        <Directory Id="ReferenceAssemblies" Name="Reference Assemblies">
+          <Directory Id="ReferenceAssemblies_Microsoft" Name="Microsoft">
+            <Directory Id="ReferenceAssemblies_Microsoft_FSharp" Name="FSharp">
+              <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework" Name=".NETFramework">
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0" Name="v4.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.1.0" Name="4.4.1.0">
+                    <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.1.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                  </Directory>
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.0.0" Name="4.4.0.0">
+                    <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.0.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                  </Directory>
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.1.0" Name="4.3.1.0">
+                    <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.1.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                  </Directory>
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.0.0" Name="4.3.0.0">
+                    <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.0.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                  </Directory>
+                </Directory>
+              </Directory>
 
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.41.0" Name="3.78.41.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.41.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.4.0" Name="3.78.4.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.3.1" Name="3.78.3.1">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.3.1_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
+              <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable" Name=".NETPortable">
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.41.0" Name="3.47.41.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.41.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.4.0" Name="3.47.4.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.1" Name="2.3.5.1">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.1_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.0" Name="2.3.5.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+              </Directory>
 
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.41.0" Name="3.259.41.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.41.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.4.0" Name="3.259.4.0">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-								<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.3.1" Name="3.259.3.1">
-									<Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.3.1_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-							</Directory>
-						</Directory>
-					</Directory>
-				</Directory>
-				
-				<Directory Id="MicrosoftSDKs" Name="Microsoft SDKs">
-					<Directory Id="MicrosoftSDKs_FS" Name="F#">
-						<Directory Id="MicrosoftSDKs_FS_4.1" Name="4.1">
-							<Directory Id="MicrosoftSDKs_FS_4.1_Framework" Name="Framework">
-								<Directory Id="MicrosoftSDKs_FS_4.1_Framework_v4.0" Name="v4.0">
-                                    <Directory Id="MicrosoftSDKs_FS_4.1_Framework_v4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
-								</Directory>
-							</Directory>
-						</Directory>
-						
-						<Directory Id="MicrosoftSDKs_FS_Licenses" Name="Licenses">
-							<Directory Id="MicrosoftSDKs_FS_Licenses_$(var.LocaleId)" Name="$(var.LocaleId)" />
-						</Directory>
-					</Directory>
-				</Directory>
-			</Directory>
-		</Directory>
-	</Fragment>
+              <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore" Name=".NETCore">
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.41.0" Name="3.7.41.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.41.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.4.0" Name="3.7.4.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.3.1.0" Name="3.3.1.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.3.1.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.41.0" Name="3.78.41.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.41.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.4.0" Name="3.78.4.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.3.1" Name="3.78.3.1">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.3.1_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.41.0" Name="3.259.41.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.41.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.4.0" Name="3.259.4.0">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+                <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.3.1" Name="3.259.3.1">
+                  <Directory Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.3.1_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+              </Directory>
+            </Directory>
+          </Directory>
+        </Directory>
+
+        <Directory Id="MicrosoftSDKs" Name="Microsoft SDKs">
+          <Directory Id="MicrosoftSDKs_FS" Name="F#">
+            <Directory Id="MicrosoftSDKs_FS_4.1" Name="4.1">
+              <Directory Id="MicrosoftSDKs_FS_4.1_Framework" Name="Framework">
+                <Directory Id="MicrosoftSDKs_FS_4.1_Framework_v4.0" Name="v4.0">
+                  <Directory Id="MicrosoftSDKs_FS_4.1_Framework_v4.0_$(var.LocaleId)" Name="$(var.LocaleRegion)" />
+                </Directory>
+              </Directory>
+            </Directory>
+
+            <Directory Id="MicrosoftSDKs_FS_Licenses" Name="Licenses">
+              <Directory Id="MicrosoftSDKs_FS_Licenses_$(var.LocaleId)" Name="$(var.LocaleId)" />
+            </Directory>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+  </Fragment>
 </Wix>

--- a/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
+++ b/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
@@ -25,6 +25,11 @@
       <ComponentRef Id="Compiler_Redist_Microsoft.Build.Tasks.Core.dll" />
       <ComponentRef Id="Compiler_Redist_Microsoft.Build.Utilities.Core.dll" />
 
+      <ComponentRef Id="Compiler_Redist_Microsoft.DiaSymReader.PortablePdb.dll" />
+      <ComponentRef Id="Compiler_Redist_Microsoft.DiaSymReader.dll" />
+      <ComponentRef Id="Compiler_Redist_System.Reflection.Metadata.dll" />
+      <ComponentRef Id="Compiler_Redist_System.Collections.Immutable.dll" />
+
       <ComponentRef Id="Compiler_Redist_OtherResources_Redist.txt" />
       <ComponentRef Id="Compiler_Redist_OtherResources_ThirdPartyNotices.txt" />
       <ComponentRef Id="Compiler_Redist_OtherResources_FSharp_eula.$(var.LocaleCode).rtf" />
@@ -95,6 +100,7 @@
       <Component Id="Compiler_Redist_Microsoft.FSharp.targets" Guid="$(fsharp.guid(Compiler_Redist_Microsoft.FSharp.targets, $(var.LocaleCode)))">
         <File Id="Compiler_Redist_Microsoft.FSharp.targets" Source="$(var.BinariesDir)\net40\bin\Microsoft.FSharp.targets" />
       </Component>
+
       <Component Id="Compiler_Redist_Microsoft.Portable.FSharp.targets" Guid="$(fsharp.guid(Compiler_Redist_Microsoft.Portable.FSharp.targets, $(var.LocaleCode)))">
         <File Id="Compiler_Redist_Microsoft.Portable.FSharp.targets" Source="$(var.BinariesDir)\net40\bin\Microsoft.Portable.FSharp.targets" />
       </Component>
@@ -138,6 +144,22 @@
 
       <Component Id="Compiler_Redist_Microsoft.Build.Utilities.Core.dll" Guid="$(fsharp.guid(Compiler_Redist_Microsoft.Build.Utilities.Core.dll, $(var.LocaleCode)))">
         <File Id="Compiler_Redist_Microsoft.Build.Utilities.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Utilities.Core.dll" />
+      </Component>
+
+      <Component Id="Compiler_Redist_System.Collections.Immutable.dll" Guid="$(fsharp.guid(Compiler_Redist_System.Collections.Immutable.dll, $(var.LocaleCode)))">
+        <File Id="Compiler_Redist_System.Collections.Immutable.dll" Source="$(var.NugetPackagesDir)\System.Collections.Immutable.1.2.0\lib\netstandard1.0\System.Collections.Immutable.dll" />
+      </Component>
+
+      <Component Id="Compiler_Redist_System.Reflection.Metadata.dll" Guid="$(fsharp.guid(Compiler_Redist_System.Reflection.Metadata.dll, $(var.LocaleCode)))">
+        <File Id="Compiler_Redist_System.Reflection.Metadata.dll" Source="$(var.NugetPackagesDir)\System.Reflection.Metadata\1.4.1-beta-24227-04\lib\netstandard1.1\System.Reflection.Metadata.dll" />
+      </Component>
+
+      <Component Id="Compiler_Redist_Microsoft.DiaSymReader.PortablePdb.dll" Guid="$(fsharp.guid(Compiler_Redist_Microsoft.DiaSymReader.PortablePdb.dll, $(var.LocaleCode)))">
+        <File Id="Compiler_Redist_Microsoft.DiaSymReader.PortablePdb.dll" Source="$(var.NugetPackagesDir)\Microsoft.DiaSymReader.PortablePdb.1.1.0\lib\net45\Microsoft.DiaSymReader.PortablePdb.dll" />
+      </Component>
+
+      <Component Id="Compiler_Redist_Microsoft.DiaSymReader.dll.dll" Guid="$(fsharp.guid(Compiler_Redist_Microsoft.DiaSymReader.dll, $(var.LocaleCode)))">
+        <File Id="Compiler_Redist_Microsoft.DiaSymReader.dll" Source="$(var.NugetPackagesDir)\Microsoft.DiaSymReader.1.0.8\lib\netstandard1.1Microsoft.DiaSymReader.dll" />
       </Component>
     </DirectoryRef>
 

--- a/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
@@ -21,7 +21,7 @@ folder "InstallDir:Common7\IDE\PublicAssemblies"
   file source="$(BinariesFolder)\net40\bin\FSharp.Core.dll" vs.file.ngen=yes
   file source="$(BinariesFolder)\net40\bin\FSharp.Core.optdata"
   file source="$(BinariesFolder)\net40\bin\FSharp.Core.sigdata"
-  
+
 folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp"
   file source="$(PackagesFolder)\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Conversion.Core.dll"
   file source="$(PackagesFolder)\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.dll"
@@ -29,11 +29,15 @@ folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp"
   file source="$(PackagesFolder)\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Framework.dll"
   file source="$(PackagesFolder)\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Tasks.Core.dll"
   file source="$(PackagesFolder)\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Utilities.Core.dll"
-  
+  file source="$(PackagesFolder)\System.Collections.Immutable.1.2.0\lib\netstandard1.0\System.Collections.Immutable.dll"
+  file source="$(PackagesFolder)\System.Reflection.Metadata.1.4.1-beta-24227-04\lib\netstandard1.1\System.Reflection.Metadata.dll"
+  file source="$(PackagesFolder)\Microsoft.DiaSymReader.1.0.8\lib\netstandard1.1\Microsoft.DiaSymReader.dll"
+  file source="$(PackagesFolder)\Microsoft.DiaSymReader.PortablePdb.1.1.0\lib\netstandard1.1\Microsoft.DiaSymReader.PortablePdb.dll"
+
 folder "InstallDir:Common7\IDE\NewScriptItems"
   file source="$(BinariesFolder)\setup\resources\NewFileDialog\Script\NewFSharpScriptItems.vsdir"
   file source="$(BinariesFolder)\setup\resources\NewFileDialog\Script\Script.fsx"
-  
+
 folder "InstallDir:Common7\IDE\NewFileItems"
   file source="$(BinariesFolder)\setup\resources\NewFileDialog\General\NewFSharpFileItems.vsdir"
   file source="$(BinariesFolder)\setup\resources\NewFileDialog\General\File.fs"


### PR DESCRIPTION
Fixes #1489 : Visual Studio Preview 4 --- FSharp compiler has missing dependencies for supporting portable PDBs #1489 

Added : 
* 'Microsoft.DiaSymReader.PortablePdb'
* 'Microsoft.DiaSymReader'
* 'System.Reflection.Metadata'
* 'System.Collections.Immutable'

to setup for vs.