### PR TITLE
[WIP] Virtual Tags for Discriminated Unions

### DIFF
--- a/src/absil/ilprint.fs
+++ b/src/absil/ilprint.fs
@@ -439,12 +439,12 @@ let goutput_alternative_ref env os (alt: IlxUnionAlternative) =
   output_id os alt.Name; 
   alt.FieldDefs |> Array.toList |> output_parens (output_seq "," (fun os fdef -> goutput_typ env os fdef.Type)) os 
 
-let goutput_curef env os (IlxUnionRef(_,tref,alts,_,_)) =
+let goutput_curef env os (IlxUnionRef(_,tref,alts,_,_,_)) =
   output_string os " .classunion import ";
   goutput_tref env os tref;
   output_parens (output_seq "," (goutput_alternative_ref env)) os (Array.toList alts)
     
-let goutput_cuspec env os (IlxUnionSpec(IlxUnionRef(_,tref,_,_,_),i)) =
+let goutput_cuspec env os (IlxUnionSpec(IlxUnionRef(_,tref,_,_,_,_),i)) =
   output_string os "class /* classunion */ ";
   goutput_tref env os  tref;
   goutput_gactuals env os i

--- a/src/absil/ilx.fs
+++ b/src/absil/ilx.fs
@@ -49,16 +49,16 @@ type IlxUnionRef =
 
 type IlxUnionSpec = 
     | IlxUnionSpec of IlxUnionRef * ILGenericArgs
-    member x.EnclosingType     = let (IlxUnionSpec(IlxUnionRef(bx,tref,_,_,_,_),inst)) = x in mkILNamedTy bx tref inst
-    member x.Boxity            = let (IlxUnionSpec(IlxUnionRef(bx,_,_,_,_,_),_))       = x in bx 
-    member x.TypeRef           = let (IlxUnionSpec(IlxUnionRef(_,tref,_,_,_,_),_))     = x in tref
-    member x.GenericArgs       = let (IlxUnionSpec(_,inst))                            = x in inst
-    member x.AlternativesArray = let (IlxUnionSpec(IlxUnionRef(_,_,alts,_,_,_),_))     = x in alts
-    member x.IsNullPermitted   = let (IlxUnionSpec(IlxUnionRef(_,_,_,np,_,_),_))       = x in np
-    member x.HasHelpers        = let (IlxUnionSpec(IlxUnionRef(_,_,_,_,b,_),_))        = x in b
-    member x.VirtualTag        = let (IlxUnionSpec(IlxUnionRef(_,_,_,_,_,vt),_))       = x in vt
-    member x.Alternatives      = Array.toList x.AlternativesArray
-    member x.Alternative idx   = x.AlternativesArray.[idx]
+    member x.EnclosingType = let (IlxUnionSpec(IlxUnionRef(bx,tref,_,_,_,_),inst)) = x in mkILNamedTy bx tref inst
+    member x.Boxity = let (IlxUnionSpec(IlxUnionRef(bx,_,_,_,_,_),_)) = x in bx 
+    member x.TypeRef = let (IlxUnionSpec(IlxUnionRef(_,tref,_,_,_,_),_)) = x in tref
+    member x.GenericArgs = let (IlxUnionSpec(_,inst)) = x in inst
+    member x.AlternativesArray = let (IlxUnionSpec(IlxUnionRef(_,_,alts,_,_,_),_)) = x in alts
+    member x.IsNullPermitted = let (IlxUnionSpec(IlxUnionRef(_,_,_,np,_,_),_)) = x in np
+    member x.HasHelpers = let (IlxUnionSpec(IlxUnionRef(_,_,_,_,b,_),_)) = x in b
+    member x.VirtualTag = let (IlxUnionSpec(IlxUnionRef(_,_,_,_,_,vt),_)) = x in vt
+    member x.Alternatives = Array.toList x.AlternativesArray
+    member x.Alternative idx = x.AlternativesArray.[idx]
     member x.FieldDef idx fidx = x.Alternative(idx).FieldDef(fidx)
 
 type IlxClosureLambdas = 

