### PR TITLE
Make async test less flakey.

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -285,18 +285,24 @@ type AsyncModule() =
     member this.``OnCancel.RaceBetweenCancellationHandlerAndDisposingHandlerRegistration``() = 
         let test() = 
             use flag = new ManualResetEvent(false)
+            use cancelHandlerRegistered = new ManualResetEvent(false)
             let cts = new System.Threading.CancellationTokenSource()
             let go = async {
                 use! holder = Async.OnCancel(fun() -> lock flag (fun() -> flag.Set()) |> ignore)
+                let _ = cancelHandlerRegistered.Set()
                 while true do
                     do! Async.Sleep 50
                 }
+
             Async.Start (go, cancellationToken = cts.Token)
-            sleep(100)
+            //wait until we are sure the Async.OnCancel has run:
+            Assert.IsTrue(cancelHandlerRegistered.WaitOne(TimeSpan.FromSeconds 5.))
+            //now cancel:
             cts.Cancel()
+            //cancel handler should have run:
             Assert.IsTrue(flag.WaitOne(TimeSpan.FromSeconds 5.))
 
-        for _i = 1 to 3 do test()
+        for _i = 1 to 300 do test()
 
     [<Test>]
     member this.``OnCancel.RaceBetweenCancellationAndDispose``() = 


### PR DESCRIPTION
See #1755. Instead of a ref cell with a lock, we use a ManualResetEvent so that the sleep 100ms - which I assume is the reason for the flakiness, this is not proven - can be replaced with a generous timeout, while the test can still complete in reasonable time.