### PR TITLE
[WIP] -  Suggestion: Don't implicitly append Module suffix if type with same name has type arguments.

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -16059,10 +16059,11 @@ and TcSignatureElementsNonMutRec cenv parent endm env defs =
             [ for def in defs do 
                match def with 
                | SynModuleSigDecl.Types (typeSpecs,_) -> 
-                  for (TypeDefnSig(ComponentInfo(_,_,_,ids,_,_,_,_),trepr,extraMembers,_)) in typeSpecs do 
-                      match trepr with 
-                      | SynTypeDefnSigRepr.Simple((SynTypeDefnSimpleRepr.None _),_) when not (isNil extraMembers) -> ()
-                      | _ -> yield (List.last ids).idText
+                  for (TypeDefnSig(ComponentInfo(_,typars,_,ids,_,_,_,_),trepr,extraMembers,_)) in typeSpecs do 
+                      if isNil typars then
+                          match trepr with 
+                          | SynTypeDefnSigRepr.Simple((SynTypeDefnSimpleRepr.None _),_) when not (isNil extraMembers) -> ()
+                          | _ -> yield (List.last ids).idText
                | _ -> () ]
             |> set
 
@@ -16487,10 +16488,11 @@ and TcModuleOrNamespaceElements cenv parent endm env xml mutRecNSInfo defs =
             [ for def in defs do 
                 match def with 
                 | SynModuleDecl.Types (typeSpecs,_) -> 
-                    for (TypeDefn(ComponentInfo(_,_,_,ids,_,_,_,_),trepr,_,_)) in typeSpecs do 
-                        match trepr with 
-                        | SynTypeDefnRepr.ObjectModel(TyconAugmentation,_,_) -> ()
-                        | _ -> yield (List.last ids).idText
+                    for (TypeDefn(ComponentInfo(_,typars,_,ids,_,_,_,_),trepr,_,_)) in typeSpecs do 
+                        if isNil typars then
+                            match trepr with 
+                            | SynTypeDefnRepr.ObjectModel(TyconAugmentation,_,_) -> ()
+                            | _ -> yield (List.last ids).idText
                 | _ -> () ]
             |> set
 

--- a/tests/fsharp/core/longnames/test.fsx
+++ b/tests/fsharp/core/longnames/test.fsx
@@ -528,8 +528,8 @@ module Ok9b =
         let create() = 1
         type Dummy = A | B
 
-
-    test "lkneecec09iew9" (typeof<A.Dummy>.FullName.Contains("AModule") )
+    //A<'T> has a type parameter, so appending Module is not necessary.
+    test "lkneecec09iew9" (not (typeof<A.Dummy>.FullName.Contains("AModule") ) )
 
 module rec Ok10 = 
 


### PR DESCRIPTION
Don't implicitly append 'Module' to module names if the type with the same name as the module has a type argument. In that case the name is not ambiguous.

In addition, the current situation breaks these fairly common use cases for libraries that need to interoperate with other .NET languages, as with the new compiler some modules will suddenly gain a Module suffix.

There is no way to turn this off, short of making the module into a static class, which is silly.

This issue is also discussed in somewhat more detail here: https://github.com/fsharp/fslang-design/issues/108