--- a/src/absil/ilx.fs
+++ b/src/absil/ilx.fs
@@ -45,21 +45,21 @@ type IlxUnionHasHelpers =
    | SpecialFSharpOptionHelpers 
    
 type IlxUnionRef = 
-    | IlxUnionRef of boxity: ILBoxity * ILTypeRef * IlxUnionAlternative[] * bool * (* hasHelpers: *) IlxUnionHasHelpers 
+    | IlxUnionRef of boxity: ILBoxity * ILTypeRef * IlxUnionAlternative[] * bool * (* hasHelpers: *) IlxUnionHasHelpers * bool
 
 type IlxUnionSpec = 
     | IlxUnionSpec of IlxUnionRef * ILGenericArgs
-    member x.EnclosingType = let (IlxUnionSpec(IlxUnionRef(bx,tref,_,_,_),inst)) = x in mkILNamedTy bx tref inst
-    member x.Boxity = let (IlxUnionSpec(IlxUnionRef(bx,_,_,_,_),_)) = x in bx 
-    member x.TypeRef = let (IlxUnionSpec(IlxUnionRef(_,tref,_,_,_),_)) = x in tref
-    member x.GenericArgs = let (IlxUnionSpec(_,inst)) = x in inst
-    member x.AlternativesArray = let (IlxUnionSpec(IlxUnionRef(_,_,alts,_,_),_)) = x in alts
-    member x.IsNullPermitted = let (IlxUnionSpec(IlxUnionRef(_,_,_,np,_),_)) = x in np
-    member x.HasHelpers = let (IlxUnionSpec(IlxUnionRef(_,_,_,_,b),_)) = x in b
-    member x.Alternatives = Array.toList x.AlternativesArray
-    member x.Alternative idx = x.AlternativesArray.[idx]
+    member x.EnclosingType     = let (IlxUnionSpec(IlxUnionRef(bx,tref,_,_,_,_),inst)) = x in mkILNamedTy bx tref inst
+    member x.Boxity            = let (IlxUnionSpec(IlxUnionRef(bx,_,_,_,_,_),_))       = x in bx 
+    member x.TypeRef           = let (IlxUnionSpec(IlxUnionRef(_,tref,_,_,_,_),_))     = x in tref
+    member x.GenericArgs       = let (IlxUnionSpec(_,inst))                            = x in inst
+    member x.AlternativesArray = let (IlxUnionSpec(IlxUnionRef(_,_,alts,_,_,_),_))     = x in alts
+    member x.IsNullPermitted   = let (IlxUnionSpec(IlxUnionRef(_,_,_,np,_,_),_))       = x in np
+    member x.HasHelpers        = let (IlxUnionSpec(IlxUnionRef(_,_,_,_,b,_),_))        = x in b
+    member x.VirtualTag        = let (IlxUnionSpec(IlxUnionRef(_,_,_,_,_,vt),_))       = x in vt
+    member x.Alternatives      = Array.toList x.AlternativesArray
+    member x.Alternative idx   = x.AlternativesArray.[idx]
     member x.FieldDef idx fidx = x.Alternative(idx).FieldDef(fidx)
-
 
 type IlxClosureLambdas = 
     | Lambdas_forall of ILGenericParameterDef * IlxClosureLambdas
@@ -134,6 +134,7 @@ type IlxUnionInfo =
       cudDebugDisplayAttributes: ILAttribute list
       cudAlternatives: IlxUnionAlternative[]
       cudNullPermitted: bool
+      cudVirtualTag: bool
       /// debug info for generated code for classunions 
       cudWhere: ILSourceMarker option }
 

--- a/src/absil/ilx.fsi
+++ b/src/absil/ilx.fsi
@@ -40,20 +40,27 @@ type IlxUnionHasHelpers =
    | SpecialFSharpOptionHelpers 
    
 type IlxUnionRef = 
-    | IlxUnionRef of boxity: ILBoxity * ILTypeRef * IlxUnionAlternative[] * bool (* cudNullPermitted *)  * IlxUnionHasHelpers (* cudHasHelpers *)
+    | IlxUnionRef
+         of boxity: ILBoxity
+          * ILTypeRef
+          * IlxUnionAlternative[]
+          * bool (* cudNullPermitted *)
+          * IlxUnionHasHelpers (* cudHasHelpers *)
+          * bool (* cudVirtualTag *)
 
 type IlxUnionSpec = 
     | IlxUnionSpec of IlxUnionRef * ILGenericArgs
