### PR TITLE
Fix FS0052 warnings

### DIFF
--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -148,10 +148,12 @@ module internal List =
         let mutable ie = dict.GetEnumerator()
         if not (ie.MoveNext()) then []
         else
-            let res = freshConsNoTail (keyf ie.Current.Key, ie.Current.Value)
+            let current = ie.Current
+            let res = freshConsNoTail (keyf current.Key, current.Value)
             let mutable cons = res
             while ie.MoveNext() do
-                let cons2 = freshConsNoTail (keyf ie.Current.Key, ie.Current.Value)
+                let current = ie.Current
+                let cons2 = freshConsNoTail (keyf current.Key, current.Value)
                 setFreshConsTail cons cons2
                 cons <- cons2
             setFreshConsTail cons []

--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -576,7 +576,7 @@ namespace Microsoft.FSharp.Collections
                 let rec loop () = 
                     let m1 = e1.MoveNext() 
                     let m2 = e2.MoveNext()
-                    (m1 = m2) && (not m1 || ((e1.Current.Key = e2.Current.Key) && (Unchecked.equals e1.Current.Value e2.Current.Value) && loop()))
+                    (m1 = m2) && (not m1 || let e1c, e2c = e1.Current, e2.Current in ((e1c.Key = e2c.Key) && (Unchecked.equals e1c.Value e2c.Value) && loop()))
                 loop()
             | _ -> false
 

--- a/src/fsharp/FSharp.Core/printf.fs
+++ b/src/fsharp/FSharp.Core/printf.fs
@@ -1094,7 +1094,7 @@ module internal PrintfImpl =
                 mi.Invoke(null, args)
 
         let buildPlainFinal(args : obj[], argTypes : Type[]) = 
-            let mi = typeof<Specializations<'S, 'Re, 'Res>>.GetMethod("Final" + (argTypes.Length.ToString()), NonPublicStatics)
+            let mi = typeof<Specializations<'S, 'Re, 'Res>>.GetMethod("Final" + (let x = argTypes.Length in x.ToString()), NonPublicStatics)
 #if DEBUG
             verifyMethodInfoWasTaken mi
 #else
@@ -1103,7 +1103,7 @@ module internal PrintfImpl =
             mi.Invoke(null, args)
     
         let buildPlainChained(args : obj[], argTypes : Type[]) = 
-            let mi = typeof<Specializations<'S, 'Re, 'Res>>.GetMethod("Chained" + ((argTypes.Length - 1).ToString()), NonPublicStatics)
+            let mi = typeof<Specializations<'S, 'Re, 'Res>>.GetMethod("Chained" + (let x = (argTypes.Length - 1) in x.ToString()), NonPublicStatics)
 #if DEBUG
             verifyMethodInfoWasTaken mi
 #else

--- a/src/fsharp/FSharp.Core/reflect.fs
+++ b/src/fsharp/FSharp.Core/reflect.fs
@@ -128,9 +128,9 @@ module internal Impl =
                     let args = a.ConstructorArguments
                     let flags = 
                          match args.Count  with 
-                         | 1 -> ((args.[0].Value :?> SourceConstructFlags), 0, 0)
-                         | 2 -> ((args.[0].Value :?> SourceConstructFlags), (args.[1].Value :?> int), 0)
-                         | 3 -> ((args.[0].Value :?> SourceConstructFlags), (args.[1].Value :?> int), (args.[2].Value :?> int))
+                         | 1 -> ((let x = args.[0] in x.Value :?> SourceConstructFlags), 0, 0)
+                         | 2 -> ((let x = args.[0] in x.Value :?> SourceConstructFlags), (let x = args.[1] in x.Value :?> int), 0)
+                         | 3 -> ((let x = args.[0] in x.Value :?> SourceConstructFlags), (let x = args.[1] in x.Value :?> int), (let x = args.[2] in x.Value :?> int))
                          | _ -> (enum 0, 0, 0)
                     res <- Some flags
             res


### PR DESCRIPTION
This should fix all the warnings on `FSharp.Core`.
With this PR, we can up the warning level of `FSharp.Core` to 5.
Closes #1542.