### PR TITLE
[CompilerPerf] Parallel file parsing

### DIFF
--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -412,7 +412,6 @@ let GetTcImportsFromCommandLine
         try
             let (isLastCompiland : bool list), (isExe : bool) = sourceFiles |> tcConfig.ComputeCanContainEntryPoint 
             List.zip sourceFiles isLastCompiland
-            // PERF: consider making this parallel, once uses of global state relevant to parsing are cleaned up 
             |> List.map (fun (filename:string, isLastCompiland) -> async {
                 let pathOfMetaCommandSource = Path.GetDirectoryName(filename)
                 return

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -410,7 +410,7 @@ let GetTcImportsFromCommandLine
     use unwindParsePhase = PushThreadBuildPhaseUntilUnwind (BuildPhase.Parse)            
     let inputs =
         try
-            let (isLastCompiland : bool list), (isExe : bool) = sourceFiles |> tcConfig.ComputeCanContainEntryPoint 
+            let isLastCompiland, isExe = sourceFiles |> tcConfig.ComputeCanContainEntryPoint 
             List.zip sourceFiles isLastCompiland
             |> List.map (fun (filename:string, isLastCompiland) -> async {
                 let pathOfMetaCommandSource = Path.GetDirectoryName(filename)

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -42,12 +42,13 @@ type LightSyntaxStatus(initial:bool,warn:bool) =
 [<Sealed>]
 type LexResourceManager() =
     let strings = new System.Collections.Generic.Dictionary<string,Parser.token>(100)
-    member x.InternIdentifierToken(s) = 
-        let mutable res = Unchecked.defaultof<_> 
-        let ok = strings.TryGetValue(s,&res)  
-        if ok then res  else 
-        let res = IDENT s
-        (strings.[s] <- res; res)
+    member x.InternIdentifierToken(s) =
+        let mutable res = Unchecked.defaultof<_>
+        lock strings <| fun () ->
+            let ok = strings.TryGetValue(s,&res)  
+            if ok then res  else 
+            let res = IDENT s
+            (strings.[s] <- res; res)
               
 /// Lexer parameters 
 type lexargs =  

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -41,7 +41,7 @@ type LightSyntaxStatus(initial:bool,warn:bool) =
 /// Manage lexer resources (string interning)
 [<Sealed>]
 type LexResourceManager() =
-    let strings = new System.Collections.Concurrent.ConcurrentDictionary<string,Parser.token>(100)
+    let strings = new System.Collections.Concurrent.ConcurrentDictionary<string,Parser.token>(4 * System.Environment.ProcessorCount, 101)
     member x.InternIdentifierToken(s) =
         strings.GetOrAdd(s, IDENT s)
 

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -41,15 +41,10 @@ type LightSyntaxStatus(initial:bool,warn:bool) =
 /// Manage lexer resources (string interning)
 [<Sealed>]
 type LexResourceManager() =
-    let strings = new System.Collections.Generic.Dictionary<string,Parser.token>(100)
+    let strings = new System.Collections.Concurrent.ConcurrentDictionary<string,Parser.token>(100)
     member x.InternIdentifierToken(s) =
-        let mutable res = Unchecked.defaultof<_>
-        lock strings <| fun () ->
-            let ok = strings.TryGetValue(s,&res)  
-            if ok then res  else 
-            let res = IDENT s
-            (strings.[s] <- res; res)
-              
+        strings.GetOrAdd(s, IDENT s)
+
 /// Lexer parameters 
 type lexargs =  
     { defines: string list


### PR DESCRIPTION
There was a comment in `fsc` indicating that we could do parsing in parallel with some minor changes. After this change, files can now be parsed in parallel before type checking. This can help build performance on projects with a large number of files.

Within the parsing section (fsc.fs, L414), the only item mutable within the `List.choose` closure is the `lexResourceManager`. `errorLogger` is also there, but we do not presume additional problematic mutation.

The `LexResourceManager` is a thin wrapper around a dictionary of interned strings. Changing this to a `ConcurrentDictionary` and using `GetOrAdd` allows for more concurrent access to the cache. The `ConcurrentDictionary` doesn't have a constructor that takes just a single capacity, but also requires a concurrency level if the capacity is specified. Based on [MSDN documentation](https://msdn.microsoft.com/en-us/library/dd287173%28v=vs.110%29.aspx), this is `4 * System.Environment.ProcessorCount`. Capacity was changed to `101` because the documentation also indicates that the initial capacity should not be divisible by a small prime.

There is a current test failure (`tests/fsharp/typecheck/sigs/neg27`), due to the fact that error messages may now be in a non-deterministic order. We should resolve how this test should be handled.