-    member EnclosingType : ILType
-    member GenericArgs : ILGenericArgs
-    member Alternatives : IlxUnionAlternative list
+    member EnclosingType     : ILType
+    member GenericArgs       : ILGenericArgs
+    member Alternatives      : IlxUnionAlternative list
     member AlternativesArray : IlxUnionAlternative[]
-    member Boxity : ILBoxity
-    member TypeRef : ILTypeRef 
-    member IsNullPermitted : bool
-    member HasHelpers : IlxUnionHasHelpers
-    member Alternative : int -> IlxUnionAlternative
-    member FieldDef : int -> int -> IlxUnionField
+    member Boxity            : ILBoxity
+    member TypeRef           : ILTypeRef 
+    member IsNullPermitted   : bool
+    member HasHelpers        : IlxUnionHasHelpers
+    member VirtualTag        : bool
+    member Alternative       : int -> IlxUnionAlternative
+    member FieldDef          : int -> int -> IlxUnionField
 
 // -------------------------------------------------------------------- 
 // Closure references 
@@ -110,6 +117,7 @@ type IlxUnionInfo =
       cudDebugDisplayAttributes: ILAttribute list
       cudAlternatives: IlxUnionAlternative[]
       cudNullPermitted: bool
+      cudVirtualTag: bool
       /// Debug info for generated code for classunions.
       cudWhere: ILSourceMarker option  
     }

--- a/src/absil/ilx.fsi
+++ b/src/absil/ilx.fsi
@@ -40,27 +40,21 @@ type IlxUnionHasHelpers =
    | SpecialFSharpOptionHelpers 
    
 type IlxUnionRef = 
-    | IlxUnionRef
-         of boxity: ILBoxity
-          * ILTypeRef
-          * IlxUnionAlternative[]
-          * bool (* cudNullPermitted *)
-          * IlxUnionHasHelpers (* cudHasHelpers *)
-          * bool (* cudVirtualTag *)
+    | IlxUnionRef of boxity: ILBoxity * ILTypeRef * IlxUnionAlternative[] * bool (* cudNullPermitted *)  * IlxUnionHasHelpers (* cudHasHelpers *) * bool (* cudVirtualTag *)
 
 type IlxUnionSpec = 
     | IlxUnionSpec of IlxUnionRef * ILGenericArgs
-    member EnclosingType     : ILType
-    member GenericArgs       : ILGenericArgs
-    member Alternatives      : IlxUnionAlternative list
+    member EnclosingType : ILType
+    member GenericArgs : ILGenericArgs
+    member Alternatives : IlxUnionAlternative list
     member AlternativesArray : IlxUnionAlternative[]
-    member Boxity            : ILBoxity
-    member TypeRef           : ILTypeRef 
-    member IsNullPermitted   : bool
-    member HasHelpers        : IlxUnionHasHelpers
-    member VirtualTag        : bool
-    member Alternative       : int -> IlxUnionAlternative
-    member FieldDef          : int -> int -> IlxUnionField
+    member Boxity : ILBoxity
+    member TypeRef : ILTypeRef 
+    member IsNullPermitted : bool
+    member HasHelpers : IlxUnionHasHelpers
+    member VirtualTag : bool
+    member Alternative : int -> IlxUnionAlternative
+    member FieldDef : int -> int -> IlxUnionField
 
 // -------------------------------------------------------------------- 
 // Closure references 

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/PrimTypes.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/PrimTypes.fs
@@ -630,7 +630,7 @@ type CompilationRepresentationFlagsEnum() =
 
     [<Test>]
     member this.Getvalue() =
