### PR TITLE
test fixes

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -555,9 +555,6 @@ if 'TEST_NET40_COMPILERUNIT_SUITE' == '0' and 'TEST_PORTABLE_COREUNIT_SUITE' == 
 echo ---------------- Done with update, starting tests -----------------------
 
 
-pushd tests
-
-
 if NOT "%INCLUDE_TEST_SPEC_NUNIT%" == "" (
     set WHERE_ARG_NUNIT=--where "%INCLUDE_TEST_SPEC_NUNIT%"
 )
@@ -788,8 +785,8 @@ if '%TEST_CORECLR_COREUNIT_SUITE%' == '1' (
     REM these copies should not be needed, see https://github.com/fsharp/fsharp/issues/642
     xcopy /S /Q /Y src\fsharp\FSharp.Core.Unittests\bin\!BUILD_CONFIG!\netcoreapp1.0\* "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\fsharp.core.unittests\"
 
-    echo "%_dotnetexe%" "tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Core.Unittests\FSharp.Core.Unittests.dll" !WHERE_ARG_NUNIT!
-         "%_dotnetexe%" "tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Core.Unittests\FSharp.Core.Unittests.dll" !WHERE_ARG_NUNIT!
+    echo "%_dotnetexe%" "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Core.Unittests\FSharp.Core.Unittests.dll" !WHERE_ARG_NUNIT!
+         "%_dotnetexe%" "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Core.Unittests\FSharp.Core.Unittests.dll" !WHERE_ARG_NUNIT!
 
     rem call :UPLOAD_TEST_RESULTS "!XMLFILE!" "!OUTPUTFILE!"  "!ERRORFILE!"
     if ERRORLEVEL 1 (

--- a/build.cmd
+++ b/build.cmd
@@ -688,8 +688,8 @@ if '%TEST_NET40_FSHARPQA_SUITE%' == '1' (
 
 
 	pushd %~dp0tests\fsharpqa\source
-	echo perl %~dp0tests\fsharpqa\testenv\bin\runall.pl -resultsroot !RESULTSDIR! -results !OUTPUTFILE! -log !ERRORFILE! -fail !FAILENV! -cleanup:no !TTAGS_ARG_RUNALL! !_architecture! !PARALLEL_ARG!
-		 perl %~dp0tests\fsharpqa\testenv\bin\runall.pl -resultsroot !RESULTSDIR! -results !OUTPUTFILE! -log !ERRORFILE! -fail !FAILENV! -cleanup:no !TTAGS_ARG_RUNALL! !_architecture! !PARALLEL_ARG!
+	echo perl %~dp0tests\fsharpqa\testenv\bin\runall.pl -resultsroot !RESULTSDIR! -results !OUTPUTFILE! -log !ERRORFILE! -fail !FAILENV! -cleanup:no !TTAGS_ARG_RUNALL! !PARALLEL_ARG!
+		 perl %~dp0tests\fsharpqa\testenv\bin\runall.pl -resultsroot !RESULTSDIR! -results !OUTPUTFILE! -log !ERRORFILE! -fail !FAILENV! -cleanup:no !TTAGS_ARG_RUNALL! !PARALLEL_ARG!
 
     popd
     if ERRORLEVEL 1 (

--- a/build.cmd
+++ b/build.cmd
@@ -782,9 +782,6 @@ if '%TEST_CORECLR_COREUNIT_SUITE%' == '1' (
 	set OUTPUTFILE=!RESULTSDIR!\test-coreclr-coreunit-output.log
 	set ERRORFILE=!RESULTSDIR!\test-coreclr-coreunit-errors.log
 
-    REM these copies should not be needed, see https://github.com/fsharp/fsharp/issues/642
-    xcopy /S /Q /Y src\fsharp\FSharp.Core.Unittests\bin\!BUILD_CONFIG!\netcoreapp1.0\* "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\fsharp.core.unittests\"
-
     echo "%_dotnetexe%" "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Core.Unittests\FSharp.Core.Unittests.dll" !WHERE_ARG_NUNIT!
          "%_dotnetexe%" "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Core.Unittests\FSharp.Core.Unittests.dll" !WHERE_ARG_NUNIT!
 

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/CollectionModulesConsistency.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/CollectionModulesConsistency.fs
@@ -1202,7 +1202,7 @@ let unfold<'a,'b when 'b : equality> f (start:'a) =
 let ``unfold is consistent`` () =
     smallerSizeCheck unfold<int,int>
 
-[<Test; Category("Expensive")>]
+[<Test; Category("Expensive"); Explicit>]
 let ``unfold is consistent full`` () =
     smallerSizeCheck unfold<int,int>
     smallerSizeCheck unfold<string,string>

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -348,7 +348,7 @@ type AsyncModule() =
         for _i = 1 to 3 do test()
 
 
-    [<Test; Category("Expensive")>]
+    [<Test; Category("Expensive"); Explicit>]
     member this.``Async.AwaitWaitHandle does not leak memory`` () =
         // This test checks that AwaitWaitHandle does not leak continuations (described in #131),
         // We only test the worst case - when the AwaitWaitHandle is already set.
@@ -443,7 +443,7 @@ type AsyncModule() =
         testErrorAndCancelRace (Async.Sleep (-5))
 
 #if !(FSHARP_CORE_PORTABLE || FSHARP_CORE_NETCORE_PORTABLE || coreclr)
-    [<Test; Category("Expensive")>] // takes 3 minutes!
+    [<Test; Category("Expensive"); Explicit>] // takes 3 minutes!
     member this.``Async.Choice specification test``() =
         ThreadPool.SetMinThreads(100,100) |> ignore
         Check.One ({Config.QuickThrowOnFailure with EndSize = 20}, normalize >> runChoice)

--- a/src/fsharp/FSharp.Core.Unittests/project.json
+++ b/src/fsharp/FSharp.Core.Unittests/project.json
@@ -24,12 +24,9 @@
           "type": "platform",
           "version": "1.0.1"
         },
-        "Microsoft.NETCore.Portable.Compatibility": {
-          "type": "platform",
-          "version": "1.0.1"
-        }
+        "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
       },
-      "imports": "dnxcore50"
+      "imports": [ "netstandard1.6", "portable-net45+win8+wp8+wpa81" ]
     }
   }
 }

