### PR TITLE
Fix some underlying causes of long UI blocks in new LS implementation

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -109,23 +109,23 @@ Use ``VisualFSharp.sln`` if you're building the Visual F# IDE Tools.
 
 ## [Optional] Install the Visual F# IDE Tools  (Windows Only)
 
-At time of writing, the Visual F# IDE Tools can only be installed into Visual Studio "Next" (aka "Dev15") releases.
+At time of writing, the Visual F# IDE Tools can only be installed into Visual Studio "Next" releases.
 The new builds of the Visual F# IDE Tools can no longer be installed into Visual Studio 2015.
 
-You can install VIsual Studio "Next (aka "Dev15") from https://www.visualstudio.com/en-us/downloads/visual-studio-next-downloads-vs.aspx.
+You can install VIsual Studio "Next" from https://www.visualstudio.com/en-us/downloads/visual-studio-next-downloads-vs.aspx.
 
-**Note:** This step will install a VSIX extension into Visual Studio "Next" (aka "Dev15") that changes the Visual F# IDE Tools 
+**Note:** This step will install a VSIX extension into Visual Studio "Next" that changes the Visual F# IDE Tools 
 components installed in that VS installation.  You can revert this step by disabling or uninstalling the addin.
 
-For **Debug**:
+For **Debug**, uninstall then reinstall:
 
-1. Ensure that the VSIX package is uninstalled. In VS, select Tools/Extensions and Updates and if the package `Visual F# Tools` is installed, select Uninstall
-1. Run ``debug\net40\bin\VisualFSharpVsix.vsix``
+    VSIXInstaller.exe  /a /u:"VisualFSharp"
+    VSIXInstaller.exe /a  debug\net40\bin\VisualFSharpFull.vsix
 
-For **Release**:
+For **Release**, uninstall then reinstall:
 
-1. Ensure that the VSIX package is uninstalled. In VS, select Tools/Extensions and Updates and if the package `Visual F# Tools` is installed, select Uninstall
-1. Run ``release\net40\bin\VisualFSharpVsix.vsix``
+    VSIXInstaller.exe  /a /u:"VisualFSharp"
+    VSIXInstaller.exe /a  release\net40\bin\VisualFSharpFull.vsix
 
 Restart Visual Studio, it should now be running your freshly-built Visual F# IDE Tools with updated F# Interactive. 
 

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -6,6 +6,8 @@ namespace Microsoft.FSharp.Compiler
 open System
 open System.IO
 open System.Collections.Generic
+open System.Threading
+open System.Threading.Tasks
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.NameResolution
 open Microsoft.FSharp.Compiler.Tastops
@@ -747,12 +749,26 @@ module internal IncrementalBuild =
                 PartialBuild(bt.Rules, Map.add id (VectorResult(results)) bt.Results)
             | _ -> failwith "Unexpected"
         
-    let ExecuteApply (action:Action) bt = 
+    let mutable injectCancellationFault = false
+    let LocallyInjectCancellationFault() = 
+        injectCancellationFault <- true
+        { new IDisposable with member __.Dispose() =  injectCancellationFault <- false }
+
+    /// Apply the result, and call the 'save' function to update the build.  
+    ///
+    /// Will throw OperationCanceledException if the cancellation token has been set.
+    let ExecuteApply save (ct: CancellationToken) (action:Action) bt = 
+        ct.ThrowIfCancellationRequested()
+        if (injectCancellationFault) then raise (OperationCanceledException("injected fault"))
         let actionResult = action.Execute()
-        ApplyResult(actionResult,bt)
+        let newBt = ApplyResult(actionResult,bt)
+        save newBt
+        newBt
 
     /// Evaluate the result of a single output
-    let EvalLeafsFirst target bt =
+    ///
+    /// Will throw OperationCanceledException if the cancellation token has been set.
+    let EvalLeafsFirst save (ct: CancellationToken) target bt =
 
         let rec eval(bt,gen) =
             #if DEBUG
@@ -760,31 +776,40 @@ module internal IncrementalBuild =
             // Possibly could detect this case directly.
             if gen>5000 then failwith "Infinite loop in incremental builder?"
             #endif
-            let newBt = ForeachAction target bt ExecuteApply bt
-            if newBt=bt then bt else eval(newBt,gen+1)
+            let newBt = ForeachAction target bt (ExecuteApply save ct) bt
+            if newBt=bt then  bt else eval(newBt,gen+1)
         eval(bt,0)
         
-    let Step target (bt:PartialBuild) = 
+    /// Evaluate one step of the build.  Call the 'save' function to save the intermediate result.
+    ///
+    /// Will throw OperationCanceledException if the cancellation token has been set.
+    let Step save ct target (bt:PartialBuild) = 
         
         // Hey look, we're building up the whole list, executing one thing and then throwing
         // the list away. What about saving the list inside the Build instance?
         let worklist = ForeachAction target bt (fun a l -> a :: l) []
             
         match worklist with 
-        | action::_ -> Some (ExecuteApply action bt)
+        | action::_ -> Some (ExecuteApply save ct action bt)
         | _ -> None
             
     /// Evaluate an output of the build.
-    let Eval node bt = EvalLeafsFirst (Target(node,None)) bt
+    ///
+    /// Will throw OperationCanceledException if the cancellation token has been set.  Intermediate
+    /// progrewss along the way may be saved through the use of the 'save' function.
+    let Eval save ct node bt = EvalLeafsFirst save ct (Target(node,None)) bt
 
     /// Evaluate an output of the build.
-    let EvalUpTo (node, n) bt = EvalLeafsFirst (Target(node, Some n)) bt
+    ///
+    /// Will throw OperationCanceledException if the cancellation token has been set.  Intermediate
+    /// progrewss along the way may be saved through the use of the 'save' function.
+    let EvalUpTo save ct (node, n) bt = EvalLeafsFirst save ct (Target(node, Some n)) bt
 
     /// Check if an output is up-to-date and ready
     let IsReady target bt = 
         let worklist = ForeachAction target bt (fun a l -> a :: l) []
         worklist.IsEmpty
