### PR TITLE
Speed up Constraint Solver's overload resolution (II)

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -723,7 +723,7 @@ and solveTypMeetsTyparConstraints (csenv:ConstraintSolverEnv) ndeep m2 trace ty 
       | TyparConstraint.SimpleChoice(tys,m2)          -> SolveTypChoice                     csenv ndeep m2 trace ty tys
       | TyparConstraint.CoercesTo(ty2,m2)         -> SolveTypSubsumesTypKeepAbbrevs     csenv ndeep m2 trace None ty2 ty
       | TyparConstraint.MayResolveMember(traitInfo,m2) -> 
-          SolveMemberConstraint csenv false ndeep m2 trace traitInfo ++ (fun _ -> CompleteD) 
+          SolveMemberConstraint csenv false false ndeep m2 trace traitInfo ++ (fun _ -> CompleteD) 
     )))
 
         
@@ -919,7 +919,7 @@ and SolveDimensionlessNumericType (csenv:ConstraintSolverEnv) ndeep m2 trace ty 
 /// We pretend int and other types support a number of operators.  In the actual IL for mscorlib they 
 /// don't, however the type-directed static optimization rules in the library code that makes use of this 
 /// will deal with the problem. 
-and SolveMemberConstraint (csenv:ConstraintSolverEnv) permitWeakResolution ndeep m2 trace (TTrait(tys,nm,memFlags,argtys,rty,sln)) :  OperationResult<bool> =
+and SolveMemberConstraint (csenv:ConstraintSolverEnv) ignoreUnresolvedOverload permitWeakResolution ndeep m2 trace (TTrait(tys,nm,memFlags,argtys,rty,sln)) :  OperationResult<bool> =
     // Do not re-solve if already solved
     if sln.Value.IsSome then ResultD true else
     let g = csenv.g
@@ -1284,7 +1284,7 @@ and SolveMemberConstraint (csenv:ConstraintSolverEnv) permitWeakResolution ndeep
                   // Otherwise re-record the trait waiting for canonicalization 
                    else AddMemberConstraint csenv ndeep m2 trace traitInfo support frees) ++ (fun () -> 
                        match errors with
-                       | ErrorResult (_,UnresolvedOverloading _) when not permitWeakResolution && (not (nm = "op_Explicit" || nm = "op_Implicit")) -> ErrorD LocallyAbortOperationThatFailsToResolveOverload
+                       | ErrorResult (_,UnresolvedOverloading _) when not ignoreUnresolvedOverload && (not (nm = "op_Explicit" || nm = "op_Implicit")) -> ErrorD LocallyAbortOperationThatFailsToResolveOverload
                        | _ -> ResultD TTraitUnsolved)
     ) 
     ++ 
@@ -1435,7 +1435,7 @@ and SolveRelevantMemberConstraintsForTypar (csenv:ConstraintSolverEnv) ndeep per
 
     cxs |> AtLeastOneD (fun (traitInfo,m2) -> 
         let csenv = { csenv with m = m2 }
-        SolveMemberConstraint csenv permitWeakResolution (ndeep+1) m2 trace traitInfo)
+        SolveMemberConstraint csenv true permitWeakResolution (ndeep+1) m2 trace traitInfo)
 
 and CanonicalizeRelevantMemberConstraints (csenv:ConstraintSolverEnv) ndeep trace tps =
     SolveRelevantMemberConstraints csenv ndeep true trace tps 
@@ -2491,7 +2491,7 @@ let AddCxTypeMustSubsumeType contextInfo denv css m trace ty1 ty2 =
     |> RaiseOperationResult
 
 let AddCxMethodConstraint denv css m trace traitInfo  =
-    TryD (fun () -> SolveMemberConstraint (MakeConstraintSolverEnv ContextInfo.NoContext css m denv) false 0 m trace traitInfo ++ (fun _ -> CompleteD))
+    TryD (fun () -> SolveMemberConstraint (MakeConstraintSolverEnv ContextInfo.NoContext css m denv) true false 0 m trace traitInfo ++ (fun _ -> CompleteD))
          (fun res -> ErrorD (ErrorFromAddingConstraint(denv,res,m)))
     |> RaiseOperationResult
 
@@ -2546,7 +2546,7 @@ let CodegenWitnessThatTypSupportsTraitConstraint tcVal g amap m (traitInfo:Trait
                 ExtraCxs=HashMultiMap(10, HashIdentity.Structural)
                 InfoReader=new InfoReader(g,amap) }
     let csenv = MakeConstraintSolverEnv ContextInfo.NoContext css m (DisplayEnv.Empty g)
-    SolveMemberConstraint csenv true 0 m NoTrace traitInfo ++ (fun _res -> 
+    SolveMemberConstraint csenv true true 0 m NoTrace traitInfo ++ (fun _res -> 
         let sln = 
               match traitInfo.Solution with 
               | None -> Choice4Of4()

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/OverloadingMembers/SlowOverloadResolution.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/MemberDefinitions/OverloadingMembers/SlowOverloadResolution.fs
@@ -1,6 +1,6 @@
 // #Conformance #DeclarationElements #MemberDefinitions #Overloading 
 // https://github.com/Microsoft/visualfsharp/issues/351 - slow overlaod resolution
-//<Expects id="FS0001" status="error">No overloads match</Expects>
+//<Expects id="FS0003" status="error">This value is not a function and cannot be applied</Expects>
 type Switcher = Switcher
 
 let inline checker< ^s, ^r when (^s or ^r) : (static member pass : ^r -> unit)> (s : ^s) (r : ^r) = ()


### PR DESCRIPTION
This will **speed up to 2x overload resolution** in cases like [this](https://github.com/gmpl/FsControl/blob/f125b96d252080f722a1ff7a9efcfaf53420a339/FsControl.Core/Samples/Converter.fsx#L57).

This PR is a follow-up of #1530 where it was discussed that ideally the constraint solution can be committed a bit early.

The problem was that knowing the solution early would make some very exotic cases like [this one](https://gist.github.com/gmpl/453e55a0a615644561fbec1a0a771f62) to fail.

After analysing the problem I found that cases like that would fail because the first overload that is considered would succeed if the constraint is assumed as solved, when in fact it should fail (false positive).

Assuming that specific constraint solution makes impossible to solve the nested overload resolution called by <code>SolveMemberConstraint</code> which is expected to fail and indeed it fails, but because that result is ignored, it's marked as a false positive and the compilation breaks later by not being able to decide between 2 overloads: the good one and the bad one which is treated as good.

The proposed change adds an internal exception to signal the calling function (in the analysed case it was called from <code>solveTypMeetsTyparConstraints</code>) an unresolved overload and make the whole assumption fail.

The tests I made show no performance degradation but an improvement in some cases, which is  logically expected because we will be using a shortcut in some cases.

But the improvement went a bit further since now by signaling an inconsistent case it also discards early some paths and I wouldn't be surprised if it fixes some existing bugs which were consequence of this previously ignored result.

Here's a [test](https://gist.github.com/gmpl/13cafa9d3ca871b05443583f8f053610) I run with the following results:

```
(* before #1530 *)  val compileTime : float = 20613.1785
(* after #1530 *)   val compileTime : float = 563.0135
(* after this PR *) val compileTime : float = 280.0141
```
