### PR TITLE
add simple project classifier authoring for .fsproj

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Vsix.Core/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Vsix.Core/Files.swr
@@ -11,3 +11,6 @@ vs.dependencies
 
 vs.payloads
   vs.payload source="$(BinariesFolder)\net40\bin\VisualFSharp$(VSSku).vsix"
+
+vs.projectClassifier extension=.fsproj
+  factoryGuid={F2A71F9B-5D33-465A-A702-920D77279786}


### PR DESCRIPTION
This will enable newer installs of VS to prompt you to install the F# tools when attempting to open a .fsproj.

@KevinRansom @OmarTawfik 

Fixes internal bug 271787.