### PR TITLE
Fix deploy extension

### DIFF
--- a/vsintegration/Vsix/VisualFSharpDesktop/VisualFSharpDesktop.csproj
+++ b/vsintegration/Vsix/VisualFSharpDesktop/VisualFSharpDesktop.csproj
@@ -80,6 +80,7 @@
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0-beta-24631-01\System.ValueTuple.4.4.0-beta-24631-01.nupkg">

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -80,6 +80,7 @@
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0-beta-24631-01\System.ValueTuple.4.4.0-beta-24631-01.nupkg">

--- a/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
+++ b/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
@@ -79,6 +79,7 @@
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0-beta-24631-01\System.ValueTuple.4.4.0-beta-24631-01.nupkg">

--- a/vsintegration/Vsix/VisualFSharpWeb/VisualFSharpWeb.csproj
+++ b/vsintegration/Vsix/VisualFSharpWeb/VisualFSharpWeb.csproj
@@ -80,6 +80,7 @@
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0-beta-24631-01\System.ValueTuple.4.4.0-beta-24631-01.nupkg">


### PR DESCRIPTION
For the last couple of weeks, with certain vssdks the build has failed with this error message:
````
"c:\kevinransom\visualfsharp\build-everything.proj" (default target) (1) ->
"c:\kevinransom\visualfsharp\vsintegration\fsharp-vsintegration-src-build.proj" (Build target) (10) ->
"c:\kevinransom\visualfsharp\vsintegration\src\FSharp.ProjectSystem.FSharp\ProjectSystem.fsproj" (Build target) (17) ->
(MergeCtoResource target) ->
  c:\kevinransom\visualfsharp\packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\Microsoft.VsSDK.targets(906,5): warning VSSDK1011: obj\release\net40\MenusAndCommand
s.cto has no valid Resource. [c:\kevinransom\visualfsharp\vsintegration\src\FSharp.ProjectSystem.FSharp\ProjectSystem.fsproj]


"c:\kevinransom\visualfsharp\build-everything.proj" (default target) (1) ->
"c:\kevinransom\visualfsharp\vsintegration\fsharp-vsintegration-vsix-build.proj" (Build target) (34) ->
"c:\kevinransom\visualfsharp\vsintegration\Vsix\VisualFSharpOpenSource\VisualFSharpOpenSource.csproj" (Build target) (38) ->
(DeployVsixExtensionFiles target) ->
  c:\kevinransom\visualfsharp\packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\Microsoft.VsSDK.targets(661,5): error VSSDK1081: Problem occurred while extracting t
he vsix to the experimental extensions path. [c:\kevinransom\visualfsharp\vsintegration\Vsix\VisualFSharpOpenSource\VisualFSharpOpenSource.csproj]

    7 Warning(s)
    1 Error(s)

Time Elapsed 00:03:22.58
Error: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\..\..\MSBuild\15.0\Bin\MSBuild.exe" /nr:false /nologo build-everything.proj /p:Configuration=release   /p:BUILD_PUBLICSIGN=
````

This fixes it, by using the Link to specify the path of the License file in the built vsix.  This is a bug in the VSSDK, the Link mechanism is a neat method of being explicit though.

Kevin
