### PR TITLE
Update desktop components to use the latest published System.ValueTuple package

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -16,7 +16,7 @@
   <package id="System.Reflection.Metadata" version="1.4.1-beta-24227-04" />
   <package id="Microsoft.DiaSymReader.PortablePdb" version="1.1.0"  />
   <package id="Microsoft.DiaSymReader" version="1.0.8" />
-  <package id="System.ValueTuple" version="4.4.0-beta-24631-01" />
+  <package id="System.ValueTuple" version="4.3.0" />
   <package id="Microsoft.VisualFSharp.Msbuild.15.0" version="1.0.1" />
 
   <!-- Testing -->
@@ -29,7 +29,7 @@
   <package id="BenchmarkDotNet.Diagnostics.Windows" version="0.9.8"/>
   <package id="VisualCppTools" version="14.0.24519-Pre"/>
   <package id="Newtonsoft.Json" version="6.0.8"/>
-  <package id="Microsoft.FSharp.TupleSample" version="1.0.0-alpha-161112"/>
+  <package id="Microsoft.FSharp.TupleSample" version="1.0.0-alpha-161121"/>
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.25907-RC2"/>
 
   <!-- Annoyingly the build of FSharp.Compiler.Server.Shared references a Visual Studio-specific attribute -->

--- a/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
+++ b/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
@@ -165,7 +165,7 @@
       </Component>
 
       <Component Id="Compiler_Redist_System.ValueTuple.dll" Guid="$(fsharp.guid(Compiler_Redist_System.ValueTuple.dll, $(var.LocaleCode)))">
-        <File Id="Compiler_Redist_System.ValueTuple.dll" Source="$(var.NugetPackagesDir)\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll" />
+        <File Id="Compiler_Redist_System.ValueTuple.dll" Source="$(var.NugetPackagesDir)\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll" />
       </Component>
     </DirectoryRef>
 

--- a/setup/packages.config
+++ b/setup/packages.config
@@ -12,6 +12,6 @@
   <package id="Microsoft.VisualFSharp.Core.Redist" version="1.0.0" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualFSharp.Msbuild.15.0" version="1.0.1" />
-  <package id="System.ValueTuple" version="4.0.0-rc3-24212-01" />
+  <package id="System.ValueTuple" version="4.3.0" />
   <package id="Microsoft.VisualFSharp.Type.Providers.Redist" version="1.0.0" />
 </packages>

--- a/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
+++ b/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
@@ -468,7 +468,7 @@
     <Reference Include="Microsoft.DiaSymReader"><HintPath>..\..\..\packages\Microsoft.DiaSymReader.1.0.8\lib\portable-net45+win8\Microsoft.DiaSymReader.dll</HintPath></Reference>
     <Reference Include="System.Reflection.Metadata"><HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.1-beta-24227-04\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath></Reference>
     <Reference Include="System.Collections.Immutable"><HintPath>..\..\..\packages\System.Collections.Immutable.1.2.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath></Reference>
-    <Reference Include="System.ValueTuple"><HintPath>..\..\..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath></Reference>
+    <Reference Include="System.ValueTuple"><HintPath>..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath></Reference>
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
   <Import Project="$(FSharpSourcesRoot)\..\packages\FsLexYacc.7.0.1\build\FsLexYacc.targets" />

--- a/src/fsharp/FSharp.Compiler.Unittests/FSharp.Compiler.Unittests.fsproj
+++ b/src/fsharp/FSharp.Compiler.Unittests/FSharp.Compiler.Unittests.fsproj
@@ -51,7 +51,7 @@
     <Reference Include="System.Numerics" Condition="'$(TargetFramework)' == 'net40'" />
     <Reference Include="System.Core" />
     <Reference Include="System.ValueTuple">
-        <HintPath>..\..\..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+        <HintPath>..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj
+++ b/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj
@@ -515,7 +515,7 @@
     <Reference Include="Microsoft.DiaSymReader"><HintPath>..\..\..\packages\Microsoft.DiaSymReader.1.0.8\lib\portable-net45+win8\Microsoft.DiaSymReader.dll</HintPath></Reference>
     <Reference Include="System.Reflection.Metadata"><HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.1-beta-24227-04\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath></Reference>
     <Reference Include="System.Collections.Immutable"><HintPath>..\..\..\packages\System.Collections.Immutable.1.2.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath></Reference>
