### PR TITLE
RFC FS-1007: Add Option.apply

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Core/OptionModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Core/OptionModule.fs
@@ -19,6 +19,56 @@ Make sure each method works on:
 type OptionModule() =
 
     [<Test>]
+    member this.Apply () =
+        let oneMinus x = 1 - x
+        Assert.AreEqual(Option.apply None None, None)
+        Assert.AreEqual(Option.apply (Some 2) None, None)
+        Assert.AreEqual(Option.apply None (Some oneMinus), None)
+        Assert.AreEqual(Option.apply (Some 2) (Some oneMinus), Some -1)
+
+        let afterX x = "x" + x
+        Assert.AreEqual(Option.apply None None, None)
+        Assert.AreEqual(Option.apply (Some "y") None, None)
+        Assert.AreEqual(Option.apply None (Some afterX), None)
+        Assert.AreEqual(Option.apply (Some "y") (Some afterX), Some "xy")
+
+        let lengthPlus3 x = 3 + String.length x
+        Assert.AreEqual(Option.apply None (Some lengthPlus3), None)
+        Assert.AreEqual(Option.apply (Some "y") (Some lengthPlus3), Some 4)
+
+    [<Test>]
+    member this.MapPipeApply () =
+        let add3 x y z = string x + string y + string z
+        Assert.AreEqual(Option.map add3 None |> Option.apply None |> Option.apply None, None)
+        Assert.AreEqual(Option.map add3 None |> Option.apply (Some 2) |> Option.apply None, None)
+        Assert.AreEqual(Option.map add3 (Some 1) |> Option.apply None |> Option.apply None, None)
+        Assert.AreEqual(Option.map add3 (Some 1) |> Option.apply (Some 2) |> Option.apply None, None)
+        Assert.AreEqual(Option.map add3 None |> Option.apply None |> Option.apply (Some 3), None)
+        Assert.AreEqual(Option.map add3 None |> Option.apply (Some 2) |> Option.apply (Some 3), None)
+        Assert.AreEqual(Option.map add3 (Some 1) |> Option.apply None |> Option.apply (Some 3), None)
+        Assert.AreEqual(Option.map add3 (Some 1) |> Option.apply (Some 2) |> Option.apply (Some 3), Some "123")
+
+        let concat3 x y z = x + y + z
+        Assert.AreEqual(Option.map concat3 None |> Option.apply None |> Option.apply None, None)
+        Assert.AreEqual(Option.map concat3 None |> Option.apply (Some "y") |> Option.apply None, None)
+        Assert.AreEqual(Option.map concat3 (Some "x") |> Option.apply None |> Option.apply None, None)
+        Assert.AreEqual(Option.map concat3 (Some "x") |> Option.apply (Some "y") |> Option.apply None, None)
+        Assert.AreEqual(Option.map concat3 None |> Option.apply None |> Option.apply (Some "z"), None)
+        Assert.AreEqual(Option.map concat3 None |> Option.apply (Some "y") |> Option.apply (Some "z"), None)
+        Assert.AreEqual(Option.map concat3 (Some "x") |> Option.apply None |> Option.apply (Some "z"), None)
+        Assert.AreEqual(Option.map concat3 (Some "x") |> Option.apply (Some "y") |> Option.apply (Some "z"), Some "xyz")
+
+        let mix3 x y z = String.length x * y + int32 z
+        Assert.AreEqual(Option.map mix3 None |> Option.apply None |> Option.apply None, None)
+        Assert.AreEqual(Option.map mix3 None |> Option.apply (Some 6) |> Option.apply None, None)
+        Assert.AreEqual(Option.map mix3 (Some "asdwxf") |> Option.apply None |> Option.apply None, None)
+        Assert.AreEqual(Option.map mix3 (Some "asdwxf") |> Option.apply (Some 6) |> Option.apply None, None)
+        Assert.AreEqual(Option.map mix3 None |> Option.apply None |> Option.apply (Some 6UL), None)
+        Assert.AreEqual(Option.map mix3 None |> Option.apply (Some 6) |> Option.apply (Some 6UL), None)
+        Assert.AreEqual(Option.map mix3 (Some "asdwxf") |> Option.apply None |> Option.apply (Some 6UL), None)
+        Assert.AreEqual(Option.map mix3 (Some "asdwxf") |> Option.apply (Some 6) |> Option.apply (Some 6UL), Some 42)
+
+    [<Test>]
     member this.FilterSomeIntegerWhenPredicateReturnsTrue () =
         let test x =
             let actual = x |> Some |> Option.filter (fun _ -> true)

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Core/OptionModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Core/OptionModule.fs
@@ -69,6 +69,16 @@ type OptionModule() =
         Assert.AreEqual(Option.map mix3 (Some "asdwxf") |> Option.apply (Some 6) |> Option.apply (Some 6UL), Some 42)
 
     [<Test>]
