### PR TITLE
Fix bug in seekReadMethodDefAsMethodDataUncached

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -1908,12 +1908,12 @@ let gparam_of_gactual (_ga:ILType) = mkILSimpleTypar "T"
 
 let mkILFormalTypars (x: ILGenericArgsList) = List.map gparam_of_gactual x
 
-let mkILFormalGenericArgs (gparams:ILGenericParameterDefs)  =
-    List.mapi (fun n _gf -> mkILTyvarTy (uint16 n)) gparams
+let mkILFormalGenericArgs numtypars (gparams:ILGenericParameterDefs)  =
+    List.mapi (fun n _gf -> mkILTyvarTy (uint16 (numtypars + n))) gparams
  
-let mkILFormalBoxedTy tref gparams = mkILBoxedTy tref (mkILFormalGenericArgs gparams)
+let mkILFormalBoxedTy tref gparams = mkILBoxedTy tref (mkILFormalGenericArgs 0 gparams)
 
-let mkILFormalNamedTy bx tref gparams = mkILNamedTy bx tref (mkILFormalGenericArgs gparams)
+let mkILFormalNamedTy bx tref gparams = mkILNamedTy bx tref (mkILFormalGenericArgs 0 gparams)
 
 // -------------------------------------------------------------------- 
 // Operations on class etc. defs.

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1686,7 +1686,7 @@ val mkILFormalBoxedTy: ILTypeRef -> ILGenericParameterDef list -> ILType
 val mkILFormalNamedTy: ILBoxity -> ILTypeRef -> ILGenericParameterDef list -> ILType
 
 val mkILFormalTypars: ILType list -> ILGenericParameterDefs
-val mkILFormalGenericArgs: ILGenericParameterDefs -> ILGenericArgsList
+val mkILFormalGenericArgs: int -> ILGenericParameterDefs -> ILGenericArgsList
 val mkILSimpleTypar : string -> ILGenericParameterDef
 /// Make custom attributes.
 val mkILCustomAttribMethRef: 

--- a/src/absil/ilx.fs
+++ b/src/absil/ilx.fs
@@ -143,7 +143,7 @@ type IlxUnionInfo =
 
 let destTyFuncApp = function Apps_tyapp (b,c) -> b,c | _ -> failwith "destTyFuncApp"
 
-let mkILFormalCloRef gparams csig = IlxClosureSpec.Create(csig, mkILFormalGenericArgs gparams)
+let mkILFormalCloRef gparams csig = IlxClosureSpec.Create(csig, mkILFormalGenericArgs 0 gparams)
 
 let actualTypOfIlxUnionField (cuspec : IlxUnionSpec) idx fidx =
   instILType cuspec.GenericArgs (cuspec.FieldDef idx fidx).Type

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -3462,7 +3462,7 @@ and GenMethodImpl cenv eenv (useMethodImpl,(TSlotSig(nameOfOverridenMethod,_,_,_
         let eenvForOverrideBy = AddTyparsToEnv methTyparsOfOverridingMethod eenv 
         let ilParamsOfOverridingMethod,ilReturnOfOverridingMethod = GenActualSlotsig m cenv eenvForOverrideBy slotsig methTyparsOfOverridingMethod
         let ilOverrideMethGenericParams = GenGenericParams cenv eenvForOverrideBy methTyparsOfOverridingMethod 
-        let ilOverrideMethGenericArgs = mkILFormalGenericArgs ilOverrideMethGenericParams
+        let ilOverrideMethGenericArgs = mkILFormalGenericArgs 0 ilOverrideMethGenericParams
         let ilOverrideBy = mkILInstanceMethSpecInTy(ilTyForOverriding, nameOfOverridingMethod, typesOfILParams ilParamsOfOverridingMethod, ilReturnOfOverridingMethod.Type, ilOverrideMethGenericArgs)
         { Overrides = OverridesSpec(ilOverrideMethRef,ilOverrideTy)
           OverrideBy = ilOverrideBy })
@@ -3607,7 +3607,7 @@ and GenSequenceExpr cenv (cgbuf:CodeGenBuffer) eenvouter (nextEnumeratorValRef:V
     let ilCloLambdas = Lambdas_return ilCloRetTyInner 
     let cloref = IlxClosureRef(ilCloTypeRef, ilCloLambdas, ilCloFreeVars)
     let ilxCloSpec = IlxClosureSpec.Create(cloref, GenGenericArgs m eenvouter.tyenv cloFreeTyvars)
-    let formalClospec = IlxClosureSpec.Create(cloref, mkILFormalGenericArgs ilCloGenericParams)
+    let formalClospec = IlxClosureSpec.Create(cloref, mkILFormalGenericArgs 0 ilCloGenericParams)
 
     let getFreshMethod = 
         let _,mbody =
@@ -4080,7 +4080,7 @@ and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod((TSlotSig(_,delega
     let takenNames = List.map nameOfVal tmvs
     let (cloAttribs,_,_,cloFreeTyvars,cloFreeVars,ilDelegeeTypeRef,ilCloFreeVars,eenvinner) = GetIlxClosureFreeVars cenv m None eenvouter takenNames expr
     let ilDelegeeGenericParams = GenGenericParams cenv eenvinner cloFreeTyvars
-    let ilDelegeeGenericActualsInner = mkILFormalGenericArgs ilDelegeeGenericParams
+    let ilDelegeeGenericActualsInner = mkILFormalGenericArgs 0 ilDelegeeGenericParams
 
     // Create a new closure class with a single "delegee" method that implements the delegate. 
     let delegeeMethName = "Invoke"


### PR DESCRIPTION
This is a fix for #1689

seekReadMethodDefAsMethodDataUncached didn't honour the total parameter count of both the type object and the method object. If there was only one (i.e. generic parameters on either the method, or the class), then the correct result would have been achieved, but when both were specific it caused corruption of the resultant MethodData structure.