### PR TITLE
Reduce calls to checkPathForIllegalChars

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1849,7 +1849,7 @@ type AssemblyReference =
     member x.Text = (let (AssemblyReference(_,text,_)) = x in text)
     member x.ProjectReference = (let (AssemblyReference(_,_,contents)) = x in contents)
     member x.SimpleAssemblyNameIs(name) = 
-        (String.Compare(fileNameWithoutExtension x.Text, name, StringComparison.OrdinalIgnoreCase) = 0) ||
+        (String.Compare(fileNameWithoutExtensionWithValidate false x.Text, name, StringComparison.OrdinalIgnoreCase) = 0) ||
         (let text = x.Text.ToLowerInvariant()
          not (text.Contains "/") && not (text.Contains "\\") && not (text.Contains ".dll") && not (text.Contains ".exe") &&
            try let aname = System.Reflection.AssemblyName(x.Text) in aname.Name = name 

--- a/src/utils/filename.fs
+++ b/src/utils/filename.fs
@@ -30,7 +30,7 @@ let checkPathForIllegalChars (path:string) =
 let checkSuffix (x:string) (y:string) = x.EndsWith(y,System.StringComparison.Ordinal) 
 
 let hasExtensionWithValidate (validate:bool) (s:string) = 
-    if validate then  (checkPathForIllegalChars s) |> ignore
+    if validate then (checkPathForIllegalChars s) |> ignore
     let sLen = s.Length
     (sLen >= 1 && s.[sLen - 1] = '.' && s <> ".." && s <> ".") 
     || Path.HasExtension(s)
@@ -56,9 +56,11 @@ let fileNameOfPath s =
     checkPathForIllegalChars s
     Path.GetFileName(s)
 
-let fileNameWithoutExtension s = 
-    checkPathForIllegalChars s
+let fileNameWithoutExtensionWithValidate (validate:bool) s = 
+    if validate then checkPathForIllegalChars s |> ignore
     Path.GetFileNameWithoutExtension(s)
+
+let fileNameWithoutExtension s = fileNameWithoutExtensionWithValidate true s
 
 let trimQuotes (s:string) =
     s.Trim( [|' '; '\"'|] )

--- a/src/utils/filename.fsi
+++ b/src/utils/filename.fsi
@@ -23,6 +23,7 @@ val hasExtension: string -> bool
 val fileNameOfPath: string -> string
 
 /// Get the filename without extension of the given path.
+val fileNameWithoutExtensionWithValidate: bool -> string -> string
 val fileNameWithoutExtension: string -> string
 
 /// Trim the quotes and spaces from either end of a string


### PR DESCRIPTION
This function
````
type AssemblyReference = 
    member x.SimpleAssemblyNameIs(name) = 
````

calls fileNameWithoutExtension which in turn calls checkPathForIllegalChars.  However,  x.SimpleAssemblyNameIs only uses the result of fileNameWithoutExtension to compare with a passed in Value name.

So there is no real reason for validating that fileNameWithoutExtension has illegal chars, since it will just fail to match the name.

This reduces the number of calls from 
````
checkPathForIllegalCharsCalls : {contents = 947;}
fileNameWithoutExtensionCalls : {contents = 745;}
````
down to
````
checkPathForIllegalCharsCalls : {contents = 203;}
fileNameWithoutExtensionCalls : {contents = 745;}
````






