### PR TITLE
Remove the default perl test runner for the FSharp test suite

### DIFF
--- a/TESTGUIDE.md
+++ b/TESTGUIDE.md
@@ -48,7 +48,7 @@ The F# tests are split as follows:
 
 ### FSharp Suite
 
-This is now compiled using [tests\fsharp\FSharp.Tests.fsproj] to a unit test DLL which acts as a driver script.
+This is now compiled using [tests\fsharp\FSharp.Tests.fsproj](tests/fsharp/FSharp.Tests.fsproj) to a unit test DLL which acts as a driver script.
 
 This compiles and executes the `test.fsx` file using some combination of compiler or FSI flags.  
 If the compilation and execution encounter no errors, the test is considered to have passed.

--- a/build.cmd
+++ b/build.cmd
@@ -418,14 +418,12 @@ call BuildTestTools.cmd %BUILD_CONFIG_LOWERCASE%
 
 @echo on
 if '%TEST_FSHARP_SUITE%' == '1' (
-    set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=true
     call RunTests.cmd %BUILD_CONFIG_LOWERCASE% fsharp %TEST_TAGS% 
     @if ERRORLEVEL 1 (
         type testresults\FSharpNunit_Error.log
         echo Error: 'RunTests.cmd %BUILD_CONFIG_LOWERCASE% fsharp %TEST_TAGS%' failed
         goto :failed_tests
     )
-    set FSHARP_TEST_SUITE_USE_NUNIT_RUNNER=
 )
 
 if '%TEST_FSHARPQA_SUITE%' == '1' (

--- a/tests/RunTests.cmd
+++ b/tests/RunTests.cmd
@@ -153,36 +153,6 @@ REM ----------------------------------------------------------------------------
 
 :FSHARP
 
-if not '%FSHARP_TEST_SUITE_USE_NUNIT_RUNNER%' == '' (
-    goto :FSHARP_NUNIT
-)
-
-set RESULTFILE=FSharp_Results.log
-set FAILFILE=FSharp_Failures.log
-set FAILENV=FSharp_Failures
-
-rem Hosted compiler not supported for FSHARP suite
-set HOSTED_COMPILER=
-
-where.exe perl > NUL 2> NUL
-if errorlevel 1 (
-  echo Error: perl is not in the PATH
-  exit /b 1
-)
-
-echo perl %~dp0\fsharpqa\testenv\bin\runall.pl -resultsroot %RESULTSDIR% -results %RESULTFILE% -log %FAILFILE% -fail %FAILENV% -cleanup:yes %TTAGS_ARG% %NO_TTAGS_ARG% %PARALLEL_ARG%
-     perl %~dp0\fsharpqa\testenv\bin\runall.pl -resultsroot %RESULTSDIR% -results %RESULTFILE% -log %FAILFILE% -fail %FAILENV% -cleanup:yes %TTAGS_ARG% %NO_TTAGS_ARG% %PARALLEL_ARG% -savelog:all
-)
-if errorlevel 1 (
-  type %RESULTSDIR%\%FAILFILE%
-  exit /b 1
-)
-goto :EOF
-
-REM ----------------------------------------------------------------------------
-
-:FSHARP_NUNIT
-
 set FSHARP_TEST_SUITE_CONFIGURATION=%FLAVOR%
 
 set XMLFILE=%RESULTSDIR%\FSharpNunit_Xml.xml


### PR DESCRIPTION
I had been trying to run the FSharp test suite through `RunTests.cmd` and was shocked to learn that I needed perl despite the TestGuide.md saying that only the FSharpQA suite needed perl. This removes the default perl runner for the FSharp test suite, which appeared to be unused anyways. Also fixes a broken link in TestGuide.md.