### PR TITLE
[WIP] Fuse Seq.* calls

### DIFF
--- a/src/fsharp/FSharp.Compiler.Unittests/FSharp.Compiler.Unittests.fsproj
+++ b/src/fsharp/FSharp.Compiler.Unittests/FSharp.Compiler.Unittests.fsproj
@@ -55,7 +55,7 @@
     <Reference Include="System.Net" Condition="'$(TargetFramework)' == 'sl5' " />
     <Reference Include="System.Observable" Condition="'$(TargetFramework)' == 'sl3-wp' " />
     <Reference Include="System.ValueTuple">
-        <HintPath>..\..\..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
+      <HintPath>..\..\..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -63,6 +63,7 @@
     <Compile Include="NunitHelpers.fs" />
     <Compile Include="CompilerTestHelpers.fs" />
     <Compile Include="ManglingNameOfProvidedTypes.fs" />
+    <Compile Include="SeqFusion.fs" />
     <Compile Include="HashIfExpression.fs" />
     <Compile Include="ProductVersion.fs" />
     <Compile Include="EditDistance.fs" />

--- a/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
+++ b/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
@@ -40,3 +40,14 @@ type SeqFusionTestsModule() =
         Assert.areEqual [15; 15; 3] (Seq.toList result)
 
         Assert.areEqual  ["hello"; "5"; "world"; "5"; "!"; "1"] (Seq.toList list)
+
+    [<Test>]
+    member this.FusisonOfMapIntoIterKeepsSideEffectOrder() =
+        let list = List<string>()
+        let data = ["hello"; "world"; "!"]
+        let results = List<int>()
+            
+        Seq.iter (fun x -> results.Add x) (Seq.map (fun x -> list.Add(x.ToString()); x * 3) (Seq.map (fun y -> list.Add y; y.Length) data))
+
+        Assert.areEqual [15; 15; 3] (Seq.toList results)
+        Assert.areEqual  ["hello"; "5"; "world"; "5"; "!"; "1"] (Seq.toList list)

--- a/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
+++ b/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
@@ -31,7 +31,7 @@ type SeqFusionTestsModule() =
     member this.FusisonOfTwoMapsKeepsSideEffectOrder() =
         let list = List<string>()
         let data = ["hello"; "world"; "!"]
-        let result = Seq.map (fun x -> x * 3) (Seq.map (fun y -> list.Add y; y.Length) data)
+        let result = Seq.map (fun x -> list.Add(x.ToString()); x * 3) (Seq.map (fun y -> list.Add y; y.Length) data)
         
         // seq is not evaluated yet
         Assert.areEqual 0 list.Count
@@ -39,4 +39,4 @@ type SeqFusionTestsModule() =
         // evaluate it
         Assert.areEqual [15; 15; 3] (Seq.toList result)
 
-        Assert.areEqual data (Seq.toList list)
+        Assert.areEqual  ["hello"; "5"; "world"; "5"; "!"; "1"] (Seq.toList list)

--- a/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
+++ b/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
@@ -13,7 +13,7 @@ type SeqFusionTestsModule() =
     member this.FuseTwoMapsWithSameType() =
         let data = [3; 1; 2]
         let result = Seq.map (fun x -> x * 2) (Seq.map (fun x -> x + 2) data)
-        Assert.areEqual [12; 6; 8] (Seq.toList result)
+        Assert.areEqual [10; 6; 8] (Seq.toList result)
 
     [<Test>]
     member this.FuseTwoMapsWithSameType_String() =

--- a/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
+++ b/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace FSharp.Compiler.Unittests
+
+open System
+open NUnit.Framework
+
+[<TestFixture>]
+type SeqFusionTestsModule() =
+
+    [<Test>]
+    member this.FuseTwoMapsWithSameType() =
+        let data = [3; 1; 2]
+        let result = Seq.map (fun x -> x * 2) (Seq.map (fun x -> x + 2) data)
+        Assert.areEqual ([12; 6; 8]) (Seq.toList result)
+
+    [<Test>]
+    member this.FuseTwoMapsWithSameType_String() =
+        let data = ["hello"; "world"; "!"]
+        let result = Seq.map (fun x -> "hello" + x) (Seq.map (fun (y:string) -> " " + y) data)
+        Assert.areEqual (["hello hello"; "hello world"; "hello !"]) (Seq.toList result)
+        
+    [<Test>]
+    member this.FuseTwoMapsWithDifferentType() =
+        let data = ["hello"; "world"; "!"]
+        let result = Seq.map (fun x -> x * 3) (Seq.map (fun (y:string) -> y.Length) data)
+        Assert.areEqual ([15; 15; 3]) (Seq.toList result)