-        let names = [| "None";"Static";"Instance";"ModuleSuffix";"UseNullAsTrueValue";"Event" |]
+        let names = [| "None";"Static";"Instance";"ModuleSuffix";"UseNullAsTrueValue";"Event";"UseVirtualTag" |]
         Assert.AreEqual(names, SourceConstructFlags.GetNames(typeof<CompilationRepresentationFlags>))
 #endif
 

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.coreclr.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.coreclr.fs
@@ -844,6 +844,7 @@ Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.Comp
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags None
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags Static
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseNullAsTrueValue
+Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseVirtualTag
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString()
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.IFormatProvider)
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.String)

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net20.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net20.fs
@@ -833,6 +833,7 @@ Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.Comp
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags None
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags Static
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseNullAsTrueValue
+Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseVirtualTag
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString()
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.IFormatProvider)
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.String)

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net40.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net40.fs
@@ -864,6 +864,7 @@ Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.Comp
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags None
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags Static
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseNullAsTrueValue
+Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseVirtualTag
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString()
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.IFormatProvider)
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.String)

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable259.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable259.fs
@@ -848,6 +848,7 @@ Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.Comp
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags None
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags Static
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseNullAsTrueValue
+Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseVirtualTag
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString()
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.IFormatProvider)
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.String)

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable47.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable47.fs
@@ -845,6 +845,7 @@ Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.Comp
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags None
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags Static
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseNullAsTrueValue
+Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseVirtualTag
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString()
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.IFormatProvider)
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.String)

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable7.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable7.fs
@@ -861,6 +861,7 @@ Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.Comp
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags None
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags Static
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseNullAsTrueValue
+Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseVirtualTag
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString()
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.IFormatProvider)
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.String)

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable78.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable78.fs
@@ -848,6 +848,7 @@ Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.Comp
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags None
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags Static
 Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseNullAsTrueValue
+Microsoft.FSharp.Core.CompilationRepresentationFlags: Microsoft.FSharp.Core.CompilationRepresentationFlags UseVirtualTag
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString()
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.IFormatProvider)
 Microsoft.FSharp.Core.CompilationRepresentationFlags: System.String ToString(System.String)

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -64,7 +64,8 @@ namespace Microsoft.FSharp.Collections
 
         let empty = MapEmpty 
 
-        let height  = function
+        let inline height x =
+          match x with
           | MapEmpty -> 0
           | MapOne _ -> 1
           | MapNode(_,_,_,_,h) -> h
@@ -74,7 +75,7 @@ namespace Microsoft.FSharp.Collections
             | MapEmpty -> true
             | _ -> false
 
-        let mk l k v r = 
+        let inline mk l k v r = 
             match l,r with 
             | MapEmpty,MapEmpty -> MapOne(k,v)
             | _ -> 

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -8,7 +8,7 @@ namespace Microsoft.FSharp.Collections
     open Microsoft.FSharp.Core
     open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
 
-    [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue)>]
+    [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue ||| CompilationRepresentationFlags.UseVirtualTag)>]
     [<NoEquality; NoComparison>]
     type MapTree<'Key,'Value when 'Key : comparison > = 
         | MapEmpty 

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -92,6 +92,7 @@ namespace Microsoft.FSharp.Core
        | ModuleSuffix = 4  // append 'Module' to the end of a non-unique module
        | UseNullAsTrueValue = 8  // Note if you change this then change CompilationRepresentationFlags_PermitNull further below
        | Event = 16
+       | UseVirtualTag = 32
 
 #if FX_NO_ICLONEABLE
     module ICloneableExtensions =

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -95,6 +95,8 @@ namespace Microsoft.FSharp.Core
        | UseNullAsTrueValue = 8
        /// <summary>Compile a property as a CLI event.</summary>
        | Event = 16
+       /// <summary>Rather than storing Tag:int for every discriminated union element (or GetType() comparison) use a virtual Tag property</summary>
+       | UseVirtualTag = 32
 
 #if FX_NO_ICLONEABLE
     module ICloneableExtensions =

--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -13,7 +13,7 @@ namespace Microsoft.FSharp.Collections
 
     (* A classic functional language implementation of binary trees *)
 
-    [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue)>]
+    [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue ||| CompilationRepresentationFlags.UseVirtualTag)>]
     [<NoEquality; NoComparison>]
     type SetTree<'T> when 'T : comparison = 
         | SetEmpty                                          // height = 0   

