### PR TITLE
Fix #1594 - fsiCommands.vsct Included Twice

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
@@ -52,9 +52,6 @@
     <EmbeddedResource Include="VSPackage.resx">
       <MergeWithCTO>true</MergeWithCTO>
     </EmbeddedResource>
-    <VSCTCompile Include="..\FSharp.VS.FSI\fsiCommands.vsct">
-      <Link>fsiCommands.vsct</Link>
-    </VSCTCompile>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ProjectPrelude.fs" />
     <Compile Include="MSBuildUtilities.fs" />


### PR DESCRIPTION
@Microsoft/fsharp-compiler 
Fixes #1594