### PR TITLE
[WIP] Add simple snippet support for VS

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Vsix/Microsoft.FSharp.Vsix.swixproj
+++ b/setup/Swix/Microsoft.FSharp.Vsix/Microsoft.FSharp.Vsix.swixproj
@@ -29,7 +29,7 @@
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);LocaleId=$(LocaleId)</PackagePreprocessorDefinitions>
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);LocaleRegion=$(LocaleRegion)</PackagePreprocessorDefinitions>
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);IsLangPack=$(IsLangPack)</PackagePreprocessorDefinitions>
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);SnippetsDir=$(FSharpSourcesRoot)\..\vsintegration\Snippets\$(LocaleId)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);SnippetsDir=$(FSharpSourcesRoot)\..\vsintegration\Snippets\1033</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsLangPack)' == 'false'">

--- a/setup/Swix/Microsoft.FSharp.Vsix/Microsoft.FSharp.Vsix.swixproj
+++ b/setup/Swix/Microsoft.FSharp.Vsix/Microsoft.FSharp.Vsix.swixproj
@@ -11,11 +11,11 @@
     <OutputName>Microsoft.FSharp.VSIX.$(VSSku).$(LocaleCode)</OutputName>
     <IntermediateOutputPath>$(MSBuildThisFileDirectory)obj</IntermediateOutputPath>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(IsLangPack)' == 'false'">
     <OutputType>manifest</OutputType>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(IsLangPack)' == 'true'">
     <OutputType>vsix</OutputType>
   </PropertyGroup>
@@ -29,21 +29,26 @@
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);LocaleId=$(LocaleId)</PackagePreprocessorDefinitions>
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);LocaleRegion=$(LocaleRegion)</PackagePreprocessorDefinitions>
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);IsLangPack=$(IsLangPack)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);SnippetsDir=$(FSharpSourcesRoot)\..\vsintegration\Snippets\$(LocaleId)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsLangPack)' == 'false'">
     <Package Include="Core.Files.swr" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(IsLangPack)' == 'true'">
     <Package Include="LangPack.Files.swr" />
     <Package Include="LangPack.$(VSSku).Templates.swr" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <Package Include="snippets.swr" />
+  </ItemGroup>
+
   <Target Name="GatherBinariesToBeSigned" AfterTargets="Localize">
     <!-- SWIX plugin adds the built vsix to signing automatically -->
   </Target>
-  
+
   <Target Name="CheckPropertiesArePassed" BeforeTargets="Build">
     <Error Condition="'$(VSSku)' == ''" Text="A 'VSSku' property must be passed to the project." />
     <Error Condition="'$(LocaleCode)' == ''" Text="A 'LocaleCode' property must be passed to the project." />

--- a/setup/Swix/Microsoft.FSharp.Vsix/snippets.swr
+++ b/setup/Swix/Microsoft.FSharp.Vsix/snippets.swr
@@ -1,0 +1,15 @@
+use vs
+
+package name=Microsoft.FSharp.VSIX.$(VSSku)
+        version=4.1
+        vs.package.language=$(LocaleRegion)
+
+#
+# This file should be kept in sync with the "$(RepoRoot)\vsintegration\Vsix\FSharpSnippets.targets" file
+# and the "$(RepoRoot)\vsintegration\Snippets\1033\" directory.
+#
+
+folder "InstallDir:FSharp\Snippets\$(LocaleId)"
+  file source="$(SnippetsDir)\SnippetsIndex.xml"
+  folder "Snippets"
+    file source="$(SnippetsDir)\Snippets\match.snippet"

--- a/setup/Swix/Microsoft.FSharp.Vsix/snippets.swr
+++ b/setup/Swix/Microsoft.FSharp.Vsix/snippets.swr
@@ -9,7 +9,7 @@ package name=Microsoft.FSharp.VSIX.$(VSSku)
 # and the "$(RepoRoot)\vsintegration\Snippets\1033\" directory.
 #
 
-folder "InstallDir:FSharp\Snippets\$(LocaleId)"
+folder "InstallDir:FSharp\Snippets\1033"
   file source="$(SnippetsDir)\SnippetsIndex.xml"
   folder "Snippets"
     file source="$(SnippetsDir)\Snippets\match.snippet"

--- a/vsintegration/Snippets/1033/README.txt
+++ b/vsintegration/Snippets/1033/README.txt
@@ -1,0 +1,4 @@
+The files in this directory should be kept in sync with the following files:
+
+$(RepoRoot)\setup\Swix\Microsoft.FSharp.vsix\snippets.swr
+$(RepoRoot)\vsintegration\Vsix\FSharpSnippets.targets