--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -70,7 +70,7 @@ namespace Microsoft.FSharp.Collections
     #endif
     
 
-        let height t = 
+        let inline height t = 
             match t with 
             | SetEmpty -> 0
             | SetOne _ -> 1
@@ -90,7 +90,7 @@ namespace Microsoft.FSharp.Collections
 
         let tolerance = 2
 
-        let mk l k r = 
+        let inline mk l k r = 
             match l,r with 
             | SetEmpty,SetEmpty -> SetOne (k)
             | _ -> 

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -479,7 +479,8 @@ and GenUnionRef amap m g (tcref: TyconRef) =
               let nullPermitted = IsUnionTypeWithNullAsTrueValue g tycon
               let hasHelpers = ComputeUnionHasHelpers g tcref
               let boxity = (if tcref.IsStructOrEnumTycon then ILBoxity.AsValue else ILBoxity.AsObject)
-              IlxUnionRef(boxity, tref,alternatives,nullPermitted,hasHelpers))
+              let useVirtualTag = IsUnionTypeWithUseVirtualTag g tycon
+              IlxUnionRef(boxity, tref,alternatives,nullPermitted,hasHelpers,useVirtualTag))
 
 and ComputeUnionHasHelpers g (tcref : TyconRef) = 
     if tyconRefEq g tcref g.unit_tcr_canon then NoHelpers
@@ -6588,6 +6589,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                let cuinfo =
                   { cudReprAccess=reprAccess
                     cudNullPermitted=IsUnionTypeWithNullAsTrueValue cenv.g tycon
+                    cudVirtualTag=IsUnionTypeWithUseVirtualTag cenv.g tycon
                     cudHelpersAccess=reprAccess
                     cudHasHelpers=ComputeUnionHasHelpers cenv.g tcref
                     cudDebugProxies= generateDebugProxies

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -1036,6 +1036,9 @@ val (|ByrefTy|_|)   : TcGlobals -> TType -> TType option
 val IsUnionTypeWithNullAsTrueValue: TcGlobals -> Tycon -> bool
 val TyconHasUseNullAsTrueValueAttribute : TcGlobals -> Tycon -> bool
 val CanHaveUseNullAsTrueValueAttribute : TcGlobals -> Tycon -> bool
+val IsUnionTypeWithUseVirtualTag: TcGlobals -> Tycon -> bool
+val TyconHasUseVirtualTagAttribute : TcGlobals -> Tycon -> bool
+val CanHaveUseVirtualTagAttribute : TcGlobals -> Tycon -> bool
 val MemberIsCompiledAsInstance : TcGlobals -> TyconRef -> bool -> ValMemberInfo -> Attribs -> bool
 val ValSpecIsCompiledAsInstance : TcGlobals -> Val -> bool
 val ValRefIsCompiledAsInstanceMember : TcGlobals -> ValRef -> bool


### PR DESCRIPTION
Discriminated Unions are represented internally as a shallow object hierarchy. Externally only the base class is exposed. Determining which actually type it is (i.e. some for of RTTI) is broadly handled using one of two mechanisms, the mechasim being determined by how many union cases exist (there are some optimizatins around using NULL, and when Nullary items exists).

The first mechanism uses .net RTTI for determining underlying cases, and the second uses a Tag field stored in the base class, which is populated by by the case on construction. When four or more cases exist, the second method is used.

The first method is lighter on memory, but somewhat slower, especially when threes cases exist, the second method is faster, but consumes an extra 4 bytes per object instance.

The PR introduces a third, opt-in method, which is a halfway house between the two methods.  It creates an abstract Tag on the base class, and each of the derived types just return a constant value.

Speed wise this falls between the two existing methods, and memory wise it is as good as the first.

Opt is has been handled by adding another flag to CompilationRepresentationFlags (currently it overrides UseNullAsTrueValue - as in ORing them together doesn't work, although it could be used in conjunction, which would be faster for the null case;)

I'll create some performance number soon. 

This is represented as a WIP to determine if this is a) a good idea, and b) using CompilationRepresentationFlags is a good idea. Also, I've only really just done this as a proof of concept really so I don't know if I'm broken things at the moment...