-
+        
     /// Check if an output is up-to-date and ready
     let MaxTimeStampInDependencies target bt = 
         ComputeMaxTimeStamp target bt DateTime.MinValue 
@@ -1610,10 +1635,7 @@ type IncrementalBuilder(frameworkTcImportsCache: FrameworkImportsCache, tcConfig
     // This is the initial representation of progress through the build, i.e. we have made no progress.
     let mutable partialBuild = buildDescription.GetInitialPartialBuild buildInputs
 
-    let EvalAndKeepOutput f = 
-        let newPartialBuild = f partialBuild
-        partialBuild <- newPartialBuild
-        newPartialBuild
+    let SavePartialBuild b = partialBuild <- b
 
     let MaxTimeStampInDependencies (output:INode) = 
         IncrementalBuild.MaxTimeStampInDependencies output.Name partialBuild 
@@ -1650,16 +1672,15 @@ type IncrementalBuilder(frameworkTcImportsCache: FrameworkImportsCache, tcConfig
         | _ -> true                
 #endif
 
-    member __.Step () =  
-        match IncrementalBuild.Step (Target(tcStatesNode, None)) partialBuild with 
+    member __.Step (ct) =  
+        match IncrementalBuild.Step SavePartialBuild ct (Target(tcStatesNode, None)) partialBuild with 
         | None -> 
             projectChecked.Trigger()
             false
-        | Some newPartialBuild -> 
-            partialBuild <- newPartialBuild
+        | Some _ -> 
             true
     
-    member ib.GetCheckResultsBeforeFileInProjectIfReady filename: PartialCheckResults option  = 
+    member ib.GetCheckResultsBeforeFileInProjectIfReady (filename): PartialCheckResults option  = 
         let slotOfFile = ib.GetSlotOfFileName filename
         let result = 
             match slotOfFile with
@@ -1677,33 +1698,33 @@ type IncrementalBuilder(frameworkTcImportsCache: FrameworkImportsCache, tcConfig
         | (*first file*) 0 -> IncrementalBuild.IsReady (Target(initialTcAccNode, None)) partialBuild 
         | _ -> IncrementalBuild.IsReady (Target(tcStatesNode, Some (slotOfFile-1))) partialBuild  
         
-    member ib.GetCheckResultsBeforeFileInProject filename = 
+    member ib.GetCheckResultsBeforeFileInProject (filename, ct) = 
         let slotOfFile = ib.GetSlotOfFileName filename
-        ib.GetTypeCheckResultsBeforeSlotInProject slotOfFile
+        ib.GetTypeCheckResultsBeforeSlotInProject (slotOfFile, ct)
 
-    member ib.GetCheckResultsAfterFileInProject filename = 
+    member ib.GetCheckResultsAfterFileInProject (filename, ct) = 
         let slotOfFile = ib.GetSlotOfFileName filename + 1
-        ib.GetTypeCheckResultsBeforeSlotInProject slotOfFile
+        ib.GetTypeCheckResultsBeforeSlotInProject (slotOfFile, ct)
 
-    member ib.GetTypeCheckResultsBeforeSlotInProject slotOfFile = 
+    member ib.GetTypeCheckResultsBeforeSlotInProject (slotOfFile, ct) = 
         let result = 
             match slotOfFile with
             | (*first file*) 0 -> 
-                let build = EvalAndKeepOutput (IncrementalBuild.Eval initialTcAccNode)  
+                let build = IncrementalBuild.Eval SavePartialBuild ct initialTcAccNode partialBuild
                 GetScalarResult(initialTcAccNode,build)
             | _ -> 
-                let build = EvalAndKeepOutput (IncrementalBuild.EvalUpTo (tcStatesNode, (slotOfFile-1))) 
+                let build = IncrementalBuild.EvalUpTo SavePartialBuild ct (tcStatesNode, (slotOfFile-1)) partialBuild
                 GetVectorResultBySlot(tcStatesNode,slotOfFile-1,build)  
         
         match result with
         | Some (tcAcc,timestamp) -> PartialCheckResults.Create (tcAcc,timestamp)
         | None -> failwith "Build was not evaluated, expected the results to be ready after 'Eval'."
 
-    member b.GetCheckResultsAfterLastFileInProject () = 
-        b.GetTypeCheckResultsBeforeSlotInProject(b.GetSlotsCount()) 
+    member b.GetCheckResultsAfterLastFileInProject (ct) = 
+        b.GetTypeCheckResultsBeforeSlotInProject(b.GetSlotsCount(), ct) 
 
-    member __.GetCheckResultsAndImplementationsForProject() = 
-        let build = EvalAndKeepOutput (IncrementalBuild.Eval finalizedTypeCheckNode)
+    member __.GetCheckResultsAndImplementationsForProject(ct) = 
+        let build = IncrementalBuild.Eval SavePartialBuild ct finalizedTypeCheckNode partialBuild
         match GetScalarResult(finalizedTypeCheckNode,build) with
         | Some ((ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt, tcAcc), timestamp) -> 
             PartialCheckResults.Create (tcAcc,timestamp), ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt
@@ -1731,12 +1752,12 @@ type IncrementalBuilder(frameworkTcImportsCache: FrameworkImportsCache, tcConfig
         | Some (VectorResult vr) -> vr.Size
         | _ -> failwith "Failed to find sizes"
       
-    member ib.GetParseResultsForFile filename =
+    member ib.GetParseResultsForFile (filename, ct) =
         let slotOfFile = ib.GetSlotOfFileName filename
         match GetVectorResultBySlot(parseTreesNode,slotOfFile,partialBuild) with
         | Some (results, _) -> results
         | None -> 
-            let build = EvalAndKeepOutput (IncrementalBuild.EvalUpTo (parseTreesNode, slotOfFile))  
+            let build = IncrementalBuild.EvalUpTo SavePartialBuild ct (parseTreesNode, slotOfFile) partialBuild  
             match GetVectorResultBySlot(parseTreesNode,slotOfFile,build) with
             | Some (results, _) -> results
             | None -> failwith "Build was not evaluated, expcted the results to be ready after 'Eval'."

--- a/src/fsharp/vs/IncrementalBuild.fsi
+++ b/src/fsharp/vs/IncrementalBuild.fsi
@@ -3,6 +3,8 @@
 namespace Microsoft.FSharp.Compiler
 
 open System
+open System.Threading
+open System.Threading.Tasks
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler.ErrorLogger
@@ -142,7 +144,7 @@ type internal IncrementalBuilder =
       member ThereAreLiveTypeProviders : bool
 #endif
       /// Perform one step in the F# build. Return true if the background work is finished.
-      member Step : unit -> bool
+      member Step : ct: CancellationToken -> bool
 
       /// Get the preceding typecheck state of a slot, without checking if it is up-to-date w.r.t.
       /// the timestamps on files and referenced DLLs prior to this one. Return None if the result is not available.
@@ -158,25 +160,25 @@ type internal IncrementalBuilder =
       /// to the necessary point if the result is not available. This may be a long-running operation.
       ///
       // TODO: make this an Eventually (which can be scheduled) or an Async (which can be cancelled)
-      member GetCheckResultsBeforeFileInProject : filename:string -> PartialCheckResults 
+      member GetCheckResultsBeforeFileInProject : filename:string * ct: CancellationToken -> PartialCheckResults 
 
       /// Get the typecheck state after checking a file. Compute the entire type check of the project up
       /// to the necessary point if the result is not available. This may be a long-running operation.
       ///
       // TODO: make this an Eventually (which can be scheduled) or an Async (which can be cancelled)
-      member GetCheckResultsAfterFileInProject : filename:string -> PartialCheckResults 
+      member GetCheckResultsAfterFileInProject : filename:string * ct: CancellationToken -> PartialCheckResults 
 
       /// Get the typecheck result after the end of the last file. The typecheck of the project is not 'completed'.
       /// This may be a long-running operation.
       ///
       // TODO: make this an Eventually (which can be scheduled) or an Async (which can be cancelled)
-      member GetCheckResultsAfterLastFileInProject : unit -> PartialCheckResults 
+      member GetCheckResultsAfterLastFileInProject : ct: CancellationToken  -> PartialCheckResults 
 
       /// Get the final typecheck result. If 'generateTypedImplFiles' was set on Create then the TypedAssemblyAfterOptimization will contain implementations.
       /// This may be a long-running operation.
       ///
       // TODO: make this an Eventually (which can be scheduled) or an Async (which can be cancelled)
-      member GetCheckResultsAndImplementationsForProject : unit -> PartialCheckResults * IL.ILAssemblyRef * IRawFSharpAssemblyData option * TypedImplFile list option
+      member GetCheckResultsAndImplementationsForProject : ct: CancellationToken  -> PartialCheckResults * IL.ILAssemblyRef * IRawFSharpAssemblyData option * TypedImplFile list option
 
       /// Get the logical time stamp that is associated with the output of the project if it were gully built immediately
       member GetLogicalTimeStampForProject: unit -> DateTime
@@ -184,7 +186,7 @@ type internal IncrementalBuilder =
       /// Await the untyped parse results for a particular slot in the vector of parse results.
       ///
       /// This may be a marginally long-running operation (parses are relatively quick, only one file needs to be parsed)
-      member GetParseResultsForFile : filename:string -> Ast.ParsedInput option * Range.range * string * (PhasedError * FSharpErrorSeverity) list
+      member GetParseResultsForFile : filename:string * ct: CancellationToken -> Ast.ParsedInput option * Range.range * string * (PhasedError * FSharpErrorSeverity) list
 
       static member TryCreateBackgroundBuilderForProjectOptions : ReferenceResolver.Resolver * FrameworkImportsCache * scriptClosureOptions:LoadClosure option * sourceFiles:string list * commandLineArgs:string list * projectReferences: IProjectReference list * projectDirectory:string * useScriptResolutionRules:bool * keepAssemblyContents: bool * keepAllBackgroundResolutions: bool -> IncrementalBuilder option * FSharpErrorInfo list 
 
@@ -242,14 +244,17 @@ module internal IncrementalBuild =
 
     type Target = Target of INode * int  option
 
+    /// Used for unit testing. Causes all steps of underlying incremental graph evaluation to throw OperationCanceledException
+    val LocallyInjectCancellationFault : unit -> IDisposable
+    
     /// Evaluate a build. Only required for unit testing.
-    val Eval : INode -> PartialBuild -> PartialBuild
+    val Eval : (PartialBuild -> unit) -> CancellationToken -> INode -> PartialBuild -> PartialBuild
 
     /// Evaluate a build for a vector up to a limit. Only required for unit testing.
-    val EvalUpTo : INode * int -> PartialBuild -> PartialBuild
+    val EvalUpTo : (PartialBuild -> unit) -> CancellationToken -> INode * int -> PartialBuild -> PartialBuild
 
     /// Do one step in the build. Only required for unit testing.
-    val Step : Target -> PartialBuild -> PartialBuild option
+    val Step : (PartialBuild -> unit) -> CancellationToken -> Target -> PartialBuild -> PartialBuild option
     /// Get a scalar vector. Result must be available. Only required for unit testing.
     val GetScalarResult : Scalar<'T> * PartialBuild -> ('T * System.DateTime) option
     /// Get a result vector. All results must be available or thrown an exception. Only required for unit testing.

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -141,6 +141,7 @@ type Reactor() =
                         try
                             f ct |> AsyncUtil.AsyncOk
                         with
+                        |   :? OperationCanceledException as e -> AsyncUtil.AsyncCanceled e
                         |   e -> e |> AsyncUtil.AsyncException
                     resultCell.RegisterResult(result)),
                     ccont=(fun () -> resultCell.RegisterResult (AsyncUtil.AsyncCanceled(OperationCanceledException())) )

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -312,16 +312,10 @@ type internal FSharpProjectOptions =
     }
          
           
-/// Callback which can be used by the host to indicate to the checker that a requested result has become obsolete,
-/// e.g. because of typing by the user in the editor window. This can be used to marginally increase accuracy
-/// of intellisense results in some situations.
-type internal IsResultObsolete = 
-    | IsResultObsolete of (unit->bool)
-
 /// The result of calling TypeCheckResult including the possibility of abort and background compiler not caught up.
 [<RequireQualifiedAccess>]
 type internal FSharpCheckFileAnswer =
-    | Aborted // because isResultObsolete caused an abandonment of the operation
+    | Aborted // because cancellation caused an abandonment of the operation
     | Succeeded of FSharpCheckFileResults    
 
 [<Sealed; AutoSerializable(false)>]      
@@ -383,7 +377,7 @@ type internal FSharpChecker =
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>
     ///
-    member CheckFileInProjectIfReady : parsed: FSharpParseFileResults * filename: string * fileversion: int * source: string * options: FSharpProjectOptions * ?isResultObsolete: IsResultObsolete * ?textSnapshotInfo: obj -> Async<FSharpCheckFileAnswer option>
+    member CheckFileInProjectIfReady : parsed: FSharpParseFileResults * filename: string * fileversion: int * source: string * options: FSharpProjectOptions * ?textSnapshotInfo: obj -> Async<FSharpCheckFileAnswer option>
 
     /// <summary>
     /// <para>
@@ -413,7 +407,7 @@ type internal FSharpChecker =
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>
     ///
-    member CheckFileInProject : parsed: FSharpParseFileResults * filename: string * fileversion: int * source: string * options: FSharpProjectOptions * ?isResultObsolete: IsResultObsolete * ?textSnapshotInfo: obj -> Async<FSharpCheckFileAnswer>
+    member CheckFileInProject : parsed: FSharpParseFileResults * filename: string * fileversion: int * source: string * options: FSharpProjectOptions * ?textSnapshotInfo: obj -> Async<FSharpCheckFileAnswer>
 
     /// <summary>
     /// <para>
@@ -442,7 +436,7 @@ type internal FSharpChecker =
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>
     ///
-    member ParseAndCheckFileInProject : filename: string * fileversion: int * source: string * options: FSharpProjectOptions * ?isResultObsolete: IsResultObsolete * ?textSnapshotInfo: obj -> Async<FSharpParseFileResults * FSharpCheckFileAnswer>
+    member ParseAndCheckFileInProject : filename: string * fileversion: int * source: string * options: FSharpProjectOptions * ?textSnapshotInfo: obj -> Async<FSharpParseFileResults * FSharpCheckFileAnswer>
 
     /// <summary>
     /// <para>Parse and typecheck all files in a project.</para>

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -5,13 +5,15 @@
 //
 // Technique 2:
 //
-//   Compile this file as an EXE that has InternalsVisibleTo access into the
+//   Enable some tests in the #if EXE section at the end of the file, 
+//   then compile this file as an EXE that has InternalsVisibleTo access into the
 //   appropriate DLLs.  This can be the quickest way to get turnaround on updating the tests
 //   and capturing large amounts of structured output.
-//    cd Debug\net40\bin
-//    .\fsc.exe --define:EXE -o VisualFSharp.Unittests.exe -g --optimize- -r .\FSharp.LanguageService.Compiler.dll -r nunit.framework.dll ..\..\..\tests\service\FsUnit.fs ..\..\..\tests\service\Common.fs /delaysign /keyfile:..\..\..\src\fsharp\msft.pubkey ..\..\..\tests\service\EditorTests.fs 
-//    .\VisualFSharp.Unittests.exe 
-//
+(*
+    cd Debug\net40\bin
+    .\fsc.exe --define:EXE -r:.\Microsoft.Build.Utilities.Core.dll -o SomeTests.exe -g --optimize- -r .\FSharp.LanguageService.Compiler.dll -r nunit.framework.dll ..\..\..\tests\service\FsUnit.fs ..\..\..\tests\service\Common.fs /delaysign /keyfile:..\..\..\src\fsharp\msft.pubkey ..\..\..\tests\service\EditorTests.fs 
+    .\SomeTests.exe 
+*)
 // Technique 3: 
 // 
 //    Use F# Interactive.  This only works for FSHarp.Compiler.Service.dll which has a public API
@@ -93,6 +95,26 @@ let ``Intro test`` () =
                ("Concat", ["str0: string"; "str1: string"; "str2: string"]);
                ("Concat", ["arg0: obj"; "arg1: obj"; "arg2: obj"; "arg3: obj"]);
                ("Concat", ["str0: string"; "str1: string"; "str2: string"; "str3: string"])]