--- a/src/fsharp/FSharp.Core.Unittests/project.json
+++ b/src/fsharp/FSharp.Core.Unittests/project.json
@@ -6,13 +6,16 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "System.ValueTuple": "4.0.0-rc3-24212-01"
+    "System.ValueTuple": "4.0.0-rc3-24212-01",
+    "NUnitLite": "3.5.0",
+    "NUnit": "3.5.0",
+    "FsCheck": "2.6.2"
   },
   "runtimes": {
-    "win7-x86": { },
-    "win7-x64": { },
-    "osx.10.11-x64": { },
-    "ubuntu.14.04-x64": { }
+    "win7-x86": {},
+    "win7-x64": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {}
   },
   "frameworks": {
     "netcoreapp1.0": {
@@ -24,5 +27,5 @@
       },
       "imports": "dnxcore50"
     }
-  },
+  }
 }

--- a/src/fsharp/FSharp.Core.Unittests/project.json
+++ b/src/fsharp/FSharp.Core.Unittests/project.json
@@ -8,8 +8,7 @@
   "dependencies": {
     "System.ValueTuple": "4.0.0-rc3-24212-01",
     "NUnitLite": "3.5.0",
-    "NUnit": "3.5.0",
-    "FsCheck": "2.6.2"
+    "NUnit": "3.5.0"
   },
   "runtimes": {
     "win7-x86": {},

--- a/src/fsharp/FSharp.Core.Unittests/project.json
+++ b/src/fsharp/FSharp.Core.Unittests/project.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "System.ValueTuple": "4.0.0-rc3-24212-01",
     "NUnitLite": "3.5.0",
-    "NUnit": "3.5.0"
+    "NUnit": "3.5.0",
+    "FsCheck": "2.6.2"
   },
   "runtimes": {
     "win7-x86": {},
@@ -20,6 +21,10 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        },
+        "Microsoft.NETCore.Portable.Compatibility": {
           "type": "platform",
           "version": "1.0.1"
         }

