### PR TITLE
Tell the compiler to emit the correct reference to system.runtime.numerics for non mscorlib builds

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -4570,7 +4570,7 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
         // OK, now we have both mscorlib.dll and FSharp.Core.dll we can create TcGlobals
         let tcGlobals = mkTcGlobals(tcConfig.compilingFslib,sysCcu.FSharpViewOfMetadata,ilGlobals,fslibCcu,
                                     tcConfig.implicitIncludeDir,tcConfig.mlCompatibility,using40environment,
-                                    tcConfig.isInteractive,getTypeCcu, tcConfig.emitDebugInfoInQuotations) 
+                                    tcConfig.isInteractive,getTypeCcu, tcConfig.emitDebugInfoInQuotations, (tcConfig.primaryAssembly.Name = "mscorlib") )
 
 #if DEBUG
         // the global_g reference cell is used only for debug printing

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -547,6 +547,7 @@ type public TcGlobals =
       splice_raw_expr_vref       : ValRef
       new_format_vref            : ValRef
       mkSysTyconRef : string list -> string -> TyconRef
+      usesMscorlib               : bool 
 
       // A list of types that are explicitly suppressed from the F# intellisense 
       // Note that the suppression checks for the precise name of the type
@@ -572,7 +573,7 @@ let global_g = ref (None : TcGlobals option)
 #endif
 
 let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePaths,mlCompatibility,
-                 using40environment,isInteractive,getTypeCcu, emitDebugInfoInQuotations) = 
+                 using40environment,isInteractive,getTypeCcu, emitDebugInfoInQuotations, usesMscorlib) =
 
   let vara = NewRigidTypar "a" envRange
   let varb = NewRigidTypar "b" envRange
@@ -1545,6 +1546,7 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
     suppressed_types = suppressed_types
     isInteractive=isInteractive
     mkSysTyconRef=mkSysTyconRef
+    usesMscorlib = usesMscorlib
    }
      
 let public mkMscorlibAttrib g nm = 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -959,7 +959,11 @@ let createMscorlibExportList tcGlobals =
 
 let createSystemNumericsExportList tcGlobals =
     let sysAssemblyRef = tcGlobals.sysCcu.ILScopeRef.AssemblyRef
-    let systemNumericsAssemblyRef = ILAssemblyRef.Create("System.Numerics", sysAssemblyRef.Hash, sysAssemblyRef.PublicKey, sysAssemblyRef.Retargetable, sysAssemblyRef.Version, sysAssemblyRef.Locale)
+    let systemNumericsAssemblyRef =  
+        let refNumericsDllName =  
+            if  tcGlobals.usesMscorlib then "System.Numerics"
+            else "System.Runtime.Numerics"  
+        ILAssemblyRef.Create(refNumericsDllName, sysAssemblyRef.Hash, sysAssemblyRef.PublicKey, sysAssemblyRef.Retargetable, sysAssemblyRef.Version, sysAssemblyRef.Locale)  
     typesForwardedToSystemNumerics |>
         Seq.map (fun t ->
                     {   ScopeRef = ILScopeRef.Assembly(systemNumericsAssemblyRef)


### PR DESCRIPTION
TypeForwards on netcore builds were referencing system.numerics.

This PR fixes that by having non mscorlib builds reference system.runtime.numerics