### PR TITLE
Don't match braces at the end of the caret

### DIFF
--- a/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
+++ b/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
@@ -14,7 +14,7 @@ type internal FSharpBraceMatchingService() =
     static member GetBraceMatchingResult(sourceText, fileName, options, position) = async {
         let isPositionInRange(range) =
             let span = CommonRoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
-            span.Start <= position && position <= span.End
+            span.Start <= position && position < span.End
         let! matchedBraces = FSharpChecker.Instance.MatchBracesAlternate(fileName, sourceText.ToString(), options)
 
         return matchedBraces |> Seq.tryFind(fun(left, right) -> isPositionInRange(left) || isPositionInRange(right))

--- a/vsintegration/tests/unittests/BraceMatchingServiceTests.fs
+++ b/vsintegration/tests/unittests/BraceMatchingServiceTests.fs
@@ -140,3 +140,16 @@ type BraceMatchingServiceTests()  =
             \" )endsInString <startsInString \" +
             + >startsInString"
         this.VerifyNoBraceMatch(code, startMarker)
+        
+    [<Test>]
+    member this.BraceMatchingAtEndOfLine_Bug1597() = 
+        // https://github.com/Microsoft/visualfsharp/issues/1597
+        let code = """
+[<EntryPoint>]
+let main argv = 
+    let arg1 = ""
+    let arg2 = ""
+    let arg3 = ""
+    (printfn "%A '%A' '%A'" (arg1) (arg2) (arg3))endBrace
+    0 // return an integer exit code"""
+        this.VerifyBraceMatch(code, "(printfn", ")endBrace")


### PR DESCRIPTION
Fixes #1597
@Microsoft/fsharp-compiler 

Due to how [ProduceTagsAsync](https://github.com/dotnet/roslyn/blob/master/src/EditorFeatures/Core/Implementation/BraceMatching/BraceHighlightingViewTaggerProvider.cs)() behaves, position position passed to the service is the character that should be matched (not the caret position). So we should not match carets after the braces. The tagger will check in both directions for braces.