+    member this.MapBindApplyEquivalenceProperties () =
+        let fn x = x + 3
+        Assert.AreEqual(Option.map fn None, Option.bind (fn >> Some) None)
+        Assert.AreEqual(Option.map fn (Some 5), Option.bind (fn >> Some) (Some 5))
+        Assert.AreEqual(Option.apply None None, (fun xOpt -> Option.bind (fun f -> Option.map f xOpt)) None None)
+        Assert.AreEqual(Option.apply (Some 5) None, (fun xOpt -> Option.bind (fun f -> Option.map f xOpt)) (Some 5) None)
+        Assert.AreEqual(Option.apply None (Some fn), (fun xOpt -> Option.bind (fun f -> Option.map f xOpt)) None (Some fn))
+        Assert.AreEqual(Option.apply (Some 5) (Some fn), (fun xOpt -> Option.bind (fun f -> Option.map f xOpt)) (Some 5) (Some fn))
+
+    [<Test>]
     member this.FilterSomeIntegerWhenPredicateReturnsTrue () =
         let test x =
             let actual = x |> Some |> Option.filter (fun _ -> true)

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.coreclr.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.coreclr.fs
@@ -2721,6 +2721,7 @@ Microsoft.FSharp.Core.OptionModule: Boolean IsSome[T](Microsoft.FSharp.Core.FSha
 Microsoft.FSharp.Core.OptionModule: Int32 Count[T](Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Int32 GetHashCode()
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Collections.FSharpList`1[T] ToList[T](Microsoft.FSharp.Core.FSharpOption`1[T])
+Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Apply[T,TResult](Microsoft.FSharp.Core.FSharpOption`1[T], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpFunc`2[T,TResult]])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Bind[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,Microsoft.FSharp.Core.FSharpOption`1[TResult]], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Map[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,TResult], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[T] Filter[T](Microsoft.FSharp.Core.FSharpFunc`2[T,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[T])

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net40.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.net40.fs
@@ -2755,6 +2755,7 @@ Microsoft.FSharp.Core.OptionModule: Boolean IsSome[T](Microsoft.FSharp.Core.FSha
 Microsoft.FSharp.Core.OptionModule: Int32 Count[T](Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Int32 GetHashCode()
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Collections.FSharpList`1[T] ToList[T](Microsoft.FSharp.Core.FSharpOption`1[T])
+Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Apply[T,TResult](Microsoft.FSharp.Core.FSharpOption`1[T], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpFunc`2[T,TResult]])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Bind[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,Microsoft.FSharp.Core.FSharpOption`1[TResult]], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Map[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,TResult], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[T] Filter[T](Microsoft.FSharp.Core.FSharpFunc`2[T,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[T])

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable259.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable259.fs
@@ -2726,6 +2726,7 @@ Microsoft.FSharp.Core.OptionModule: Boolean IsSome[T](Microsoft.FSharp.Core.FSha
 Microsoft.FSharp.Core.OptionModule: Int32 Count[T](Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Int32 GetHashCode()
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Collections.FSharpList`1[T] ToList[T](Microsoft.FSharp.Core.FSharpOption`1[T])
+Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Apply[T,TResult](Microsoft.FSharp.Core.FSharpOption`1[T], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpFunc`2[T,TResult]])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Bind[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,Microsoft.FSharp.Core.FSharpOption`1[TResult]], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Map[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,TResult], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[T] Filter[T](Microsoft.FSharp.Core.FSharpFunc`2[T,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[T])

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable47.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable47.fs
@@ -2727,6 +2727,7 @@ Microsoft.FSharp.Core.OptionModule: Boolean IsSome[T](Microsoft.FSharp.Core.FSha
 Microsoft.FSharp.Core.OptionModule: Int32 Count[T](Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Int32 GetHashCode()
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Collections.FSharpList`1[T] ToList[T](Microsoft.FSharp.Core.FSharpOption`1[T])
+Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Apply[T,TResult](Microsoft.FSharp.Core.FSharpOption`1[T], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpFunc`2[T,TResult]])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Bind[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,Microsoft.FSharp.Core.FSharpOption`1[TResult]], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Map[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,TResult], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[T] Filter[T](Microsoft.FSharp.Core.FSharpFunc`2[T,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[T])

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable7.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable7.fs
@@ -2739,6 +2739,7 @@ Microsoft.FSharp.Core.OptionModule: Boolean IsSome[T](Microsoft.FSharp.Core.FSha
 Microsoft.FSharp.Core.OptionModule: Int32 Count[T](Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Int32 GetHashCode()
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Collections.FSharpList`1[T] ToList[T](Microsoft.FSharp.Core.FSharpOption`1[T])
+Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Apply[T,TResult](Microsoft.FSharp.Core.FSharpOption`1[T], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpFunc`2[T,TResult]])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Bind[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,Microsoft.FSharp.Core.FSharpOption`1[TResult]], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Map[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,TResult], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[T] Filter[T](Microsoft.FSharp.Core.FSharpFunc`2[T,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[T])

--- a/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable78.fs
+++ b/src/fsharp/FSharp.Core.Unittests/SurfaceArea.portable78.fs
@@ -2726,6 +2726,7 @@ Microsoft.FSharp.Core.OptionModule: Boolean IsSome[T](Microsoft.FSharp.Core.FSha
 Microsoft.FSharp.Core.OptionModule: Int32 Count[T](Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Int32 GetHashCode()
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Collections.FSharpList`1[T] ToList[T](Microsoft.FSharp.Core.FSharpOption`1[T])
+Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Apply[T,TResult](Microsoft.FSharp.Core.FSharpOption`1[T], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Core.FSharpFunc`2[T,TResult]])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Bind[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,Microsoft.FSharp.Core.FSharpOption`1[TResult]], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[TResult] Map[T,TResult](Microsoft.FSharp.Core.FSharpFunc`2[T,TResult], Microsoft.FSharp.Core.FSharpOption`1[T])
 Microsoft.FSharp.Core.OptionModule: Microsoft.FSharp.Core.FSharpOption`1[T] Filter[T](Microsoft.FSharp.Core.FSharpFunc`2[T,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[T])

--- a/src/fsharp/FSharp.Core/option.fs
+++ b/src/fsharp/FSharp.Core/option.fs
@@ -37,6 +37,12 @@ namespace Microsoft.FSharp.Core
         [<CompiledName("Map")>]
         let map f inp = match inp with None -> None | Some x -> Some (f x)
 
+        [<CompiledName("Apply")>]
+        let apply inp fOpt =
+            match fOpt, inp with
+            | Some f, Some x -> Some (f x)
+            | _ -> None
+
         [<CompiledName("Bind")>]
         let bind f inp = match inp with None -> None | Some x -> f x
 

--- a/src/fsharp/FSharp.Core/option.fsi
+++ b/src/fsharp/FSharp.Core/option.fsi
@@ -85,6 +85,13 @@ namespace Microsoft.FSharp.Core
         [<CompiledName("Map")>]
         val map: mapping:('T -> 'U) -> option:'T option -> 'U option
 
+        /// <summary><c>apply inp fOpt</c> evaluates to <c>match inp, fOpt with Some x, f -> Some (f x) | _ -> None</c>.</summary>
+        /// <param name="option">The input option.</param>
+        /// <param name="mappingOpt">An optional function to apply to the option value.</param>
+        /// <returns>An option of the input value after applying the mapping function, or None if either the input or the mapping function is None.</returns>
+        [<CompiledName("Apply")>]
+        val apply: option:'T option -> mappingOpt:('T -> 'U) option -> 'U option
+
         /// <summary><c>bind f inp</c> evaluates to <c>match inp with None -> None | Some x -> f x</c></summary>
         /// <param name="binder">A function that takes the value of type T from an option and transforms it into
         /// an option containing a value of type U.</param>


### PR DESCRIPTION
This PR is a proposed addition to the Option module. Relevant discussion can be found on RFC FS-1007 and fsharp/fslang-design#60.

Also includes some additional tests that verify certain properties between `map`, `apply`, and `bind`.