### PR TITLE
Fix #977 - CompiledName on a member whose declaring type is in a namespace

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -1390,13 +1390,15 @@ let MakeAndPublishVal cenv env (altActualParent,inSig,declKind,vrec,(ValScheme(i
 
     // CompiledName not allowed on virtual/abstract/override members        
     let compiledNameAttrib  = TryFindFSharpStringAttribute cenv.g cenv.g.attrib_CompiledNameAttribute attrs
-    if Option.isSome compiledNameAttrib && (   (   match memberInfoOpt with 
-                                                   | Some (ValMemberInfoTransient(memberInfo,_,_)) -> 
-                                                       memberInfo.MemberFlags.IsDispatchSlot 
-                                                       || memberInfo.MemberFlags.IsOverrideOrExplicitImpl 
-                                                   | None -> false)
-                                            || (match altActualParent with ParentNone -> true | _ -> false)) then 
-        errorR(Error(FSComp.SR.tcCompiledNameAttributeMisused(),m))
+    if Option.isSome compiledNameAttrib then
+        match memberInfoOpt with 
+        | Some (ValMemberInfoTransient(memberInfo,_,_)) -> 
+            if memberInfo.MemberFlags.IsDispatchSlot || memberInfo.MemberFlags.IsOverrideOrExplicitImpl then
+                errorR(Error(FSComp.SR.tcCompiledNameAttributeMisused(),m))
+        | None -> 
+            match altActualParent with
+            | ParentNone -> errorR(Error(FSComp.SR.tcCompiledNameAttributeMisused(),m)) 
+            | _ -> ()
 
     let compiledNameIsOnProp =
         match memberInfoOpt with

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/CompiledNameAttribute/CompiledNameAttribute05.fs
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/CompiledNameAttribute/CompiledNameAttribute05.fs
@@ -1,0 +1,6 @@
+//<Expects status="success"></Expects>
+namespace Test
+
+type T() =
+    [<CompiledName "A">]
+    member this.a() = ()

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/CompiledNameAttribute/env.lst
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/CompiledNameAttribute/env.lst
@@ -3,3 +3,4 @@
 	SOURCE=CompiledNameAttribute03.fs SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd CompiledNameAttribute03.exe"		# CompiledNameAttribute03.fs
 
 	SOURCE=CompiledNameAttribute04.fs SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd CompiledNameAttribute04.exe NetFx40"	# CompiledNameAttribute04.fs - NetFx40
+	SOURCE=CompiledNameAttribute05.fs # CompiledNameAttribute05.fs


### PR DESCRIPTION
Basically I removed the || condition and now we can write:

    namespace Test
    
    type T() =
        [<CompiledName "A">]
        member this.a() = () 