### PR TITLE
Make Async.AwaitHandle Timeout test more lenient.

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -227,7 +227,7 @@ type AsyncModule() =
     [<Test>]
     member this.``AwaitWaitHandle.Timeout``() = 
         use waitHandle = new System.Threading.ManualResetEvent(false)
-        let startMs = DateTime.Now.Millisecond
+        let startTime = DateTime.Now
 
         let r = 
             Async.AwaitWaitHandle(waitHandle, 500)
@@ -235,9 +235,9 @@ type AsyncModule() =
 
         Assert.IsFalse(r, "Timeout expected")
 
-        let endMs = DateTime.Now.Millisecond
-        let delta = endMs - startMs
-        Assert.IsTrue(abs ((abs delta) - 500) < 400, sprintf "Delta is too big %d" delta)
+        let endTime = DateTime.Now
+        let delta = endTime - startTime
+        Assert.IsTrue(delta.TotalMilliseconds < 1100.0, sprintf "Expected faster timeout than %.0f ms" delta.TotalMilliseconds)
 
     [<Test>]
     member this.``AwaitWaitHandle.TimeoutWithCancellation``() = 


### PR DESCRIPTION
This test is failing regularly on AppVeyor, hopefully this helps.