### PR TITLE
allow Dev15 setup to uninstall F# packages by listing the package ID

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Vsix/Core.Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Vsix/Core.Files.swr
@@ -4,6 +4,7 @@ package name=Microsoft.FSharp.VSIX.$(VSSku)
         version=4.1
         vs.package.type=vsix
         vs.package.language=$(LocaleRegion)
+        vs.package.vsixId=VisualFSharp
 
 vs.payloads
   vs.payload source="$(BinariesFolder)\net40\bin\VisualFSharp$(VSSku).vsix"


### PR DESCRIPTION
The package ID from VisualFSharp(Desktop|Full|Web) needs to be listed in the .swr file to allow Dev15 setup to uninstall/upgrade properly.

@KevinRansom, @OmarTawfik