+
+
+[<Test>]
+let ``Basic cancellation test`` () = 
+   try 
+    printfn "locally injecting a cancellation condition in incremental building"
+    use _holder = IncrementalBuild.LocallyInjectCancellationFault()
+    
+    // Split the input & define file name
+    let inputLines = input.Split('\n')
+    let file = "/home/user/Test.fsx"
+    async { 
+        checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
+        let! checkOptions = checker.GetProjectOptionsFromScript(file, input) 
+        let! parseResult, typedRes = checker.ParseAndCheckFileInProject(file, 0, input, checkOptions) 
+        return parseResult, typedRes
+    } |> Async.RunSynchronously
+      |> ignore
+    Assert.Fail("expected a cancellation")
+   with :? OperationCanceledException -> ()
 
 [<Test>]
 let ``GetMethodsAsSymbols should return all overloads of a method as FSharpSymbolUse`` () =
@@ -715,8 +737,10 @@ let ``Test TPProject param info`` () =
 #if EXE
 
 ``Intro test`` () 
-``Test TPProject all symbols`` () 
-``Test TPProject errors`` () 
-``Test TPProject quick info`` () 
-``Test TPProject param info`` () 
+//``Test TPProject all symbols`` () 
+//``Test TPProject errors`` () 
+//``Test TPProject quick info`` () 
+//``Test TPProject param info`` () 
+``Basic cancellation test`` ()
+``Intro test`` () 
 #endif