--- a/vsintegration/Snippets/1033/Snippets/match.snippet
+++ b/vsintegration/Snippets/1033/Snippets/match.snippet
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<CodeSnippets  xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+	<CodeSnippet Format="1.0.0">
+		<Header>
+			<Title>match</Title>
+			<Shortcut>match</Shortcut>
+			<Description>Code snippet for 'match' expression</Description>
+			<Author>Microsoft Corporation</Author>
+			<SnippetTypes>
+				<SnippetType>Expansion</SnippetType>
+				<SnippetType>SurroundsWith</SnippetType>
+			</SnippetTypes>
+		</Header>
+		<Snippet>
+			<Declarations>
+				<Literal>
+					<ID>expression</ID>
+					<Default>expr</Default>
+					<ToolTip>Expression</ToolTip>
+				</Literal>
+				<Literal>
+					<ID>value</ID>
+					<Default>value</Default>
+					<ToolTip>Value</ToolTip>
+				</Literal>
+			</Declarations>
+			<Code Language="fsharp"><![CDATA[match $expression$ with
+| $value$ -> $end$]]>
+			</Code>
+		</Snippet>
+	</CodeSnippet>
+</CodeSnippets>

--- a/vsintegration/Snippets/1033/SnippetsIndex.xml
+++ b/vsintegration/Snippets/1033/SnippetsIndex.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<SnippetCollection>
+    <Language Lang="FSharp" Guid="{bc6dd5a5-d4d6-4dab-a00d-a51242dbaf1b}">
+        <SnippetDir>
+            <OnOff>On</OnOff>
+            <Installed>true</Installed>
+            <Locale>1033</Locale>
+            <DirPath>%InstallRoot%\FSharp\Snippets\%LCID%\Snippets\</DirPath>	
+            <LocalizedName>F# snippets</LocalizedName>
+        </SnippetDir>
+    </Language>
+</SnippetCollection>

--- a/vsintegration/Snippets/1033/SnippetsIndex.xml
+++ b/vsintegration/Snippets/1033/SnippetsIndex.xml
@@ -5,7 +5,7 @@
             <OnOff>On</OnOff>
             <Installed>true</Installed>
             <Locale>1033</Locale>
-            <DirPath>%InstallRoot%\FSharp\Snippets\%LCID%\Snippets\</DirPath>	
+            <DirPath>%InstallRoot%\FSharp\Snippets\1033\Snippets\</DirPath>
             <LocalizedName>F# snippets</LocalizedName>
         </SnippetDir>
     </Language>

--- a/vsintegration/Vsix/FSharpSnippets.targets
+++ b/vsintegration/Vsix/FSharpSnippets.targets
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+  This is a hack to make snippets work in the F5 scenario while developing.
+
+  This file should be kept in sync with the "$(RepoRoot)\setup\Swix\Microsoft.FSharp.vsix\snippets.swr" file
+  and the "$(RepoRoot)\vsintegration\Snippets\1033\" directory.
+  -->
+  <PropertyGroup>
+    <SnippetIndexLocation>$(MSBuildThisFileDirectory)..\Snippets\1033</SnippetIndexLocation>
+    <SnippetsLocation>$(SnippetIndexLocation)\Snippets</SnippetsLocation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="$(SnippetIndexLocation)\SnippetsIndex.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Snippets\1033\SnippetsIndex.xml</Link>
+    </Content>
+    <Content Include="$(SnippetsLocation)\match.snippet">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Snippets\1033\Snippets\match.snippet</Link>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/vsintegration/Vsix/VisualFSharpDesktop/VisualFSharpDesktop.csproj
+++ b/vsintegration/Vsix/VisualFSharpDesktop/VisualFSharpDesktop.csproj
@@ -82,6 +82,9 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>
+  <ImportGroup>
+    <Import Project="..\FSharpSnippets.targets" />
+  </ImportGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6">
       <Visible>False</Visible>

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -82,6 +82,9 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>
+  <ImportGroup>
+    <Import Project="..\FSharpSnippets.targets" />
+  </ImportGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6">
       <Visible>False</Visible>

--- a/vsintegration/Vsix/VisualFSharpWeb/VisualFSharpWeb.csproj
+++ b/vsintegration/Vsix/VisualFSharpWeb/VisualFSharpWeb.csproj
@@ -82,6 +82,9 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>
+  <ImportGroup>
+    <Import Project="..\FSharpSnippets.targets" />
+  </ImportGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6">
       <Visible>False</Visible>

