### PR TITLE
add F#-specific command line initialization batch file for Dev15

### DIFF
--- a/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
+++ b/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
@@ -110,6 +110,7 @@
       </Component>
 
       <Component Id="Compiler_Redist_RegistryKeys_CompilerLocation" Guid="$(fsharp.guid(Compiler_Redist_RegistryKeys_CompilerLocation, $(var.LocaleCode)))">
+        <Environment Id="Compiler_Redist_FSHARPINSTALLDIR_Environment_Variable" Name="FSHARPINSTALLDIR" Value="[MicrosoftSDKs_FS_4.1_Framework_v4.0]" />
         <RegistryKey Root="HKLM" Key="Software\Microsoft\FSharp\4.1\Runtime\v4.0" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
           <RegistryValue Value="[MicrosoftSDKs_FS_4.1_Framework_v4.0]" Type="string" />
         </RegistryKey>

--- a/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
@@ -32,3 +32,6 @@ folder "InstallDir:Common7\IDE\NewFileItems"
   file source="$(BinariesFolder)\setup\resources\NewFileDialog\General\NewFSharpFileItems.vsdir"
   file source="$(BinariesFolder)\setup\resources\NewFileDialog\General\File.fs"
   file source="$(BinariesFolder)\setup\resources\NewFileDialog\General\Script.fsx"
+
+folder "InstallDir:Common7\Tools\VsDevCmd\Ext"
+  file source="fsharp.bat"

--- a/setup/Swix/Microsoft.FSharp.Dependencies/fsharp.bat
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/fsharp.bat
@@ -1,0 +1,45 @@
+if "%VSCMD_TEST%" NEQ "" goto :test
+if "%VSCMD_ARG_CLEAN_ENV%" NEQ "" goto :clean_env
+
+if "%FSHARPINSTALLDIR%" NEQ "" set "PATH=%FSHARPINSTALLDIR%;%PATH%"
+
+goto :end
+
+:test
+
+set __VSCMD_TEST_FSHARP_STATUS=pass
+
+@REM ******************************************************************
+@REM basic environment validation cases go here
+@REM ******************************************************************
+
+where fsc.exe
+if "%ERRORLEVEL%" NEQ "0" (
+    @echo [ERROR:%~nx0] Unable to find F# compiler via 'where fsc.exe'.
+    set __VSCMD_TEST_FSHARP_STATUS=fail
+)
+
+where fsi.exe
+if "%ERRORLEVEL%" NEQ "0" (
+    @echo [ERROR:%~nx0] Unable to find F# Interactive via 'where fsi.exe'.
+    set __VSCMD_TEST_FSHARP_STATUS=fail
+)
+
+@REM return value other than 0 if tests failed.
+if "%__VSCMD_TEST_FSHARP_STATUS%" NEQ "pass" (
+    set __VSCMD_TEST_FSHARP_STATUS=
+    exit /B 1
+)
+
+set __VSCMD_TEST_FSHARP_STATUS=
+exit /B 0
+
+:clean_env
+
+@REM Script only adds to PATH, no custom action required for -clean_env
+@REM vsdevcmd.bat will clean-up this variable.
+
+goto :end
+:end
+
+exit /B 0


### PR DESCRIPTION
Dev15 packages should now include their own batch file for command line initialization.

The `fsharp.bat` file simply adds to the `%PATH%` environment variable.  As per internal documentation, if `%VSCMD_TEST%` has a value, simple smoke testing will occur.

@KevinRansom and @OmarTawfik for review.