### PR TITLE
(Nugetize F# templates.  Ensure value tuple installed on create templ…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ tests/fsharp/core/array/dont.run.peverify
 tests/fsharp/core/innerpoly/dont.run.peverify
 tests/fsharp/typecheck/sigs/neg94-pre.dll
 times
+/tests/fsharpqa/testenv/bin/System.ValueTuple.dll

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -16,7 +16,6 @@
     <ToolsDir>$(MSBuildThisFileDirectory)..\Tools\</ToolsDir>
     <BuildToolsTaskDir>$(ToolsDir)net45\</BuildToolsTaskDir>
     <WarningsAsErrors />
-    <DeployExtension>false</DeployExtension>
 
     <FX_NO_LOADER Condition=" '$(FX_NO_LOADER)'==''">false</FX_NO_LOADER>
   </PropertyGroup>

--- a/src/fsharp/FSharp.LanguageService.Compiler/FSharp.LanguageService.Compiler.fsproj
+++ b/src/fsharp/FSharp.LanguageService.Compiler/FSharp.LanguageService.Compiler.fsproj
@@ -593,7 +593,6 @@
     <Reference Include="System.Reflection.Metadata"><HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.1-beta-24227-04\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath></Reference>
     <Reference Include="System.Collections.Immutable"><HintPath>..\..\..\packages\System.Collections.Immutable.1.2.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath></Reference>
     <Reference Include="System.ValueTuple"><HintPath>..\..\..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath></Reference>
-    <Reference Include="System.ValueTuple"><HintPath>..\..\..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\\System.ValueTuple.dll</HintPath></Reference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" >
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>

--- a/vsintegration/ProjectTemplates/ConsoleProject/ConsoleProject.csproj
+++ b/vsintegration/ProjectTemplates/ConsoleProject/ConsoleProject.csproj
@@ -18,13 +18,14 @@
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <ProjectGuid>{604F0DAA-2D33-48DD-B162-EDF0B672803D}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net40</TargetFramework>
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(TargetFramework)\bin\$(TemplateCategory)\$(AssemblyName)</OutputPath>
   </PropertyGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Common.props" />
 
   <ItemGroup>
@@ -41,25 +42,25 @@
       <InProject>false</InProject>
     </FilesToLocalize>
   </ItemGroup>
-  
+
   <ItemGroup>
     <VSTemplate Include="Template\ConsoleApplication.vstemplate" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <TemplateFiles Include="Template\App.config" />
     <TemplateFiles Include="Template\ConsoleApplication.fsproj" />
     <TemplateFiles Include="Template\AssemblyInfo.fs" />
     <TemplateFiles Include="Template\Program.fs" />
-    <TemplateFiles Include="Template\packages.config" />
+
     <TemplateFiles Include="Template\ConsoleApplication.vstemplate" />
   </ItemGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.tools.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
-  
+
   <Target Name="CoreCompile" />
-  
+
   <Target Name="CopyFilesToOutputDirectory" AfterTargets="CoreCompile">
     <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="@(TemplateFiles->'$(OutDir)$(TemplateCategory)\$(AssemblyName)\%(Filename)%(Extension)')" />
   </Target>

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
@@ -60,7 +60,6 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Program.fs" />
-    <Content Include="packages.config" />
     <None Include="App.config" />
   </ItemGroup>
   <PropertyGroup>

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
@@ -17,8 +17,16 @@
     <Project File="ConsoleApplication.fsproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true">AssemblyInfo.fs</ProjectItem>
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Program.fs</ProjectItem>
-      <ProjectItem ReplaceParameters="false">packages.config</ProjectItem>
       <ProjectItem ReplaceParameters="true">App.config</ProjectItem>
     </Project>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <packages repository="extension" repositoryId="VisualFSharp">
+      <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
+     </packages>
+  </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
-</packages>

--- a/vsintegration/ProjectTemplates/LibraryProject/LibraryProject.csproj
+++ b/vsintegration/ProjectTemplates/LibraryProject/LibraryProject.csproj
@@ -18,13 +18,14 @@
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <ProjectGuid>{01678CDA-A11F-4DEE-9344-2EDF91CF1AE7}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net40</TargetFramework>
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(TargetFramework)\bin\$(TemplateCategory)\$(AssemblyName)</OutputPath>
   </PropertyGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Common.props" />
   
   <ItemGroup>
@@ -45,21 +46,20 @@
   <ItemGroup>
     <VSTemplate Include="Template\Library.vstemplate" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <TemplateFiles Include="Template\AssemblyInfo.fs" />
     <TemplateFiles Include="Template\Library.fsproj" />
     <TemplateFiles Include="Template\Library.vstemplate" />
     <TemplateFiles Include="Template\Library1.fs" />
-    <TemplateFiles Include="Template\packages.config" />
     <TemplateFiles Include="Template\Script.fsx" />
   </ItemGroup>
 
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.tools.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
-  
+
   <Target Name="CoreCompile" />
-  
+
   <Target Name="CopyFilesToOutputDirectory" AfterTargets="CoreCompile">
     <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="@(TemplateFiles->'$(OutDir)$(TemplateCategory)\$(AssemblyName)\%(Filename)%(Extension)')" />
   </Target>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
@@ -56,7 +56,6 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Library1.fs" />
-    <Content Include="packages.config" />
     <None Include="Script.fsx" />
   </ItemGroup>
   <PropertyGroup>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
@@ -17,8 +17,16 @@
     <Project File="Library.fsproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true">AssemblyInfo.fs</ProjectItem>
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Library1.fs</ProjectItem>
-      <ProjectItem ReplaceParameters="false">packages.config</ProjectItem>
       <ProjectItem ReplaceParameters="true">Script.fsx</ProjectItem>
     </Project>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <packages repository="extension" repositoryId="VisualFSharp">
+      <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
+     </packages>
+  </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
-</packages>

--- a/vsintegration/ProjectTemplates/NetCore259Project/NetCore259Project.csproj
+++ b/vsintegration/ProjectTemplates/NetCore259Project/NetCore259Project.csproj
@@ -18,15 +18,16 @@
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <ProjectGuid>{D9D95330-3626-4199-B7AF-17B8E4AF6D87}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net40</TargetFramework>
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(TargetFramework)\bin\$(TemplateCategory)\$(AssemblyName)</OutputPath>
   </PropertyGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Common.props" />
-  
+
   <ItemGroup>
     <FilesToLocalize Include="$(OutDir)$(TemplateCategory)\$(AssemblyName)\AssemblyInfo.fs">
       <TranslationFile>$(FSharpSourcesRoot)\..\loc\lcl\{Lang}\$(TemplateCategory)\$(AssemblyName)\AssemblyInfo.fs.lcl</TranslationFile>
@@ -41,25 +42,26 @@
       <InProject>false</InProject>
     </FilesToLocalize>
   </ItemGroup>
-  
+
   <ItemGroup>
     <VSTemplate Include="Template\NETCore259PortableLibrary.vstemplate" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <TemplateFiles Include="Template\AssemblyInfo.fs" />
     <TemplateFiles Include="Template\NETCore259PortableLibrary.vstemplate" />
     <TemplateFiles Include="Template\PortableLibrary.fsproj" />
     <TemplateFiles Include="Template\PortableLibrary1.fs" />
-    <TemplateFiles Include="Template\packages.config" />
+
     <TemplateFiles Include="Template\Script.fsx" />
   </ItemGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.tools.targets" />
-  <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
-  
+
+	  <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
+
   <Target Name="CoreCompile" />
-  
+
   <Target Name="CopyFilesToOutputDirectory" AfterTargets="CoreCompile">
     <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="@(TemplateFiles->'$(OutDir)$(TemplateCategory)\$(AssemblyName)\%(Filename)%(Extension)')" />
   </Target>

--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/NETCore259PortableLibrary.vstemplate
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/NETCore259PortableLibrary.vstemplate
@@ -17,8 +17,16 @@
     <Project File="PortableLibrary.fsproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="AssemblyInfo.fs">AssemblyInfo.fs</ProjectItem>
       <ProjectItem ReplaceParameters="true" OpenInEditor="true" TargetFileName="PortableLibrary1.fs">PortableLibrary1.fs</ProjectItem>
-      <ProjectItem ReplaceParameters="false">packages.config</ProjectItem>
       <ProjectItem ReplaceParameters="true">Script.fsx</ProjectItem>
     </Project>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <packages repository="extension" repositoryId="VisualFSharp">
+      <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
+     </packages>
+  </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
@@ -48,7 +48,6 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="PortableLibrary1.fs" />
-    <Content Include="packages.config" />
     <None Include="Script.fsx" />
   </ItemGroup>
   <PropertyGroup>

--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/packages.config
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
-</packages>

--- a/vsintegration/ProjectTemplates/NetCore78Project/NetCore78Project.csproj
+++ b/vsintegration/ProjectTemplates/NetCore78Project/NetCore78Project.csproj
@@ -18,15 +18,14 @@
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <ProjectGuid>{1A8DBF70-4178-4AE3-AF5F-39DDD5692210}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net40</TargetFramework>
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(TargetFramework)\bin\$(TemplateCategory)\$(AssemblyName)</OutputPath>
   </PropertyGroup>
-  
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Common.props" />
-  
   <ItemGroup>
     <FilesToLocalize Include="$(OutDir)$(TemplateCategory)\$(AssemblyName)\AssemblyInfo.fs">
       <TranslationFile>$(FSharpSourcesRoot)\..\loc\lcl\{Lang}\$(TemplateCategory)\$(AssemblyName)\AssemblyInfo.fs.lcl</TranslationFile>
@@ -41,25 +40,19 @@
       <InProject>false</InProject>
     </FilesToLocalize>
   </ItemGroup>
-
   <ItemGroup>
     <VSTemplate Include="Template\NETCore78PortableLibrary.vstemplate" />
   </ItemGroup>
-
   <ItemGroup>
     <TemplateFiles Include="Template\AssemblyInfo.fs" />
     <TemplateFiles Include="Template\NETCore78PortableLibrary.vstemplate" />
     <TemplateFiles Include="Template\PortableLibrary.fsproj" />
     <TemplateFiles Include="Template\PortableLibrary1.fs" />
-    <TemplateFiles Include="Template\packages.config" />
     <TemplateFiles Include="Template\Script.fsx" />
   </ItemGroup>
-
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.tools.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
-  
   <Target Name="CoreCompile" />
-  
   <Target Name="CopyFilesToOutputDirectory" AfterTargets="CoreCompile">
     <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="@(TemplateFiles->'$(OutDir)$(TemplateCategory)\$(AssemblyName)\%(Filename)%(Extension)')" />
   </Target>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/NETCore78PortableLibrary.vstemplate
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/NETCore78PortableLibrary.vstemplate
@@ -17,8 +17,16 @@
     <Project File="PortableLibrary.fsproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="AssemblyInfo.fs">AssemblyInfo.fs</ProjectItem>
       <ProjectItem ReplaceParameters="true" OpenInEditor="true" TargetFileName="PortableLibrary1.fs">PortableLibrary1.fs</ProjectItem>
-      <ProjectItem ReplaceParameters="false">packages.config</ProjectItem>
       <ProjectItem ReplaceParameters="true">Script.fsx</ProjectItem>
     </Project>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <packages repository="extension" repositoryId="VisualFSharp">
+      <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
+     </packages>
+  </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
@@ -48,7 +48,6 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="PortableLibrary1.fs" />
-    <Content Include="packages.config" />
     <None Include="Script.fsx" />
   </ItemGroup>
   <PropertyGroup>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/packages.config
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
-</packages>

--- a/vsintegration/ProjectTemplates/NetCoreProject/NetCoreProject.csproj
+++ b/vsintegration/ProjectTemplates/NetCoreProject/NetCoreProject.csproj
@@ -18,6 +18,7 @@
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <ProjectGuid>{5B739CF3-1116-4EB4-B598-6C16BEA81CE5}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
@@ -41,25 +42,25 @@
       <InProject>false</InProject>
     </FilesToLocalize>
   </ItemGroup>
-  
+
   <ItemGroup>
     <VSTemplate Include="Template\NETCore7PortableLibrary.vstemplate" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <TemplateFiles Include="Template\AssemblyInfo.fs" />
     <TemplateFiles Include="Template\NETCore7PortableLibrary.vstemplate" />
     <TemplateFiles Include="Template\PortableLibrary.fsproj" />
     <TemplateFiles Include="Template\PortableLibrary1.fs" />
     <TemplateFiles Include="Template\Script.fsx" />
-    <TemplateFiles Include="Template\packages.config" />
+
   </ItemGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.tools.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
-  
+
   <Target Name="CoreCompile" />
-  
+
   <Target Name="CopyFilesToOutputDirectory" AfterTargets="CoreCompile">
     <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="@(TemplateFiles->'$(OutDir)$(TemplateCategory)\$(AssemblyName)\%(Filename)%(Extension)')" />
   </Target>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/NETCore7PortableLibrary.vstemplate
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/NETCore7PortableLibrary.vstemplate
@@ -18,7 +18,15 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="AssemblyInfo.fs">AssemblyInfo.fs</ProjectItem>
       <ProjectItem ReplaceParameters="true" OpenInEditor="true" TargetFileName="PortableLibrary1.fs">PortableLibrary1.fs</ProjectItem>
       <ProjectItem ReplaceParameters="true">Script.fsx</ProjectItem>
-      <ProjectItem ReplaceParameters="false">packages.config</ProjectItem>
     </Project>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <packages repository="extension" repositoryId="VisualFSharp">
+      <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
+     </packages>
+  </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
@@ -48,7 +48,6 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="PortableLibrary1.fs" />
-    <Content Include="packages.config" />
     <None Include="Script.fsx" />
   </ItemGroup>
   <PropertyGroup>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
-</packages>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/PortableLibraryProject.csproj
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/PortableLibraryProject.csproj
@@ -18,15 +18,16 @@
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <ProjectGuid>{DB374A0C-7560-479F-9B21-D37C81F7624F}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net40</TargetFramework>
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(TargetFramework)\bin\$(TemplateCategory)\$(AssemblyName)</OutputPath>
   </PropertyGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Common.props" />
-  
+
   <ItemGroup>
     <FilesToLocalize Include="$(OutDir)$(TemplateCategory)\$(AssemblyName)\AssemblyInfo.fs">
       <TranslationFile>$(FSharpSourcesRoot)\..\loc\lcl\{Lang}\$(TemplateCategory)\$(AssemblyName)\AssemblyInfo.fs.lcl</TranslationFile>
@@ -41,25 +42,19 @@
       <InProject>false</InProject>
     </FilesToLocalize>
   </ItemGroup>
-  
   <ItemGroup>
     <VSTemplate Include="Template\PortableLibrary.vstemplate" />
   </ItemGroup>
-  
   <ItemGroup>
     <TemplateFiles Include="Template\AssemblyInfo.fs" />
     <TemplateFiles Include="Template\PortableLibrary.vstemplate" />
     <TemplateFiles Include="Template\PortableLibrary.fsproj" />
     <TemplateFiles Include="Template\PortableLibrary1.fs" />
-    <TemplateFiles Include="Template\packages.config" />
     <TemplateFiles Include="Template\Script.fsx" />
   </ItemGroup>
-  
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.tools.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
-  
   <Target Name="CoreCompile" />
-  
   <Target Name="CopyFilesToOutputDirectory" AfterTargets="CoreCompile">
     <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="@(TemplateFiles->'$(OutDir)$(TemplateCategory)\$(AssemblyName)\%(Filename)%(Extension)')" />
   </Target>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
@@ -47,7 +47,6 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="PortableLibrary1.fs" />
-    <Content Include="packages.config" />
     <None Include="Script.fsx" />
   </ItemGroup>
   <PropertyGroup>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.vstemplate
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.vstemplate
@@ -18,7 +18,15 @@
       <ProjectItem ReplaceParameters="true">AssemblyInfo.fs</ProjectItem>
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">PortableLibrary1.fs</ProjectItem>
       <ProjectItem ReplaceParameters="true">Script.fsx</ProjectItem>
-      <ProjectItem ReplaceParameters="false">packages.config</ProjectItem>
     </Project>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <packages repository="extension" repositoryId="VisualFSharp">
+      <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
+     </packages>
+  </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
-</packages>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
@@ -62,7 +62,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Tutorial.fsx" />
-    <Content Include="packages.config" />
    </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
@@ -16,7 +16,15 @@
   <TemplateContent>
     <Project File="Tutorial.fsproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" OpenInEditor="true">Tutorial.fsx</ProjectItem>
-      <ProjectItem ReplaceParameters="false">packages.config</ProjectItem>
     </Project>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+  </WizardExtension>
+  <WizardData>
+    <packages repository="extension" repositoryId="VisualFSharp">
+      <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
+     </packages>
+  </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/packages.config
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" targetFramework="net452" />
-</packages>

--- a/vsintegration/ProjectTemplates/TutorialProject/TutorialProject.csproj
+++ b/vsintegration/ProjectTemplates/TutorialProject/TutorialProject.csproj
@@ -18,15 +18,16 @@
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <ProjectGuid>{2FACEE44-48BD-40B5-A2EE-B54A0C9BB7C4}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net40</TargetFramework>
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(TargetFramework)\bin\$(TemplateCategory)\$(AssemblyName)</OutputPath>
   </PropertyGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Common.props" />
-  
+
   <ItemGroup>
     <FilesToLocalize Include="$(OutDir)$(TemplateCategory)\$(AssemblyName)\Tutorial.fsx">
       <TranslationFile>$(FSharpSourcesRoot)\..\loc\lcl\{Lang}\$(TemplateCategory)\$(AssemblyName)\Tutorial.fsx.lcl</TranslationFile>
@@ -35,23 +36,23 @@
       <InProject>false</InProject>
     </FilesToLocalize>
   </ItemGroup>
-  
+
   <ItemGroup>
     <VSTemplate Include="Template\Tutorial.vstemplate" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <TemplateFiles Include="Template\Tutorial.fsproj" />
     <TemplateFiles Include="Template\Tutorial.fsx" />
-    <TemplateFiles Include="Template\packages.config" />
+
     <TemplateFiles Include="Template\Tutorial.vstemplate" />
   </ItemGroup>
-  
+
   <Import Project="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.tools.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
-  
+
   <Target Name="CoreCompile" />
-  
+
   <Target Name="CopyFilesToOutputDirectory" AfterTargets="CoreCompile">
     <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="@(TemplateFiles->'$(OutDir)$(TemplateCategory)\$(AssemblyName)\%(Filename)%(Extension)')" />
   </Target>

--- a/vsintegration/Vsix/VisualFSharpDesktop/VisualFSharpDesktop.csproj
+++ b/vsintegration/Vsix/VisualFSharpDesktop/VisualFSharpDesktop.csproj
@@ -53,6 +53,7 @@
     <OutputPath>$(RootBinPath)</OutputPath>
     <MicroBuildAssemblyVersion>15.4.1.0</MicroBuildAssemblyVersion>
     <MicroBuildAssemblyFileLanguage>cs</MicroBuildAssemblyFileLanguage>
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <StartAction>Program</StartAction>
@@ -79,6 +80,11 @@
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.0.0-rc3-24212-01\System.ValueTuple.4.0.0-rc3-24212-01.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>packages\System.ValueTuple.4.0.0-rc3-24212-01.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>

--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -51,8 +51,7 @@
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" Path="ProjectTemplates" d:TargetPath="|TutorialProject;TemplateProjectOutputGroup|" d:ProjectName="TutorialProject" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" Path="ProjectTemplates" d:TargetPath="|ConsoleProject;TemplateProjectOutputGroup|" d:ProjectName="ConsoleProject" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" Path="ProjectTemplates" d:TargetPath="|LibraryProject;TemplateProjectOutputGroup|" d:ProjectName="LibraryProject" d:VsixSubPath="ProjectTemplates" />
-    
-    
+
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" Path="ItemTemplates" d:TargetPath="|AppConfig;TemplateProjectOutputGroup|" d:ProjectName="AppConfig" d:VsixSubPath="ItemTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" Path="ItemTemplates" d:TargetPath="|CodeFile;TemplateProjectOutputGroup|" d:ProjectName="CodeFile" d:VsixSubPath="ItemTemplates" />
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" Path="ItemTemplates" d:TargetPath="|ScriptFile;TemplateProjectOutputGroup|" d:ProjectName="ScriptFile" d:VsixSubPath="ItemTemplates" />

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -53,6 +53,7 @@
     <OutputPath>$(RootBinPath)</OutputPath>
     <MicroBuildAssemblyVersion>15.4.1.0</MicroBuildAssemblyVersion>
     <MicroBuildAssemblyFileLanguage>cs</MicroBuildAssemblyFileLanguage>
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <StartAction>Program</StartAction>
@@ -79,6 +80,11 @@
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.0.0-rc3-24212-01\System.ValueTuple.4.0.0-rc3-24212-01.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>packages\System.ValueTuple.4.0.0-rc3-24212-01.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>

--- a/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
+++ b/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
@@ -81,6 +81,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.0.0-rc3-24212-01\System.ValueTuple.4.0.0-rc3-24212-01.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>packages\System.ValueTuple.4.0.0-rc3-24212-01.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6">

--- a/vsintegration/Vsix/VisualFSharpWeb/VisualFSharpWeb.csproj
+++ b/vsintegration/Vsix/VisualFSharpWeb/VisualFSharpWeb.csproj
@@ -53,6 +53,7 @@
     <OutputPath>$(RootBinPath)</OutputPath>
     <MicroBuildAssemblyVersion>15.4.1.0</MicroBuildAssemblyVersion>
     <MicroBuildAssemblyFileLanguage>cs</MicroBuildAssemblyFileLanguage>
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <StartAction>Program</StartAction>
@@ -79,6 +80,11 @@
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.0.0-rc3-24212-01\System.ValueTuple.4.0.0-rc3-24212-01.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>packages\System.ValueTuple.4.0.0-rc3-24212-01.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
…ate.

The f# templates with system.valuetuple references when the project is first created have an error because the package has not been restored.

This checkin modifies the vsix packaging to include the System.ValueType nupkg.  And ensures that on template creation the nugget package is restored correctly.

Fixes: #1558 

Kevin