--- a/vsintegration/src/FSharp.LanguageService.Base/Microsoft.VisualStudio.Package.LanguageService.cs
+++ b/vsintegration/src/FSharp.LanguageService.Base/Microsoft.VisualStudio.Package.LanguageService.cs
@@ -55,6 +55,7 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService.Resources {
     internal const string TemplateNotPrepared = "TemplateNotPrepared";
     internal const string UnknownBuffer = "UnknownBuffer";
     internal const string UnrecognizedFilterFormat = "UnrecognizedFilterFormat";
+    internal const string InsertSnippet = "InsertSnippet";
 
         static SR loader = null;
         ResourceManager resources;

--- a/vsintegration/src/FSharp.LanguageService.Base/Microsoft.VisualStudio.Package.LanguageService.resx
+++ b/vsintegration/src/FSharp.LanguageService.Base/Microsoft.VisualStudio.Package.LanguageService.resx
@@ -175,4 +175,8 @@
     <value>Unrecognized filter format: {0}</value>
     <comment>ArgumentException</comment>
   </data>
+  <data name="InsertSnippet">
+    <value>Insert Snippet</value>
+    <comment>Shown as the prompt when inserting a code snippet.</comment>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.LanguageService.Base/ViewFilter.cs
+++ b/vsintegration/src/FSharp.LanguageService.Base/ViewFilter.cs
@@ -537,6 +537,15 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService {
                         this.source.OutliningEnabled = true;
                         break;
 
+                    case VsCommands2K.INSERTSNIPPET:
+                        var ep = GetExpansionProvider();
+                        if (ep != null)
+                        {
+                            ep.DisplayExpansionBrowser(TextView, SR.GetString(SR.InsertSnippet), new[] { "Expansion", "SurroundsWith" }, true, null, false);
+                        }
+
+                        break;
+
                 }
             }
             else if (guidCmdGroup == Microsoft.VisualStudio.VSConstants.VsStd11)

--- a/vsintegration/src/FSharp.LanguageService/FSharp.LanguageService.fsproj
+++ b/vsintegration/src/FSharp.LanguageService/FSharp.LanguageService.fsproj
@@ -54,6 +54,7 @@
     <Compile Include="Intellisense.fs" />
     <Compile Include="BackgroundRequests.fs" />
     <Compile Include="FSharpLanguageService.fs" />
+    <Compile Include="ProvideCodeExpansionsAttribute.fs" />
     <Compile Include="FSharpPackage.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/vsintegration/src/FSharp.LanguageService/FSharpLanguageService.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpLanguageService.fs
@@ -270,6 +270,7 @@ module internal VsConstants =
 
     let cmdidGotoDecl = 936u // "Go To Declaration"
     let cmdidGotoRef = 1107u // "Go To Reference"
+    let cmdidInsertSnippet = 0x143u // "Insert Snippet"
     
     let IDM_VS_EDITOR_CSCD_OUTLINING_MENU = 773u // "Outlining"
     let ECMD_OUTLN_HIDE_SELECTION = 128u // "Hide Selection" - 
@@ -305,12 +306,16 @@ type internal FSharpViewFilter(mgr:CodeWindowManager,view:IVsTextView) =
                                                                    cmd = VsConstants.ECMD_OUTLN_STOP_HIDING_CURRENT) then false
             else true
 
-    override this.QueryCommandStatus(guidCmdGroup:byref<Guid>,cmd:uint32) =        
-        if this.IsSupportedCommand(&guidCmdGroup,cmd) then
-            base.QueryCommandStatus(&guidCmdGroup,cmd)
+    override this.QueryCommandStatus(guidCmdGroup:byref<Guid>,cmd:uint32) =
+        if guidCmdGroup = VsMenus.guidStandardCommandSet2K && cmd = VsConstants.cmdidInsertSnippet then
+            // snippets are explicitly allowed
+            QueryStatusResult.SUPPORTED ||| QueryStatusResult.ENABLED |> int
         else
-            // Hide the menu item. Just returning QueryStatusResult.NOTSUPPORTED does not work
-            QueryStatusResult.INVISIBLE ||| QueryStatusResult.SUPPORTED |> int
+            if this.IsSupportedCommand(&guidCmdGroup,cmd) then
+                base.QueryCommandStatus(&guidCmdGroup,cmd)
+            else
+                // Hide the menu item. Just returning QueryStatusResult.NOTSUPPORTED does not work
+                QueryStatusResult.INVISIBLE ||| QueryStatusResult.SUPPORTED |> int
 
         
 [<Guid(FSharpConstants.languageServiceGuidString)>]

--- a/vsintegration/src/FSharp.LanguageService/FSharpPackage.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpPackage.fs
@@ -17,8 +17,8 @@ open Microsoft.VisualStudio.OLE.Interop
 type internal SVsSettingsPersistenceManager = class end
 
 [<Guid(FSharpConstants.packageGuidString)>]
