### PR TITLE
Update nuspec for FSharp.Compilerto point to shipped system.valuetuple

### DIFF
--- a/src/fsharp/FSharp.Compiler.netcore.nuget/Microsoft.FSharp.Compiler.netcore.nuspec
+++ b/src/fsharp/FSharp.Compiler.netcore.nuget/Microsoft.FSharp.Compiler.netcore.nuspec
@@ -33,7 +33,7 @@
                 <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
                 <dependency id="System.Threading.Thread" version="4.0.0" />
                 <dependency id="System.Threading.ThreadPool" version="4.0.10" />
-                <dependency id="System.ValueTuple" version="4.0.1-beta-24405-03" />
+                <dependency id="System.ValueTuple" version="4.0.0-rc3-24212-01" />
                 <dependency id="Microsoft.DiaSymReader.PortablePdb" version="1.1.0" />
                 <dependency id="Microsoft.DiaSymReader" version="1.0.8" />
             </group>


### PR DESCRIPTION
nuspec specified system.valuetuple only available on myget.  It now references a system.valuetuple on nuget.org