-    <Reference Include="System.ValueTuple"><HintPath>..\..\..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath><Private>true</Private></Reference>
+    <Reference Include="System.ValueTuple"><HintPath>..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath><Private>true</Private></Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
@@ -57,12 +57,12 @@
       <Name>FSharp.Core</Name>
     </ProjectReference>
     <Reference Include="System.ValueTuple">
-        <HintPath Condition=" '$(TargetFramework)' == 'profile47' ">..\..\..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-        <HintPath Condition="'$(TargetFramework)' != 'profile47' ">..\..\..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
+        <HintPath Condition=" '$(TargetFramework)' == 'profile47' ">..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+        <HintPath Condition="'$(TargetFramework)' != 'profile47' ">..\..\..\packages\System.ValueTuple.4.3.0\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
         <Private>True</Private>
     </Reference>
     <Reference Include="TupleSample">
-        <HintPath>..\..\..\packages\Microsoft.FSharp.TupleSample.1.0.0-alpha-161112/lib/portable-net40+sl4+win8+wp8/TupleSample.dll</HintPath>
+        <HintPath>..\..\..\packages\Microsoft.FSharp.TupleSample.1.0.0-alpha-161121/lib/portable-net40+sl4+win8+wp8/TupleSample.dll</HintPath>
         <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/SampleTuples/Microsoft.FSharp.TupleSample.nuspec
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/SampleTuples/Microsoft.FSharp.TupleSample.nuspec
@@ -17,7 +17,7 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="4.0.0-rc3-24212-01\TupleSample.dll"     target="lib/netstandard1.1" />
-        <file src="4.4.0-beta-24631-01\TupleSample.dll"     target="lib/portable-net40+sl4+win8+wp8" />
+        <file src="lib/netstandard1.1/TupleSample.dll"     target="lib/netstandard1.1" />
+        <file src="lib/portable-net40+sl4+win8+wp8/TupleSample.dll"     target="lib/portable-net40+sl4+win8+wp8" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/SampleTuples/TupleSample.csproj
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/SampleTuples/TupleSample.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\..\..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.ValueTuple.4.3.0\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/fsharp/FSharp.Core.Unittests/TypeForwarding.fs
+++ b/src/fsharp/FSharp.Core.Unittests/TypeForwarding.fs
@@ -18,10 +18,10 @@ type TypeForwardingModule() =
         let currentRuntimeVersion = System.Runtime.InteropServices.RuntimeEnvironment.GetSystemVersion()
         let currentFSharpCoreTargetRuntime = typeof<int list>.Assembly.ImageRuntimeVersion
         let tupleAssemblyName = typeof<System.Tuple<int,int>>.Assembly.FullName
-        
+
         let mscorlib4AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
         let fsharpCore2AssemblyName = "FSharp.Core, Version=2.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
-        
+
         printfn "currentRuntimeVersion = %s; currentFSharpCoreTargetRuntime=%s tupleAssemblyName=%s" currentRuntimeVersion currentFSharpCoreTargetRuntime tupleAssemblyName
         match (currentRuntimeVersion, currentFSharpCoreTargetRuntime) with
         | ("v2.0.50727", _)           

--- a/src/fsharp/FSharp.LanguageService.Compiler/FSharp.LanguageService.Compiler.fsproj
+++ b/src/fsharp/FSharp.LanguageService.Compiler/FSharp.LanguageService.Compiler.fsproj
@@ -590,7 +590,7 @@
     <Reference Include="Microsoft.DiaSymReader"><HintPath>..\..\..\packages\Microsoft.DiaSymReader.1.0.8\lib\portable-net45+win8\Microsoft.DiaSymReader.dll</HintPath></Reference>
     <Reference Include="System.Reflection.Metadata"><HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.1-beta-24227-04\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath></Reference>
     <Reference Include="System.Collections.Immutable"><HintPath>..\..\..\packages\System.Collections.Immutable.1.2.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath></Reference>