-[<ProvideCodeExpansions(FSharpCommonConstants.languageServiceGuidString, false, 106s, "FSharp", @"Snippets\%LCID%\SnippetsIndex.xml")>]
-[<ProvideCodeExpansionPath("FSharp", "Description", @"Snippets\%LCID%\Snippets\")>]
+[<ProvideCodeExpansions(FSharpCommonConstants.languageServiceGuidString, false, 106s, "FSharp", @"Snippets\1033\SnippetsIndex.xml")>]
+[<ProvideCodeExpansionPath("FSharp", "Description", @"Snippets\1033\Snippets\")>]
 [<ProvideLanguageService(languageService = typeof<FSharpLanguageService>,
                          strLanguageName = FSharpConstants.fsharpLanguageName,
                          languageResourceID = 100,

--- a/vsintegration/src/FSharp.LanguageService/FSharpPackage.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpPackage.fs
@@ -11,13 +11,14 @@ open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.OLE.Interop
 
-
 // Workaround to access non-public settings persistence type.
 // GetService( ) with this will work as long as the GUID matches the real type.
 [<Guid("9B164E40-C3A2-4363-9BC5-EB4039DEF653")>]
 type internal SVsSettingsPersistenceManager = class end
 
 [<Guid(FSharpConstants.packageGuidString)>]
+[<ProvideCodeExpansions(FSharpCommonConstants.languageServiceGuidString, false, 106s, "FSharp", @"Snippets\%LCID%\SnippetsIndex.xml")>]
+[<ProvideCodeExpansionPath("FSharp", "Description", @"Snippets\%LCID%\Snippets\")>]
 [<ProvideLanguageService(languageService = typeof<FSharpLanguageService>,
                          strLanguageName = FSharpConstants.fsharpLanguageName,
                          languageResourceID = 100,

--- a/vsintegration/src/FSharp.LanguageService/ProvideCodeExpansionsAttribute.fs
+++ b/vsintegration/src/FSharp.LanguageService/ProvideCodeExpansionsAttribute.fs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.LanguageService
+
+open System
+open System.IO
+open Microsoft.FSharp.Core
+open Microsoft.VisualStudio.Shell
+
+type ProvideCodeExpansionsAttribute(
+                                    languageGuidString: string,
+                                    showRoots: bool,
+                                    displayName: int16,
+                                    languageStringId: string,
+                                    indexPath: string) =
+    inherit RegistrationAttribute()
+
+    let languageName = @"Languages\CodeExpansions\" + languageStringId
+
+    override this.Register(context: RegistrationAttribute.RegistrationContext) =
+        if context <> null then
+            let fullEscapedPath p =
+                Path.Combine(context.ComponentPath, p)
+                |> Path.GetFullPath
+                |> context.EscapePath
+            use childKey = context.CreateKey(languageName)            
+            childKey.SetValue("", new Guid(languageGuidString))
+            childKey.SetValue("DisplayName", displayName.ToString())
+            childKey.SetValue("IndexPath", fullEscapedPath indexPath)
+            childKey.SetValue("LangStringId", languageStringId.ToLowerInvariant())
+            childKey.SetValue("Package", context.ComponentType.GUID.ToString("B"))
+            childKey.SetValue("ShowRoots", if showRoots then 1 else 0)
+
+    override this.Unregister(context: RegistrationAttribute.RegistrationContext) =
+        if context <> null then
+            context.RemoveKey(languageName)
+
+type ProvideCodeExpansionPathAttribute(
+                                       languageStringId: string,
+                                       description: string,
+                                       paths: string) =
+    inherit RegistrationAttribute()
+
+    let languageName = @"Languages\CodeExpansions\" + languageStringId
+
+    override this.Register(context: RegistrationAttribute.RegistrationContext) =
+        if context <> null then
+            use childKey = context.CreateKey(languageName)
+            let snippetPaths =
+                Path.Combine(context.ComponentPath, paths)
+                |> Path.GetFullPath
+                |> context.EscapePath
+            use pathsSubKey = childKey.CreateSubkey("Paths")
+            pathsSubKey.SetValue(description, snippetPaths)
+
+    override this.Unregister(_context: RegistrationAttribute.RegistrationContext) =
+        ()


### PR DESCRIPTION
## This is meant to start the discussion for enabling F# snippets in the VS IDE.
### What's included in this PR:
- Snippet's can be inserted with `Edit -> Insert Snippet`, the `Ctrl+K, Ctrl+X` keyboard shortcut, or the `Edit.InsertSnippet` DTE command.
- The snippets are packed inside the VSIX to enable F5 testing on developer boxes.
### Shortcomings of these changes and the next steps:
- Only one snippet is included for the `match` expression.  This was added to lay the groundwork for others to add many more snippets with relatively few changes.  E.g., to add a new snippet, simply add a `.snippet` XML file next to `match.snippet` and update `FSharpSnippets.targets` and `snippets.swr`.
- Multi-line snippets aren't properly formatted/indented.  The fix for this is to (1) enable the `Preferences.EnableFormatSelection` option, and (2) implement [`ReformatSpan()`](https://github.com/Microsoft/visualfsharp/blob/master/vsintegration/src/FSharp.LanguageService.Base/Source.cs#L622).
- No tests were added.

Addresses #1498.