--- a/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
+++ b/src/fsharp/FSharp.Compiler.Unittests/SeqFusion.fs
@@ -4,6 +4,7 @@ namespace FSharp.Compiler.Unittests
 
 open System
 open NUnit.Framework
+open System.Collections.Generic
 
 [<TestFixture>]
 type SeqFusionTestsModule() =
@@ -12,16 +13,30 @@ type SeqFusionTestsModule() =
     member this.FuseTwoMapsWithSameType() =
         let data = [3; 1; 2]
         let result = Seq.map (fun x -> x * 2) (Seq.map (fun x -> x + 2) data)
-        Assert.areEqual ([12; 6; 8]) (Seq.toList result)
+        Assert.areEqual [12; 6; 8] (Seq.toList result)
 
     [<Test>]
     member this.FuseTwoMapsWithSameType_String() =
         let data = ["hello"; "world"; "!"]
         let result = Seq.map (fun x -> "hello" + x) (Seq.map (fun (y:string) -> " " + y) data)
-        Assert.areEqual (["hello hello"; "hello world"; "hello !"]) (Seq.toList result)
+        Assert.areEqual ["hello hello"; "hello world"; "hello !"] (Seq.toList result)
         
     [<Test>]
     member this.FuseTwoMapsWithDifferentType() =
         let data = ["hello"; "world"; "!"]
         let result = Seq.map (fun x -> x * 3) (Seq.map (fun (y:string) -> y.Length) data)
-        Assert.areEqual ([15; 15; 3]) (Seq.toList result)
+        Assert.areEqual [15; 15; 3] (Seq.toList result)
+
+    [<Test>]
+    member this.FusisonOfTwoMapsKeepsSideEffectOrder() =
+        let list = List<string>()
+        let data = ["hello"; "world"; "!"]
+        let result = Seq.map (fun x -> x * 3) (Seq.map (fun y -> list.Add y; y.Length) data)
+        
+        // seq is not evaluated yet
+        Assert.areEqual 0 list.Count
+
+        // evaluate it
+        Assert.areEqual [15; 15; 3] (Seq.toList result)
+
+        Assert.areEqual data (Seq.toList list)

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -2619,14 +2619,13 @@ and OptimizeApplication cenv env (f0,f0ty,tyargs,args,m) =
     | _ -> 
         match expr' with
         // Rewrite Seq.map f (Seq.map g) xs into Seq.map (fun x -> f(g x)) xs
-        | Expr.App(Expr.Val(valRef,_,_) as outerSeqMap,ttype1,[_;fOutType],
+        | Expr.App(Expr.Val(outerValRef,_,_) as outerSeqMap,ttype1,[_;fOutType],
                     [(Expr.Lambda(_,None,None,_,_,m1,fRetType) as f)
-                     Expr.App(Expr.Val(valRef2,_,_),_,[gInType;_],
+                     Expr.App(Expr.Val(innerValRef,_,_),_,[gInType;_],
                                 [Expr.Lambda(_,None,None,gVals,g,_,gRetType)
                                  rest],_)],m2) when
-            valRefEq cenv.g valRef cenv.g.seq_map_vref &&
-            valRefEq cenv.g valRef2 cenv.g.seq_map_vref 
-            -> 
+            valRefEq cenv.g innerValRef cenv.g.seq_map_vref &&
+            valRefEq cenv.g outerValRef cenv.g.seq_map_vref -> 
             let newApp = Expr.App(f,TType_fun(gRetType, fRetType),[],[g],m2)
             
             let reduced =

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -2620,19 +2620,19 @@ and OptimizeApplication cenv env (f0,f0ty,tyargs,args,m) =
         match expr' with
         // Rewrite Seq.map f (Seq.map g) xs into Seq.map (fun x -> f(g x)) xs
         | Expr.App(Expr.Val(valRef,_,_) as outerSeqMap,ttype1,[_;t12],
-                    [(Expr.Lambda(_,None,None,_,_,m1,rty1) as outerL)
+                    [(Expr.Lambda(_,None,None,_,_,m1,fRetType) as f)
                      Expr.App(Expr.Val(valRef2,_,_),_,[t21;_],
                                 [Expr.Lambda(_,None,None,gVals,g,_,gRetType)
-                                 rest],_)],r1) when
+                                 rest],_)],m2) when
             valRefEq cenv.g valRef cenv.g.seq_map_vref &&
             valRefEq cenv.g valRef2 cenv.g.seq_map_vref 
             -> 
