### PR TITLE
Fix portable pdb debugging

### DIFF
--- a/src/absil/ilwritepdb.fsi
+++ b/src/absil/ilwritepdb.fsi
@@ -72,6 +72,7 @@ type idd =
       iddMajorVersion: int32; (* actually u16 in IMAGE_DEBUG_DIRECTORY *)
       iddMinorVersion: int32; (* actually u16 in IMAGE_DEBUG_DIRECTORY *)
       iddType: int32;
+      iddTimestamp: int32;
       iddData: byte[]; }
 
 val writePortablePdbInfo : fixupOverlappingSequencePoints:bool -> showTimes:bool -> fpdb:string -> info:PdbData -> idd

--- a/tests/fsharp/project.json
+++ b/tests/fsharp/project.json
@@ -33,6 +33,7 @@
     "System.Threading.Thread": "4.0.0",
     "System.Threading.ThreadPool": "4.0.10",
     "System.Threading.Timer": "4.0.1",
+    "System.ValueTuple": "4.0.0-rc3-24212-01",
 
     "Microsoft.DiaSymReader.PortablePdb": "1.1.0",
     "Microsoft.DiaSymReader": "1.0.8",


### PR DESCRIPTION
Fixes #1491 

https://github.com/Microsoft/visualfsharp/issues/1491

Portable PDB didn't work because the id written to the pdb file (timestamp+MVID) did not match those written to the Debug Record of the PE file.



