### PR TITLE
Update vssdk to latest.  Add sdk version detection to build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -350,13 +350,13 @@ echo.
 
 echo ---------------- Done with arguments, starting preparation -----------------
 if '%VSSDKInstall%'=='' (
-     set VSSDKInstall=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk
+     set VSSDKInstall=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25914-RC2\tools\vssdk
 )
 if '%VSSDKToolsPath%'=='' (
-     set VSSDKToolsPath=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\bin
+     set VSSDKToolsPath=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25914-RC2\tools\vssdk\bin
 )
 if '%VSSDKIncludes%'=='' (
-     set VSSDKIncludes=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\inc
+     set VSSDKIncludes=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25914-RC2\tools\vssdk\inc
 )
 
 if '%RestorePackages%'=='' (

--- a/build.cmd
+++ b/build.cmd
@@ -350,13 +350,13 @@ echo.
 
 echo ---------------- Done with arguments, starting preparation -----------------
 if '%VSSDKInstall%'=='' (
-     set VSSDKInstall=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25914-RC2\tools\vssdk
+     set VSSDKInstall=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk
 )
 if '%VSSDKToolsPath%'=='' (
-     set VSSDKToolsPath=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25914-RC2\tools\vssdk\bin
+     set VSSDKToolsPath=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\bin
 )
 if '%VSSDKIncludes%'=='' (
-     set VSSDKIncludes=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25914-RC2\tools\vssdk\inc
+     set VSSDKIncludes=%~dp0packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\inc
 )
 
 if '%RestorePackages%'=='' (

--- a/build.cmd
+++ b/build.cmd
@@ -389,8 +389,8 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\common7\ide\devenv.ex
 if exist "%ProgramFiles%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
 
 :vsversionset
-if '%VisualStudioVersion%' == '' echo Error: Could not find an installation of Visual Studio && goto :failure
-if '%VSSDK150Install%' == '' (if '%BUILD_VS%' == '1' echo Error: Could not find an installation of Visual Studio 2015 RC2 VSSDK which is required for building VS components && goto :failure)
+if "%VisualStudioVersion%" == "" echo Error: Could not find an installation of Visual Studio && goto :failure
+if "%VSSDK150Install%" == "" (if "%BUILD_VS%" == "1" echo Error: Could not find an installation of Visual Studio 2015 RC2 VSSDK which is required for building VS components && goto :failure)
 
 if exist "%VS150COMNTOOLS%\..\..\MSBuild\15.0\Bin\MSBuild.exe" (
     set _msbuildexe="%VS150COMNTOOLS%\..\..\MSBuild\15.0\Bin\MSBuild.exe"

--- a/build.cmd
+++ b/build.cmd
@@ -390,6 +390,7 @@ if exist "%ProgramFiles%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" se
 
 :vsversionset
 if '%VisualStudioVersion%' == '' echo Error: Could not find an installation of Visual Studio && goto :failure
+if '%VSSDK150Install%' == '' (if '%BUILD_VS%' == '1' echo Error: Could not find an installation of Visual Studio 2015 RC2 VSSDK which is required for building VS components && goto :failure)
 
 if exist "%VS150COMNTOOLS%\..\..\MSBuild\15.0\Bin\MSBuild.exe" (
     set _msbuildexe="%VS150COMNTOOLS%\..\..\MSBuild\15.0\Bin\MSBuild.exe"

--- a/packages.config
+++ b/packages.config
@@ -30,7 +30,7 @@
   <package id="VisualCppTools" version="14.0.24519-Pre"/>
   <package id="Newtonsoft.Json" version="6.0.8"/>
   <package id="Microsoft.FSharp.TupleSample" version="1.0.0-alpha-161112"/>
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25914-RC2"/>
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25907-RC2"/>
 
   <!-- Annoyingly the build of FSharp.Compiler.Server.Shared references a Visual Studio-specific attribute -->
   <!-- That DLL is logically part of the F# Compiler and F# Interactive but is shipped as part of the Visual F# IDE Tools -->

--- a/packages.config
+++ b/packages.config
@@ -30,7 +30,7 @@
   <package id="VisualCppTools" version="14.0.24519-Pre"/>
   <package id="Newtonsoft.Json" version="6.0.8"/>
   <package id="Microsoft.FSharp.TupleSample" version="1.0.0-alpha-161112"/>
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25907-RC2"/>
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25914-RC2"/>
 
   <!-- Annoyingly the build of FSharp.Compiler.Server.Shared references a Visual Studio-specific attribute -->
   <!-- That DLL is logically part of the F# Compiler and F# Interactive but is shipped as part of the Visual F# IDE Tools -->

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -32,6 +32,7 @@
     <WarningsAsErrors />
 
     <FX_NO_LOADER Condition=" '$(FX_NO_LOADER)'==''">false</FX_NO_LOADER>
+    <VSSDK_BUILDTOOLS_VERSION>Microsoft.VSSDK.BuildTools.15.0.25914-RC2</VSSDK_BUILDTOOLS_VERSION>
 
     <!-- Always qualify the IntermediateOutputPath by the TargetFramework if any exists -->
     <IntermediateOutputPath>obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
@@ -44,10 +45,10 @@
     <UseSourceLink>true</UseSourceLink>
     <UseGatherBinaries>true</UseGatherBinaries>
     <AddVsSdkAttributesToSomeCoreComponents>true</AddVsSdkAttributesToSomeCoreComponents>
-    <VsSDKInstall>$(MSBuildThisFileDirectory)..\packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk</VsSDKInstall>
-    <VsSDKToolPath>$(MSBuildThisFileDirectory)..\packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\bin</VsSDKToolPath>
-    <VsSDKIncludes>$(MSBuildThisFileDirectory)..\packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\inc</VsSDKIncludes>
-    <VsixSchemaPath>$(MSBuildThisFileDirectory)..\packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\schemas\VSIXManifestSchema.xsd</VsixSchemaPath>
+    <VsSDKInstall Condition=" '$(VsSDKInstall)' == '' ">$(MSBuildThisFileDirectory)..\packages\$(VSSDK_BUILDTOOLS_VERSION)\tools\vssdk</VsSDKInstall>
+    <VsSDKToolPath Condition=" '$(VsSDKToolPath)' == '' ">$(MSBuildThisFileDirectory)..\packages\$(VSSDK_BUILDTOOLS_VERSION)\tools\vssdk\bin</VsSDKToolPath>
+    <VsSDKIncludes Condition=" '$(VsSDKIncludes)' == '' ">$(MSBuildThisFileDirectory)..\packages\$(VSSDK_BUILDTOOLS_VERSION)\tools\vssdk\inc</VsSDKIncludes>
+    <VsixSchemaPath Condition=" '$(VsixSchemaPath)' == '' ">$(MSBuildThisFileDirectory)..\packages\Microsoft.VSSDK.BuildTools.15.0.25914-RC2\tools\vssdk\schemas\VSIXManifestSchema.xsd</VsixSchemaPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(ProjectLanguage)' == 'FSharp' ">

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -32,7 +32,7 @@
     <WarningsAsErrors />
 
     <FX_NO_LOADER Condition=" '$(FX_NO_LOADER)'==''">false</FX_NO_LOADER>
-    <VSSDK_BUILDTOOLS_VERSION>Microsoft.VSSDK.BuildTools.15.0.25914-RC2</VSSDK_BUILDTOOLS_VERSION>
+    <VSSDK_BUILDTOOLS_VERSION>Microsoft.VSSDK.BuildTools.15.0.25907-RC2</VSSDK_BUILDTOOLS_VERSION>
 
     <!-- Always qualify the IntermediateOutputPath by the TargetFramework if any exists -->
     <IntermediateOutputPath>obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
@@ -48,7 +48,7 @@
     <VsSDKInstall Condition=" '$(VsSDKInstall)' == '' ">$(MSBuildThisFileDirectory)..\packages\$(VSSDK_BUILDTOOLS_VERSION)\tools\vssdk</VsSDKInstall>
     <VsSDKToolPath Condition=" '$(VsSDKToolPath)' == '' ">$(MSBuildThisFileDirectory)..\packages\$(VSSDK_BUILDTOOLS_VERSION)\tools\vssdk\bin</VsSDKToolPath>
     <VsSDKIncludes Condition=" '$(VsSDKIncludes)' == '' ">$(MSBuildThisFileDirectory)..\packages\$(VSSDK_BUILDTOOLS_VERSION)\tools\vssdk\inc</VsSDKIncludes>
-    <VsixSchemaPath Condition=" '$(VsixSchemaPath)' == '' ">$(MSBuildThisFileDirectory)..\packages\Microsoft.VSSDK.BuildTools.15.0.25914-RC2\tools\vssdk\schemas\VSIXManifestSchema.xsd</VsixSchemaPath>
+    <VsixSchemaPath Condition=" '$(VsixSchemaPath)' == '' ">$(MSBuildThisFileDirectory)..\packages\Microsoft.VSSDK.BuildTools.15.0.25907-RC2\tools\vssdk\schemas\VSIXManifestSchema.xsd</VsixSchemaPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(ProjectLanguage)' == 'FSharp' ">

--- a/vsintegration/packages.config
+++ b/vsintegration/packages.config
@@ -16,6 +16,7 @@
   <package id="Microsoft.VisualStudio.Threading" version="14.1.131" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Design" version="14.3.25407" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Settings.15.0" version="15.0.25824-RC" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net46" />  
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Language.Intellisense" version="14.3.25407" targetFramework="net46" />  


### PR DESCRIPTION
VisualStudio 2015 RC2 requires us to build vsix v3.0 now which uses the latest VSSDK.

Unfortunately this cannot build or run on downlevel versions of VisualStudio.

- Updated build to use latest public vssdk preview.
- build.cmd fails if developer tries build vs on a machine without VS 2017 and the VSSDK.