-            let newApp = Expr.App(outerL,TType_fun(gRetType, rty1),[],[g],r1)
+            let newApp = Expr.App(f,TType_fun(gRetType, fRetType),[],[g],m2)
             
             let reduced =
                Expr.App(outerSeqMap,ttype1,[t21;t12],
                          [Expr.Lambda (newUnique(), None, None, gVals, newApp, m1, gRetType)
-                          rest],r1)
+                          rest],m2)
 
             OptimizeExpr cenv env reduced
         | _ ->

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -2619,9 +2619,9 @@ and OptimizeApplication cenv env (f0,f0ty,tyargs,args,m) =
     | _ -> 
         match expr' with
         // Rewrite Seq.map f (Seq.map g) xs into Seq.map (fun x -> f(g x)) xs
-        | Expr.App(Expr.Val(valRef,_,_) as outerSeqMap,ttype1,[_;t12],
+        | Expr.App(Expr.Val(valRef,_,_) as outerSeqMap,ttype1,[_;fOutType],
                     [(Expr.Lambda(_,None,None,_,_,m1,fRetType) as f)
-                     Expr.App(Expr.Val(valRef2,_,_),_,[t21;_],
+                     Expr.App(Expr.Val(valRef2,_,_),_,[gInType;_],
                                 [Expr.Lambda(_,None,None,gVals,g,_,gRetType)
                                  rest],_)],m2) when
             valRefEq cenv.g valRef cenv.g.seq_map_vref &&
@@ -2630,7 +2630,7 @@ and OptimizeApplication cenv env (f0,f0ty,tyargs,args,m) =
             let newApp = Expr.App(f,TType_fun(gRetType, fRetType),[],[g],m2)
             
             let reduced =
-               Expr.App(outerSeqMap,ttype1,[t21;t12],
+               Expr.App(outerSeqMap,ttype1,[gInType;fOutType],
                          [Expr.Lambda (newUnique(), None, None, gVals, newApp, m1, gRetType)
                           rest],m2)
 

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -5180,7 +5180,7 @@ let rec tyOfExpr g e =
         | TOp.Goto _ | TOp.Label _ | TOp.Return -> 
             //assert false; 
             //errorR(InternalError("unexpected goto/label/return in tyOfExpr",m)); 
-            // It doesn't matter what type we return here. THis is only used in free variable analysis in the code generator
+            // It doesn't matter what type we return here. This is only used in free variable analysis in the code generator
             g.unit_ty
 
 //--------------------------------------------------------------------------
@@ -5546,8 +5546,8 @@ let rec mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress 
 let mkExprAddrOfExpr g mustTakeAddress useReadonlyForGenericArrayAddress mut e addrExprVal m =
     let optBind, addre = mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress mut e addrExprVal m
     match optBind with 
-    | None -> (fun x -> x), addre
-    | Some (tmp,rval) -> (fun x -> mkCompGenLet m tmp rval x), addre
+    | None -> id, addre
+    | Some (tmp,rval) -> mkCompGenLet m tmp rval, addre
 
 let mkTupleFieldGet g (tupInfo,e,tinst,i,m) = 
     let wrap,e' = mkExprAddrOfExpr g (evalTupInfoIsStruct tupInfo) false NeverMutates e None m


### PR DESCRIPTION
this is highly experimental. 
This PR enables the compiler to rewrite

```
[1; 2] |> Seq.map (fun x -> x + 2) |> Seq.map (fun x -> x * 2)
["hello"; "world"; "!"] |> Seq.map (fun (y:string) -> y.Length) |> Seq.map (fun x -> x * 3)
```

into:

```
Seq.map (fun x -> (x + 2) * 2) [1; 2]
Seq.map (fun x -> x.Length * 3) ["hello"; "world"; "!"]
```

Future rules:

```
Seq.filter f (Seq.filter g xs)  ==>  Seq.filter (fun x -> g x && f x)) xs
Seq.iter f (Seq.map g xs)  ==>  Seq.iter (fun x -> f(g x)) xs
Seq.iter f (Seq.filter g xs)  ==>  Seq.iter (fun x -> if g x then f x)) xs
```
