### PR TITLE
Implement RFC fs-1025:  Improve record type inference

### DIFF
--- a/tests/fsharp/core/recordResolution/build.bat
+++ b/tests/fsharp/core/recordResolution/build.bat
@@ -1,0 +1,6 @@
+@if "%_echo%"=="" echo off
+
+call %~d0%~p0..\..\single-test-build.bat
+
+exit /b %ERRORLEVEL%
+

--- a/tests/fsharp/core/recordResolution/test.fs
+++ b/tests/fsharp/core/recordResolution/test.fs
@@ -1,0 +1,60 @@
+module Ex1 =
+  //simple example
+  
+  type A = { FA: int }
+  type B = { FB: int }
+  type AB = { FA: int; FB: int }
+
+  let a = { FA = 1 } 
+  let b = { FB = 2 }
+  let a' = { a with FA = 2 }
+  
+module Ex2 =
+
+  //more confusing fields
+
+  type A = { FA: int }
+  type B = { FB: int }
+  type C = { FC: int }
+  type AB = { FA: int; FB: int }
+  type AC = { FA: int; FC: int }
+  type CB = { FC: int; FB: int }
+  type ABC = { FA: int; FB: int; FC: int }
+
+  let a = { FA = 1 }
+  let b = { FB = 1 }
+  let c = { FC = 1 }
+  let ab = { FA = 1; FB = 2 }
+  let ac = { FA = 1; FC = 2 }
+  let cb = { FC = 1; FB = 2 }
+  let abc = { FA = 1; FB = 2; FC = 3 }
+  
+  let a' = { a with FA = 2 }
+
+module Ex3 =
+
+  //make sure this works with open
+  open Ex2
+  
+  let a = { FA = 1 }
+  let b = { FB = 1 }
+  let c = { FC = 1 }
+  let ab = { FA = 1; FB = 2 }
+  let ac = { FA = 1; FC = 2 }
+  let cb = { FC = 1; FB = 2 }
+  let abc = { FA = 1; FB = 2; FC = 3 }
+  
+ module Ex4 =
+ 
+  //still choose the last occurring match
+  
+  type A1 = { FA: int }
+  type A2 = { FA: int }
+  type C = { FC: int }
+  type AB = { FA: int; FB: int }
+  
+  let a2 = { FA = 1 }
+  let r = a2 :> A2 //this produces warnings, but proves that a2 is indeed of type A2.
+  
+System.IO.File.WriteAllText("test.ok","ok") 
+exit 0

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -690,6 +690,8 @@ module CoreTests =
     [<Test; Category("lift")>]
     let lift () = singleTestBuildAndRun "core/lift" FSC_OPT_PLUS_DEBUG
 
+    [<Test>]
+    let recordResolution () = singleTestBuildAndRun "core/recordResolution" FSC_OPT_PLUS_DEBUG
 
     [<Test>]
     let ``load-script`` () = 

--- a/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/RecordTypes/E_TypeInference01.fs
+++ b/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/RecordTypes/E_TypeInference01.fs
@@ -5,7 +5,7 @@
 
 module N
 
-type Red  = { X : int }
+type Red  = { A : int }
 type Blue = { X : int; Y : int }
 
 let aBlue   = { X = 0; Y = 1 }

--- a/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/RecordTypes/E_TypeInference01b.fs
+++ b/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/RecordTypes/E_TypeInference01b.fs
@@ -6,7 +6,7 @@
 namespace N
 module M =
 
-    type GRed<'a>  = { GX : 'a }
+    type GRed<'a>  = { GA : 'a }
     type Blue<'a> = { GX : 'a; Y : int }
 
     let gaBlue   = { GX = 0; Y = 1 }


### PR DESCRIPTION
Take 2. Rebased on master after all the recent changes.

[RFC](https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1025-improve-record-type-inference.md).