--- a/tests/fsharp/FSharp.Tests.fsproj
+++ b/tests/fsharp/FSharp.Tests.fsproj
@@ -74,12 +74,22 @@
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'" >
     <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'coreclr'" >
+    <Reference Include="nunit.framework, Version=$(NUnitFullVersion), Culture=neutral, PublicKeyToken=2638cd05610744eb" Condition="'$(TargetFramework)' != 'coreclr'">
+      <SpecificVersion>true</SpecificVersion>
+      <Private>True</Private>
+      <HintPath>$(NUnitLibDir)\nunit.framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/tests/fsharp/core/tests_core.fs
+++ b/tests/fsharp/core/tests_core.fs
@@ -929,7 +929,7 @@ let opsMutrec p = singleTestBuildAndRun p
 [<Test; FSharpSuiteScriptPermutations("core/nested")>]
 let nested p = singleTestBuildAndRun p
 
-[<Test; Category("Expensive"); FSharpSuiteTest("core/netcore/netcore259")>]
+[<Test; Category("Expensive"); Explicit; FSharpSuiteTest("core/netcore/netcore259")>]
 let ``Run all tests using PCL profie 259 FSHarp.Core``() = check (attempt {
     let cfg = FSharpTestSuite.testConfig ()
 
@@ -954,7 +954,7 @@ let ``Run all tests using PCL profie 259 FSHarp.Core``() = check (attempt {
     })
 
 
-[<Test; Category("Expensive"); FSharpSuiteTest("core/netcore/netcore7")>]
+[<Test; Category("Expensive"); Explicit; FSharpSuiteTest("core/netcore/netcore7")>]
 let ``Run all tests using PCL profie 7 FSHarp.Core`` () = check (attempt {
     let cfg = FSharpTestSuite.testConfig ()
 
@@ -978,7 +978,7 @@ let ``Run all tests using PCL profie 7 FSHarp.Core`` () = check (attempt {
                 
     })
 
-[<Test; Category("Expensive"); FSharpSuiteTest("core/netcore/netcore78")>]
+[<Test; Category("Expensive"); Explicit; FSharpSuiteTest("core/netcore/netcore78")>]
 let ``Run all tests using PCL profie 78 FSHarp.Core``() = check (attempt {
     let cfg = FSharpTestSuite.testConfig ()
 
@@ -1002,7 +1002,7 @@ let ``Run all tests using PCL profie 78 FSHarp.Core``() = check (attempt {
                 
     })
 
-[<Test; Category("Expensive"); FSharpSuiteTest("core/portable")>]
+[<Test; Category("Expensive"); Explicit; FSharpSuiteTest("core/portable")>]
 let ``Run all tests using PCL profie 47 FSHarp.Core`` () = check (attempt {
     let cfg = FSharpTestSuite.testConfig ()
 

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SeqExpressionTailCalls/env.lst
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SeqExpressionTailCalls/env.lst
@@ -1,2 +1,2 @@
 	SOURCE=SeqExpressionTailCalls01.fs SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd SeqExpressionTailCalls01.exe NetFx40"	# SeqExpressionTailCalls01.fs - NetFx40
-Expensive	SOURCE=SeqExpressionTailCalls02.fs SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd SeqExpressionTailCalls02.exe NetFx40"	# SeqExpressionTailCalls02.fs - NetFx40
+	SOURCE=SeqExpressionTailCalls02.fs SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd SeqExpressionTailCalls02.exe NetFx40"	# SeqExpressionTailCalls02.fs - NetFx40


### PR DESCRIPTION
This fixes #1728 and makes sure we are checking the error code.


@KevinRansom I'm using an explicit copy to publish some of the missing dependencies for FSHarp.Core.Unittests (FSharp.Core, FsCheck), this isn't quite right but https://github.com/fsharp/fsharp/issues/642 is causing problems in listing FsCheck and FSharp.Core.

This PR also removes the ``exclude`` option from build.cmd which was causing batch file hell (because of the use of a ``!`` character!), which was only used to exclude Expensive tests.  Now use an explicit ``include Expensive``.
