### PR TITLE
Ensure that portable libraries have correct hintpath for preview 5

### DIFF
--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
@@ -38,7 +38,7 @@
     <Reference Include="FSharp.Core">
       <Name>FSharp.Core</Name>
       <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
@@ -38,7 +38,7 @@
     <Reference Include="FSharp.Core">
       <Name>FSharp.Core</Name>
       <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+      <HintPath>$(MSBuildProgramFile32)\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
@@ -38,7 +38,7 @@
     <Reference Include="FSharp.Core">
       <Name>FSharp.Core</Name>
       <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
@@ -37,7 +37,7 @@
     <Reference Include="FSharp.Core">
       <Name>FSharp.Core</Name>
       <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETPortable\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETPortable\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\packages\System.ValueTuple.4.0.0-rc3-24212-01\lib\netstandard1.1\System.ValueTuple.dll</HintPath>


### PR DESCRIPTION
The Hintpath for F# templates does not work correctly in preview 5.  This PR corrects the hintpath to allow portable libraries to correctly reference fsharp.core.  

It cures this error:
````
1>
1>FSC: error FS0193: The module/namespace 'System.Net' from compilation unit 'System' did not contain the namespace, module or type 'WebClient'
1>Done building project "PortableLibrary13.fsproj" -- FAILED.
1>
1>Build FAILED.
========== Rebuild All: 0 succeeded, 1 failed, 0 skipped ==========
````
