### PR TITLE
Fix ilread cache

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3713,10 +3713,6 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
                 | None -> false
         | None -> false
   
-    member tcImports.SetBase(baseTcImports) =
-        CheckDisposed()
-        importsBase <- Some(baseTcImports)
-
     member private tcImports.Base  = 
             CheckDisposed()
             importsBase

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -582,7 +582,6 @@ type TcAssemblyResolutions =
 type TcImports =
     interface System.IDisposable
     //new : TcImports option -> TcImports
-    member SetBase : TcImports -> unit
     member DllTable : NameMap<ImportedBinary> with get
     member GetImportedAssemblies : unit -> ImportedAssembly list
     member GetCcusInDeclOrder : unit -> CcuThunk list

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -1336,25 +1336,35 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
             // the TyconRef's we have in our hands, hence we can't dereference them to find their stamps.
 
             // So this dictionary is indexed by names.
+            //
+            // Make it lazy to avoid dereferencing while setting up the base imports. 
             let dict = 
+              lazy
                 entries 
                 |> List.map (fun (nm,tcref,builder) -> nm, (fun tcref2 tinst -> if tyconRefEq tcref tcref2 then Some(builder tinst) else None)) 
                 |> Dictionary.ofList  
             (fun tcref tinst -> 
-                 if dict.ContainsKey tcref.LogicalName then dict.[tcref.LogicalName] tcref tinst
+                 let dict = dict.Value
+                 let key = tcref.LogicalName
+                 if dict.ContainsKey key nm then dict.[key] tcref tinst
                  else None )  
         else
             // This map is for use in normal times (not building FSharp.Core.dll). It is indexed by tcref stamp which is 
             // faster than the indexing technique used in the case above.
             //
             // So this dictionary is indexed by integers.
+            //
+            // Make it lazy to avoid dereferencing while setting up the base imports. 
             let dict = 
+              lazy
                 entries  
                 |> List.filter (fun (_,tcref,_) -> tcref.CanDeref) 
                 |> List.map (fun (_,tcref,builder) -> tcref.Stamp, builder) 
                 |> Dictionary.ofList 
             (fun tcref2 tinst -> 
-                 if dict.ContainsKey tcref2.Stamp then Some(dict.[tcref2.Stamp] tinst)
+                 let dict = dict.Value
+                 let key = tcref2.Stamp
+                 if dict.ContainsKey key then Some(dict.[key] tinst)
                  else None)  
        end
            

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -1346,7 +1346,7 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
             (fun tcref tinst -> 
                  let dict = dict.Value
                  let key = tcref.LogicalName
-                 if dict.ContainsKey key nm then dict.[key] tcref tinst
+                 if dict.ContainsKey key then dict.[key] tcref tinst
                  else None )  
         else
             // This map is for use in normal times (not building FSharp.Core.dll). It is indexed by tcref stamp which is 


### PR DESCRIPTION
While working on FSharp.Compiler.Service for .NET Core I noticed that there is a flaw in the cache used for IL readers in ilread.fs: the cache key should include the primary assembly name (i.e. the cache could incorrectly confuse mscorlib-based interpretations of assemblies with System.Runtime-based interpretations).  

For example this could repro in situations where Visual Studio was being used to edit a mix of projects using both System.Runtime Profiles and mscorlib profiles.

This is significant enough that we need to integrate the fix back into this repo.