--- a/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
+++ b/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
@@ -15,7 +15,7 @@ type internal FSharpBraceMatchingService() =
         let isPositionInRange(range) =
             let span = CommonRoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
             span.Start <= position && position < span.End
-        let! matchedBraces = FSharpChecker.Instance.MatchBracesAlternate(fileName, sourceText.ToString(), options)
+        let! matchedBraces = FSharpLanguageService.Checker.MatchBracesAlternate(fileName, sourceText.ToString(), options)
 
         return matchedBraces |> Seq.tryFind(fun(left, right) -> isPositionInRange(left) || isPositionInRange(right))
     }

--- a/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
+++ b/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
@@ -21,8 +21,8 @@ type internal FSharpBraceMatchingService() =
     }
         
     interface IBraceMatcher with
-        member this.FindBracesAsync(document, position, cancellationToken) =
-            let computation = async {
+        member this.FindBracesAsync(document, position, cancellationToken) = 
+            async {
                 match FSharpLanguageService.GetOptions(document.Project.Id) with
                 | Some(options) ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
@@ -34,7 +34,4 @@ type internal FSharpBraceMatchingService() =
                                            CommonRoslynHelpers.FSharpRangeToTextSpan(sourceText, left),
                                            CommonRoslynHelpers.FSharpRangeToTextSpan(sourceText, right)))
                 | None -> return Nullable()
