### PR TITLE
highlight DU cases and Active Patterns as "Enum" Roslyn classification

### DIFF
--- a/src/fsharp/vs/ServiceLexing.fs
+++ b/src/fsharp/vs/ServiceLexing.fs
@@ -89,6 +89,7 @@ type FSharpTokenColorKind =
     | Operator = 10
     | TypeName = 11
     | Pattern = 12
+    | Module = 13
 
 /// Categorize an action the editor should take in response to a token, e.g. brace matching
 /// 

--- a/src/fsharp/vs/ServiceLexing.fs
+++ b/src/fsharp/vs/ServiceLexing.fs
@@ -88,6 +88,7 @@ type FSharpTokenColorKind =
     | Number = 9
     | Operator = 10
     | TypeName = 11
+    | Pattern = 12
 
 /// Categorize an action the editor should take in response to a token, e.g. brace matching
 /// 

--- a/src/fsharp/vs/ServiceLexing.fsi
+++ b/src/fsharp/vs/ServiceLexing.fsi
@@ -54,6 +54,7 @@ type internal FSharpTokenColorKind =
     | Operator = 10
     | TypeName = 11
     | Pattern = 12
+    | Module = 13
     
 /// Gives an indication of what should happen when the token is typed in an IDE
 type internal FSharpTokenTriggerClass =

--- a/src/fsharp/vs/ServiceLexing.fsi
+++ b/src/fsharp/vs/ServiceLexing.fsi
@@ -53,6 +53,7 @@ type internal FSharpTokenColorKind =
     | Number = 9
     | Operator = 10
     | TypeName = 11
+    | Pattern = 12
     
 /// Gives an indication of what should happen when the token is typed in an IDE
 type internal FSharpTokenTriggerClass =

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1365,13 +1365,23 @@ type TypeCheckInfo
                | CNR(_, (Item.Value vref), ItemOccurence.Use, _, _, _, m) when valRefEq g g.seq_vref vref -> 
                    yield (m, FSharpTokenColorKind.Keyword) 
                // custom builders, custom operations get colored as keywords
-               | CNR(_, (Item.CustomBuilder _ | Item.CustomOperation _), ItemOccurence.Use, _, _, _, m) -> 
+               | CNR(_, Item.CustomBuilder(_, valRef), ItemOccurence.Use, _, _, _, _) -> 
+                   yield (valRef.Range, FSharpTokenColorKind.Keyword) 
+               | CNR(_, Item.CustomOperation _, ItemOccurence.Use, _, _, _, m) -> 
                    yield (m, FSharpTokenColorKind.Keyword) 
                // types get colored as types when they occur in syntactic types or custom attributes
                // typevariables get colored as types when they occur in syntactic types custom builders, custom operations get colored as keywords
-               | CNR(_, (Item.TypeVar  _ | Item.Types _ | Item.UnqualifiedType _) , (ItemOccurence.UseInType | ItemOccurence.UseInAttribute), _, _, _, m) -> 
+               | CNR(_, (Item.TypeVar  _ | Item.Types _ | Item.UnqualifiedType _), 
+                     (ItemOccurence.UseInType | ItemOccurence.UseInAttribute | ItemOccurence.Binding _), _, _, _, m) -> 
+                   yield (m, FSharpTokenColorKind.TypeName)
+               | CNR(_, Item.CtorGroup _, ItemOccurence.Use, _, _, _, m) -> 
                    yield (m, FSharpTokenColorKind.TypeName) 
-               | CNR(_, (Item.UnionCase _ | Item.ActivePatternCase _), 
+               | CNR(_, Item.ModuleOrNamespaces _, ItemOccurence.Binding, _, _, _, m) ->
+                   yield (m, FSharpTokenColorKind.Module)
+               | CNR(_, Item.UnionCase (UnionCaseInfo (_, r), _), 
+                     (ItemOccurence.Binding | ItemOccurence.Implemented | ItemOccurence.Pattern | ItemOccurence.Use | ItemOccurence.UseInType), _, _, _, _) ->
+                   yield (r.Range, FSharpTokenColorKind.Pattern)
+               | CNR(_, Item.ActivePatternCase _, 
                      (ItemOccurence.Binding | ItemOccurence.Implemented | ItemOccurence.Pattern | ItemOccurence.Use | ItemOccurence.UseInType), _, _, _, m) ->
                    yield (m, FSharpTokenColorKind.Pattern)
                | _ -> () 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1371,6 +1371,9 @@ type TypeCheckInfo
                // typevariables get colored as types when they occur in syntactic types custom builders, custom operations get colored as keywords
                | CNR(_, (Item.TypeVar  _ | Item.Types _ | Item.UnqualifiedType _) , (ItemOccurence.UseInType | ItemOccurence.UseInAttribute), _, _, _, m) -> 
                    yield (m, FSharpTokenColorKind.TypeName) 
+               | CNR(_, (Item.UnionCase _ | Item.ActivePatternCase _), 
+                     (ItemOccurence.Binding | ItemOccurence.Implemented | ItemOccurence.Pattern | ItemOccurence.Use | ItemOccurence.UseInType), _, _, _, m) ->
+                   yield (m, FSharpTokenColorKind.Pattern)
                | _ -> () 
            |]
     member x.ScopeResolutions = sResolutions

--- a/vsintegration/src/FSharp.Editor/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/ColorizationService.fs
@@ -51,7 +51,9 @@ type internal FSharpColorizationService() =
         | FSharpTokenColorKind.PreprocessorKeyword -> ClassificationTypeNames.PreprocessorKeyword 
         | FSharpTokenColorKind.Operator -> ClassificationTypeNames.Operator
         | FSharpTokenColorKind.TypeName  -> ClassificationTypeNames.ClassName
-        | FSharpTokenColorKind.Default | _ -> ClassificationTypeNames.Text
+        | FSharpTokenColorKind.Pattern -> ClassificationTypeNames.EnumName
+        | FSharpTokenColorKind.Default 
+        | _ -> ClassificationTypeNames.Text
     
     static let scanSourceLine(sourceTokenizer: FSharpSourceTokenizer, textLine: TextLine, lineContents: string, lexState: FSharpTokenizerLexState) : SourceLineData =
     

--- a/vsintegration/src/FSharp.Editor/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/ColorizationService.fs
@@ -52,6 +52,7 @@ type internal FSharpColorizationService() =
         | FSharpTokenColorKind.Operator -> ClassificationTypeNames.Operator
         | FSharpTokenColorKind.TypeName  -> ClassificationTypeNames.ClassName
         | FSharpTokenColorKind.Pattern -> ClassificationTypeNames.EnumName
+        | FSharpTokenColorKind.Module -> ClassificationTypeNames.ModuleName
         | FSharpTokenColorKind.Default 
         | _ -> ClassificationTypeNames.Text
     


### PR DESCRIPTION
WIP

It looks like this:

![image](https://cloud.githubusercontent.com/assets/873919/20537593/c8590604-b0fe-11e6-8731-68cf73422b96.png)

Issues:

* it does not highlight enums
* it does not highlight Active Patterns on declaration site

If this change is OK in principle, I can add highlighting for modules and, maybe, some other symbol kinds.