### PR TITLE
An alternative List.filter implementation

### DIFF
--- a/src/fsharp/FSharp.Core/list.fs
+++ b/src/fsharp/FSharp.Core/list.fs
@@ -408,7 +408,7 @@ namespace Microsoft.FSharp.Collections
                 | Some r -> r
 
         [<CompiledName("Filter")>]
-        let filter f x = Microsoft.FSharp.Primitives.Basics.List.filter f x
+        let filter f x = Microsoft.FSharp.Primitives.Basics.List.Filter.whileFalse f x
 
         [<CompiledName("Except")>]
         let except itemsToExclude list =
@@ -423,7 +423,7 @@ namespace Microsoft.FSharp.Collections
                 list |> filter cached.Add
 
         [<CompiledName("Where")>]
-        let where f x = Microsoft.FSharp.Primitives.Basics.List.filter f x
+        let where f x = Microsoft.FSharp.Primitives.Basics.List.Filter.whileFalse f x
 
         let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (list: 'T list) =
             Microsoft.FSharp.Primitives.Basics.List.groupBy comparer keyf getKey list

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -33,7 +33,8 @@ module internal List =
     val distinctByWithComparer : System.Collections.Generic.IEqualityComparer<'Key> -> ('T -> 'Key) -> list:'T list -> 'T list when 'Key : equality
     val init : int -> (int -> 'T) -> 'T list
     val iter : ('T -> unit) -> 'T list -> unit
-    val filter : predicate:('T -> bool) -> 'T list -> 'T list
+    module Filter =
+        val whileFalse : predicate:('T -> bool) -> 'T list -> 'T list
     val collect : ('T -> 'U list) -> 'T list -> 'U list
     val partition : predicate:('T -> bool) -> 'T list -> 'T list * 'T list
     val map : mapping : ('T -> 'U) -> 'T list -> 'U list


### PR DESCRIPTION
This alternative implementation tries to reuse the tail of the list. It does this first by filtering without copying whilst the predicate returns true. If a false is found, the section that has been scanned is then copied and it falls back to a more traditional building or result list, with the exception that it keeps track of the final set of true values in order to paste these to the end of the resultant list, thereby reusing some of the original list, and freeing up the temporary tail for garbage collection.

[This gist](https://gist.github.com/manofstick/e090c61b8d03b3fbee701eabcaf1753d) shows the performance test. This [Google doc](https://docs.google.com/spreadsheets/d/1ouYmO4wbsI8H0Fwin5N6wOfDwM2kg1F-EMCapyqJ0iE/edit?usp=sharing) shows results.

Test info:

```
Host Process Environment Information:
BenchmarkDotNet.Core=v0.9.9.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7 CPU 930 2.80GHz, ProcessorCount=8
Frequency=2767279 ticks, Resolution=361.3658 ns, Timer=TSC
```

The implementation performs worst when all items except the last are true. It performs best when all items are true, and performs better the longer the number of true items at the end of the list are. But performs for the most part pretty well across the test suite. 

_I don't think it is a slam dunk that this will be accepted. I think it should be for consideration given it's performance characteristics because it is not an across the board improvement. It was original envisaged to be a memory saving enhancement, rather than a performance enhancement, but it appears to have, for the most part, favourable performance characteristics_

**NOTE: I have attached this to the most recent 'master' branch, but I can't build from there as I appear not to have access to the nuget repository for VisualCppTools? (I had tested it on at a previous point, so I think I'm OK; unless I failed in my copying and pasting... it's possible...)**
