### PR TITLE
Allow single backticks to use anywhere double ones are used

### DIFF
--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -490,6 +490,9 @@ rule token args skip = parse
  | '`' '`' ([^'`' '\n' '\r' '\t'] | '`' [^'`''\n' '\r' '\t']) + '`' '`' 
      { Keywords.IdentifierToken args lexbuf (lexemeTrimBoth lexbuf 2 2) }
 
+ | '`' ([^'`' '\n' '\r' '\t'] | '`' [^'`''\n' '\r' '\t']) + '`' 
+     { Keywords.IdentifierToken args lexbuf (lexemeTrimBoth lexbuf 1 1) }
+
  | ('#' anywhite* | "#line" anywhite+ ) digit+ anywhite* ('@'? "\"" [^'\n''\r''"']+ '"')? anywhite* newline
      {  let pos = lexbuf.EndPos 
         if skip then 


### PR DESCRIPTION
Maybe I don't see the big picture why double backtickes were uses initially, but this simple change allows to use single backticks instead of double ones anywhere.

The following code compiles OK:

```fsharp
module File5

let `foo bar` x = x
let ``foo bar 1`` x = x

let x = `foo bar` 1
let y = ``foo bar 1`` 1

type ``Foo bar``() = class end
type `Foo bar 1`() = class end

let f = ``Foo bar``()
let f' = `Foo bar 1`()

type DU =
    | ``Case 1``
    | ``Case 2`` of int
    
type DU1 =
    | `Case 11`
    | `Case 22` of int

let _ =
    match DU.``Case 1`` with
    | ``Case 1`` -> ()
    | ``Case 2`` _ -> ()

let _ =
    match DU1.`Case 11` with
    | `Case 11` -> ()
    | `Case 22` _ -> ()

type R1 =
    { ``field 1``: int }

type R2 =
    { `field 2`: int }

let _ = { ``field 1`` = 1 }
let _ = { `field 2` = 1 }
```