-    <Reference Include="System.ValueTuple"><HintPath>..\..\..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath></Reference>
+    <Reference Include="System.ValueTuple"><HintPath>..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath></Reference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" >
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
@@ -48,7 +48,7 @@
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System"/>

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
@@ -26,7 +26,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
-      <package id="System.ValueTuple" version="4.4.0-beta-24631-01" targetFramework="net40" />
+      <package id="System.ValueTuple" version="4.3.0" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
@@ -44,7 +44,7 @@
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System"/>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
@@ -26,7 +26,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
-      <package id="System.ValueTuple" version="4.4.0-beta-24631-01" targetFramework="net40" />
+      <package id="System.ValueTuple" version="4.3.0" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/NETCore259PortableLibrary.vstemplate
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/NETCore259PortableLibrary.vstemplate
@@ -26,7 +26,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
-      <package id="System.ValueTuple" version="4.4.0-beta-24631-01" targetFramework="net40" />
+      <package id="System.ValueTuple" version="4.3.0" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
@@ -41,7 +41,7 @@
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/NETCore78PortableLibrary.vstemplate
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/NETCore78PortableLibrary.vstemplate
@@ -26,7 +26,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
-      <package id="System.ValueTuple" version="4.4.0-beta-24631-01" targetFramework="net40" />
+      <package id="System.ValueTuple" version="4.3.0" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
@@ -41,7 +41,7 @@
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/NETCore7PortableLibrary.vstemplate
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/NETCore7PortableLibrary.vstemplate
@@ -26,7 +26,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
-      <package id="System.ValueTuple" version="4.4.0-beta-24631-01" targetFramework="net40" />
+      <package id="System.ValueTuple" version="4.3.0" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
@@ -41,7 +41,7 @@
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
@@ -40,7 +40,7 @@
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETPortable\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.vstemplate
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.vstemplate
@@ -26,7 +26,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
-      <package id="System.ValueTuple" version="4.4.0-beta-24631-01" targetFramework="net40" />
+      <package id="System.ValueTuple" version="4.3" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
@@ -58,7 +58,7 @@
     <Reference Include="System.Drawing"/>
     <Reference Include="System.Windows.Forms"/>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0-beta-24631-01\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
@@ -24,7 +24,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
-      <package id="System.ValueTuple" version="4.4.0-beta-24631-01" targetFramework="net40" />
+      <package id="System.ValueTuple" version="4.3.0" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/Vsix/VisualFSharpDesktop/VisualFSharpDesktop.csproj
+++ b/vsintegration/Vsix/VisualFSharpDesktop/VisualFSharpDesktop.csproj
@@ -83,9 +83,9 @@
       <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0-beta-24631-01\System.ValueTuple.4.4.0-beta-24631-01.nupkg">
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.0\System.ValueTuple.4.3.0.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>packages\System.ValueTuple.4.4.0-beta-24631-01.nupkg</Link>
+      <Link>packages\System.ValueTuple.4.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -83,9 +83,9 @@
       <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0-beta-24631-01\System.ValueTuple.4.4.0-beta-24631-01.nupkg">
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.0\System.ValueTuple.4.3.0.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>packages\System.ValueTuple.4.4.0-beta-24631-01.nupkg</Link>
+      <Link>packages\System.ValueTuple.4.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>

--- a/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
+++ b/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
@@ -82,9 +82,9 @@
       <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0-beta-24631-01\System.ValueTuple.4.4.0-beta-24631-01.nupkg">
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.0\System.ValueTuple.4.3.0.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>packages\System.ValueTuple.4.4.0-beta-24631-01.nupkg</Link>
+      <Link>packages\System.ValueTuple.4.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>

--- a/vsintegration/Vsix/VisualFSharpWeb/VisualFSharpWeb.csproj
+++ b/vsintegration/Vsix/VisualFSharpWeb/VisualFSharpWeb.csproj
@@ -83,9 +83,9 @@
       <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0-beta-24631-01\System.ValueTuple.4.4.0-beta-24631-01.nupkg">
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.0\System.ValueTuple.4.3.0.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>packages\System.ValueTuple.4.4.0-beta-24631-01.nupkg</Link>
+      <Link>packages\System.ValueTuple.4.3.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
Fixes #1754

Update shipped components and tests to use the latest shipped nugget.

*** Does not upgrade the coreclr components ***


