### PR TITLE
Deferencing only once per function call for RangeEnumerator

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -5324,12 +5324,13 @@ namespace Microsoft.FSharp.Core
                             // is undefined prior to the first call of MoveNext and post called to MoveNext
                             // that return false (see https://msdn.microsoft.com/en-us/library/58e146b7%28v=vs.110%29.aspx)
                             // so we should be able to just return value here, which would be faster
-                            if !value < n then
+                            let derefValue = !value
+                            if derefValue < n then
                                 notStarted ()
-                            elif !value > m then
+                            elif derefValue > m then
                                 alreadyFinished ()
                             else 
-                                !value
+                                derefValue
 
                         { new IEnumerator<'T> with
                             member __.Dispose () = ()
@@ -5339,11 +5340,12 @@ namespace Microsoft.FSharp.Core
                             member __.Current = box (current ())
                             member __.Reset () = value := n - LanguagePrimitives.GenericOne
                             member __.MoveNext () =
-                                if !value < m then
-                                    value := !value + LanguagePrimitives.GenericOne
+                                let derefValue = !value
+                                if derefValue < m then
+                                    value := derefValue + LanguagePrimitives.GenericOne
                                     true
-                                elif !value = m then 
-                                    value := m + LanguagePrimitives.GenericOne
+                                elif derefValue = m then 
+                                    value := derefValue + LanguagePrimitives.GenericOne
                                     false
                                 else false }
 


### PR DESCRIPTION
Thanks to @manofstick's test [gist](https://gist.github.com/manofstick/6467b5b16714209750739b68d7a911bd), I found out that one major slowdown for his test case was because of dereferencing. This PR switches to using a mutable variable instead of dereferencing multiple times. It makes the state machine more comparable to his test case (2x slower for 64bit and slightly faster for 32bit), those translate to a 3x speed increase for 64bit and a 7x for 32bit