### PR TITLE
Move NuGet.Config to root

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <solution>
     <add key="disableSourceControlIntegration" value="true" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+  <packageSources>
+    <clear />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Unfortunatly the clear tag has no effect if the NuGet.Config is not found. So we need to move it up