-            }
-
-            Async.StartAsTask(computation, TaskCreationOptions.None, cancellationToken)
-                 .ContinueWith(CommonRoslynHelpers.GetCompletedTaskResult, cancellationToken)
+            } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken

--- a/vsintegration/src/FSharp.Editor/BreakpointResolutionService.fs
+++ b/vsintegration/src/FSharp.Editor/BreakpointResolutionService.fs
@@ -32,7 +32,7 @@ open Microsoft.FSharp.Compiler.Range
 type internal FSharpBreakpointResolutionService() =
 
     static member GetBreakpointLocation(sourceText: SourceText, fileName: string, textSpan: TextSpan, options: FSharpProjectOptions) = async {
-        let! parseResults = FSharpChecker.Instance.ParseFileInProject(fileName, sourceText.ToString(), options)
+        let! parseResults = FSharpLanguageService.Checker.ParseFileInProject(fileName, sourceText.ToString(), options)
         let textLine = sourceText.Lines.GetLineFromPosition(textSpan.Start)
 
         let textLineNumber = textLine.LineNumber + 1 // Roslyn line numbers are zero-based

--- a/vsintegration/src/FSharp.Editor/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/ColorizationService.fs
@@ -149,9 +149,9 @@ type internal FSharpColorizationService() =
                 match FSharpLanguageService.GetOptions(document.Project.Id) with
                 | Some(options) ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                    let! parseResults = FSharpChecker.Instance.ParseFileInProject(document.Name, sourceText.ToString(), options)
+                    let! parseResults = FSharpLanguageService.Checker.ParseFileInProject(document.Name, sourceText.ToString(), options)
                     let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask
-                    let! checkResultsAnswer = FSharpChecker.Instance.CheckFileInProject(parseResults, document.FilePath, textVersion.GetHashCode(), textSpan.ToString(), options)
+                    let! checkResultsAnswer = FSharpLanguageService.Checker.CheckFileInProject(parseResults, document.FilePath, textVersion.GetHashCode(), textSpan.ToString(), options)
 
                     let extraColorizationData = match checkResultsAnswer with
                                                 | FSharpCheckFileAnswer.Aborted -> failwith "Compilation isn't complete yet"

--- a/vsintegration/src/FSharp.Editor/CommonRoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CommonRoslynHelpers.fs
@@ -20,15 +20,6 @@ module internal CommonRoslynHelpers =
         let endPosition = sourceText.Lines.[range.EndLine - 1].Start + range.EndColumn
         TextSpan(startPosition, endPosition - startPosition)
 
-    let GetTaskAction(computation: Async<unit>) =
-        // Shortcut due to nonstandard way of converting Async<unit> to Task
-        let action() =
-            try
-                computation |> Async.RunSynchronously
-            with ex ->
-                Assert.Exception(ex.GetBaseException())
-                raise(ex.GetBaseException())
-        Action action
 
     let GetCompletedTaskResult(task: Task<'TResult>) =
         if task.Status = TaskStatus.RanToCompletion then
@@ -36,6 +27,13 @@ module internal CommonRoslynHelpers =
         else
             Assert.Exception(task.Exception.GetBaseException())
             raise(task.Exception.GetBaseException())
+
+    let StartAsyncAsTask cancellationToken computation =
+        Async.StartAsTask(computation, TaskCreationOptions.None, cancellationToken)
+             .ContinueWith(GetCompletedTaskResult, cancellationToken)
+
+    let StartAsyncUnitAsTask cancellationToken (computation:Async<unit>) = 
+        StartAsyncAsTask cancellationToken computation  :> Task
 
     let SupportedDiagnostics() =
         // We are constructing our own descriptors at run-time. Compiler service is already doing error formatting and localization.

--- a/vsintegration/src/FSharp.Editor/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CompletionProvider.fs
@@ -73,8 +73,8 @@ type internal FSharpCompletionProvider(workspace: Workspace, serviceProvider: SV
                 | _ -> true // anything else is a valid classification type
 
     static member ProvideCompletionsAsyncAux(sourceText: SourceText, caretPosition: int, options: FSharpProjectOptions, filePath: string, textVersionHash: int) = async {
-        let! parseResults = FSharpChecker.Instance.ParseFileInProject(filePath, sourceText.ToString(), options)
-        let! checkFileAnswer = FSharpChecker.Instance.CheckFileInProject(parseResults, filePath, textVersionHash, sourceText.ToString(), options)
+        let! parseResults = FSharpLanguageService.Checker.ParseFileInProject(filePath, sourceText.ToString(), options)
+        let! checkFileAnswer = FSharpLanguageService.Checker.CheckFileInProject(parseResults, filePath, textVersionHash, sourceText.ToString(), options)
         let checkFileResults = match checkFileAnswer with
                                 | FSharpCheckFileAnswer.Aborted -> failwith "Compilation isn't complete yet"
                                 | FSharpCheckFileAnswer.Succeeded(results) -> results

--- a/vsintegration/src/FSharp.Editor/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentDiagnosticAnalyzer.fs
@@ -25,10 +25,10 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
     inherit DocumentDiagnosticAnalyzer()
 
     static member GetDiagnostics(filePath: string, sourceText: SourceText, textVersionHash: int, options: FSharpProjectOptions, addSemanticErrors: bool) =
-        let parseResults = FSharpChecker.Instance.ParseFileInProject(filePath, sourceText.ToString(), options) |> Async.RunSynchronously
+        let parseResults = FSharpLanguageService.Checker.ParseFileInProject(filePath, sourceText.ToString(), options) |> Async.RunSynchronously
         let errors =
             if addSemanticErrors then
-                let checkResultsAnswer = FSharpChecker.Instance.CheckFileInProject(parseResults, filePath, textVersionHash, sourceText.ToString(), options) |> Async.RunSynchronously
+                let checkResultsAnswer = FSharpLanguageService.Checker.CheckFileInProject(parseResults, filePath, textVersionHash, sourceText.ToString(), options) |> Async.RunSynchronously
                 match checkResultsAnswer with
                 | FSharpCheckFileAnswer.Aborted -> failwith "Compilation isn't complete yet"
                 | FSharpCheckFileAnswer.Succeeded(results) -> results.Errors

--- a/vsintegration/src/FSharp.Editor/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/GoToDefinitionService.fs
@@ -61,31 +61,33 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>] ([<ImportMany
             FSharpColorizationService.GetColorizationData(sourceText, textLine.Span, Some(filePath), defines, cancellationToken)
             |> Seq.tryFind(fun classifiedSpan -> classifiedSpan.TextSpan.Contains(position))
 
-        let processQualifiedIdentifier(qualifiers, islandColumn) = async {
-            let! parseResults = FSharpLanguageService.Checker.ParseFileInProject(filePath, sourceText.ToString(), options)
-            let! checkFileAnswer = FSharpLanguageService.Checker.CheckFileInProject(parseResults, filePath, textVersionHash, sourceText.ToString(), options)
-            let checkFileResults = match checkFileAnswer with
-                                    | FSharpCheckFileAnswer.Aborted -> failwith "Compilation isn't complete yet"
-                                    | FSharpCheckFileAnswer.Succeeded(results) -> results
+        match classifiedSpanOption with
+        | Some(classifiedSpan) ->
+            match classifiedSpan.ClassificationType with
+            | ClassificationTypeNames.Identifier ->
+                match QuickParse.GetCompleteIdentifierIsland true (textLine.ToString()) textLineColumn with
+                | Some(islandIdentifier, islandColumn, isQuoted) ->
+                    let qualifiers = if isQuoted then [islandIdentifier] else islandIdentifier.Split '.' |> Array.toList
+                    // REVIEW: ParseFileInProject and CheckFileInProject can cause FSharp.Compiler.Service to become unavailable (i.e. not responding to requests) for 
+                    // an arbitrarily long time while they process all files prior to this one in the project (plus dependent projects
+                    // if we enable cross-project checking in multi-project solutions). FCS will not respond to other 
+                    // requests unless this task is cancelled. We need to check that this task is cancelled in a timely way by the
+                    // Roslyn UI machinery.
+                    let! parseResults = FSharpLanguageService.Checker.ParseFileInProject(filePath, sourceText.ToString(), options)
+                    let! checkFileAnswer = FSharpLanguageService.Checker.CheckFileInProject(parseResults, filePath, textVersionHash, sourceText.ToString(), options)
+                    let checkFileResults = 
+                        match checkFileAnswer with
+                        | FSharpCheckFileAnswer.Aborted -> failwith "Compilation isn't complete yet"
+                        | FSharpCheckFileAnswer.Succeeded(results) -> results
 
-            let! declarations = checkFileResults.GetDeclarationLocationAlternate (fcsTextLineNumber, islandColumn, textLine.ToString(), qualifiers, false)
+                    let! declarations = checkFileResults.GetDeclarationLocationAlternate (fcsTextLineNumber, islandColumn, textLine.ToString(), qualifiers, false)
 
-            return match declarations with
-                   | FSharpFindDeclResult.DeclFound(range) -> Some(range)
-                   | _ -> None
-        }
-
-        return match classifiedSpanOption with
-               | Some(classifiedSpan) ->
-                    match classifiedSpan.ClassificationType with
-                    | ClassificationTypeNames.Identifier ->
-                        match QuickParse.GetCompleteIdentifierIsland true (textLine.ToString()) textLineColumn with
-                        | Some(islandIdentifier, islandColumn, isQuoted) ->
-                            let qualifiers = if isQuoted then [islandIdentifier] else islandIdentifier.Split '.' |> Array.toList
-                            processQualifiedIdentifier(qualifiers, islandColumn) |> Async.RunSynchronously
-                        | None -> None
-                    | _ -> None
-               | None -> None
+                    match declarations with
+                    | FSharpFindDeclResult.DeclFound(range) -> return Some(range)
+                    | _ -> return None
+                | None -> return None
+            | _ -> return None
+        | None -> return None
     }
     
     // FSROSLYNTODO: Since we are not integrated with the Roslyn project system yet, the below call
@@ -93,7 +95,7 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>] ([<ImportMany
     // Either Roslyn INavigableItem needs to be extended to allow arbitary full paths, or we need to
     // fully integrate with their project system.
     member this.FindDefinitionsAsyncAux(document: Document, position: int, cancellationToken: CancellationToken) =
-        let computation = async {
+        async {
             let results = List<INavigableItem>()
             match FSharpLanguageService.GetOptions(document.Project.Id) with
             | Some(options) ->
@@ -104,7 +106,9 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>] ([<ImportMany
 
                 match definition with
                 | Some(range) ->
-                    let refDocumentIds = document.Project.Solution.GetDocumentIdsWithFilePath(range.FileName)
+                    // REVIEW: 
+                    let fileName = try System.IO.Path.GetFullPath(range.FileName) with _ -> range.FileName
+                    let refDocumentIds = document.Project.Solution.GetDocumentIdsWithFilePath(fileName)
                     if not refDocumentIds.IsEmpty then 
                         let refDocumentId = refDocumentIds.First()
                         let refDocument = document.Project.Solution.GetDocument(refDocumentId)
@@ -115,10 +119,7 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>] ([<ImportMany
                 | None -> ()
             | None -> ()
             return results.AsEnumerable()
-        }
-        
-        Async.StartAsTask(computation, TaskCreationOptions.None, cancellationToken)
-                .ContinueWith(CommonRoslynHelpers.GetCompletedTaskResult, cancellationToken)
+         } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken
 
     interface IGoToDefinitionService with
         member this.FindDefinitionsAsync(document: Document, position: int, cancellationToken: CancellationToken) =
@@ -126,6 +127,8 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>] ([<ImportMany
 
         member this.TryGoToDefinition(document: Document, position: int, cancellationToken: CancellationToken) =
             let definitionTask = this.FindDefinitionsAsyncAux(document, position, cancellationToken)
+            
+            // REVIEW: document this use of a blocking wait on the cancellation token, explaining why it is ok
             definitionTask.Wait(cancellationToken)
             
             if definitionTask.Status = TaskStatus.RanToCompletion then

--- a/vsintegration/src/FSharp.Editor/LanguageDebugInfoService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageDebugInfoService.fs
@@ -64,7 +64,7 @@ type internal FSharpLanguageDebugInfoService() =
             Task.FromResult(Unchecked.defaultof<DebugLocationInfo>)
 
         member this.GetDataTipInfoAsync(document: Document, position: int, cancellationToken: CancellationToken): Task<DebugDataTipInfo> =
-            let computation = async {
+            async {
                 match FSharpLanguageService.GetOptions(document.Project.Id) with
                 | Some(options) ->
                     let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.Name, options.OtherOptions |> Seq.toList)
@@ -75,9 +75,6 @@ type internal FSharpLanguageDebugInfoService() =
                            | None -> Unchecked.defaultof<DebugDataTipInfo>
                            | Some(textSpan) -> new DebugDataTipInfo(textSpan, sourceText.GetSubText(textSpan).ToString())
                 | None -> return Unchecked.defaultof<DebugDataTipInfo>
-            }
-            
-            Async.StartAsTask(computation, TaskCreationOptions.None, cancellationToken)
-                 .ContinueWith(CommonRoslynHelpers.GetCompletedTaskResult, cancellationToken)
+            } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken
             
             

--- a/vsintegration/src/FSharp.Editor/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService.fs
@@ -86,14 +86,13 @@ type internal FSharpLanguageService(package : FSharpPackage) =
             let filename = VsTextLines.GetFilename textLines
             match VsRunningDocumentTable.FindDocumentWithoutLocking(package.RunningDocumentTable,filename) with
             | Some (hier, _) ->
-                if IsScript(filename) then
+                match hier with
+                | :? IProvideProjectSite as siteProvider when not (IsScript(filename)) -> 
+                    this.SetupProjectFile(siteProvider, workspace)
+                | _ -> 
                     let editorAdapterFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>()
                     let fileContents = VsTextLines.GetFileContents(textLines, editorAdapterFactoryService)
                     this.SetupStandAloneFile(filename, fileContents, workspace, hier)
-                else
-                    match hier with
-                    | :? IProvideProjectSite as siteProvider -> this.SetupProjectFile(siteProvider, workspace)
-                    | _ -> ()
             | _ -> ()
         | _ -> ()
 

--- a/vsintegration/src/FSharp.Editor/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService.fs
@@ -49,6 +49,9 @@ type internal FSharpLanguageService(package : FSharpPackage) =
     inherit AbstractLanguageService<FSharpPackage, FSharpLanguageService>(package)
 
     static let optionsCache = Dictionary<ProjectId, FSharpProjectOptions>()
+    static let checker = lazy FSharpChecker.Create()
+    static member Checker with get() = checker.Value
+
     static member GetOptions(projectId: ProjectId) =
         if optionsCache.ContainsKey(projectId) then
             Some(optionsCache.[projectId])
@@ -118,7 +121,7 @@ type internal FSharpLanguageService(package : FSharpPackage) =
         | _ -> ()
 
     member this.SetupStandAloneFile(fileName: string, fileContents: string, workspace: VisualStudioWorkspaceImpl, hier: IVsHierarchy) =
-        let options = FSharpChecker.Instance.GetProjectOptionsFromScript(fileName, fileContents, DateTime.Now, [| |]) |> Async.RunSynchronously
+        let options = FSharpLanguageService.Checker.GetProjectOptionsFromScript(fileName, fileContents, DateTime.Now, [| |]) |> Async.RunSynchronously
         let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(options.ProjectFileName, options.ProjectFileName)
 
         if not(optionsCache.ContainsKey(projectId)) then

--- a/vsintegration/src/FSharp.Editor/ProjectDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/ProjectDiagnosticAnalyzer.fs
@@ -26,7 +26,7 @@ type internal FSharpProjectDiagnosticAnalyzer() =
     inherit ProjectDiagnosticAnalyzer()
 
     static member GetDiagnostics(options: FSharpProjectOptions) =
-        let checkProjectResults = FSharpChecker.Instance.ParseAndCheckProject(options) |> Async.RunSynchronously
+        let checkProjectResults = FSharpLanguageService.Checker.ParseAndCheckProject(options) |> Async.RunSynchronously
         (checkProjectResults.Errors |> Seq.choose(fun (error) ->
             if error.StartLineAlternate = 0 || error.EndLineAlternate = 0 then
                 Some(CommonRoslynHelpers.ConvertError(error, Location.None))

--- a/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
+++ b/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
@@ -169,15 +169,9 @@ type internal FSharpLanguageServiceBackgroundRequests
                         // Should never matter but don't let anything in FSharp.Compiler extend the lifetime of 'source'
                         let sr = ref (Some source)
 
-                        // Determine whether to abandon the CheckFileIfReady operation
-                        let isResultObsolete() = 
-                            match !sr with
-                            | None -> false
-                            | Some source -> req.Timestamp <> source.ChangeCount
-                        
                         // Type-checking
                         let typedResults,aborted = 
-                            match interactiveChecker.CheckFileInProjectIfReady(parseResults,req.FileName,req.Timestamp,req.Text,checkOptions,IsResultObsolete(isResultObsolete),req.Snapshot) |> Async.RunSynchronously with 
+                            match interactiveChecker.CheckFileInProjectIfReady(parseResults,req.FileName,req.Timestamp,req.Text,checkOptions,req.Snapshot) |> Async.RunSynchronously with 
                             | None -> None,false
                             | Some FSharpCheckFileAnswer.Aborted -> 
                                 // isResultObsolete returned true during the type check.

--- a/vsintegration/tests/unittests/DocumentDiagnosticAnalyzerTests.fs
+++ b/vsintegration/tests/unittests/DocumentDiagnosticAnalyzerTests.fs
@@ -38,12 +38,14 @@ type DocumentDiagnosticAnalyzerTests()  =
                                 | None -> options
                                 | Some(flags) -> {options with OtherOptions = Array.append options.OtherOptions flags}
 
-        let errors = FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(filePath, SourceText.From(fileContents), 0, additionalOptions, true)
+        let errors = FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(filePath, SourceText.From(fileContents), 0, additionalOptions, true) |> Async.RunSynchronously
         Assert.AreEqual(0, errors.Length, "There should be no errors generated")
 
     member private this.VerifyErrorAtMarker(fileContents: string, expectedMarker: string, ?expectedMessage: string) =
-        let errors = FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(filePath, SourceText.From(fileContents), 0, options, true) |>
-            Seq.filter(fun e -> e.Severity = DiagnosticSeverity.Error) |> Seq.toArray
+        let errors = 
+             FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(filePath, SourceText.From(fileContents), 0, options, true) 
+             |> Async.RunSynchronously
+             |> Seq.filter(fun e -> e.Severity = DiagnosticSeverity.Error) |> Seq.toArray
         Assert.AreEqual(1, errors.Length, "There should be exactly one error generated")
         let actualError = errors.[0]
         if expectedMessage.IsSome then
@@ -55,8 +57,10 @@ type DocumentDiagnosticAnalyzerTests()  =
         Assert.AreEqual(expectedEnd, actualError.Location.SourceSpan.End, "Error end positions should match")
 
     member private this.VerifyDiagnosticBetweenMarkers(fileContents: string, expectedMessage: string, expectedSeverity: DiagnosticSeverity) =
-        let errors = FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(filePath, SourceText.From(fileContents), 0, options, true) |>
-            Seq.filter(fun e -> e.Severity = expectedSeverity) |> Seq.toArray
+        let errors = 
+            FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(filePath, SourceText.From(fileContents), 0, options, true) 
+             |> Async.RunSynchronously
+             |> Seq.filter(fun e -> e.Severity = expectedSeverity) |> Seq.toArray
         Assert.AreEqual(1, errors.Length, "There should be exactly one error generated")
         let actualError = errors.[0]
         Assert.AreEqual(expectedSeverity, actualError.Severity)

--- a/vsintegration/tests/unittests/ProjectDiagnosticAnalyzerTests.fs
+++ b/vsintegration/tests/unittests/ProjectDiagnosticAnalyzerTests.fs
@@ -43,7 +43,7 @@ printf "%d" x
         let options = CreateProjectAndGetOptions(fileContents)
         let additionalOptions = {options with OtherOptions = Array.append options.OtherOptions [| "--times" |]}
 
-        let errors = FSharpProjectDiagnosticAnalyzer.GetDiagnostics(additionalOptions)
+        let errors = FSharpProjectDiagnosticAnalyzer.GetDiagnostics(additionalOptions)  |> Async.RunSynchronously
         Assert.AreEqual(1, errors.Length, "Exactly one warning should have been reported")
         
         let warning = errors.[0]
@@ -59,5 +59,5 @@ printf "%d" x
 """
         let options = CreateProjectAndGetOptions(fileContents)
 
-        let errors = FSharpProjectDiagnosticAnalyzer.GetDiagnostics(options)
+        let errors = FSharpProjectDiagnosticAnalyzer.GetDiagnostics(options)  |> Async.RunSynchronously
         Assert.AreEqual(0, errors.Length, "No semantic errors should have been reported")


### PR DESCRIPTION
Fixes underlying issues associated with https://github.com/Microsoft/visualfsharp/issues/1815

After getting a 15+ second UI block in VS 2017, I've done a complete review of the way the new LanguageService implementation is using FSharp.Compiler.Service (the DLL internally called FSharp.Compiler.LanguageService in the Visual F# Tools repo, but it's basically the same component as FCS)

In short, the new LS implementation expects FCS to honour cancellation of submitted tasks in a more timely way.  This PR greatly improves the cancellability of FCS requests, which was one of the underlying causes of such a long UI block.

1. Improve FCS so that it respects cancellation in a more timely way.  Cancellation will now be respected at each step of the evaluation of the incremental build graph (IncrementalBuild.fs). This represents a fundamental improvement to FCS which will be very useful to other F# editors as well, as long as they are cancelling tasks.

   In particular, some FCS requests could be _very_ long running, e.g. CheckFileInProject may require checking **all** the files prior to this file (and if cross-F#-to-F#-project checking is enabled then it will  require checking all the dependent projects too).  

   Prior to this PR FCS was not respecting cancellation of these requests, and was simply running them through and then throwing the results away.

2. The new LS implementation was using some unnecessary calls to Async.RunSynchronously.  All of these could inject arbitrary non-responsiveness into some part of the causality chains.  I've removed these in favour of fully async code.

3. In FCS the old IsResultObsolete logic can be removed in favour of checking a cancellation token



