### PR TITLE
Field Names for AST union cases

### DIFF
--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -22,16 +22,16 @@ open Microsoft.FSharp.Compiler.Range
 let FsiDynamicModulePrefix = "FSI_"
 
 [<RequireQualifiedAccess>]
-module FSharpLib = 
+module FSharpLib =
     let Root      = "Microsoft.FSharp"
-    let RootPath  = IL.splitNamespace Root 
+    let RootPath  = IL.splitNamespace Root
     let Core      = Root + ".Core"
     let CorePath  = IL.splitNamespace Core
 
 
 [<RequireQualifiedAccess>]
 module CustomOperations =
-    [<Literal>] 
+    [<Literal>]
     let Into = "into"
 
 //------------------------------------------------------------------------
@@ -44,84 +44,84 @@ type XmlDocCollector() =
     let mutable savedLines = new ResizeArray<(string * pos)>()
     let mutable savedGrabPoints = new ResizeArray<pos>()
     let posCompare p1 p2 = if posGeq p1 p2 then 1 else if posEq p1 p2 then 0 else -1
-    let savedGrabPointsAsArray = 
+    let savedGrabPointsAsArray =
         lazy (savedGrabPoints.ToArray() |> Array.sortWith posCompare)
 
-    let savedLinesAsArray = 
+    let savedLinesAsArray =
         lazy (savedLines.ToArray() |> Array.sortWith (fun (_,p1) (_,p2) -> posCompare p1 p2))
 
-    let check() = 
+    let check() =
         assert (not savedLinesAsArray.IsValueCreated && "can't add more XmlDoc elements to XmlDocCollector after extracting first XmlDoc from the overall results" <> "")
 
-    member x.AddGrabPoint(pos) = 
+    member x.AddGrabPoint(pos) =
         check()
-        savedGrabPoints.Add pos 
+        savedGrabPoints.Add pos
 
-    member x.AddXmlDocLine(line,pos) = 
+    member x.AddXmlDocLine(line,pos) =
         check()
         savedLines.Add(line,pos)
 
-    member x.LinesBefore(grabPointPos) = 
-                        
+    member x.LinesBefore(grabPointPos) =
+
         let lines = savedLinesAsArray.Force()
         let grabPoints = savedGrabPointsAsArray.Force()
-        let firstLineIndexAfterGrabPoint = Array.findFirstIndexWhereTrue lines (fun (_,pos) -> posGeq pos grabPointPos) 
-        let grabPointIndex = Array.findFirstIndexWhereTrue grabPoints (fun pos -> posGeq pos grabPointPos) 
+        let firstLineIndexAfterGrabPoint = Array.findFirstIndexWhereTrue lines (fun (_,pos) -> posGeq pos grabPointPos)
+        let grabPointIndex = Array.findFirstIndexWhereTrue grabPoints (fun pos -> posGeq pos grabPointPos)
         assert (posEq grabPoints.[grabPointIndex] grabPointPos)
-        let firstLineIndexAfterPrevGrabPoint = 
-            if grabPointIndex = 0 then 
-                0 
+        let firstLineIndexAfterPrevGrabPoint =
+            if grabPointIndex = 0 then
+                0
             else
                 let prevGrabPointPos = grabPoints.[grabPointIndex-1]
-                Array.findFirstIndexWhereTrue lines (fun (_,pos) -> posGeq pos prevGrabPointPos) 
+                Array.findFirstIndexWhereTrue lines (fun (_,pos) -> posGeq pos prevGrabPointPos)
         //printfn "#lines = %d, firstLineIndexAfterPrevGrabPoint = %d, firstLineIndexAfterGrabPoint = %d" lines.Length firstLineIndexAfterPrevGrabPoint  firstLineIndexAfterGrabPoint
         lines.[firstLineIndexAfterPrevGrabPoint..firstLineIndexAfterGrabPoint-1] |> Array.map fst
 
-type XmlDoc = 
+type XmlDoc =
     | XmlDoc of string[]
     static member Empty = XmlDocStatics.Empty
     static member Merge (XmlDoc lines) (XmlDoc lines') = XmlDoc (Array.append lines lines')
-    static member Process (XmlDoc lines) = 
+    static member Process (XmlDoc lines) =
         // This code runs for .XML generation and thus influences cross-project xmldoc tooltips; for within-project tooltips, see XmlDocumentation.fs in the language service
         let rec processLines (lines:string list) =
-            match lines with 
+            match lines with
             | [] -> []
             | (lineA::rest) as lines ->
                 let lineAT = lineA.TrimStart([|' '|])
                 if lineAT = "" then processLines rest
                 else if String.hasPrefix lineAT "<" then lines
-                else ["<summary>"] @     
+                else ["<summary>"] @
                      (lines |> List.map (fun line -> Microsoft.FSharp.Core.XmlAdapters.escape(line))) @
-                     ["</summary>"]               
+                     ["</summary>"]
 
         let lines = processLines (Array.toList lines)
-        if lines.Length = 0 then XmlDoc.Empty 
+        if lines.Length = 0 then XmlDoc.Empty
         else XmlDoc (Array.ofList lines)
 
 // Discriminated unions can't contain statics, so we use a separate type
-and XmlDocStatics() = 
+and XmlDocStatics() =
     static let empty = XmlDoc[| |]
     static member Empty = empty
 
-type PreXmlDoc = 
+type PreXmlDoc =
     | PreXmlMerge of PreXmlDoc * PreXmlDoc
     | PreXmlDoc of pos * XmlDocCollector
-    | PreXmlDocEmpty 
+    | PreXmlDocEmpty
 
-    member x.ToXmlDoc() = 
-        match x with 
+    member x.ToXmlDoc() =
+        match x with
         | PreXmlMerge(a,b) -> XmlDoc.Merge (a.ToXmlDoc()) (b.ToXmlDoc())
         | PreXmlDocEmpty -> XmlDoc.Empty
-        | PreXmlDoc (pos,collector) -> 
+        | PreXmlDoc (pos,collector) ->
             let lines = collector.LinesBefore pos
             if lines.Length = 0 then XmlDoc.Empty
             else XmlDoc lines
 
-    static member CreateFromGrabPoint(collector:XmlDocCollector,grabPointPos) = 
+    static member CreateFromGrabPoint(collector:XmlDocCollector,grabPointPos) =
         collector.AddGrabPoint grabPointPos
         PreXmlDoc(grabPointPos,collector)
 
-    static member Empty = PreXmlDocEmpty 
+    static member Empty = PreXmlDocEmpty
     static member Merge a b = PreXmlMerge (a,b)
 
 type ParserDetail =
@@ -137,20 +137,20 @@ type ParserDetail =
 [<System.Diagnostics.DebuggerDisplay("{idText}")>]
 [<Sealed>]
 [<NoEquality; NoComparison>]
-type Ident (text,range) = 
+type Ident (text,range) =
      member x.idText = text
      member x.idRange = range
      override x.ToString() = text
 
 type LongIdent = Ident list
 type LongIdentWithDots =
-    /// LongIdentWithDots(lid, dotms)   
+    /// LongIdentWithDots(lid, dotms)
     /// Typically dotms.Length = lid.Length-1, but they may be same if (incomplete) code ends in a dot, e.g. "Foo.Bar."
-    /// The dots mostly matter for parsing, and are typically ignored by the typechecker, but 
+    /// The dots mostly matter for parsing, and are typically ignored by the typechecker, but
     /// if dotms.Length = lid.Length, then the parser must have reported an error, so the typechecker is allowed
     /// more freedom about typechecking these expressions.
     /// LongIdent can be empty list - it is used to denote that name of some AST element is absent (i.e. empty type name in inherit)
-    | LongIdentWithDots of LongIdent * range list
+    | LongIdentWithDots of id:LongIdent * dotms:range list
     with member this.Range =
             match this with
             | LongIdentWithDots([],_) -> failwith "rangeOfLidwd"
@@ -164,21 +164,21 @@ type LongIdentWithDots =
             match this with
             | LongIdentWithDots([],_) -> failwith "rangeOfLidwd"
             | LongIdentWithDots([id],_) -> id.idRange
-            | LongIdentWithDots(h::t,dotms) -> 
+            | LongIdentWithDots(h::t,dotms) ->
                 let nonExtraDots = if dotms.Length = t.Length then dotms else List.take t.Length dotms
                 unionRanges h.idRange (List.last t).idRange |> unionRanges (List.last nonExtraDots)
 
 //------------------------------------------------------------------------
-//  AST: the grammar of implicitly scoped type parameters 
+//  AST: the grammar of implicitly scoped type parameters
 //-----------------------------------------------------------------------
 
-type TyparStaticReq = 
-    | NoStaticReq 
-    | HeadTypeStaticReq 
+type TyparStaticReq =
+    | NoStaticReq
+    | HeadTypeStaticReq
 
 [<NoEquality; NoComparison>]
-type SynTypar = 
-    | Typar of Ident * TyparStaticReq * (* isCompGen: *) bool 
+type SynTypar =
+    | Typar of id:Ident * staticReq:TyparStaticReq * isCompGen:bool
     with member this.Range =
             match this with
             | Typar(id,_,_) ->
@@ -188,10 +188,10 @@ type SynTypar =
 //  AST: the grammar of constants and measures
 //-----------------------------------------------------------------------
 
-type 
+type
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     /// The unchecked abstract syntax tree of constants in F# types and expressions.
-    SynConst = 
+    SynConst =
     /// F# syntax: ()
     | Unit
     /// F# syntax: true, false
@@ -227,42 +227,42 @@ type
     /// UserNum(value, suffix)
     ///
     /// F# syntax: 1Q, 1Z, 1R, 1N, 1G
-    | UserNum of ( string * string)
+    | UserNum of  (string * string)
     /// F# syntax: verbatim or regular string, e.g. "abc"
-    | String of string * range 
+    | String of text:string * range:range
     /// F# syntax: verbatim or regular byte string, e.g. "abc"B.
     ///
-    /// Also used internally in the typechecker once an array of unit16 constants 
-    /// is detected, to allow more efficient processing of large arrays of uint16 constants. 
-    | Bytes of byte[] * range 
-    /// Used internally in the typechecker once an array of unit16 constants 
-    /// is detected, to allow more efficient processing of large arrays of uint16 constants. 
-    | UInt16s of uint16[] 
+    /// Also used internally in the typechecker once an array of unit16 constants
+    /// is detected, to allow more efficient processing of large arrays of uint16 constants.
+    | Bytes of bytes:byte[] * range:range
+    /// Used internally in the typechecker once an array of unit16 constants
+    /// is detected, to allow more efficient processing of large arrays of uint16 constants.
+    | UInt16s of uint16[]
     /// Old comment: "we never iterate, so the const here is not another SynConst.Measure"
-    | Measure of SynConst * SynMeasure 
-    member c.Range dflt = 
-        match c with 
-        | SynConst.String (_,m0) | SynConst.Bytes (_,m0) -> m0 
+    | Measure of constant:SynConst * SynMeasure
+    member c.Range dflt =
+        match c with
+        | SynConst.String (_,m0) | SynConst.Bytes (_,m0) -> m0
         | _ -> dflt
-      
-and  
-    [<NoEquality; NoComparison; RequireQualifiedAccess>]
-    /// The unchecked abstract syntax tree of F# unit of measure annotations. 
-    /// This should probably be merged with the representation of SynType.
-    SynMeasure = 
-    | Named of LongIdent * range
-    | Product of SynMeasure * SynMeasure * range
-    | Seq of SynMeasure list * range
-    | Divide of SynMeasure * SynMeasure * range
-    | Power of SynMeasure * SynRationalConst * range
-    | One 
-    | Anon of range
-    | Var of SynTypar * range
 
 and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
-    /// The unchecked abstract syntax tree of F# unit of measure exponents. 
-    SynRationalConst = 
+    /// The unchecked abstract syntax tree of F# unit of measure annotations.
+    /// This should probably be merged with the representation of SynType.
+    SynMeasure =
+    | Named of longId:LongIdent * range:range
+    | Product of SynMeasure * SynMeasure * range:range
+    | Seq of SynMeasure list * range:range
+    | Divide of SynMeasure * SynMeasure * range:range
+    | Power of SynMeasure * SynRationalConst * range:range
+    | One
+    | Anon of range
+    | Var of SynTypar * range:range
+
+and
+    [<NoEquality; NoComparison; RequireQualifiedAccess>]
+    /// The unchecked abstract syntax tree of F# unit of measure exponents.
+    SynRationalConst =
     | Integer of int32
     | Rational of int32 * int32 * range
     | Negate of SynRationalConst
@@ -273,48 +273,48 @@ and
 //-----------------------------------------------------------------------
 
 [<RequireQualifiedAccess>]
-type SynAccess = 
+type SynAccess =
     | Public
     | Internal
     | Private
 
 
-type SequencePointInfoForTarget = 
+type SequencePointInfoForTarget =
     | SequencePointAtTarget
     | SuppressSequencePointAtTarget
 
-type SequencePointInfoForSeq = 
+type SequencePointInfoForSeq =
     | SequencePointsAtSeq
     // This means "suppress a in 'a;b'" and "suppress b in 'a before b'"
     | SuppressSequencePointOnExprOfSequential
     // This means "suppress b in 'a;b'" and "suppress a in 'a before b'"
     | SuppressSequencePointOnStmtOfSequential
 
-type SequencePointInfoForTry = 
+type SequencePointInfoForTry =
     | SequencePointAtTry of range
     // Used for "use" and "for"
-    | SequencePointInBodyOfTry 
+    | SequencePointInBodyOfTry
     | NoSequencePointAtTry
 
-type SequencePointInfoForWith = 
+type SequencePointInfoForWith =
     | SequencePointAtWith of range
     | NoSequencePointAtWith
 
-type SequencePointInfoForFinally = 
+type SequencePointInfoForFinally =
     | SequencePointAtFinally of range
     | NoSequencePointAtFinally
 
-type SequencePointInfoForForLoop = 
+type SequencePointInfoForForLoop =
     | SequencePointAtForLoop of range
     | NoSequencePointAtForLoop
-    
-type SequencePointInfoForWhileLoop = 
+
+type SequencePointInfoForWhileLoop =
     | SequencePointAtWhileLoop of range
     | NoSequencePointAtWhileLoop
-    
-type SequencePointInfoForBinding = 
+
+type SequencePointInfoForBinding =
     | SequencePointAtBinding of range
-    // Indicates the omission of a sequence point for a binding for a 'do expr' 
+    // Indicates the omission of a sequence point for a binding for a 'do expr'
     | NoSequencePointAtDoBinding
     // Indicates the omission of a sequence point for a binding for a 'let e = expr' where 'expr' has immediate control flow
     | NoSequencePointAtLetBinding
@@ -324,22 +324,22 @@ type SequencePointInfoForBinding =
     // The let bindings are 'sticky' in that the inversion of the inlining would involve
     // replacing the entire expression with the original and not just the let bindings alone.
     | NoSequencePointAtStickyBinding
-    // Given 'let v = e1 in e2', where this is a compiler generated binding, 
+    // Given 'let v = e1 in e2', where this is a compiler generated binding,
     // we are sometimes forced to generate a sequence point for the expression anyway based on its
     // overall range. If the let binding is given the flag below then it is asserting that
     // the binding has no interesting side effects and can be totally ignored and the range
     // of the inner expression is used instead
     | NoSequencePointAtInvisibleBinding
-    
+
     // Don't drop sequence points when combining sequence points
-    member x.Combine(y:SequencePointInfoForBinding) = 
-        match x,y with 
+    member x.Combine(y:SequencePointInfoForBinding) =
+        match x,y with
         | SequencePointAtBinding _ as g, _  -> g
         | _, (SequencePointAtBinding _ as g)  -> g
         | _ -> x
 
 /// Indicates if a for loop is 'for x in e1 -> e2', only valid in sequence expressions
-type SeqExprOnly = 
+type SeqExprOnly =
     | SeqExprOnly of bool
 
 /// denotes location of the separator block + optional position of the semicolon (used for tooling support)
@@ -348,58 +348,58 @@ type BlockSeparator = range * pos option
 type RecordFieldName = LongIdentWithDots * bool
 
 type ExprAtomicFlag =
-    /// Says that the expression is an atomic expression, i.e. is of a form that has no whitespace unless 
+    /// Says that the expression is an atomic expression, i.e. is of a form that has no whitespace unless
     /// enclosed in parentheses, e.g. 1, "3", ident, ident.[expr] and (expr). If an atomic expression has
     /// type T, then the largest expression ending at the same range as the atomic expression also has type T.
     | Atomic = 0
     | NonAtomic = 1
 
 /// The kind associated with a binding - "let", "do" or a standalone expression
-type SynBindingKind = 
+type SynBindingKind =
     /// A standalone expression in a module
     | StandaloneExpression
     /// A normal 'let' binding in a module
     | NormalBinding
     /// A 'do' binding in a module. Must have type 'unit'
     | DoBinding
-  
+
 type
     [<NoEquality; NoComparison>]
     /// Represents the explicit declaration of a type parameter
-    SynTyparDecl = 
-    | TyparDecl of SynAttributes * SynTypar
+    SynTyparDecl =
+    | TyparDecl of attributes:SynAttributes * SynTypar
 
 
-and 
+and
     [<NoEquality; NoComparison>]
     /// The unchecked abstract syntax tree of F# type constraints
     SynTypeConstraint =
     /// F# syntax : is 'typar : struct
-    | WhereTyparIsValueType of SynTypar * range
+    | WhereTyparIsValueType of genericName:SynTypar * range:range
     /// F# syntax : is 'typar : not struct
-    | WhereTyparIsReferenceType of SynTypar * range
+    | WhereTyparIsReferenceType of genericName:SynTypar * range:range
     /// F# syntax is 'typar : unmanaged
-    | WhereTyparIsUnmanaged of SynTypar * range
+    | WhereTyparIsUnmanaged of genericName:SynTypar * range:range
     /// F# syntax is 'typar : null
-    | WhereTyparSupportsNull of SynTypar * range
-    /// F# syntax is 'typar : comparison 
-    | WhereTyparIsComparable of SynTypar * range
+    | WhereTyparSupportsNull of genericName:SynTypar * range:range
+    /// F# syntax is 'typar : comparison
+    | WhereTyparIsComparable of genericName:SynTypar * range:range
     /// F# syntax is 'typar : equality
-    | WhereTyparIsEquatable of SynTypar * range
+    | WhereTyparIsEquatable of genericName:SynTypar * range:range
     /// F# syntax is default ^T : type
-    | WhereTyparDefaultsToType of SynTypar * SynType * range
+    | WhereTyparDefaultsToType of genericName:SynTypar * typeSig:SynType * range:range
     /// F# syntax is 'typar :> type
-    | WhereTyparSubtypeOfType of SynTypar *  SynType * range
-    /// F# syntax is ^T : (static member MemberName : ^T * int -> ^T) 
-    | WhereTyparSupportsMember of SynType list * SynMemberSig * range
+    | WhereTyparSubtypeOfType of genericName:SynTypar *  typeSig:SynType * range:range
+    /// F# syntax is ^T : (static member MemberName : ^T * int -> ^T)
+    | WhereTyparSupportsMember of genericNames:SynType list * memberSig:SynMemberSig * range:range
     /// F# syntax is 'typar : enum<'UnderlyingType>
-    | WhereTyparIsEnum of SynTypar * SynType list * range
+    | WhereTyparIsEnum of genericName:SynTypar * enumTypes:SynType list * range:range
     /// F# syntax is 'typar : delegate<'Args,unit>
-    | WhereTyparIsDelegate of SynTypar * SynType list * range
+    | WhereTyparIsDelegate of genericName:SynTypar * delegateTypes:SynType list * range:range
 
-and 
+and
     [<NoEquality; NoComparison;RequireQualifiedAccess>]
-    /// The unchecked abstract syntax tree of F# types 
+    /// The unchecked abstract syntax tree of F# types
     SynType =
     /// F# syntax : A.B.C
     | LongIdent of LongIdentWithDots
@@ -408,55 +408,66 @@ and
     /// F# syntax : type<type, ..., type> or type type or (type,...,type) type
     ///   isPostfix: indicates a postfix type application e.g. "int list" or "(int,string) dict"
     ///   commasm: ranges for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
-    | App of SynType * range option * SynType list * range list * range option * bool * range
+    | App of typeName:SynType * leftAngleRange:range option * typeArgs:SynType list * commaRanges:range list * rightAngleRange:range option * isPostfix:bool * range:range
     /// LongIdentApp(typeName, longId, LESSm, tyArgs, commasm, GREATERm, wholem)
     ///
     /// F# syntax : type.A.B.C<type, ..., type>
     ///   commasm: ranges for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
-    | LongIdentApp of SynType * LongIdentWithDots * range option * SynType list * range list * range option * range
+    | LongIdentApp of typeName:SynType * dotId:LongIdentWithDots * leftAngleRange:range option * genericNames:SynType list * commaRanges:range list * rightAngleRange:range option * range:range
 
     /// F# syntax : type * ... * type
     // the bool is true if / rather than * follows the type
-    | Tuple of (bool*SynType) list * range    
+    | Tuple of (bool*SynType) list * range:range
 
     /// F# syntax : struct (type * ... * type)
     // the bool is true if / rather than * follows the type
-    | StructTuple of (bool*SynType) list * range    
+    | StructTuple of (bool*SynType) list * range:range
 
     /// F# syntax : type[]
-    | Array of  int * SynType * range
+    | Array of  int * elementType:SynType * range:range
     /// F# syntax : type -> type
-    | Fun of  SynType * SynType * range
+    | Fun of  argType:SynType * returnType:SynType * range:range
     /// F# syntax : 'Var
-    | Var of SynTypar * range
+    | Var of SynTypar * range:range
     /// F# syntax : _
-    | Anon of range
+    | Anon of range:range
     /// F# syntax : typ with constraints
-    | WithGlobalConstraints of SynType * SynTypeConstraint list * range
+    | WithGlobalConstraints of typeName:SynType * constraints:SynTypeConstraint list * range:range
     /// F# syntax : #type
-    | HashConstraint of SynType * range
-    /// F# syntax : for units of measure e.g. m / s 
-    | MeasureDivide of SynType * SynType * range       
+    | HashConstraint of typeName:SynType * range:range
+    /// F# syntax : for units of measure e.g. m / s
+    | MeasureDivide of typeName:SynType * SynType * range:range
     /// F# syntax : for units of measure e.g. m^3, kg^1/2
-    | MeasurePower of SynType * SynRationalConst * range      
+    | MeasurePower of typeName:SynType * SynRationalConst * range:range
     /// F# syntax : 1, "abc" etc, used in parameters to type providers
     /// For the dimensionless units i.e. 1 , and static parameters to provided types
-    | StaticConstant of SynConst * range          
+    | StaticConstant of constant:SynConst * range:range
     /// F# syntax : const expr, used in static parameters to type providers
-    | StaticConstantExpr of SynExpr * range
+    | StaticConstantExpr of expr:SynExpr * range:range
     /// F# syntax : ident=1 etc., used in static parameters to type providers
-    | StaticConstantNamed of SynType * SynType * range
+    | StaticConstantNamed of SynType * SynType * range:range
     /// Get the syntactic range of source code covered by this construct.
-    member x.Range = 
-        match x with 
+    member x.Range =
+        match x with
+        | SynType.App (range=m)
+        | SynType.LongIdentApp (range=m)
+        | SynType.Tuple (range=m)
+        | SynType.StructTuple (range=m)
+        | SynType.Array (range=m)
+        | SynType.Fun (range=m)
+        | SynType.Var (range=m)
+        | SynType.Anon (range=m)
+        | SynType.WithGlobalConstraints (range=m)
+        | SynType.StaticConstant (range=m)
+        | SynType.StaticConstantExpr (range=m)
+        | SynType.StaticConstantNamed (range=m)
+        | SynType.HashConstraint (range=m)
+        | SynType.MeasureDivide (range=m)
+        | SynType.MeasurePower (range=m) -> m
         | SynType.LongIdent(lidwd) -> lidwd.Range
-        | SynType.App(_,_,_,_,_,_,m) | SynType.LongIdentApp(_,_,_,_,_,_,m) | SynType.Tuple(_,m) | SynType.StructTuple(_,m) | SynType.Array(_,_,m) | SynType.Fun(_,_,m)
-        | SynType.Var(_,m) | SynType.Anon m | SynType.WithGlobalConstraints(_,_,m)
-        | SynType.StaticConstant(_,m) | SynType.StaticConstantExpr(_,m) | SynType.StaticConstantNamed(_,_,m)
-        | SynType.HashConstraint(_,m) | SynType.MeasureDivide(_,_,m) | SynType.MeasurePower(_,_,m) -> m
 
-    
-and  
+
+and
     [<NoEquality; NoComparison;RequireQualifiedAccess>]
     SynExpr =
 
@@ -464,244 +475,244 @@ and
     ///
     /// Paren(expr, leftParenRange, rightParenRange, wholeRangeIncludingParentheses)
     ///
-    /// Parenthesized expressions. Kept in AST to distinguish A.M((x,y)) 
+    /// Parenthesized expressions. Kept in AST to distinguish A.M((x,y))
     /// from A.M(x,y), among other things.
-    | Paren of SynExpr * range * range option * range  
+    | Paren of expr:SynExpr * leftParenRange:range * rightParenRange:range option * range:range
 
     /// F# syntax: <@ expr @>, <@@ expr @@>
-    /// 
+    ///
     /// Quote(operator,isRaw,quotedSynExpr,isFromQueryExpression,m)
-    | Quote of SynExpr * bool * SynExpr * bool * range 
+    | Quote of operator:SynExpr * isRaw:bool * quotedSynExpr:SynExpr * isFromQueryExpression:bool * range:range
 
     /// F# syntax: 1, 1.3, () etc.
-    | Const of SynConst * range
+    | Const of constant:SynConst * range:range
 
     /// F# syntax: expr : type
-    | Typed of  SynExpr * SynType * range
+    | Typed of  expr:SynExpr * typeSig:SynType * range:range
 
     /// F# syntax: e1, ..., eN
-    | Tuple of  SynExpr list * range list * range  // "range list" is for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
+    | Tuple of  exprs:SynExpr list * commaRanges:range list * range:range  // "range list" is for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
 
     /// F# syntax: struct (e1, ..., eN)
-    | StructTuple of  SynExpr list * range list * range  // "range list" is for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
+    | StructTuple of  SynExpr list * range list * range:range  // "range list" is for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
 
     /// F# syntax: [ e1; ...; en ], [| e1; ...; en |]
-    | ArrayOrList of  bool * SynExpr list * range 
+    | ArrayOrList of  isList:bool * exprs:SynExpr list * range:range
 
     /// F# syntax: { f1=e1; ...; fn=en }
     /// SynExpr.Record((baseType, baseCtorArgs, mBaseCtor, sepAfterBase, mInherits), (copyExpr, sepAfterCopyExpr), (recordFieldName, fieldValue, sepAfterField), mWholeExpr)
-    /// inherit includes location of separator (for tooling) 
+    /// inherit includes location of separator (for tooling)
     /// copyOpt contains range of the following WITH part (for tooling)
     /// every field includes range of separator after the field (for tooling)
-    | Record of (SynType * SynExpr * range * BlockSeparator option * range) option * (SynExpr * BlockSeparator) option * (RecordFieldName * (SynExpr option) * BlockSeparator option) list * range
+    | Record of baseInfo:(SynType * SynExpr * range * BlockSeparator option * range) option * copyInfo:(SynExpr * BlockSeparator) option * recordFields:(RecordFieldName * (SynExpr option) * BlockSeparator option) list * range:range
 
     /// F# syntax: new C(...)
-    /// The flag is true if known to be 'family' ('protected') scope 
-    | New of bool * SynType * SynExpr * range 
+    /// The flag is true if known to be 'family' ('protected') scope
+    | New of isProtected:bool * typeName:SynType * expr:SynExpr * range:range
 
     /// SynExpr.ObjExpr(objTy,argOpt,binds,extraImpls,mNewExpr,mWholeExpr)
     ///
     /// F# syntax: { new ... with ... }
-    | ObjExpr of SynType * (SynExpr * Ident option) option * SynBinding list * SynInterfaceImpl list * range * range
+    | ObjExpr of objType:SynType * argOpt:(SynExpr * Ident option) option * bindings:SynBinding list * extraImpls:SynInterfaceImpl list * newPos:range * range:range
 
     /// F# syntax: 'while ... do ...'
-    | While of SequencePointInfoForWhileLoop * SynExpr * SynExpr * range
+    | While of spWhile:SequencePointInfoForWhileLoop * whileBody:SynExpr * doBody:SynExpr * range:range
 
     /// F# syntax: 'for i = ... to ... do ...'
-    | For of SequencePointInfoForForLoop * Ident * SynExpr * bool * SynExpr * SynExpr * range
+    | For of spFor:SequencePointInfoForForLoop * id:Ident * idBody:SynExpr * bool * toBody:SynExpr * doBody:SynExpr * range:range
 
     /// SynExpr.ForEach (spBind, seqExprOnly, isFromSource, pat, enumExpr, bodyExpr, mWholeExpr).
     ///
     /// F# syntax: 'for ... in ... do ...'
-    | ForEach of SequencePointInfoForForLoop * SeqExprOnly * bool * SynPat * SynExpr * SynExpr * range
+    | ForEach of spFor:SequencePointInfoForForLoop * seqExprOnly:SeqExprOnly * isFromSource:bool * pattern:SynPat * enumExpr:SynExpr * bodyExpr:SynExpr * range:range
 
     /// F# syntax: [ expr ], [| expr |]
-    | ArrayOrListOfSeqExpr of bool * SynExpr * range
+    | ArrayOrListOfSeqExpr of isList:bool * elements:SynExpr * range:range
 
     /// CompExpr(isArrayOrList, isNotNakedRefCell, expr)
     ///
     /// F# syntax: { expr }
-    | CompExpr of bool * bool ref * SynExpr * range
+    | CompExpr of isArrayOrList:bool * isNotNakedRefCell:bool ref * expr:SynExpr * range:range
 
-    /// First bool indicates if lambda originates from a method. Patterns here are always "simple" 
+    /// First bool indicates if lambda originates from a method. Patterns here are always "simple"
     /// Second bool indicates if this is a "later" part of an iterated sequence of lambdas
     ///
     /// F# syntax: fun pat -> expr
-    | Lambda of  bool * bool * SynSimplePats * SynExpr * range 
+    | Lambda of  fromMethod:bool * inLambdaSeq:bool * args:SynSimplePats * body:SynExpr * range:range
 
     /// F# syntax: function pat1 -> expr | ... | patN -> exprN
-    | MatchLambda of bool * range * SynMatchClause list * SequencePointInfoForBinding * range
+    | MatchLambda of bool * range * clauses:SynMatchClause list * spBind:SequencePointInfoForBinding * range:range
 
     /// F# syntax: match expr with pat1 -> expr | ... | patN -> exprN
-    | Match of  SequencePointInfoForBinding * SynExpr * SynMatchClause list * bool * range (* bool indicates if this is an exception match in a computation expression which throws unmatched exceptions *)
+    | Match of  spBind:SequencePointInfoForBinding * matchExpr:SynExpr * clauses:SynMatchClause list * isCexprExceptionMatch:bool * range:range (* bool indicates if this is an exception match in a computation expression which throws unmatched exceptions *)
 
-    /// F# syntax: do expr 
-    | Do of  SynExpr * range
+    /// F# syntax: do expr
+    | Do of  expr:SynExpr * range:range
 
-    /// F# syntax: assert expr 
-    | Assert of SynExpr * range
+    /// F# syntax: assert expr
+    | Assert of expr:SynExpr * range:range
 
     /// App(exprAtomicFlag, isInfix, funcExpr, argExpr, m)
     ///  - exprAtomicFlag: indicates if the application is syntactically atomic, e.g. f.[1] is atomic, but 'f x' is not
-    ///  - isInfix is true for the first app of an infix operator, e.g. 1+2 becomes App(App(+,1),2), where the inner node is marked isInfix 
+    ///  - isInfix is true for the first app of an infix operator, e.g. 1+2 becomes App(App(+,1),2), where the inner node is marked isInfix
     ///      (or more generally, for higher operator fixities, if App(x,y) is such that y comes before x in the source code, then the node is marked isInfix=true)
     ///
     /// F# syntax: f x
-    | App of ExprAtomicFlag * bool * SynExpr * SynExpr * range
+    | App of exprAtomicFlag:ExprAtomicFlag * isInfix:bool * funcExpr:SynExpr * argExpr:SynExpr * range:range
 
-    /// TypeApp(expr, mLessThan, types, mCommas, mGreaterThan, mTypeArgs, mWholeExpr) 
+    /// TypeApp(expr, mLessThan, types, mCommas, mGreaterThan, mTypeArgs, mWholeExpr)
     ///     "mCommas" are the ranges for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
     ///
     /// F# syntax: expr<type1,...,typeN>
-    | TypeApp of SynExpr * range * SynType list * range list * range option * range * range
+    | TypeApp of expr:SynExpr * leftAngleRange:range * typeNames:SynType list * commaRanges:range list * rightAngleRange:range option * typeArgs:range * range:range
 
     /// LetOrUse(isRecursive, isUse, bindings, body, wholeRange)
     ///
-    /// F# syntax: let pat = expr in expr 
-    /// F# syntax: let f pat1 .. patN = expr in expr 
-    /// F# syntax: let rec f pat1 .. patN = expr in expr 
-    /// F# syntax: use pat = expr in expr 
-    | LetOrUse of bool * bool * SynBinding list * SynExpr * range
+    /// F# syntax: let pat = expr in expr
+    /// F# syntax: let f pat1 .. patN = expr in expr
+    /// F# syntax: let rec f pat1 .. patN = expr in expr
+    /// F# syntax: use pat = expr in expr
+    | LetOrUse of isRecursive:bool * isUse:bool * bindings:SynBinding list * exprBody:SynExpr * range:range
 
     /// F# syntax: try expr with pat -> expr
-    | TryWith of SynExpr * range * SynMatchClause list * range * range * SequencePointInfoForTry * SequencePointInfoForWith
+    | TryWith of tryExpr:SynExpr * range * SynMatchClause list * range * range:range * spTry:SequencePointInfoForTry * spWith:SequencePointInfoForWith
 
     /// F# syntax: try expr finally expr
-    | TryFinally of SynExpr * SynExpr * range * SequencePointInfoForTry * SequencePointInfoForFinally
+    | TryFinally of tryExpr:SynExpr * finallyExpr:SynExpr * range:range * spTry:SequencePointInfoForTry * spFinally:SequencePointInfoForFinally
 
     /// F# syntax: lazy expr
-    | Lazy of SynExpr * range
+    | Lazy of expr:SynExpr * range:range
 
     /// Seq(seqPoint, isTrueSeq, e1, e2, m)
-    ///  isTrueSeq: false indicates "let v = a in b; v" 
+    ///  isTrueSeq: false indicates "let v = a in b; v"
     ///
     /// F# syntax: expr; expr
-    | Sequential of SequencePointInfoForSeq * bool * SynExpr * SynExpr * range 
+    | Sequential of spSeq:SequencePointInfoForSeq * isTrueSeq:bool * expr1:SynExpr * expr2:SynExpr * range:range
 
     ///  IfThenElse(exprGuard,exprThen,optionalExprElse,spIfToThen,isFromErrorRecovery,mIfToThen,mIfToEndOfLastBranch)
     ///
     /// F# syntax: if expr then expr
     /// F# syntax: if expr then expr else expr
-    | IfThenElse of SynExpr * SynExpr * SynExpr option * SequencePointInfoForBinding * bool * range * range
+    | IfThenElse of exprGuard:SynExpr * exprThen:SynExpr * optionalExprElse:SynExpr option * spIfToThen:SequencePointInfoForBinding * isFromErrorRecovery:bool * ifToThen:range * range:range
 
     /// F# syntax: ident
-    /// Optimized representation, = SynExpr.LongIdent(false,[id],id.idRange) 
-    | Ident of Ident 
+    /// Optimized representation, = SynExpr.LongIdent(false,[id],id.idRange)
+    | Ident of Ident
 
     /// F# syntax: ident.ident...ident
     /// LongIdent(isOptional, longIdent, altNameRefCell, m)
-    ///   isOptional: true if preceded by a '?' for an optional named parameter 
+    ///   isOptional: true if preceded by a '?' for an optional named parameter
     ///   altNameRefCell: Normally 'None' except for some compiler-generated variables in desugaring pattern matching. See SynSimplePat.Id
-    | LongIdent of bool * LongIdentWithDots * SynSimplePatAlternativeIdInfo ref option * range  
+    | LongIdent of isOptional:bool * longIdent:LongIdentWithDots * altNameRefCell:SynSimplePatAlternativeIdInfo ref option * range:range
 
     /// F# syntax: ident.ident...ident <- expr
-    | LongIdentSet of LongIdentWithDots * SynExpr * range
+    | LongIdentSet of dotId:LongIdentWithDots * expr:SynExpr * range:range
 
     /// DotGet(expr, rangeOfDot, lid, wholeRange)
     ///
     /// F# syntax: expr.ident.ident
-    | DotGet of SynExpr * range * LongIdentWithDots * range
+    | DotGet of expr:SynExpr * rangeOfDot:range * dotId:LongIdentWithDots * range:range
 
     /// F# syntax: expr.ident...ident <- expr
-    | DotSet of SynExpr * LongIdentWithDots * SynExpr * range
+    | DotSet of expr:SynExpr * dotId:LongIdentWithDots * exprValue:SynExpr * range:range
 
-    /// F# syntax: expr.[expr,...,expr] 
-    | DotIndexedGet of SynExpr * SynIndexerArg list * range * range
+    /// F# syntax: expr.[expr,...,expr]
+    | DotIndexedGet of expr:SynExpr * indexExprs:SynIndexerArg list * range * range:range
 
     /// DotIndexedSet (objectExpr, indexExprs, valueExpr, rangeOfLeftOfSet, rangeOfDot, rangeOfWholeExpr)
     ///
     /// F# syntax: expr.[expr,...,expr] <- expr
-    | DotIndexedSet of SynExpr * SynIndexerArg list * SynExpr * range * range * range
+    | DotIndexedSet of objectExpr:SynExpr * indexExprs:SynIndexerArg list * valueExpr:SynExpr * rangeOfLeftOfSet:range * rangeOfDot:range * range:range
 
     /// F# syntax: Type.Items(e1) <- e2 , rarely used named-property-setter notation, e.g. Foo.Bar.Chars(3) <- 'a'
-    | NamedIndexedPropertySet of LongIdentWithDots * SynExpr * SynExpr * range
+    | NamedIndexedPropertySet of LongIdentWithDots * SynExpr * SynExpr * range:range
 
     /// F# syntax: expr.Items(e1) <- e2 , rarely used named-property-setter notation, e.g. (stringExpr).Chars(3) <- 'a'
-    | DotNamedIndexedPropertySet of SynExpr * LongIdentWithDots * SynExpr * SynExpr * range
+    | DotNamedIndexedPropertySet of SynExpr * LongIdentWithDots * SynExpr * SynExpr * range:range
 
     /// F# syntax: expr :? type
-    | TypeTest of  SynExpr * SynType * range
+    | TypeTest of  expr:SynExpr * typeName:SynType * range:range
 
-    /// F# syntax: expr :> type 
-    | Upcast of  SynExpr * SynType * range
+    /// F# syntax: expr :> type
+    | Upcast of  expr:SynExpr * typeSig:SynType * range:range
 
-    /// F# syntax: expr :?> type 
-    | Downcast of  SynExpr * SynType * range
+    /// F# syntax: expr :?> type
+    | Downcast of  expr:SynExpr * typeName:SynType * range:range
 
     /// F# syntax: upcast expr
-    | InferredUpcast of  SynExpr * range
+    | InferredUpcast of  expr:SynExpr * range:range
 
     /// F# syntax: downcast expr
-    | InferredDowncast of  SynExpr * range
+    | InferredDowncast of  expr:SynExpr * range:range
 
     /// F# syntax: null
-    | Null of range
+    | Null of range:range
 
     /// F# syntax: &expr, &&expr
-    | AddressOf of  bool * SynExpr * range * range
+    | AddressOf of  bool * SynExpr * range * range:range
 
     /// F# syntax: ((typar1 or ... or typarN): (member-dig) expr)
-    | TraitCall of SynTypar list * SynMemberSig * SynExpr * range
+    | TraitCall of SynTypar list * SynMemberSig * SynExpr * range:range
 
-    /// F# syntax: ... in ... 
+    /// F# syntax: ... in ...
     /// Computation expressions only, based on JOIN_IN token from lex filter
-    | JoinIn of SynExpr * range * SynExpr * range 
+    | JoinIn of SynExpr * inPos:range * SynExpr * range:range
 
     /// F# syntax: <implicit>
     /// Computation expressions only, implied by final "do" or "do!"
-    | ImplicitZero of range 
+    | ImplicitZero of range:range
 
-    /// F# syntax: yield expr 
-    /// F# syntax: return expr 
+    /// F# syntax: yield expr
+    /// F# syntax: return expr
     /// Computation expressions only
-    | YieldOrReturn   of (bool * bool) * SynExpr * range
+    | YieldOrReturn   of (bool * bool) * expr:SynExpr * range:range
 
-    /// F# syntax: yield! expr 
-    /// F# syntax: return! expr 
+    /// F# syntax: yield! expr
+    /// F# syntax: return! expr
     /// Computation expressions only
-    | YieldOrReturnFrom  of (bool * bool) * SynExpr * range
+    | YieldOrReturnFrom  of (bool * bool) * expr:SynExpr * range:range
 
     /// SynExpr.LetOrUseBang(spBind, isUse, isFromSource, pat, rhsExpr, bodyExpr, mWholeExpr).
     ///
     /// F# syntax: let! pat = expr in expr
     /// F# syntax: use! pat = expr in expr
     /// Computation expressions only
-    | LetOrUseBang    of SequencePointInfoForBinding * bool * bool * SynPat * SynExpr * SynExpr * range
+    | LetOrUseBang    of spBind:SequencePointInfoForBinding * isUse:bool * isFromSource:bool * pattern:SynPat * rhsExpr:SynExpr * bodyExpr:SynExpr * range:range
 
-    /// F# syntax: do! expr 
+    /// F# syntax: do! expr
     /// Computation expressions only
-    | DoBang      of SynExpr * range
+    | DoBang      of expr:SynExpr * range:range
 
     /// Only used in FSharp.Core
-    | LibraryOnlyILAssembly of ILInstr array *  SynType list * SynExpr list * SynType list * range (* Embedded IL assembly code *)
+    | LibraryOnlyILAssembly of ILInstr array *  SynType list * SynExpr list * SynType list * range:range (* Embedded IL assembly code *)
 
     /// Only used in FSharp.Core
-    | LibraryOnlyStaticOptimization of SynStaticOptimizationConstraint list * SynExpr * SynExpr * range
+    | LibraryOnlyStaticOptimization of SynStaticOptimizationConstraint list * SynExpr * SynExpr * range:range
 
     /// Only used in FSharp.Core
-    | LibraryOnlyUnionCaseFieldGet of SynExpr * LongIdent * int * range
+    | LibraryOnlyUnionCaseFieldGet of SynExpr * longId:LongIdent * int * range:range
 
     /// Only used in FSharp.Core
-    | LibraryOnlyUnionCaseFieldSet of SynExpr * LongIdent * int * SynExpr * range
-  
-    /// Inserted for error recovery
-    | ArbitraryAfterError  of (*debugStr:*) string * range  
+    | LibraryOnlyUnionCaseFieldSet of SynExpr * longId:LongIdent * int * SynExpr * range:range
 
     /// Inserted for error recovery
-    | FromParseError  of SynExpr * range  
+    | ArbitraryAfterError  of debugStr:string * range:range
+
+    /// Inserted for error recovery
+    | FromParseError  of expr:SynExpr * range:range
 
     /// Inserted for error recovery when there is "expr." and missing tokens or error recovery after the dot
-    | DiscardAfterMissingQualificationAfterDot  of SynExpr * range  
+    | DiscardAfterMissingQualificationAfterDot  of expr:SynExpr * range:range
 
     /// 'use x = fixed expr'
-    | Fixed of SynExpr * range  
+    | Fixed of SynExpr * range
 
     /// Get the syntactic range of source code covered by this construct.
-    member e.Range = 
-        match e with 
-        | SynExpr.Paren(_,_,_,m) 
-        | SynExpr.Quote(_,_,_,_,m) 
-        | SynExpr.Const(_,m) 
+    member e.Range =
+        match e with
+        | SynExpr.Paren(_,_,_,m)
+        | SynExpr.Quote(_,_,_,_,m)
+        | SynExpr.Const(_,m)
         | SynExpr.Typed (_,_,m)
         | SynExpr.Tuple (_,_,m)
         | SynExpr.StructTuple (_,_,m)
@@ -726,8 +737,8 @@ and
         | SynExpr.TryFinally (_,_,m,_,_)
         | SynExpr.Sequential (_,_,_,_,m)
         | SynExpr.ArbitraryAfterError(_,m)
-        | SynExpr.FromParseError (_,m) 
-        | SynExpr.DiscardAfterMissingQualificationAfterDot (_,m) 
+        | SynExpr.FromParseError (_,m)
+        | SynExpr.DiscardAfterMissingQualificationAfterDot (_,m)
         | SynExpr.IfThenElse (_,_,_,_,_,_,m)
         | SynExpr.LongIdent (_,_,_,m)
         | SynExpr.LongIdentSet (_,_,m)
@@ -758,146 +769,147 @@ and
         | SynExpr.DoBang  (_,m) -> m
         | SynExpr.Fixed (_,m) -> m
         | SynExpr.Ident id -> id.idRange
+
     /// range ignoring any (parse error) extra trailing dots
-    member e.RangeSansAnyExtraDot = 
-        match e with 
-        | SynExpr.Paren(_,_,_,m) 
-        | SynExpr.Quote(_,_,_,_,m) 
-        | SynExpr.Const(_,m) 
-        | SynExpr.Typed (_,_,m)
-        | SynExpr.Tuple (_,_,m)
-        | SynExpr.StructTuple (_,_,m)
-        | SynExpr.ArrayOrList (_,_,m)
-        | SynExpr.Record (_,_,_,m)
-        | SynExpr.New (_,_,_,m)
-        | SynExpr.ObjExpr (_,_,_,_,_,m)
-        | SynExpr.While (_,_,_,m)
-        | SynExpr.For (_,_,_,_,_,_,m)
-        | SynExpr.ForEach (_,_,_,_,_,_,m)
-        | SynExpr.CompExpr (_,_,_,m)
-        | SynExpr.ArrayOrListOfSeqExpr (_,_,m)
-        | SynExpr.Lambda (_,_,_,_,m)
-        | SynExpr.Match (_,_,_,_,m)
-        | SynExpr.MatchLambda (_,_,_,_,m)
-        | SynExpr.Do (_,m)
-        | SynExpr.Assert (_,m)
-        | SynExpr.App (_,_,_,_,m)
-        | SynExpr.TypeApp (_,_,_,_,_,_,m)
-        | SynExpr.LetOrUse (_,_,_,_,m)
-        | SynExpr.TryWith (_,_,_,_,m,_,_)
-        | SynExpr.TryFinally (_,_,m,_,_)
-        | SynExpr.Sequential (_,_,_,_,m)
-        | SynExpr.ArbitraryAfterError(_,m)
-        | SynExpr.FromParseError (_,m) 
-        | SynExpr.IfThenElse (_,_,_,_,_,_,m)
-        | SynExpr.LongIdentSet (_,_,m)
-        | SynExpr.NamedIndexedPropertySet (_,_,_,m)
-        | SynExpr.DotIndexedGet (_,_,_,m)
-        | SynExpr.DotIndexedSet (_,_,_,_,_,m)
-        | SynExpr.DotSet (_,_,_,m)
-        | SynExpr.DotNamedIndexedPropertySet (_,_,_,_,m)
-        | SynExpr.LibraryOnlyUnionCaseFieldGet (_,_,_,m)
-        | SynExpr.LibraryOnlyUnionCaseFieldSet (_,_,_,_,m)
-        | SynExpr.LibraryOnlyILAssembly (_,_,_,_,m)
-        | SynExpr.LibraryOnlyStaticOptimization (_,_,_,m)
-        | SynExpr.TypeTest (_,_,m)
-        | SynExpr.Upcast (_,_,m)
-        | SynExpr.AddressOf (_,_,_,m)
-        | SynExpr.Downcast (_,_,m)
-        | SynExpr.JoinIn (_,_,_,m)
-        | SynExpr.InferredUpcast (_,m)
-        | SynExpr.InferredDowncast (_,m)
-        | SynExpr.Null m
-        | SynExpr.Lazy (_, m)
-        | SynExpr.TraitCall(_,_,_,m)
-        | SynExpr.ImplicitZero (m)
-        | SynExpr.YieldOrReturn (_,_,m)
-        | SynExpr.YieldOrReturnFrom (_,_,m)
-        | SynExpr.LetOrUseBang  (_,_,_,_,_,_,m)
-        | SynExpr.DoBang  (_,m) -> m
+    member e.RangeSansAnyExtraDot =
+        match e with
+        | SynExpr.Paren (range=m)
+        | SynExpr.Quote (range=m)
+        | SynExpr.Const (range=m)
+        | SynExpr.Typed (range=m)
+        | SynExpr.Tuple (range=m)
+        | SynExpr.StructTuple (range=m)
+        | SynExpr.ArrayOrList (range=m)
+        | SynExpr.Record (range=m)
+        | SynExpr.New (range=m)
+        | SynExpr.ObjExpr (range=m)
+        | SynExpr.While (range=m)
+        | SynExpr.For (range=m)
+        | SynExpr.ForEach (range=m)
+        | SynExpr.CompExpr (range=m)
+        | SynExpr.ArrayOrListOfSeqExpr (range=m)
+        | SynExpr.Lambda (range=m)
+        | SynExpr.Match (range=m)
+        | SynExpr.MatchLambda (range=m)
+        | SynExpr.Do (range=m)
+        | SynExpr.Assert (range=m)
+        | SynExpr.App (range=m)
+        | SynExpr.TypeApp (range=m)
+        | SynExpr.LetOrUse (range=m)
+        | SynExpr.TryWith (range=m)
+        | SynExpr.TryFinally (range=m)
+        | SynExpr.Sequential (range=m)
+        | SynExpr.ArbitraryAfterError (range=m)
+        | SynExpr.FromParseError (range=m)
+        | SynExpr.IfThenElse (range=m)
+        | SynExpr.LongIdentSet (range=m)
+        | SynExpr.NamedIndexedPropertySet (range=m)
+        | SynExpr.DotIndexedGet (range=m)
+        | SynExpr.DotIndexedSet (range=m)
+        | SynExpr.DotSet (range=m)
+        | SynExpr.DotNamedIndexedPropertySet (range=m)
+        | SynExpr.LibraryOnlyUnionCaseFieldGet (range=m)
+        | SynExpr.LibraryOnlyUnionCaseFieldSet (range=m)
+        | SynExpr.LibraryOnlyILAssembly (range=m)
+        | SynExpr.LibraryOnlyStaticOptimization (range=m)
+        | SynExpr.TypeTest (range=m)
+        | SynExpr.Upcast (range=m)
+        | SynExpr.AddressOf (range=m)
+        | SynExpr.Downcast (range=m)
+        | SynExpr.JoinIn (range=m)
+        | SynExpr.InferredUpcast (range=m)
+        | SynExpr.InferredDowncast (range=m)
+        | SynExpr.Null (range=m)
+        | SynExpr.Lazy (range=m)
+        | SynExpr.TraitCall (range=m)
+        | SynExpr.ImplicitZero (range=m)
+        | SynExpr.YieldOrReturn (range=m)
+        | SynExpr.YieldOrReturnFrom (range=m)
+        | SynExpr.LetOrUseBang (range=m)
+        | SynExpr.DoBang  (range=m) -> m
         | SynExpr.DotGet (expr,_,lidwd,m) -> if lidwd.ThereIsAnExtraDotAtTheEnd then unionRanges expr.Range lidwd.RangeSansAnyExtraDot else m
-        | SynExpr.LongIdent (_,lidwd,_,_) -> lidwd.RangeSansAnyExtraDot 
+        | SynExpr.LongIdent (_,lidwd,_,_) -> lidwd.RangeSansAnyExtraDot
         | SynExpr.DiscardAfterMissingQualificationAfterDot (expr,_) -> expr.Range
         | SynExpr.Fixed (_,m) -> m
         | SynExpr.Ident id -> id.idRange
     /// Attempt to get the range of the first token or initial portion only - this is extremely ad-hoc, just a cheap way to improve a certain 'query custom operation' error range
-    member e.RangeOfFirstPortion = 
-        match e with 
+    member e.RangeOfFirstPortion =
+        match e with
         // haven't bothered making these cases better than just .Range
-        | SynExpr.Quote(_,_,_,_,m)
-        | SynExpr.Const(_,m) 
-        | SynExpr.Typed (_,_,m)
-        | SynExpr.Tuple (_,_,m)
-        | SynExpr.StructTuple (_,_,m)
-        | SynExpr.ArrayOrList (_,_,m)
-        | SynExpr.Record (_,_,_,m)
-        | SynExpr.New (_,_,_,m)
-        | SynExpr.ObjExpr (_,_,_,_,_,m)
-        | SynExpr.While (_,_,_,m)
-        | SynExpr.For (_,_,_,_,_,_,m)
-        | SynExpr.CompExpr (_,_,_,m)
-        | SynExpr.ArrayOrListOfSeqExpr (_,_,m)
-        | SynExpr.Lambda (_,_,_,_,m)
-        | SynExpr.Match (_,_,_,_,m)
-        | SynExpr.MatchLambda (_,_,_,_,m)
-        | SynExpr.Do (_,m)
-        | SynExpr.Assert (_,m)
-        | SynExpr.TypeApp (_,_,_,_,_,_,m)
-        | SynExpr.LetOrUse (_,_,_,_,m)
-        | SynExpr.TryWith (_,_,_,_,m,_,_)
-        | SynExpr.TryFinally (_,_,m,_,_)
-        | SynExpr.ArbitraryAfterError(_,m)
-        | SynExpr.FromParseError (_,m) 
-        | SynExpr.DiscardAfterMissingQualificationAfterDot (_,m) 
-        | SynExpr.IfThenElse (_,_,_,_,_,_,m)
-        | SynExpr.LongIdent (_,_,_,m)
-        | SynExpr.LongIdentSet (_,_,m)
-        | SynExpr.NamedIndexedPropertySet (_,_,_,m)
-        | SynExpr.DotIndexedGet (_,_,_,m)
-        | SynExpr.DotIndexedSet (_,_,_,_,_,m)
-        | SynExpr.DotGet (_,_,_,m)
-        | SynExpr.DotSet (_,_,_,m)
-        | SynExpr.DotNamedIndexedPropertySet (_,_,_,_,m)
-        | SynExpr.LibraryOnlyUnionCaseFieldGet (_,_,_,m)
-        | SynExpr.LibraryOnlyUnionCaseFieldSet (_,_,_,_,m)
-        | SynExpr.LibraryOnlyILAssembly (_,_,_,_,m)
-        | SynExpr.LibraryOnlyStaticOptimization (_,_,_,m)
-        | SynExpr.TypeTest (_,_,m)
-        | SynExpr.Upcast (_,_,m)
-        | SynExpr.AddressOf (_,_,_,m)
-        | SynExpr.Downcast (_,_,m)
-        | SynExpr.JoinIn (_,_,_,m)
-        | SynExpr.InferredUpcast (_,m)
-        | SynExpr.InferredDowncast (_,m)
-        | SynExpr.Null m
-        | SynExpr.Lazy (_, m)
-        | SynExpr.TraitCall(_,_,_,m)
-        | SynExpr.ImplicitZero (m)
-        | SynExpr.YieldOrReturn (_,_,m)
-        | SynExpr.YieldOrReturnFrom (_,_,m)
-        | SynExpr.LetOrUseBang  (_,_,_,_,_,_,m)
+        | SynExpr.Quote (range=m)
+        | SynExpr.Const (range=m)
+        | SynExpr.Typed (range=m)
+        | SynExpr.Tuple (range=m)
+        | SynExpr.StructTuple (range=m)
+        | SynExpr.ArrayOrList (range=m)
+        | SynExpr.Record (range=m)
+        | SynExpr.New (range=m)
+        | SynExpr.ObjExpr (range=m)
+        | SynExpr.While (range=m)
+        | SynExpr.For (range=m)
+        | SynExpr.CompExpr (range=m)
+        | SynExpr.ArrayOrListOfSeqExpr (range=m)
+        | SynExpr.Lambda (range=m)
+        | SynExpr.Match (range=m)
+        | SynExpr.MatchLambda (range=m)
+        | SynExpr.Do (range=m)
+        | SynExpr.Assert (range=m)
+        | SynExpr.TypeApp (range=m)
+        | SynExpr.LetOrUse (range=m)
+        | SynExpr.TryWith (range=m)
+        | SynExpr.TryFinally (range=m)
+        | SynExpr.ArbitraryAfterError (range=m)
+        | SynExpr.FromParseError (range=m)
+        | SynExpr.DiscardAfterMissingQualificationAfterDot (range=m)
+        | SynExpr.IfThenElse (range=m)
+        | SynExpr.LongIdent (range=m)
+        | SynExpr.LongIdentSet (range=m)
+        | SynExpr.NamedIndexedPropertySet (range=m)
+        | SynExpr.DotIndexedGet (range=m)
+        | SynExpr.DotIndexedSet (range=m)
+        | SynExpr.DotGet (range=m)
+        | SynExpr.DotSet (range=m)
+        | SynExpr.DotNamedIndexedPropertySet (range=m)
+        | SynExpr.LibraryOnlyUnionCaseFieldGet (range=m)
+        | SynExpr.LibraryOnlyUnionCaseFieldSet (range=m)
+        | SynExpr.LibraryOnlyILAssembly (range=m)
+        | SynExpr.LibraryOnlyStaticOptimization (range=m)
+        | SynExpr.TypeTest (range=m)
+        | SynExpr.Upcast (range=m)
+        | SynExpr.AddressOf (range=m)
+        | SynExpr.Downcast (range=m)
+        | SynExpr.JoinIn (range=m)
+        | SynExpr.InferredUpcast (range=m)
+        | SynExpr.InferredDowncast (range=m)
+        | SynExpr.Null (range=m)
+        | SynExpr.Lazy (range=m)
+        | SynExpr.TraitCall (range=m)
+        | SynExpr.ImplicitZero (range=m)
+        | SynExpr.YieldOrReturn (range=m)
+        | SynExpr.YieldOrReturnFrom (range=m)
+        | SynExpr.LetOrUseBang  (range=m)
         | SynExpr.DoBang  (_,m) -> m
         // these are better than just .Range, and also commonly applicable inside queries
         | SynExpr.Paren(_,m,_,_) -> m
         | SynExpr.Sequential (_,_,e1,_,_)
         | SynExpr.App (_,_,e1,_,_) ->
-            e1.RangeOfFirstPortion 
-        | SynExpr.ForEach (_,_,_,pat,_,_,m) ->
-            let start = m.Start 
-            let e = (pat.Range : range).Start 
-            mkRange m.FileName start e
+            e1.RangeOfFirstPortion
+        | SynExpr.ForEach (_,_,_,pat,_,_,r) ->
+            let start = r.Start
+            let e = (pat.Range : range).Start
+            mkRange r.FileName start e
         | SynExpr.Ident id -> id.idRange
         | SynExpr.Fixed (_,m) -> m
 
 
-and 
+and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
-    SynIndexerArg = 
-    | Two of SynExpr * SynExpr 
+    SynIndexerArg =
+    | Two of SynExpr * SynExpr
     | One of SynExpr
     member x.Range = match x with Two (e1,e2) -> unionRanges e1.Range e2.Range | One e -> e.Range
     member x.Exprs = match x with Two (e1,e2) -> [e1;e2] | One e -> [e]
-and  
+and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     SynSimplePat =
 
@@ -905,96 +917,110 @@ and
     ///
     /// Indicates a simple pattern variable.
     ///
-    ///   altNameRefCell 
-    ///     Normally 'None' except for some compiler-generated variables in desugaring pattern matching. 
+    ///   altNameRefCell
+    ///     Normally 'None' except for some compiler-generated variables in desugaring pattern matching.
     ///     Pattern processing sets this reference for hidden variable introduced by desugaring pattern matching in arguments.
     ///     The info indicates an alternative (compiler generated) identifier to be used because the name of the identifier is already bound.
     ///     See Product Studio FSharp 1.0, bug 6389.
     ///
-    ///   isCompilerGenerated : true if a compiler generated name 
-    ///   isThisVar: true if 'this' variable in member  
+    ///   isCompilerGenerated : true if a compiler generated name
+    ///   isThisVar: true if 'this' variable in member
     ///   isOptArg: true if a '?' is in front of the name
-    | Id of  Ident * SynSimplePatAlternativeIdInfo ref option * bool * bool *  bool * range
+    | Id of  ident:Ident * altNameRefCell:SynSimplePatAlternativeIdInfo ref option * isCompilerGenerated:bool * isThisVar:bool *  isOptArg:bool * range:range
 
-    | Typed of  SynSimplePat * SynType * range
-    | Attrib of  SynSimplePat * SynAttributes * range
+    | Typed of  SynSimplePat * typeName:SynType * range:range
+    | Attrib of  SynSimplePat * attributes:SynAttributes * range:range
 
 
-and SynSimplePatAlternativeIdInfo = 
-    /// We have not decided to use an alternative name in tha pattern and related expression 
+and SynSimplePatAlternativeIdInfo =
+    /// We have not decided to use an alternative name in tha pattern and related expression
     | Undecided of Ident
-    /// We have decided to use an alternative name in tha pattern and related expression 
+    /// We have decided to use an alternative name in tha pattern and related expression
     | Decided of Ident
 
-and 
+and
     [<NoEquality; NoComparison>]
     SynStaticOptimizationConstraint =
-    | WhenTyparTyconEqualsTycon of SynTypar *  SynType * range
-    | WhenTyparIsStruct of SynTypar * range
+    | WhenTyparTyconEqualsTycon of SynTypar *  SynType * range:range
+    | WhenTyparIsStruct of SynTypar * range:range
 
-and  
+and
     [<NoEquality; NoComparison;RequireQualifiedAccess>]
     /// Represents a simple set of variable bindings a, (a,b) or (a:Type,b:Type) at a lambda,
     /// function definition or other binding point, after the elimination of pattern matching
-    /// from the construct, e.g. after changing a "function pat1 -> rule1 | ..." to a 
+    /// from the construct, e.g. after changing a "function pat1 -> rule1 | ..." to a
     /// "fun v -> match v with ..."
     SynSimplePats =
-    | SimplePats of SynSimplePat list * range
-    | Typed of  SynSimplePats * SynType * range
+    | SimplePats of SynSimplePat list * range:range
+    | Typed of  SynSimplePats * SynType * range:range
 
 and SynConstructorArgs =
     | Pats of SynPat list
-    | NamePatPairs of (Ident * SynPat) list * range
-and  
+    | NamePatPairs of (Ident * SynPat) list * range:range
+and
     [<NoEquality; NoComparison;RequireQualifiedAccess>]
     SynPat =
-    | Const of SynConst * range
-    | Wild of range
-    | Named of  SynPat * Ident *  bool (* true if 'this' variable *)  * SynAccess option * range
-    | Typed of  SynPat * SynType * range
-    | Attrib of  SynPat * SynAttributes * range
-    | Or of  SynPat * SynPat * range
-    | Ands of  SynPat list * range
-    | LongIdent of LongIdentWithDots * (* holds additional ident for tooling *) Ident option * SynValTyparDecls option (* usually None: temporary used to parse "f<'a> x = x"*) * SynConstructorArgs  * SynAccess option * range
-    | Tuple of  SynPat list * range
-    | StructTuple of  SynPat list * range
-    | Paren of  SynPat * range
-    | ArrayOrList of  bool * SynPat list * range
-    | Record of ((LongIdent * Ident) * SynPat) list * range
+    | Const of constant:SynConst * range:range
+    | Wild of range:range
+    | Named of  SynPat * id:Ident *  isThisVar:bool (* true if 'this' variable *)  * accessiblity:SynAccess option * range:range
+    | Typed of  SynPat * typeName:SynType * range:range
+    | Attrib of  SynPat * attributes:SynAttributes * range:range
+    | Or of  SynPat * SynPat * range:range
+    | Ands of  SynPat list * range:range
+    | LongIdent of dotId:LongIdentWithDots * (* holds additional ident for tooling *) Ident option * SynValTyparDecls option (* usually None: temporary used to parse "f<'a> x = x"*) * SynConstructorArgs  * SynAccess option * range:range
+    | Tuple of  SynPat list * range:range
+    | StructTuple of  SynPat list * range:range
+    | Paren of  SynPat * range:range
+    | ArrayOrList of  bool * SynPat list * range:range
+    | Record of fields:((LongIdent * Ident) * SynPat) list * range:range
     /// 'null'
-    | Null of range
+    | Null of range:range
     /// '?id' -- for optional argument names
-    | OptionalVal of Ident * range
+    | OptionalVal of Ident * range:range
     /// ':? type '
-    | IsInst of SynType * range
+    | IsInst of typeName:SynType * range:range
     /// &lt;@ expr @&gt;, used for active pattern arguments
-    | QuoteExpr of SynExpr * range
-
+    | QuoteExpr of expr:SynExpr * range:range
     /// Deprecated character ranges
-    | DeprecatedCharRange of char * char * range
+    | DeprecatedCharRange of char * char * range:range
     /// Used internally in the type checker
-    | InstanceMember of  Ident * Ident * (* holds additional ident for tooling *) Ident option * SynAccess option * range (* adhoc overloaded method/property *)
+    | InstanceMember of  Ident * Ident * (* holds additional ident for tooling *) Ident option * accesiblity:SynAccess option * range:range (* adhoc overloaded method/property *)
 
     /// A pattern arising from a parse error
-    | FromParseError of SynPat * range
+    | FromParseError of SynPat * range:range
 
-    member p.Range = 
-      match p with 
-      | SynPat.Const(_,m) | SynPat.Wild m | SynPat.Named (_,_,_,_,m) | SynPat.Or (_,_,m) | SynPat.Ands (_,m) 
-      | SynPat.LongIdent (_,_,_,_,_,m) | SynPat.ArrayOrList(_,_,m) | SynPat.Tuple (_,m) | SynPat.StructTuple (_,m) |SynPat.Typed(_,_,m) |SynPat.Attrib(_,_,m) 
-      | SynPat.Record (_,m) | SynPat.DeprecatedCharRange (_,_,m) | SynPat.Null m | SynPat.IsInst (_,m) | SynPat.QuoteExpr (_,m)
-      | SynPat.InstanceMember(_,_,_,_,m) | SynPat.OptionalVal(_,m) | SynPat.Paren(_,m) 
-      | SynPat.FromParseError (_,m) -> m 
+    member p.Range =
+      match p with
+      | SynPat.Const (range=m)
+      | SynPat.Wild (range=m)
+      | SynPat.Named (range=m)
+      | SynPat.Or (range=m)
+      | SynPat.Ands (range=m)
+      | SynPat.LongIdent (range=m)
+      | SynPat.ArrayOrList (range=m)
+      | SynPat.Tuple (range=m)
+      | SynPat.StructTuple (range=m)
+      | SynPat.Typed (range=m)
+      | SynPat.Attrib (range=m)
+      | SynPat.Record (range=m)
+      | SynPat.DeprecatedCharRange (range=m)
+      | SynPat.Null (range=m)
+      | SynPat.IsInst (range=m)
+      | SynPat.QuoteExpr (range=m)
+      | SynPat.InstanceMember (range=m)
+      | SynPat.OptionalVal (range=m)
+      | SynPat.Paren (range=m)
+      | SynPat.FromParseError (range=m) -> m
 
-and  
+and
     [<NoEquality; NoComparison>]
-    SynInterfaceImpl = 
-    | InterfaceImpl of SynType * SynBinding list * range
+    SynInterfaceImpl =
+    | InterfaceImpl of SynType * bindings:SynBinding list * range:range
 
-and  
+and
     [<NoEquality; NoComparison>]
-    SynMatchClause = 
-    | Clause of SynPat * SynExpr option *  SynExpr * range * SequencePointInfoForTarget
+    SynMatchClause =
+    | Clause of SynPat * SynExpr option *  SynExpr * range:range * spTarget:SequencePointInfoForTarget
     member this.RangeOfGuardAndRhs =
         match this with
         | Clause(_,eo,e,_,_) ->
@@ -1010,39 +1036,39 @@ and
 
 and SynAttributes = SynAttribute list
 
-and  
+and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
-    SynAttribute = 
+    SynAttribute =
     { TypeName: LongIdentWithDots
-      ArgExpr: SynExpr 
+      ArgExpr: SynExpr
       /// Target specifier, e.g. "assembly","module",etc.
-      Target: Ident option 
+      Target: Ident option
       /// Is this attribute being applied to a property getter or setter?
       AppliesToGetterAndSetter: bool
-      Range: range } 
+      Range: range }
 
-and  
+and
     [<NoEquality; NoComparison>]
-    SynValData = 
+    SynValData =
     | SynValData of MemberFlags option * SynValInfo * Ident option
 
-and  
+and
     [<NoEquality; NoComparison>]
-    SynBinding = 
-    | Binding of 
-        SynAccess option *
-        SynBindingKind *  
-        bool (* mustinline: *) *  
-        bool (* mutable: *) *  
-        SynAttributes * 
-        PreXmlDoc *
-        SynValData * 
-        SynPat * 
-        SynBindingReturnInfo option * 
-        SynExpr  *
-        range *
-        SequencePointInfoForBinding
-    // no member just named "Range", as that would be confusing: 
+    SynBinding =
+    | Binding of
+        access:SynAccess option *
+        bindingKind:SynBindingKind *
+        mustInline:bool  *
+        isMutable:bool  *
+        attributes:SynAttributes *
+        xmlDoc:PreXmlDoc *
+        SynValData *
+        headPat:SynPat *
+        SynBindingReturnInfo option *
+        expr:SynExpr  *
+        lhsRange:range *
+        spBind:SequencePointInfoForBinding
+    // no member just named 'Range', as that would be confusing:
     //  - for everything else, the 'range' member that appears last/second-to-last is the 'full range' of the whole tree construct
     //  - but for Binding, the 'range' is only the range of the left-hand-side, the right-hand-side range is in the SynExpr
     //  - so we use explicit names to avoid confusion
@@ -1050,13 +1076,13 @@ and
     member x.RangeOfBindingAndRhs = let (Binding(_,_,_,_,_,_,_,_,_,e,m,_)) = x in unionRanges e.Range m
     member x.RangeOfHeadPat = let (Binding(_,_,_,_,_,_,_,headPat,_,_,_,_)) = x in headPat.Range
 
-and 
+and
     [<NoEquality; NoComparison>]
-    SynBindingReturnInfo = 
-    | SynBindingReturnInfo of SynType * range * SynAttributes
+    SynBindingReturnInfo =
+    | SynBindingReturnInfo of typeName:SynType * range:range * attributes:SynAttributes
 
 
-and 
+and
     [<NoComparison>]
     MemberFlags =
     { IsInstance: bool
@@ -1066,37 +1092,37 @@ and
       MemberKind: MemberKind }
 
 /// Note the member kind is actually computed partially by a syntax tree transformation in tc.fs
-and 
+and
     [<StructuralEquality; NoComparison; RequireQualifiedAccess>]
-    MemberKind = 
+    MemberKind =
     | ClassConstructor
     | Constructor
-    | Member 
-    | PropertyGet 
-    | PropertySet    
+    | Member
+    | PropertyGet
+    | PropertySet
     /// An artifical member kind used prior to the point where a get/set property is split into two distinct members.
-    | PropertyGetSet    
+    | PropertyGetSet
 
-and 
+and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     /// The untyped, unchecked syntax tree for a member signature, used in signature files, abstract member declarations
     /// and member constraints.
-    SynMemberSig = 
-    | Member of SynValSig  * MemberFlags * range 
-    | Interface of SynType  * range
-    | Inherit of SynType * range
-    | ValField of SynField  * range
-    | NestedType  of SynTypeDefnSig * range
+    SynMemberSig =
+    | Member of SynValSig  * memberFlags:MemberFlags * range:range
+    | Interface of typeName:SynType  * range:range
+    | Inherit of typeName:SynType * range:range
+    | ValField of field:SynField  * range:range
+    | NestedType  of typeDefnSig:SynTypeDefnSig * range:range
 
 and SynMemberSigs = SynMemberSig list
 
-and 
+and
     [<NoEquality; NoComparison>]
-    SynTypeDefnKind = 
-    | TyconUnspecified 
-    | TyconClass 
-    | TyconInterface 
-    | TyconStruct 
+    SynTypeDefnKind =
+    | TyconUnspecified
+    | TyconClass
+    | TyconInterface
+    | TyconStruct
     | TyconRecord
     | TyconUnion
     | TyconAbbrev
@@ -1106,36 +1132,45 @@ and
     | TyconDelegate of SynType * SynValInfo
 
 
-and 
+and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     /// The untyped, unchecked syntax tree for the core of a simple type definition, in either signature
-    /// or implementation. 
+    /// or implementation.
     SynTypeDefnSimpleRepr =
+
     /// A union type definition, type X = A | B
-    | Union      of SynAccess option * SynUnionCases * range
+    | Union      of accessiblity:SynAccess option * cases:SynUnionCases * range:range
+
     /// An enum type definition, type X = A = 1 | B = 2
-    | Enum       of SynEnumCases * range
+    | Enum       of cases:SynEnumCases * range:range
+
     /// A record type definition, type X = { A : int; B : int }
-    | Record     of SynAccess option * SynFields * range
+    | Record     of accessiblity:SynAccess option * fields:SynFields * range:range
+
     /// An object oriented type definition. This is not a parse-tree form, but represents the core
-    /// type representation which the type checker splits out from the "ObjectModel" cases of type definitions.
-    | General    of SynTypeDefnKind * (SynType * range * Ident option) list * (SynValSig * MemberFlags) list * SynField list  * bool * bool * SynSimplePat list option * range 
+    /// type representation which the type checker splits out from the 'ObjectModel' cases of type definitions.
+    | General    of SynTypeDefnKind * (SynType * range * Ident option) list * (SynValSig * MemberFlags) list * SynField list  * bool * bool * SynSimplePat list option * range:range
+
     /// A type defined by using an IL assembly representation. Only used in FSharp.Core.
-    /// 
-    /// F# syntax: "type X = (# "..."#)
-    | LibraryOnlyILAssembly of ILType * range
+    ///
+    /// F# syntax: type X = (# '...' #)
+    | LibraryOnlyILAssembly of ILType * range:range
+
     /// A type abbreviation, "type X = A.B.C"
-    | TypeAbbrev of ParserDetail * SynType * range
+    | TypeAbbrev of ParserDetail * SynType * range:range
+
     /// An abstract definition , "type X"
-    | None       of range
+    | None       of range:range
+
     /// An exception definition , "exception E = ..."
     | Exception of SynExceptionDefnRepr
+
     member this.Range =
         match this with
-        | Union(_,_,m) 
+        | Union(_,_,m)
         | Enum(_,m)
         | Record(_,_,m)
-        | General(_,_,_,_,_,_,_,m) 
+        | General(_,_,_,_,_,_,_,m)
         | LibraryOnlyILAssembly(_,m)
         | TypeAbbrev(_,_,m)
         | None(m) -> m
@@ -1143,46 +1178,46 @@ and
 
 and SynEnumCases = SynEnumCase list
 
-and 
+and
     [<NoEquality; NoComparison>]
     SynEnumCase =
     /// The untyped, unchecked syntax tree for one case in an enum definition.
-    | EnumCase of SynAttributes * Ident * SynConst * PreXmlDoc * range
+    | EnumCase of attributes:SynAttributes * id:Ident * SynConst * xmlDoc:PreXmlDoc * range:range
     member this.Range =
         match this with
-        | EnumCase(_,_,_,_,m) -> m
+        | EnumCase (range=m) -> m
 
 and SynUnionCases = SynUnionCase list
 
-and 
+and
     [<NoEquality; NoComparison>]
-    SynUnionCase = 
+    SynUnionCase =
     /// The untyped, unchecked syntax tree for one case in a union definition.
-    | UnionCase of SynAttributes * Ident * SynUnionCaseType * PreXmlDoc * SynAccess option * range
+    | UnionCase of attributes:SynAttributes * id:Ident * caseType:SynUnionCaseType * xmlDoc:PreXmlDoc * accessibility:SynAccess option * range:range
     member this.Range =
         match this with
-        | UnionCase(_,_,_,_,_,m) -> m
+        | UnionCase (range=m) -> m
 
-and 
+and
     [<NoEquality; NoComparison>]
     /// The untyped, unchecked syntax tree for the right-hand-side of union definition, excluding members,
     /// in either a signature or implementation.
-    SynUnionCaseType = 
-    /// Normal style declaration 
-    | UnionCaseFields of SynField list      
+    SynUnionCaseType =
+    /// Normal style declaration
+    | UnionCaseFields of cases:SynField list
     /// Full type spec given by 'UnionCase : ty1 * tyN -> rty'. Only used in FSharp.Core, otherwise a warning.
-    | UnionCaseFullType of (SynType * SynValInfo) 
+    | UnionCaseFullType of (SynType * SynValInfo)
 
-and 
+and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     /// The untyped, unchecked syntax tree for the right-hand-side of a type definition in a signature.
-    /// Note: in practice, using a discriminated union to make a distinction between 
+    /// Note: in practice, using a discriminated union to make a distinction between
     /// "simple" types and "object oriented" types is not particularly useful.
     SynTypeDefnSigRepr =
     /// Indicates the right right-hand-side is a class, struct, interface or other object-model type
-    | ObjectModel of SynTypeDefnKind * SynMemberSigs * range
-    /// Indicates the right right-hand-side is a record, union or other simple type. 
-    | Simple of SynTypeDefnSimpleRepr * range 
+    | ObjectModel of SynTypeDefnKind * memberSigs:SynMemberSigs * range:range
+    /// Indicates the right right-hand-side is a record, union or other simple type.
+    | Simple of SynTypeDefnSimpleRepr * range:range
     | Exception of SynExceptionDefnRepr
     member this.Range =
         match this with
@@ -1190,96 +1225,96 @@ and
         | Simple(_,m) -> m
         | Exception e -> e.Range
 
-and 
+and
     [<NoEquality; NoComparison>]
     /// The untyped, unchecked syntax tree for a type definition in a signature
     SynTypeDefnSig =
     /// The information for a type definition in a signature
-    | TypeDefnSig of SynComponentInfo * SynTypeDefnSigRepr * SynMemberSigs * range
+    | TypeDefnSig of SynComponentInfo * SynTypeDefnSigRepr * memberSigs:SynMemberSigs * range:range
 
 and SynFields = SynField list
 
-and 
+and
     [<NoEquality; NoComparison>]
     /// The untyped, unchecked syntax tree for a field declaration in a record or class
-    SynField = 
-    | Field of SynAttributes * (* static: *) bool * Ident option * SynType * bool * PreXmlDoc * SynAccess option * range
+    SynField =
+    | Field of attributes:SynAttributes * isStatic:bool * id:Ident option * typeName:SynType * bool * xmlDoc:PreXmlDoc * accessiblity:SynAccess option * range:range
 
 
-and 
+and
     [<NoEquality; NoComparison>]
     /// The untyped, unchecked syntax tree associated with the name of a type definition or module
-    /// in signature or implementation. 
+    /// in signature or implementation.
     ///
-    /// THis includes the name, attributes, type parameters, constraints, documentation and accessibility 
+    /// THis includes the name, attributes, type parameters, constraints, documentation and accessibility
     /// for a type definition or module. For modules, entries such as the type parameters are
     /// always empty.
-    SynComponentInfo = 
-    | ComponentInfo of SynAttributes * SynTyparDecl list * SynTypeConstraint list * LongIdent * PreXmlDoc * (* preferPostfix: *) bool * SynAccess option * range
+    SynComponentInfo =
+    | ComponentInfo of attributes:SynAttributes * typeParams:SynTyparDecl list * constraints:SynTypeConstraint list * LongIdent * xmlDoc:PreXmlDoc * preferPostfix:bool * accessiblity:SynAccess option * range:range
     member this.Range =
         match this with
-        | ComponentInfo(_,_,_,_,_,_,_,m) -> m
+        | ComponentInfo (range=m) -> m
 
-and 
+and
     [<NoEquality; NoComparison>]
-    SynValSig = 
-    | ValSpfn of 
-        SynAttributes * 
-        Ident * 
-        SynValTyparDecls * 
-        SynType * 
-        SynValInfo * 
-        bool * 
-        bool *  (* mutable? *) 
-        PreXmlDoc * 
-        SynAccess option *
-        SynExpr option *
-        range 
+    SynValSig =
+    | ValSpfn of
+        attributes:SynAttributes *
+        id:Ident *
+        typeParams:SynValTyparDecls *
+        typeName:SynType *
+        valInfo:SynValInfo *
+        bool *
+        isMutable:bool *  (* mutable? *)
+        xmlDoc:PreXmlDoc *
+        accessiblity:SynAccess option *
+        expr:SynExpr option *
+        range:range
 
-    member x.RangeOfId  = let (ValSpfn(_,id,_,_,_,_,_,_,_,_,_)) = x in id.idRange
-    member x.SynInfo = let (ValSpfn(_,_,_,_,v,_,_,_,_,_,_)) = x in v
+    member x.RangeOfId  = let (ValSpfn(id=id)) = x in id.idRange
+    member x.SynInfo = let (ValSpfn(valInfo=v)) = x in v
     member x.SynType = let (ValSpfn(_,_,_,ty,_,_,_,_,_,_,_)) = x in ty
 
 /// The argument names and other metadata for a member or function
-and 
+and
     [<NoEquality; NoComparison>]
-    SynValInfo = 
+    SynValInfo =
     /// SynValInfo(curriedArgInfos, returnInfo)
-    | SynValInfo of SynArgInfo list list * SynArgInfo 
+    | SynValInfo of SynArgInfo list list * SynArgInfo
     member x.ArgInfos = (let (SynValInfo(args,_)) = x in args)
 
 /// The argument names and other metadata for a parameter for a member or function
-and 
+and
     [<NoEquality; NoComparison>]
-    SynArgInfo = 
-    | SynArgInfo of SynAttributes * (*optional:*) bool *  Ident option
+    SynArgInfo =
+    | SynArgInfo of attributes:SynAttributes * optional:bool *  id:Ident option
 
 /// The names and other metadata for the type parameters for a member or function
-and 
+and
     [<NoEquality; NoComparison>]
-    SynValTyparDecls = 
-    | SynValTyparDecls of SynTyparDecl list * bool * SynTypeConstraint list
+    SynValTyparDecls =
+    | SynValTyparDecls of SynTyparDecl list * bool * constraints:SynTypeConstraint list
 
 /// 'exception E = ... '
 and [<NoEquality; NoComparison>]
-    SynExceptionDefnRepr = 
-    | SynExceptionDefnRepr of SynAttributes * SynUnionCase * LongIdent option * PreXmlDoc * SynAccess option * range
+    SynExceptionDefnRepr =
+    | SynExceptionDefnRepr of SynAttributes * case:SynUnionCase * longId:LongIdent option * xmlDoc:PreXmlDoc * accesibility:SynAccess option * range:range
     member this.Range = match this with SynExceptionDefnRepr(_,_,_,_,_,m) -> m
 
 /// 'exception E = ... with ...'
-and 
+and
     [<NoEquality; NoComparison>]
-    SynExceptionDefn = 
-    | SynExceptionDefn of SynExceptionDefnRepr * SynMemberDefns * range
+    SynExceptionDefn =
+    | SynExceptionDefn of exnRepr:SynExceptionDefnRepr * members:SynMemberDefns * range:range
     member this.Range =
         match this with
         | SynExceptionDefn(_,_,m) -> m
 
-and 
+and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     SynTypeDefnRepr =
-    | ObjectModel  of SynTypeDefnKind * SynMemberDefns * range
-    | Simple of SynTypeDefnSimpleRepr * range
+    | ObjectModel  of SynTypeDefnKind * members:SynMemberDefns * range:range
+    | Simple of SynTypeDefnSimpleRepr * range:range
     | Exception of SynExceptionDefnRepr
     member this.Range =
         match this with
@@ -1287,153 +1322,153 @@ and
         | Simple(_,m) -> m
         | Exception t -> t.Range
 
-and 
+and
     [<NoEquality; NoComparison>]
     SynTypeDefn =
-    | TypeDefn of SynComponentInfo * SynTypeDefnRepr * SynMemberDefns * range
+    | TypeDefn of SynComponentInfo * SynTypeDefnRepr * members:SynMemberDefns * range:range
     member this.Range =
         match this with
         | TypeDefn(_,_,_,m) -> m
 
-and 
+and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
-    SynMemberDefn = 
-    | Open of LongIdent * range
-    | Member of SynBinding * range                          
-    /// implicit ctor args as a defn line, 'as' specification 
-    | ImplicitCtor of SynAccess option * SynAttributes * SynSimplePat list * Ident option * range    
-    /// inherit <typ>(args...) as base 
-    | ImplicitInherit of SynType * SynExpr * Ident option * range   
+    SynMemberDefn =
+    | Open of longId:LongIdent * range:range
+    | Member of memberDefn:SynBinding * range:range
+    /// implicit ctor args as a defn line, 'as' specification
+    | ImplicitCtor of accessiblity:SynAccess option * attributes:SynAttributes * ctorArgs:SynSimplePat list * selfIdentifier:Ident option * range:range
+    /// inherit <typ>(args...) as base
+    | ImplicitInherit of inheritType:SynType * inheritArgs:SynExpr * inheritAlias:Ident option * range:range
     /// LetBindings(bindingList, isStatic, isRecursive, wholeRange)
     ///
-    /// localDefns 
-    | LetBindings of SynBinding list * bool * bool * range                    
-    | AbstractSlot of SynValSig * MemberFlags * range 
-    | Interface of SynType * SynMemberDefns option  * range
-    | Inherit of SynType  * Ident option * range
-    | ValField of SynField  * range
+    /// localDefns
+    | LetBindings of bindings:SynBinding list * isStatic:bool * isRecursive:bool * range:range
+    | AbstractSlot of valSig:SynValSig * memberFlags:MemberFlags * range:range
+    | Interface of typeName:SynType * interfaceMembers:SynMemberDefns option  * range:range
+    | Inherit of typeName:SynType  * id:Ident option * range:range
+    | ValField of field:SynField  * range:range
     /// A feature that is not implemented
-    | NestedType of SynTypeDefn * SynAccess option * range
+    | NestedType of typeDefn:SynTypeDefn * accessiblity:SynAccess option * range:range
     /// SynMemberDefn.AutoProperty (attribs,isStatic,id,tyOpt,propKind,memberFlags,xmlDoc,access,synExpr,mGetSet,mWholeAutoProp).
-    /// 
+    ///
     /// F# syntax: 'member val X = expr'
-    | AutoProperty of SynAttributes * bool * Ident * SynType option * MemberKind * (MemberKind -> MemberFlags) * PreXmlDoc * SynAccess option * SynExpr * range option * range
-    member d.Range = 
-        match d with 
-        | SynMemberDefn.Member(_, m)
-        | SynMemberDefn.Interface(_, _, m)
-        | SynMemberDefn.Open(_, m)
-        | SynMemberDefn.LetBindings(_,_,_,m) 
-        | SynMemberDefn.ImplicitCtor(_,_,_,_,m)
-        | SynMemberDefn.ImplicitInherit(_,_,_,m) 
-        | SynMemberDefn.AbstractSlot(_,_,m)
-        | SynMemberDefn.Inherit(_,_,m)
-        | SynMemberDefn.ValField(_,m)
-        | SynMemberDefn.AutoProperty(_,_,_,_,_,_,_,_,_,_,m)
-        | SynMemberDefn.NestedType(_,_,m) -> m
-      
+    | AutoProperty of attributes:SynAttributes * isStatic:bool * id:Ident * tyOpt:SynType option * propKind:MemberKind * memberFlags:(MemberKind -> MemberFlags) * xmlDoc:PreXmlDoc * accessibility:SynAccess option * expr:SynExpr * getSetPos:range option * range:range
+    member d.Range =
+        match d with
+        | SynMemberDefn.Member (range=m)
+        | SynMemberDefn.Interface (range=m)
+        | SynMemberDefn.Open (range=m)
+        | SynMemberDefn.LetBindings (range=m)
+        | SynMemberDefn.ImplicitCtor (range=m)
+        | SynMemberDefn.ImplicitInherit (range=m)
+        | SynMemberDefn.AbstractSlot (range=m)
+        | SynMemberDefn.Inherit (range=m)
+        | SynMemberDefn.ValField (range=m)
+        | SynMemberDefn.AutoProperty (range=m)
+        | SynMemberDefn.NestedType (range=m) -> m
+
 and SynMemberDefns = SynMemberDefn list
 
-and 
+and
     [<NoEquality; NoComparison;RequireQualifiedAccess>]
     SynModuleDecl =
     | ModuleAbbrev of Ident * LongIdent * range
     | NestedModule of SynComponentInfo * isRec: bool * SynModuleDecls * bool * range
     | Let of bool * SynBinding list * range
-    | DoExpr of SequencePointInfoForBinding * SynExpr * range 
+    | DoExpr of SequencePointInfoForBinding * SynExpr * range
     | Types of SynTypeDefn list * range
     | Exception of SynExceptionDefn * range
     | Open of LongIdentWithDots * range
     | Attributes of SynAttributes * range
     | HashDirective of ParsedHashDirective * range
-    | NamespaceFragment of SynModuleOrNamespace 
-    member d.Range = 
-        match d with 
-        | SynModuleDecl.ModuleAbbrev(_,_,m) 
+    | NamespaceFragment of SynModuleOrNamespace
+    member d.Range =
+        match d with
+        | SynModuleDecl.ModuleAbbrev(_,_,m)
         | SynModuleDecl.NestedModule(_,_,_,_,m)
-        | SynModuleDecl.Let(_,_,m) 
-        | SynModuleDecl.DoExpr(_,_,m) 
+        | SynModuleDecl.Let(_,_,m)
+        | SynModuleDecl.DoExpr(_,_,m)
         | SynModuleDecl.Types(_,m)
         | SynModuleDecl.Exception(_,m)
         | SynModuleDecl.Open (_,m)
         | SynModuleDecl.HashDirective (_,m)
-        | SynModuleDecl.NamespaceFragment(SynModuleOrNamespace(_,_,_,_,_,_,_,m)) 
+        | SynModuleDecl.NamespaceFragment(SynModuleOrNamespace(_,_,_,_,_,_,_,m))
         | SynModuleDecl.Attributes(_,m) -> m
 
 and SynModuleDecls = SynModuleDecl list
 
-and 
+and
     [<NoEquality; NoComparison>]
-    SynExceptionSig = 
-    | SynExceptionSig of SynExceptionDefnRepr * SynMemberSigs * range
+    SynExceptionSig =
+    | SynExceptionSig of exnRepr:SynExceptionDefnRepr * memberSigs:SynMemberSigs * range:range
 
 and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     SynModuleSigDecl =
-    | ModuleAbbrev      of Ident * LongIdent * range
-    | NestedModule      of SynComponentInfo * isRec : bool * SynModuleSigDecls * range
-    | Val               of SynValSig * range
-    | Types             of SynTypeDefnSig list * range
-    | Exception         of SynExceptionSig * range
-    | Open              of LongIdent * range
-    | HashDirective     of ParsedHashDirective * range
-    | NamespaceFragment of SynModuleOrNamespaceSig 
+    | ModuleAbbrev      of id:Ident * longId:LongIdent * range:range
+    | NestedModule      of SynComponentInfo * isRec: bool * moduleSigDecls:SynModuleSigDecls * range:range
+    | Val               of valSig:SynValSig * range:range
+    | Types             of typeDefSigs:SynTypeDefnSig list * range:range
+    | Exception         of exnSig:SynExceptionSig * range:range
+    | Open              of longId:LongIdent * range:range
+    | HashDirective     of hashDirective:ParsedHashDirective * range:range
+    | NamespaceFragment of SynModuleOrNamespaceSig
 
-    member d.Range = 
-        match d with 
+    member d.Range =
+        match d with
         | SynModuleSigDecl.ModuleAbbrev (_,_,m)
         | SynModuleSigDecl.NestedModule (_,_,_,m)
         | SynModuleSigDecl.Val      (_,m)
         | SynModuleSigDecl.Types    (_,m)
         | SynModuleSigDecl.Exception      (_,m)
         | SynModuleSigDecl.Open     (_,m)
-        | SynModuleSigDecl.NamespaceFragment (SynModuleOrNamespaceSig(_,_,_,_,_,_,_,m)) 
+        | SynModuleSigDecl.NamespaceFragment (SynModuleOrNamespaceSig(_,_,_,_,_,_,_,m))
         | SynModuleSigDecl.HashDirective     (_,m) -> m
 
 and SynModuleSigDecls = SynModuleSigDecl list
 
 /// SynModuleOrNamespace(lid,isRec,isModule,decls,xmlDoc,attribs,SynAccess,m)
-and 
+and
     [<NoEquality; NoComparison>]
-    SynModuleOrNamespace = 
-    | SynModuleOrNamespace of LongIdent * isRec: bool * isModule: bool * SynModuleDecls * PreXmlDoc * SynAttributes * SynAccess option * range 
+    SynModuleOrNamespace =
+    | SynModuleOrNamespace of id:LongIdent * isRec: bool * isModule:bool * decls:SynModuleDecls * xmlDoc:PreXmlDoc * attributes:SynAttributes * access:SynAccess option * range:range
     member this.Range =
         match this with
         | SynModuleOrNamespace(_,_,_,_,_,_,_,m) -> m
 
-and 
+and
     [<NoEquality; NoComparison>]
-    SynModuleOrNamespaceSig = 
-    | SynModuleOrNamespaceSig of LongIdent * isRec: bool * isModule: bool * SynModuleSigDecls * PreXmlDoc * SynAttributes * SynAccess option * range 
+    SynModuleOrNamespaceSig =
+    | SynModuleOrNamespaceSig of id:LongIdent * isRec: bool * isModule:bool * SynModuleSigDecls * xmlDoc:PreXmlDoc * attributes:SynAttributes * SynAccess option * range:range
 
 and [<NoEquality; NoComparison>]
-    ParsedHashDirective = 
-    | ParsedHashDirective of string * string list * range
+    ParsedHashDirective =
+    | ParsedHashDirective of string * string list * range:range
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
-type ParsedImplFileFragment = 
-    | AnonModule of SynModuleDecls * range
+type ParsedImplFileFragment =
+    | AnonModule of moduleDecls:SynModuleDecls * range:range
     | NamedModule of SynModuleOrNamespace
-    | NamespaceFragment of LongIdent * bool * bool * SynModuleDecls * PreXmlDoc * SynAttributes * range
+    | NamespaceFragment of longId:LongIdent * bool * bool * moduleDecls:SynModuleDecls * xmlDoc:PreXmlDoc * attributes:SynAttributes * range:range
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
-type ParsedSigFileFragment = 
-    | AnonModule of SynModuleSigDecls * range
+type ParsedSigFileFragment =
+    | AnonModule of moduleSigDecl:SynModuleSigDecls * range:range
     | NamedModule of SynModuleOrNamespaceSig
-    | NamespaceFragment of LongIdent * bool * bool * SynModuleSigDecls * PreXmlDoc * SynAttributes * range
+    | NamespaceFragment of longId:LongIdent * bool * bool * moduleSigDecls:SynModuleSigDecls * xmlDoc:PreXmlDoc * attributes:SynAttributes * range:range
 
 [<NoEquality; NoComparison>]
 type ParsedFsiInteraction =
-    | IDefns of SynModuleDecl list * range
-    | IHash  of ParsedHashDirective * range
+    | IDefns of SynModuleDecl list * range:range
+    | IHash  of ParsedHashDirective * range:range
 
 [<NoEquality; NoComparison>]
-type ParsedImplFile = 
-    | ParsedImplFile of ParsedHashDirective list * ParsedImplFileFragment list
+type ParsedImplFile =
+    | ParsedImplFile of hashDirectives:ParsedHashDirective list * ParsedImplFileFragment list
 
 [<NoEquality; NoComparison>]
-type ParsedSigFile = 
-    | ParsedSigFile of ParsedHashDirective list * ParsedSigFileFragment list
+type ParsedSigFile =
+    | ParsedSigFile of hashDirectives:ParsedHashDirective list * ParsedSigFileFragment list
 
 //----------------------------------------------------------------------
 // AST and parsing utilities.
@@ -1447,54 +1482,54 @@ let textOfPath path = String.concat "." path
 let textOfArrPath path = String.concat "." (List.ofArray path)
 let textOfLid lid = textOfPath (pathOfLid lid)
 
-let rangeOfLid (lid: Ident list) = 
-    match lid with 
+let rangeOfLid (lid: Ident list) =
+    match lid with
     | [] -> failwith "rangeOfLid"
     | [id] -> id.idRange
-    | h::t -> unionRanges h.idRange (List.last t).idRange 
+    | h::t -> unionRanges h.idRange (List.last t).idRange
 
 [<RequireQualifiedAccess>]
-type ScopedPragma = 
+type ScopedPragma =
    | WarningOff of range * int
    // Note: this type may be extended in the future with optimization on/off switches etc.
 
 // These are the results of parsing + folding in the implicit file name
 /// ImplFile(modname,isScript,qualName,hashDirectives,modules,isLastCompiland)
 
-/// QualifiedNameOfFile acts to fully-qualify module specifications and implementations, 
-/// most importantly the ones that simply contribute fragments to a namespace (i.e. the ParsedSigFileFragment.NamespaceFragment case) 
-/// There may be multiple such fragments in a single assembly.  There may thus also 
-/// be multiple matching pairs of these in an assembly, all contributing types to the same 
-/// namespace. 
+/// QualifiedNameOfFile acts to fully-qualify module specifications and implementations,
+/// most importantly the ones that simply contribute fragments to a namespace (i.e. the ParsedSigFileFragment.NamespaceFragment case)
+/// There may be multiple such fragments in a single assembly.  There may thus also
+/// be multiple matching pairs of these in an assembly, all contributing types to the same
+/// namespace.
 [<NoEquality; NoComparison>]
-type QualifiedNameOfFile = 
-    | QualifiedNameOfFile of Ident 
-    member x.Text = (let (QualifiedNameOfFile(t)) = x in t.idText)
-    member x.Id = (let (QualifiedNameOfFile(t)) = x in t)
-    member x.Range = (let (QualifiedNameOfFile(t)) = x in t.idRange)
+type QualifiedNameOfFile =
+    | QualifiedNameOfFile of Ident
+    member x.Text = (let (QualifiedNameOfFile t) = x in t.idText)
+    member x.Id = (let (QualifiedNameOfFile t) = x in t)
+    member x.Range = (let (QualifiedNameOfFile t) = x in t.idRange)
 
 [<NoEquality; NoComparison>]
-type ParsedImplFileInput = 
-    | ParsedImplFileInput of string * (*isScript: *) bool * QualifiedNameOfFile * ScopedPragma list * ParsedHashDirective list * SynModuleOrNamespace list * (bool * bool)
+type ParsedImplFileInput =
+    | ParsedImplFileInput of filename:string * isScript:bool * QualifiedNameOfFile * ScopedPragma list * ParsedHashDirective list * SynModuleOrNamespace list * (bool * bool)
 
 [<NoEquality; NoComparison>]
-type ParsedSigFileInput = 
-    | ParsedSigFileInput of string * QualifiedNameOfFile * ScopedPragma list * ParsedHashDirective list * SynModuleOrNamespaceSig list
+type ParsedSigFileInput =
+    | ParsedSigFileInput of filename:string * QualifiedNameOfFile * ScopedPragma list * ParsedHashDirective list * SynModuleOrNamespaceSig list
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
-type ParsedInput = 
+type ParsedInput =
     | ImplFile of ParsedImplFileInput
     | SigFile of ParsedSigFileInput
 
-    member inp.Range = 
+    member inp.Range =
         match inp with
         | ParsedInput.ImplFile (ParsedImplFileInput(_,_,_,_,_,(SynModuleOrNamespace(_,_,_,_,_,_,_,m) :: _),_))
         | ParsedInput.SigFile (ParsedSigFileInput(_,_,_,_,(SynModuleOrNamespaceSig(_,_,_,_,_,_,_,m) :: _))) -> m
         | ParsedInput.ImplFile (ParsedImplFileInput(filename,_,_,_,_,[],_))
         | ParsedInput.SigFile (ParsedSigFileInput(filename,_,_,_,[])) ->
-#if DEBUG      
+#if DEBUG
             assert("" = "compiler expects ParsedInput.ImplFile and ParsedInput.SigFile to have at least one fragment, 4488")
-#endif    
+#endif
             rangeN filename 0 (* There are no implementations, e.g. due to errors, so return a default range for the file *)
 
 
@@ -1502,9 +1537,9 @@ type ParsedInput =
 // Construct syntactic AST nodes
 //-----------------------------------------------------------------------
 
-// REVIEW: get rid of this global state 
-type SynArgNameGenerator() = 
-    let mutable count = 0 
+// REVIEW: get rid of this global state
+type SynArgNameGenerator() =
+    let mutable count = 0
     let generatedArgNamePrefix = "_arg"
 
     member __.New() : string = count <- count + 1; generatedArgNamePrefix + string count
@@ -1518,12 +1553,12 @@ type SynArgNameGenerator() =
 let mkSynId m s = Ident(s,m)
 let pathToSynLid m p = List.map (mkSynId m) p
 let mkSynIdGet m n = SynExpr.Ident(mkSynId m n)
-let mkSynLidGet m path n = 
+let mkSynLidGet m path n =
     let lid = pathToSynLid m path @ [mkSynId m n]
     let dots = List.replicate (lid.Length - 1) m
     SynExpr.LongIdent(false,LongIdentWithDots(lid,dots),None,m)
-let mkSynIdGetWithAlt m id altInfo = 
-    match altInfo with 
+let mkSynIdGetWithAlt m id altInfo =
+    match altInfo with
     | None -> SynExpr.Ident id
     | _ -> SynExpr.LongIdent(false,LongIdentWithDots([id],[]),altInfo,m)
 
@@ -1531,34 +1566,34 @@ let mkSynSimplePatVar isOpt id = SynSimplePat.Id (id,None,false,false,isOpt,id.i
 let mkSynCompGenSimplePatVar id = SynSimplePat.Id (id,None,true,false,false,id.idRange)
 
 /// Match a long identifier, including the case for single identifiers which gets a more optimized node in the syntax tree.
-let (|LongOrSingleIdent|_|) inp = 
+let (|LongOrSingleIdent|_|) inp =
     match inp with
     | SynExpr.LongIdent(isOpt,lidwd,altId,_m) -> Some (isOpt,lidwd,altId,lidwd.RangeSansAnyExtraDot)
     | SynExpr.Ident id -> Some (false,LongIdentWithDots([id],[]),None,id.idRange)
     | _ -> None
 
-let (|SingleIdent|_|) inp = 
+let (|SingleIdent|_|) inp =
     match inp with
     | SynExpr.LongIdent(false,LongIdentWithDots([id],_),None,_) -> Some id
     | SynExpr.Ident id -> Some id
     | _ -> None
-    
+
 /// This affects placement of sequence points
-let rec IsControlFlowExpression e = 
-    match e with 
-    | SynExpr.ObjExpr _ 
-    | SynExpr.Lambda _ 
-    | SynExpr.LetOrUse _ 
-    | SynExpr.Sequential _ 
+let rec IsControlFlowExpression e =
+    match e with
+    | SynExpr.ObjExpr _
+    | SynExpr.Lambda _
+    | SynExpr.LetOrUse _
+    | SynExpr.Sequential _
     // Treat "ident { ... }" as a control flow expression
-    | SynExpr.App (_, _, SynExpr.Ident _, SynExpr.CompExpr _,_) 
-    | SynExpr.IfThenElse _ 
+    | SynExpr.App (_, _, SynExpr.Ident _, SynExpr.CompExpr _,_)
+    | SynExpr.IfThenElse _
     | SynExpr.LetOrUseBang _
-    | SynExpr.Match _  
-    | SynExpr.TryWith _ 
-    | SynExpr.TryFinally _ 
-    | SynExpr.For _ 
-    | SynExpr.ForEach _ 
+    | SynExpr.Match _
+    | SynExpr.TryWith _
+    | SynExpr.TryFinally _
+    | SynExpr.For _
+    | SynExpr.ForEach _
     | SynExpr.While _ -> true
     | SynExpr.Typed(e,_,_) -> IsControlFlowExpression e
     | _ -> false
@@ -1568,60 +1603,60 @@ let mkNamedField (ident, ty: SynType) = Field([],false,Some ident,ty,false,PreXm
 
 let mkSynPatVar vis (id:Ident) = SynPat.Named (SynPat.Wild id.idRange,id,false,vis,id.idRange)
 let mkSynThisPatVar (id:Ident) = SynPat.Named (SynPat.Wild id.idRange,id,true,None,id.idRange)
-let mkSynPatMaybeVar lidwd vis m =  SynPat.LongIdent (lidwd,None,None,SynConstructorArgs.Pats [],vis,m) 
+let mkSynPatMaybeVar lidwd vis m =  SynPat.LongIdent (lidwd,None,None,SynConstructorArgs.Pats [],vis,m)
 
 /// Extract the argument for patterns corresponding to the declaration of 'new ... = ...'
-let (|SynPatForConstructorDecl|_|) x = 
-    match x with 
+let (|SynPatForConstructorDecl|_|) x =
+    match x with
     | SynPat.LongIdent (LongIdentWithDots([_],_),_,_, SynConstructorArgs.Pats [arg],_,_) -> Some arg
     | _ -> None
 
 /// Recognize the '()' in 'new()'
-let (|SynPatForNullaryArgs|_|) x = 
-    match x with 
+let (|SynPatForNullaryArgs|_|) x =
+    match x with
     | SynPat.Paren(SynPat.Const(SynConst.Unit,_),_) -> Some()
     | _ -> None
-    
-let (|SynExprErrorSkip|) (p:SynExpr) = 
-    match p with 
+
+let (|SynExprErrorSkip|) (p:SynExpr) =
+    match p with
     | SynExpr.FromParseError(p,_) -> p
     | _ -> p
 
-let (|SynExprParen|_|) (e:SynExpr) = 
-    match e with 
+let (|SynExprParen|_|) (e:SynExpr) =
+    match e with
     | SynExpr.Paren(SynExprErrorSkip e,a,b,c) -> Some (e,a,b,c)
     | _ -> None
 
-let (|SynPatErrorSkip|) (p:SynPat) = 
-    match p with 
+let (|SynPatErrorSkip|) (p:SynPat) =
+    match p with
     | SynPat.FromParseError(p,_) -> p
     | _ -> p
 
 /// Push non-simple parts of a patten match over onto the r.h.s. of a lambda.
 /// Return a simple pattern and a function to build a match on the r.h.s. if the pattern is complex
 let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
-    match p with 
-    | SynPat.Typed(p',ty,m) -> 
+    match p with
+    | SynPat.Typed(p',ty,m) ->
         let p2,laterf = SimplePatOfPat synArgNameGenerator p'
-        SynSimplePat.Typed(p2,ty,m), 
+        SynSimplePat.Typed(p2,ty,m),
         laterf
-    | SynPat.Attrib(p',attribs,m) -> 
+    | SynPat.Attrib(p',attribs,m) ->
         let p2,laterf = SimplePatOfPat synArgNameGenerator p'
-        SynSimplePat.Attrib(p2,attribs,m), 
+        SynSimplePat.Attrib(p2,attribs,m),
         laterf
-    | SynPat.Named (SynPat.Wild _, v,thisv,_,m) -> 
-        SynSimplePat.Id (v,None,false,thisv,false,m), 
+    | SynPat.Named (SynPat.Wild _, v,thisv,_,m) ->
+        SynSimplePat.Id (v,None,false,thisv,false,m),
         None
-    | SynPat.OptionalVal (v,m) -> 
-        SynSimplePat.Id (v,None,false,false,true,m), 
+    | SynPat.OptionalVal (v,m) ->
+        SynSimplePat.Id (v,None,false,false,true,m),
         None
-    | SynPat.Paren (p,_) -> SimplePatOfPat synArgNameGenerator p 
-    | SynPat.FromParseError (p,_) -> SimplePatOfPat synArgNameGenerator p 
-    | _ -> 
+    | SynPat.Paren (p,_) -> SimplePatOfPat synArgNameGenerator p
+    | SynPat.FromParseError (p,_) -> SimplePatOfPat synArgNameGenerator p
+    | _ ->
         let m = p.Range
-        let isCompGen,altNameRefCell,id,item = 
-            match p with 
-            | SynPat.LongIdent(LongIdentWithDots([id],_),_,None, SynConstructorArgs.Pats [],None,_) -> 
+        let isCompGen,altNameRefCell,id,item =
+            match p with
+            | SynPat.LongIdent(LongIdentWithDots([id],_),_,None, SynConstructorArgs.Pats [],None,_) ->
                 // The pattern is 'V' or some other capitalized identifier.
                 // It may be a real variable, in which case we want to maintain its name.
                 // But it may also be a nullary union case or some other identifier.
@@ -1629,42 +1664,42 @@ let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
                 let altNameRefCell = Some (ref (Undecided (mkSynId m (synArgNameGenerator.New()))))
                 let item = mkSynIdGetWithAlt m id altNameRefCell
                 false,altNameRefCell,id,item
-            | _ -> 
+            | _ ->
                 let nm = synArgNameGenerator.New()
                 let id = mkSynId m nm
                 let item = mkSynIdGet m nm
                 true,None,id,item
         SynSimplePat.Id (id,altNameRefCell,isCompGen,false,false,id.idRange),
-        Some (fun e -> 
+        Some (fun e ->
                 let clause = Clause(p,None,e,m,SuppressSequencePointAtTarget)
-                SynExpr.Match(NoSequencePointAtInvisibleBinding,item,[clause],false,clause.Range)) 
+                SynExpr.Match(NoSequencePointAtInvisibleBinding,item,[clause],false,clause.Range))
 
 let appFunOpt funOpt x = match funOpt with None -> x | Some f -> f x
 let composeFunOpt funOpt1 funOpt2 = match funOpt2 with None -> funOpt1 | Some f -> Some (fun x -> appFunOpt funOpt1 (f x))
 let rec SimplePatsOfPat synArgNameGenerator p =
-    match p with 
-    | SynPat.FromParseError (p,_) -> SimplePatsOfPat synArgNameGenerator p 
-    | SynPat.Typed(p',ty,m) -> 
+    match p with
+    | SynPat.FromParseError (p,_) -> SimplePatsOfPat synArgNameGenerator p
+    | SynPat.Typed(p',ty,m) ->
         let p2,laterf = SimplePatsOfPat synArgNameGenerator p'
-        SynSimplePats.Typed(p2,ty,m), 
+        SynSimplePats.Typed(p2,ty,m),
         laterf
-//    | SynPat.Paren (p,m) -> SimplePatsOfPat synArgNameGenerator p 
-    | SynPat.Tuple (ps,m) 
-    | SynPat.Paren(SynPat.Tuple (ps,m),_) -> 
-        let ps2,laterf = 
-          List.foldBack 
-            (fun (p',rhsf) (ps',rhsf') -> 
-              p'::ps', 
+//    | SynPat.Paren (p,m) -> SimplePatsOfPat synArgNameGenerator p
+    | SynPat.Tuple (ps,m)
+    | SynPat.Paren(SynPat.Tuple (ps,m),_) ->
+        let ps2,laterf =
+          List.foldBack
+            (fun (p',rhsf) (ps',rhsf') ->
+              p'::ps',
               (composeFunOpt rhsf rhsf'))
-            (List.map (SimplePatOfPat synArgNameGenerator) ps) 
+            (List.map (SimplePatOfPat synArgNameGenerator) ps)
             ([], None)
         SynSimplePats.SimplePats (ps2,m),
         laterf
-    | SynPat.Paren(SynPat.Const (SynConst.Unit,m),_) 
-    | SynPat.Const (SynConst.Unit,m) -> 
+    | SynPat.Paren(SynPat.Const (SynConst.Unit,m),_)
+    | SynPat.Const (SynConst.Unit,m) ->
         SynSimplePats.SimplePats ([],m),
         None
-    | _ -> 
+    | _ ->
         let m = p.Range
         let sp,laterf = SimplePatOfPat synArgNameGenerator p
         SynSimplePats.SimplePats ([sp],m),laterf
@@ -1676,19 +1711,19 @@ let PushPatternToExpr synArgNameGenerator isMember pat (rhs: SynExpr) =
 let private isSimplePattern pat =
     let _nowpats,laterf = SimplePatsOfPat (SynArgNameGenerator()) pat
     Option.isNone laterf
-  
-/// "fun (UnionCase x) (UnionCase y) -> body" 
-///       ==> 
-///   "fun tmp1 tmp2 -> 
-///        let (UnionCase x) = tmp1 in 
-///        let (UnionCase y) = tmp2 in 
-///        body" 
+
+/// "fun (UnionCase x) (UnionCase y) -> body"
+///       ==>
+///   "fun tmp1 tmp2 ->
+///        let (UnionCase x) = tmp1 in
+///        let (UnionCase y) = tmp2 in
+///        body"
 let PushCurriedPatternsToExpr synArgNameGenerator wholem isMember pats rhs =
     // Two phases
     // First phase: Fold back, from right to left, pushing patterns into r.h.s. expr
-    let spatsl,rhs = 
-        (pats, ([],rhs)) 
-           ||> List.foldBack (fun arg (spatsl,body) -> 
+    let spatsl,rhs =
+        (pats, ([],rhs))
+           ||> List.foldBack (fun arg (spatsl,body) ->
               let spats,bodyf = SimplePatsOfPat synArgNameGenerator arg
               // accumulate the body. This builds "let (UnionCase y) = tmp2 in body"
               let body = appFunOpt bodyf body
@@ -1696,42 +1731,42 @@ let PushCurriedPatternsToExpr synArgNameGenerator wholem isMember pats rhs =
               let spatsl = spats::spatsl
               (spatsl,body))
     // Second phase: build lambdas. Mark subsequent ones with "true" indicating they are part of an iterated sequence of lambdas
-    let expr = 
+    let expr =
         match spatsl with
         | [] -> rhs
-        | h::t -> 
+        | h::t ->
             let expr = List.foldBack (fun spats e -> SynExpr.Lambda (isMember,true,spats, e,wholem)) t rhs
             let expr = SynExpr.Lambda (isMember,false,h, expr,wholem)
             expr
     spatsl,expr
 
-/// Helper for parsing the inline IL fragments. 
+/// Helper for parsing the inline IL fragments.
 #if NO_INLINE_IL_PARSER
-let ParseAssemblyCodeInstructions _s m = 
+let ParseAssemblyCodeInstructions _s m =
     errorR(Error((193,"Inline IL not valid in a hosted environment"),m))
     [| |]
 #else
-let ParseAssemblyCodeInstructions s m = 
-    try Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiParser.ilInstrs 
-           Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiLexer.token 
+let ParseAssemblyCodeInstructions s m =
+    try Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiParser.ilInstrs
+           Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiLexer.token
            (UnicodeLexing.StringAsLexbuf s)
-    with RecoverableParseError -> 
+    with RecoverableParseError ->
       errorR(Error(FSComp.SR.astParseEmbeddedILError(), m)); [| |]
 #endif
 
 
-/// Helper for parsing the inline IL fragments. 
+/// Helper for parsing the inline IL fragments.
 #if NO_INLINE_IL_PARSER
-let ParseAssemblyCodeType _s m = 
+let ParseAssemblyCodeType _s m =
     errorR(Error((193,"Inline IL not valid in a hosted environment"),m))
     IL.EcmaMscorlibILGlobals.typ_Object
 #else
-let ParseAssemblyCodeType s m = 
-    try Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiParser.ilType 
-           Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiLexer.token 
+let ParseAssemblyCodeType s m =
+    try Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiParser.ilType
+           Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiLexer.token
            (UnicodeLexing.StringAsLexbuf s)
-    with RecoverableParseError -> 
-      errorR(Error(FSComp.SR.astParseEmbeddedILTypeError(),m)); 
+    with RecoverableParseError ->
+      errorR(Error(FSComp.SR.astParseEmbeddedILTypeError(),m));
       IL.EcmaMscorlibILGlobals.typ_Object
 #endif
 
@@ -1739,11 +1774,11 @@ let ParseAssemblyCodeType s m =
 // AST constructors
 //------------------------------------------------------------------------
 
-let opNameParenGet  = CompileOpName parenGet 
+let opNameParenGet  = CompileOpName parenGet
 let opNameQMark = CompileOpName qmark
 let mkSynOperator opm oper = mkSynIdGet opm (CompileOpName oper)
 
-let mkSynInfix opm (l:SynExpr) oper (r:SynExpr) = 
+let mkSynInfix opm (l:SynExpr) oper (r:SynExpr) =
     let firstTwoRange = unionRanges l.Range opm
     let wholeRange = unionRanges l.Range r.Range
     SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, mkSynOperator opm oper, l, firstTwoRange), r, wholeRange)
@@ -1764,9 +1799,9 @@ let mkSynDotBrackGet  m mDot a b   = SynExpr.DotIndexedGet(a,[SynIndexerArg.One 
 let mkSynQMarkSet m a b c = mkSynTrifix m qmarkSet a b c
 let mkSynDotBrackSliceGet  m mDot arr sliceArg = SynExpr.DotIndexedGet(arr,[sliceArg],mDot,m)
 
-let mkSynDotBrackSeqSliceGet  m mDot arr (argslist:list<SynIndexerArg>) = 
+let mkSynDotBrackSeqSliceGet  m mDot arr (argslist:list<SynIndexerArg>) =
     let notsliced=[ for arg in argslist do
-                       match arg with 
+                       match arg with
                        | SynIndexerArg.One x -> yield x
                        | _ -> () ]
     if notsliced.Length = argslist.Length then
@@ -1774,7 +1809,7 @@ let mkSynDotBrackSeqSliceGet  m mDot arr (argslist:list<SynIndexerArg>) =
     else
         SynExpr.DotIndexedGet(arr,argslist,mDot,m)
 
-let mkSynDotParenGet lhsm dotm a b   = 
+let mkSynDotParenGet lhsm dotm a b   =
     match b with
     | SynExpr.Tuple ([_;_],_,_)   -> errorR(Deprecated(FSComp.SR.astDeprecatedIndexerNotation(),lhsm)) ; SynExpr.Const(SynConst.Unit,lhsm)
     | SynExpr.Tuple ([_;_;_],_,_) -> errorR(Deprecated(FSComp.SR.astDeprecatedIndexerNotation(),lhsm)) ; SynExpr.Const(SynConst.Unit,lhsm)
@@ -1784,46 +1819,46 @@ let mkSynUnit m = SynExpr.Const(SynConst.Unit,m)
 let mkSynUnitPat m = SynPat.Const(SynConst.Unit,m)
 let mkSynDelay m e = SynExpr.Lambda (false,false,SynSimplePats.SimplePats ([mkSynCompGenSimplePatVar (mkSynId m "unitVar")],m), e, m)
 
-let mkSynAssign (l: SynExpr) (r: SynExpr) = 
+let mkSynAssign (l: SynExpr) (r: SynExpr) =
     let m = unionRanges l.Range r.Range
-    match l with 
+    match l with
     //| SynExpr.Paren(l2,m2)  -> mkSynAssign m l2 r
     | LongOrSingleIdent(false,v,None,_)  -> SynExpr.LongIdentSet (v,r,m)
     | SynExpr.DotGet(e,_,v,_)  -> SynExpr.DotSet (e,v,r,m)
     | SynExpr.DotIndexedGet(e1,e2,mDot,mLeft)  -> SynExpr.DotIndexedSet (e1,e2,r,mLeft,mDot,m)
-    | SynExpr.LibraryOnlyUnionCaseFieldGet (x,y,z,_) -> SynExpr.LibraryOnlyUnionCaseFieldSet (x,y,z,r,m) 
-    | SynExpr.App (_, _, SynExpr.App(_, _, SingleIdent(nm), a, _),b,_) when nm.idText = opNameQMark -> 
+    | SynExpr.LibraryOnlyUnionCaseFieldGet (x,y,z,_) -> SynExpr.LibraryOnlyUnionCaseFieldSet (x,y,z,r,m)
+    | SynExpr.App (_, _, SynExpr.App(_, _, SingleIdent(nm), a, _),b,_) when nm.idText = opNameQMark ->
         mkSynQMarkSet m a b r
-    | SynExpr.App (_, _, SynExpr.App(_, _, SingleIdent(nm), a, _),b,_) when nm.idText = opNameParenGet -> 
+    | SynExpr.App (_, _, SynExpr.App(_, _, SingleIdent(nm), a, _),b,_) when nm.idText = opNameParenGet ->
         mkSynDotParenSet m a b r
     | SynExpr.App (_, _, SynExpr.LongIdent(false,v,None,_),x,_)  -> SynExpr.NamedIndexedPropertySet (v,x,r,m)
     | SynExpr.App (_, _, SynExpr.DotGet(e,_,v,_),x,_)  -> SynExpr.DotNamedIndexedPropertySet (e,v,x,r,m)
     |   _ -> errorR(Error(FSComp.SR.astInvalidExprLeftHandOfAssignment(), m));  l  // return just the LHS, so the typechecker can see it and capture expression typings that may be useful for dot lookups
 
-let rec mkSynDot dotm m l r = 
-    match l with 
-    | SynExpr.LongIdent(isOpt,LongIdentWithDots(lid,dots),None,_) -> 
+let rec mkSynDot dotm m l r =
+    match l with
+    | SynExpr.LongIdent(isOpt,LongIdentWithDots(lid,dots),None,_) ->
         SynExpr.LongIdent(isOpt,LongIdentWithDots(lid@[r],dots@[dotm]),None,m) // REVIEW: MEMORY PERFORMANCE: This list operation is memory intensive (we create a lot of these list nodes) - an ImmutableArray would be better here
-    | SynExpr.Ident id -> 
+    | SynExpr.Ident id ->
         SynExpr.LongIdent(false,LongIdentWithDots([id;r],[dotm]),None,m)
-    | SynExpr.DotGet(e,dm,LongIdentWithDots(lid,dots),_) -> 
+    | SynExpr.DotGet(e,dm,LongIdentWithDots(lid,dots),_) ->
         SynExpr.DotGet(e,dm,LongIdentWithDots(lid@[r],dots@[dotm]),m)// REVIEW: MEMORY PERFORMANCE: This is memory intensive (we create a lot of these list nodes) - an ImmutableArray would be better here
-    | expr -> 
+    | expr ->
         SynExpr.DotGet(expr,dotm,LongIdentWithDots([r],[]),m)
 
-let rec mkSynDotMissing dotm m l = 
-    match l with 
-    | SynExpr.LongIdent(isOpt,LongIdentWithDots(lid,dots),None,_) -> 
+let rec mkSynDotMissing dotm m l =
+    match l with
+    | SynExpr.LongIdent(isOpt,LongIdentWithDots(lid,dots),None,_) ->
         SynExpr.LongIdent(isOpt,LongIdentWithDots(lid,dots@[dotm]),None,m) // REVIEW: MEMORY PERFORMANCE: This list operation is memory intensive (we create a lot of these list nodes) - an ImmutableArray would be better here
-    | SynExpr.Ident id -> 
+    | SynExpr.Ident id ->
         SynExpr.LongIdent(false,LongIdentWithDots([id],[dotm]),None,m)
-    | SynExpr.DotGet(e,dm,LongIdentWithDots(lid,dots),_) -> 
+    | SynExpr.DotGet(e,dm,LongIdentWithDots(lid,dots),_) ->
         SynExpr.DotGet(e,dm,LongIdentWithDots(lid,dots@[dotm]),m)// REVIEW: MEMORY PERFORMANCE: This is memory intensive (we create a lot of these list nodes) - an ImmutableArray would be better here
-    | expr -> 
+    | expr ->
         SynExpr.DiscardAfterMissingQualificationAfterDot(expr,m)
 
-let mkSynFunMatchLambdas synArgNameGenerator isMember wholem ps e = 
-    let _,e =  PushCurriedPatternsToExpr synArgNameGenerator wholem isMember ps e 
+let mkSynFunMatchLambdas synArgNameGenerator isMember wholem ps e =
+    let _,e =  PushCurriedPatternsToExpr synArgNameGenerator wholem isMember ps e
     e
 
 
@@ -1838,9 +1873,9 @@ type SynExpr with
 
 /// The syntactic elements associated with the "return" of a function or method. Some of this is
 /// mostly dummy information to make the return element look like an argument,
-/// the important thing is that (a) you can give a return type for the function or method, and 
+/// the important thing is that (a) you can give a return type for the function or method, and
 /// (b) you can associate .NET attributes to return of a function or method and these get stored in .NET metadata.
-type SynReturnInfo = SynReturnInfo of (SynType * SynArgInfo) * range
+type SynReturnInfo = SynReturnInfo of (SynType * SynArgInfo) * range:range
 
 
 /// Operations related to the syntactic analysis of arguments of value, function and member definitions and signatures.
@@ -1848,7 +1883,7 @@ type SynReturnInfo = SynReturnInfo of (SynType * SynArgInfo) * range
 /// Function and member definitions have strongly syntactically constrained arities.  We infer
 /// the arity from the syntax.
 ///
-/// For example, we record the arity for: 
+/// For example, we record the arity for:
 /// StaticProperty --> [1]               -- for unit arg
 /// this.InstanceProperty --> [1;1]        -- for unit arg
 /// StaticMethod(args) --> map InferSynArgInfoFromSimplePat args
@@ -1857,12 +1892,12 @@ type SynReturnInfo = SynReturnInfo of (SynType * SynArgInfo) * range
 /// StaticProperty with get(argpat) --> [InferSynArgInfoFromSimplePat argpat]
 /// this.InstanceProperty with get() --> 1 :: [InferSynArgInfoFromSimplePat argpat]
 /// StaticProperty with get() --> [InferSynArgInfoFromSimplePat argpat]
-/// 
+///
 /// this.InstanceProperty with set(argpat)(v) --> 1 :: [InferSynArgInfoFromSimplePat argpat; 1]
 /// StaticProperty with set(argpat)(v) --> [InferSynArgInfoFromSimplePat argpat; 1]
 /// this.InstanceProperty with set(v) --> 1 :: [1]
-/// StaticProperty with set(v) --> [1] 
-module SynInfo = 
+/// StaticProperty with set(v) --> [1]
+module SynInfo =
     /// The argument information for an argument without a name
     let unnamedTopArg1 = SynArgInfo([],false,None)
 
@@ -1889,22 +1924,22 @@ module SynInfo =
     /// types of optional arguments for function and member signatures.
     let HasOptionalArgs (SynValInfo(args,_)) = List.exists (List.exists IsOptionalArg) args
 
-    /// Add a parameter entry to the syntactic value information to represent the '()' argument to a property getter. This is 
+    /// Add a parameter entry to the syntactic value information to represent the '()' argument to a property getter. This is
     /// used for the implicit '()' argument in property getter signature specifications.
     let IncorporateEmptyTupledArgForPropertyGetter (SynValInfo(args,retInfo)) = SynValInfo([]::args,retInfo)
 
-    /// Add a parameter entry to the syntactic value information to represent the 'this' argument. This is 
+    /// Add a parameter entry to the syntactic value information to represent the 'this' argument. This is
     /// used for the implicit 'this' argument in member signature specifications.
     let IncorporateSelfArg (SynValInfo(args,retInfo)) = SynValInfo(selfMetadata::args,retInfo)
 
-    /// Add a parameter entry to the syntactic value information to represent the value argument for a property setter. This is 
+    /// Add a parameter entry to the syntactic value information to represent the value argument for a property setter. This is
     /// used for the implicit value argument in property setter signature specifications.
-    let IncorporateSetterArg (SynValInfo(args,retInfo)) = 
-         let args = 
-             match args with 
-             | [] -> [unnamedTopArg] 
-             | [arg] -> [arg@[unnamedTopArg1]] 
-             | _ -> failwith "invalid setter type" 
+    let IncorporateSetterArg (SynValInfo(args,retInfo)) =
+         let args =
+             match args with
+             | [] -> [unnamedTopArg]
+             | [arg] -> [arg@[unnamedTopArg1]]
+             | _ -> failwith "invalid setter type"
          SynValInfo(args,retInfo)
 
     /// Get the argument counts for each curried argument group. Used in some adhoc places in tc.fs.
@@ -1914,90 +1949,90 @@ module SynInfo =
     let AttribsOfArgData (SynArgInfo(attribs,_,_)) = attribs
 
     /// Infer the syntactic argument info for a single argument from a simple pattern.
-    let rec InferSynArgInfoFromSimplePat attribs p = 
-        match p with 
-        | SynSimplePat.Id(nm,_,isCompGen,_,isOpt,_) -> 
+    let rec InferSynArgInfoFromSimplePat attribs p =
+        match p with
+        | SynSimplePat.Id(nm,_,isCompGen,_,isOpt,_) ->
            SynArgInfo(attribs, isOpt, (if isCompGen then None else Some nm))
         | SynSimplePat.Typed(a,_,_) -> InferSynArgInfoFromSimplePat attribs a
         | SynSimplePat.Attrib(a,attribs2,_) -> InferSynArgInfoFromSimplePat (attribs @ attribs2) a
-      
+
     /// Infer the syntactic argument info for one or more arguments one or more simple patterns.
-    let rec InferSynArgInfoFromSimplePats x = 
-        match x with 
+    let rec InferSynArgInfoFromSimplePats x =
+        match x with
         | SynSimplePats.SimplePats(ps,_) -> List.map (InferSynArgInfoFromSimplePat []) ps
         | SynSimplePats.Typed(ps,_,_) -> InferSynArgInfoFromSimplePats ps
 
     /// Infer the syntactic argument info for one or more arguments a pattern.
-    let InferSynArgInfoFromPat p = 
+    let InferSynArgInfoFromPat p =
         // It is ok to use a fresh SynArgNameGenerator here, because compiler generated names are filtered from SynArgInfo, see InferSynArgInfoFromSimplePat above
-        let sp,_ = SimplePatsOfPat (SynArgNameGenerator()) p 
+        let sp,_ = SimplePatsOfPat (SynArgNameGenerator()) p
         InferSynArgInfoFromSimplePats sp
 
     /// Make sure only a solitary unit argument has unit elimination
-    let AdjustArgsForUnitElimination infosForArgs = 
-        match infosForArgs with 
-        | [[]] -> infosForArgs 
+    let AdjustArgsForUnitElimination infosForArgs =
+        match infosForArgs with
+        | [[]] -> infosForArgs
         | _ -> infosForArgs |> List.map (function [] -> unitArgData | x -> x)
 
     /// Transform a property declared using '[static] member P = expr' to a method taking a "unit" argument.
     /// This is similar to IncorporateEmptyTupledArgForPropertyGetter, but applies to member definitions
     /// rather than member signatures.
-    let AdjustMemberArgs memFlags infosForArgs = 
-        match infosForArgs with 
+    let AdjustMemberArgs memFlags infosForArgs =
+        match infosForArgs with
         | [] when memFlags=MemberKind.Member -> [] :: infosForArgs
         | _ -> infosForArgs
 
     /// For 'let' definitions, we infer syntactic argument information from the r.h.s. of a definition, if it
     /// is an immediate 'fun ... -> ...' or 'function ...' expression. This is noted in the F# language specification.
     /// This does not apply to member definitions.
-    let InferLambdaArgs origRhsExpr = 
-        let rec loop e = 
-            match e with 
-            | SynExpr.Lambda(false,_,spats,rest,_) -> 
+    let InferLambdaArgs origRhsExpr =
+        let rec loop e =
+            match e with
+            | SynExpr.Lambda(false,_,spats,rest,_) ->
                 InferSynArgInfoFromSimplePats spats :: loop rest
             | _ -> []
         loop origRhsExpr
 
-    let InferSynReturnData (retInfo: SynReturnInfo option) = 
-        match retInfo with 
-        | None -> unnamedRetVal 
+    let InferSynReturnData (retInfo: SynReturnInfo option) =
+        match retInfo with
+        | None -> unnamedRetVal
         | Some(SynReturnInfo((_,retInfo),_)) -> retInfo
 
     let private emptySynValInfo = SynValInfo([],unnamedRetVal)
-    
+
     let emptySynValData = SynValData(None,emptySynValInfo,None)
 
     /// Infer the syntactic information for a 'let' or 'member' definition, based on the argument pattern,
     /// any declared return information (e.g. .NET attributes on the return element), and the r.h.s. expression
     /// in the case of 'let' definitions.
-    let InferSynValData (memberFlagsOpt, pat, retInfo, origRhsExpr) = 
+    let InferSynValData (memberFlagsOpt, pat, retInfo, origRhsExpr) =
 
-        let infosForExplicitArgs = 
-            match pat with 
+        let infosForExplicitArgs =
+            match pat with
             | Some(SynPat.LongIdent(_,_,_, SynConstructorArgs.Pats curriedArgs,_,_)) -> List.map InferSynArgInfoFromPat curriedArgs
             | _ -> []
 
-        let explicitArgsAreSimple = 
-            match pat with 
+        let explicitArgsAreSimple =
+            match pat with
             | Some(SynPat.LongIdent(_,_,_, SynConstructorArgs.Pats curriedArgs,_,_)) -> List.forall isSimplePattern curriedArgs
             | _ -> true
 
         let retInfo = InferSynReturnData retInfo
 
         match memberFlagsOpt with
-        | None -> 
+        | None ->
             let infosForLambdaArgs = InferLambdaArgs origRhsExpr
             let infosForArgs = infosForExplicitArgs @ (if explicitArgsAreSimple then infosForLambdaArgs else [])
-            let infosForArgs = AdjustArgsForUnitElimination infosForArgs 
+            let infosForArgs = AdjustArgsForUnitElimination infosForArgs
             SynValData(None,SynValInfo(infosForArgs,retInfo),None)
 
-        | Some memFlags  -> 
-            let infosForObjArgs = 
+        | Some memFlags  ->
+            let infosForObjArgs =
                 if memFlags.IsInstance then [ selfMetadata ] else []
 
             let infosForArgs = AdjustMemberArgs memFlags.MemberKind infosForExplicitArgs
-            let infosForArgs = AdjustArgsForUnitElimination infosForArgs 
-            
+            let infosForArgs = AdjustArgsForUnitElimination infosForArgs
+
             let argInfos = infosForObjArgs @ infosForArgs
             SynValData(Some(memFlags),SynValInfo(argInfos,retInfo),None)
 
@@ -2005,16 +2040,16 @@ module SynInfo =
 
 let mkSynBindingRhs staticOptimizations rhsExpr mRhs retInfo =
     let rhsExpr = List.foldBack (fun (c,e1) e2 -> SynExpr.LibraryOnlyStaticOptimization (c,e1,e2,mRhs)) staticOptimizations rhsExpr
-    let rhsExpr,retTyOpt = 
-        match retInfo with 
+    let rhsExpr,retTyOpt =
+        match retInfo with
         | Some (SynReturnInfo((ty,SynArgInfo(rattribs,_,_)),tym)) -> SynExpr.Typed(rhsExpr,ty,rhsExpr.Range), Some(SynBindingReturnInfo(ty,tym,rattribs) )
-        | None -> rhsExpr,None 
+        | None -> rhsExpr,None
     rhsExpr,retTyOpt
 
 let mkSynBinding (xmlDoc,headPat) (vis,isInline,isMutable,mBind,spBind,retInfo,origRhsExpr,mRhs,staticOptimizations,attrs,memberFlagsOpt) =
     let info = SynInfo.InferSynValData (memberFlagsOpt, Some headPat, retInfo, origRhsExpr)
     let rhsExpr,retTyOpt = mkSynBindingRhs staticOptimizations origRhsExpr mRhs retInfo
-    Binding (vis,NormalBinding,isInline,isMutable,attrs,xmlDoc,info,headPat,retTyOpt,rhsExpr,mBind,spBind) 
+    Binding (vis,NormalBinding,isInline,isMutable,attrs,xmlDoc,info,headPat,retTyOpt,rhsExpr,mBind,spBind)
 
 let NonVirtualMemberFlags k = { MemberKind=k;                           IsInstance=true;  IsDispatchSlot=false; IsOverrideOrExplicitImpl=false; IsFinal=false }
 let CtorMemberFlags =         { MemberKind=MemberKind.Constructor;       IsInstance=false; IsDispatchSlot=false; IsOverrideOrExplicitImpl=false; IsFinal=false }
@@ -2027,22 +2062,22 @@ let inferredTyparDecls = SynValTyparDecls([],true,[])
 let noInferredTypars = SynValTyparDecls([],false,[])
 
 //------------------------------------------------------------------------
-// Lexer args: status of #if/#endif processing.  
+// Lexer args: status of #if/#endif processing.
 //------------------------------------------------------------------------
 
-type LexerIfdefStackEntry = IfDefIf | IfDefElse 
+type LexerIfdefStackEntry = IfDefIf | IfDefElse
 type LexerIfdefStackEntries = (LexerIfdefStackEntry * range) list
 type LexerIfdefStack = LexerIfdefStackEntries ref
 
 /// Specifies how the 'endline' function in the lexer should continue after
 /// it reaches end of line or eof. The options are to continue with 'token' function
 /// or to continue with 'skip' function.
-type LexerEndlineContinuation = 
+type LexerEndlineContinuation =
     | Token of LexerIfdefStackEntries
-    | Skip of LexerIfdefStackEntries * int * range
-    member x.LexerIfdefStack = 
-      match x with 
-      | LexerEndlineContinuation.Token(ifd) 
+    | Skip of LexerIfdefStackEntries * int * range:range
+    member x.LexerIfdefStack =
+      match x with
+      | LexerEndlineContinuation.Token(ifd)
       | LexerEndlineContinuation.Skip(ifd, _, _) -> ifd
 
 type LexerIfdefExpression =
@@ -2063,22 +2098,22 @@ let rec LexerIfdefEval (lookup : string -> bool) = function
 /// the whitespace.
 [<RequireQualifiedAccess>]
 [<NoComparison; NoEquality>]
-type LexerWhitespaceContinuation = 
+type LexerWhitespaceContinuation =
     | Token            of LexerIfdefStackEntries
-    | IfDefSkip        of LexerIfdefStackEntries * int * range
-    | String           of LexerIfdefStackEntries * range
-    | VerbatimString   of LexerIfdefStackEntries * range
-    | TripleQuoteString of LexerIfdefStackEntries * range
-    | Comment          of LexerIfdefStackEntries * int * range
-    | SingleLineComment of LexerIfdefStackEntries * int * range
-    | StringInComment    of LexerIfdefStackEntries * int * range
-    | VerbatimStringInComment   of LexerIfdefStackEntries * int * range
-    | TripleQuoteStringInComment   of LexerIfdefStackEntries * int * range
-    | MLOnly            of LexerIfdefStackEntries * range
+    | IfDefSkip        of LexerIfdefStackEntries * int * range:range
+    | String           of LexerIfdefStackEntries * range:range
+    | VerbatimString   of LexerIfdefStackEntries * range:range
+    | TripleQuoteString of LexerIfdefStackEntries * range:range
+    | Comment          of LexerIfdefStackEntries * int * range:range
+    | SingleLineComment of LexerIfdefStackEntries * int * range:range
+    | StringInComment    of LexerIfdefStackEntries * int * range:range
+    | VerbatimStringInComment   of LexerIfdefStackEntries * int * range:range
+    | TripleQuoteStringInComment   of LexerIfdefStackEntries * int * range:range
+    | MLOnly            of LexerIfdefStackEntries * range:range
     | EndLine           of LexerEndlineContinuation
-    
+
     member x.LexerIfdefStack =
-        match x with 
+        match x with
         | LexCont.Token ifd
         | LexCont.IfDefSkip (ifd,_,_)
         | LexCont.String (ifd,_)
@@ -2106,38 +2141,38 @@ and LexCont = LexerWhitespaceContinuation
 exception SyntaxError of obj (* ParseErrorContext<_> *) * range
 
 /// Get an F# compiler position from a lexer position
-let posOfLexPosition (p:Position) = 
+let posOfLexPosition (p:Position) =
     mkPos p.Line p.Column
 
 /// Get an F# compiler range from a lexer range
-let mkSynRange (p1:Position) (p2: Position) = 
+let mkSynRange (p1:Position) (p2: Position) =
     mkFileIndexRange p1.FileIndex (posOfLexPosition p1) (posOfLexPosition p2)
 
-type LexBuffer<'Char> with 
+type LexBuffer<'Char> with
     member lexbuf.LexemeRange  = mkSynRange lexbuf.StartPos lexbuf.EndPos
 
 /// Get the range corresponding to the result of a grammar rule while it is being reduced
-let lhs (parseState: IParseState) = 
+let lhs (parseState: IParseState) =
     let p1 = parseState.ResultStartPosition
     let p2 = parseState.ResultEndPosition
     mkSynRange p1 p2
 
 /// Get the range covering two of the r.h.s. symbols of a grammar rule while it is being reduced
-let rhs2 (parseState: IParseState) i j = 
+let rhs2 (parseState: IParseState) i j =
     let p1 = parseState.InputStartPosition i
     let p2 = parseState.InputEndPosition j
     mkSynRange p1 p2
 
 /// Get the range corresponding to one of the r.h.s. symbols of a grammar rule while it is being reduced
-let rhs parseState i = rhs2 parseState i i 
+let rhs parseState i = rhs2 parseState i i
 
-type IParseState with 
+type IParseState with
 
     /// Get the generator used for compiler-generated argument names.
-    member x.SynArgNameGenerator = 
+    member x.SynArgNameGenerator =
         let key = "SynArgNameGenerator"
         let bls = x.LexBuffer.BufferLocalStore
-        if not (bls.ContainsKey key) then  
+        if not (bls.ContainsKey key) then
             bls.[key] <- box (SynArgNameGenerator())
         bls.[key] :?> SynArgNameGenerator
 
@@ -2147,51 +2182,51 @@ type IParseState with
 
 /// XmlDoc F# lexer/parser state, held in the BufferLocalStore for the lexer.
 /// This is the only use of the lexer BufferLocalStore in the codebase.
-module LexbufLocalXmlDocStore = 
-    // The key into the BufferLocalStore used to hold the current accumulated XmlDoc lines 
+module LexbufLocalXmlDocStore =
+    // The key into the BufferLocalStore used to hold the current accumulated XmlDoc lines
     let private xmlDocKey = "XmlDoc"
 
-    let ClearXmlDoc (lexbuf:Lexbuf) = 
+    let ClearXmlDoc (lexbuf:Lexbuf) =
         lexbuf.BufferLocalStore.[xmlDocKey] <- box (XmlDocCollector())
 
     /// Called from the lexer to save a single line of XML doc comment.
-    let SaveXmlDocLine (lexbuf:Lexbuf, lineText, pos) = 
-        if not (lexbuf.BufferLocalStore.ContainsKey(xmlDocKey)) then 
+    let SaveXmlDocLine (lexbuf:Lexbuf, lineText, pos) =
+        if not (lexbuf.BufferLocalStore.ContainsKey(xmlDocKey)) then
             lexbuf.BufferLocalStore.[xmlDocKey] <- box (XmlDocCollector())
         let collector = unbox<XmlDocCollector>(lexbuf.BufferLocalStore.[xmlDocKey])
         collector.AddXmlDocLine (lineText, pos)
 
     /// Called from the parser each time we parse a construct that marks the end of an XML doc comment range,
     /// e.g. a 'type' declaration. The markerRange is the range of the keyword that delimits the construct.
-    let GrabXmlDocBeforeMarker (lexbuf:Lexbuf, markerRange:range)  = 
-        if lexbuf.BufferLocalStore.ContainsKey(xmlDocKey) then 
+    let GrabXmlDocBeforeMarker (lexbuf:Lexbuf, markerRange:range)  =
+        if lexbuf.BufferLocalStore.ContainsKey(xmlDocKey) then
             PreXmlDoc.CreateFromGrabPoint(unbox<XmlDocCollector>(lexbuf.BufferLocalStore.[xmlDocKey]),markerRange.End)
         else
             PreXmlDoc.Empty
 
 
-   
+
 /// Generates compiler-generated names. Each name generated also includes the StartLine number of the range passed in
 /// at the point of first generation.
-type NiceNameGenerator() = 
+type NiceNameGenerator() =
 
     let basicNameCounts = new Dictionary<string,int>(100)
 
     member x.FreshCompilerGeneratedName (name,m:range) =
         let basicName = GetBasicNameOfPossibleCompilerGeneratedName name
-        let n = (if basicNameCounts.ContainsKey basicName then basicNameCounts.[basicName] else 0) 
+        let n = (if basicNameCounts.ContainsKey basicName then basicNameCounts.[basicName] else 0)
         let nm = CompilerGeneratedNameSuffix basicName (string m.StartLine + (match n with 0 -> "" | n -> "-" + string n))
         basicNameCounts.[basicName] <- n+1
         nm
 
     member x.Reset () = basicNameCounts.Clear()
 
-   
+
 
 /// Generates compiler-generated names marked up with a source code location, but if given the same unique value then
 /// return precisely the same name. Each name generated also includes the StartLine number of the range passed in
 /// at the point of first generation.
-type StableNiceNameGenerator() = 
+type StableNiceNameGenerator() =
 
     let names = new Dictionary<(string * int64),string>(100)
     let basicNameCounts = new Dictionary<string,int>(100)
@@ -2200,31 +2235,31 @@ type StableNiceNameGenerator() =
         let basicName = GetBasicNameOfPossibleCompilerGeneratedName name
         if names.ContainsKey (basicName,uniq) then
             names.[(basicName,uniq)]
-        else 
-            let n = (if basicNameCounts.ContainsKey basicName then basicNameCounts.[basicName] else 0) 
+        else
+            let n = (if basicNameCounts.ContainsKey basicName then basicNameCounts.[basicName] else 0)
             let nm = CompilerGeneratedNameSuffix basicName (string m.StartLine + (match n with 0 -> "" | n -> "-" + string n))
             names.[(basicName,uniq)] <- nm
             basicNameCounts.[basicName] <- n+1
             nm
 
-    member x.Reset () = 
+    member x.Reset () =
         basicNameCounts.Clear()
         names.Clear()
 
 
 
-let rec synExprContainsError inpExpr = 
+let rec synExprContainsError inpExpr =
     let rec walkBind (Binding(_, _, _, _, _, _, _, _, _, synExpr, _, _)) = walkExpr synExpr
     and walkExprs es = es |> List.exists walkExpr
     and walkBinds es = es |> List.exists walkBind
     and walkMatchClauses cl = cl |> List.exists (fun (Clause(_,whenExpr,e,_,_)) -> walkExprOpt whenExpr || walkExpr e)
     and walkExprOpt eOpt = eOpt |> Option.exists walkExpr
-    and walkExpr e = 
-          match e with 
+    and walkExpr e =
+          match e with
           | SynExpr.FromParseError _
           | SynExpr.DiscardAfterMissingQualificationAfterDot _
           | SynExpr.ArbitraryAfterError _ -> true
-          | SynExpr.LongIdent _ 
+          | SynExpr.LongIdent _
           | SynExpr.Quote _
           | SynExpr.LibraryOnlyILAssembly _
           | SynExpr.LibraryOnlyStaticOptimization _
@@ -2236,17 +2271,17 @@ let rec synExprContainsError inpExpr =
           | SynExpr.TypeTest (e,_,_)
           | SynExpr.Upcast (e,_,_)
           | SynExpr.AddressOf (_,e,_,_)
-          | SynExpr.CompExpr (_,_,e,_) 
+          | SynExpr.CompExpr (_,_,e,_)
           | SynExpr.ArrayOrListOfSeqExpr (_,e,_)
           | SynExpr.Typed (e,_,_)
-          | SynExpr.FromParseError (e,_) 
+          | SynExpr.FromParseError (e,_)
           | SynExpr.Do (e,_)
           | SynExpr.Assert (e,_)
-          | SynExpr.DotGet (e,_,_,_) 
+          | SynExpr.DotGet (e,_,_,_)
           | SynExpr.LongIdentSet (_,e,_)
-          | SynExpr.New (_,_,e,_) 
-          | SynExpr.TypeApp (e,_,_,_,_,_,_) 
-          | SynExpr.LibraryOnlyUnionCaseFieldGet (e,_,_,_) 
+          | SynExpr.New (_,_,e,_)
+          | SynExpr.TypeApp (e,_,_,_,_,_,_)
+          | SynExpr.LibraryOnlyUnionCaseFieldGet (e,_,_,_)
           | SynExpr.Downcast (e,_,_)
           | SynExpr.InferredUpcast (e,_)
           | SynExpr.InferredDowncast (e,_)
@@ -2254,53 +2289,53 @@ let rec synExprContainsError inpExpr =
           | SynExpr.TraitCall(_,_,e,_)
           | SynExpr.YieldOrReturn (_,e,_)
           | SynExpr.YieldOrReturnFrom (_,e,_)
-          | SynExpr.DoBang (e,_) 
-          | SynExpr.Fixed (e,_) 
-          | SynExpr.Paren (e,_,_,_) -> 
+          | SynExpr.DoBang (e,_)
+          | SynExpr.Fixed (e,_)
+          | SynExpr.Paren (e,_,_,_) ->
               walkExpr e
 
           | SynExpr.NamedIndexedPropertySet (_,e1,e2,_)
           | SynExpr.DotSet (e1,_,e2,_)
           | SynExpr.LibraryOnlyUnionCaseFieldSet (e1,_,_,e2,_)
-          | SynExpr.JoinIn (e1,_,e2,_) 
-          | SynExpr.App (_,_,e1,e2,_) -> 
+          | SynExpr.JoinIn (e1,_,e2,_)
+          | SynExpr.App (_,_,e1,e2,_) ->
               walkExpr e1 || walkExpr e2
 
           | SynExpr.ArrayOrList (_,es,_)
-          | SynExpr.Tuple (es,_,_) 
-          | SynExpr.StructTuple (es,_,_) -> 
+          | SynExpr.Tuple (es,_,_)
+          | SynExpr.StructTuple (es,_,_) ->
               walkExprs es
 
           | SynExpr.Record (_,_,fs,_) ->
-              let flds = fs |> List.choose (fun (_, v, _) -> v) 
+              let flds = fs |> List.choose (fun (_, v, _) -> v)
               walkExprs (flds)
 
-          | SynExpr.ObjExpr (_,_,bs,is,_,_) -> 
+          | SynExpr.ObjExpr (_,_,bs,is,_,_) ->
               walkBinds bs || walkBinds [ for (InterfaceImpl(_,bs,_)) in is do yield! bs  ]
-          | SynExpr.ForEach (_,_,_,_,e1,e2,_) 
-          | SynExpr.While (_,e1,e2,_) -> 
+          | SynExpr.ForEach (_,_,_,_,e1,e2,_)
+          | SynExpr.While (_,e1,e2,_) ->
               walkExpr e1 || walkExpr e2
-          | SynExpr.For (_,_,e1,_,e2,e3,_) -> 
+          | SynExpr.For (_,_,e1,_,e2,e3,_) ->
               walkExpr e1 || walkExpr e2 || walkExpr e3
-          | SynExpr.MatchLambda(_,_,cl,_,_) -> 
+          | SynExpr.MatchLambda(_,_,cl,_,_) ->
               walkMatchClauses cl
-          | SynExpr.Lambda (_,_,_,e,_) -> 
+          | SynExpr.Lambda (_,_,_,e,_) ->
               walkExpr e
           | SynExpr.Match (_,e,cl,_,_) ->
               walkExpr e || walkMatchClauses cl
-          | SynExpr.LetOrUse (_,_,bs,e,_) -> 
+          | SynExpr.LetOrUse (_,_,bs,e,_) ->
               walkBinds bs || walkExpr e
 
-          | SynExpr.TryWith (e,_,cl,_,_,_,_) -> 
+          | SynExpr.TryWith (e,_,cl,_,_,_,_) ->
               walkExpr e  || walkMatchClauses cl
-                  
+
           | SynExpr.TryFinally (e1,e2,_,_,_) ->
               walkExpr e1 || walkExpr e2
-          | SynExpr.Sequential (_,_,e1,e2,_) -> 
+          | SynExpr.Sequential (_,_,e1,e2,_) ->
               walkExpr e1 || walkExpr e2
           | SynExpr.IfThenElse (e1,e2,e3opt,_,_,_,_) ->
               walkExpr e1 || walkExpr e2 || walkExprOpt e3opt
-          | SynExpr.DotIndexedGet (e1,es,_,_) -> 
+          | SynExpr.DotIndexedGet (e1,es,_,_) ->
               walkExpr e1 || walkExprs [ for e in es do yield! e.Exprs ]
 
           | SynExpr.DotIndexedSet (e1,es,e2,_,_,_) ->
@@ -2308,6 +2343,6 @@ let rec synExprContainsError inpExpr =
           | SynExpr.DotNamedIndexedPropertySet (e1,_,e2,e3,_) ->
               walkExpr e1 || walkExpr e2 || walkExpr e3
 
-          | SynExpr.LetOrUseBang  (_,_,_,_,e1,e2,_) -> 
-              walkExpr e1 || walkExpr e2 
+          | SynExpr.LetOrUseBang  (_,_,_,_,e1,e2,_) ->
+              walkExpr e1 || walkExpr e2
     walkExpr inpExpr

--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -178,7 +178,7 @@ type TyparStaticReq =
 
 [<NoEquality; NoComparison>]
 type SynTypar =
-    | Typar of id:Ident * staticReq:TyparStaticReq * isCompGen:bool
+    | Typar of ident:Ident * staticReq:TyparStaticReq * isCompGen:bool
     with member this.Range =
             match this with
             | Typar(id,_,_) ->
@@ -227,7 +227,7 @@ type
     /// UserNum(value, suffix)
     ///
     /// F# syntax: 1Q, 1Z, 1R, 1N, 1G
-    | UserNum of  (string * string)
+    | UserNum of value:string * suffix:string
     /// F# syntax: verbatim or regular string, e.g. "abc"
     | String of text:string * range:range
     /// F# syntax: verbatim or regular byte string, e.g. "abc"B.
@@ -256,7 +256,7 @@ and
     | Divide of SynMeasure * SynMeasure * range:range
     | Power of SynMeasure * SynRationalConst * range:range
     | One
-    | Anon of range
+    | Anon of range:range
     | Var of SynTypar * range:range
 
 and
@@ -264,7 +264,7 @@ and
     /// The unchecked abstract syntax tree of F# unit of measure exponents.
     SynRationalConst =
     | Integer of int32
-    | Rational of int32 * int32 * range
+    | Rational of int32 * int32 * range:range
     | Negate of SynRationalConst
 
 
@@ -291,29 +291,29 @@ type SequencePointInfoForSeq =
     | SuppressSequencePointOnStmtOfSequential
 
 type SequencePointInfoForTry =
-    | SequencePointAtTry of range
+    | SequencePointAtTry of range:range
     // Used for "use" and "for"
     | SequencePointInBodyOfTry
     | NoSequencePointAtTry
 
 type SequencePointInfoForWith =
-    | SequencePointAtWith of range
+    | SequencePointAtWith of range:range
     | NoSequencePointAtWith
 
 type SequencePointInfoForFinally =
-    | SequencePointAtFinally of range
+    | SequencePointAtFinally of range:range
     | NoSequencePointAtFinally
 
 type SequencePointInfoForForLoop =
-    | SequencePointAtForLoop of range
+    | SequencePointAtForLoop of range:range
     | NoSequencePointAtForLoop
 
 type SequencePointInfoForWhileLoop =
-    | SequencePointAtWhileLoop of range
+    | SequencePointAtWhileLoop of range:range
     | NoSequencePointAtWhileLoop
 
 type SequencePointInfoForBinding =
-    | SequencePointAtBinding of range
+    | SequencePointAtBinding of range:range
     // Indicates the omission of a sequence point for a binding for a 'do expr'
     | NoSequencePointAtDoBinding
     // Indicates the omission of a sequence point for a binding for a 'let e = expr' where 'expr' has immediate control flow
@@ -340,6 +340,7 @@ type SequencePointInfoForBinding =
 
 /// Indicates if a for loop is 'for x in e1 -> e2', only valid in sequence expressions
 type SeqExprOnly =
+    /// Indicates if a for loop is 'for x in e1 -> e2', only valid in sequence expressions
     | SeqExprOnly of bool
 
 /// denotes location of the separator block + optional position of the semicolon (used for tooling support)
@@ -387,65 +388,65 @@ and
     /// F# syntax is 'typar : equality
     | WhereTyparIsEquatable of genericName:SynTypar * range:range
     /// F# syntax is default ^T : type
-    | WhereTyparDefaultsToType of genericName:SynTypar * typeSig:SynType * range:range
+    | WhereTyparDefaultsToType of genericName:SynTypar * typeName:SynType * range:range
     /// F# syntax is 'typar :> type
-    | WhereTyparSubtypeOfType of genericName:SynTypar *  typeSig:SynType * range:range
+    | WhereTyparSubtypeOfType of genericName:SynTypar *  typeName:SynType * range:range
     /// F# syntax is ^T : (static member MemberName : ^T * int -> ^T)
     | WhereTyparSupportsMember of genericNames:SynType list * memberSig:SynMemberSig * range:range
     /// F# syntax is 'typar : enum<'UnderlyingType>
-    | WhereTyparIsEnum of genericName:SynTypar * enumTypes:SynType list * range:range
+    | WhereTyparIsEnum of genericName:SynTypar * SynType list * range:range
     /// F# syntax is 'typar : delegate<'Args,unit>
-    | WhereTyparIsDelegate of genericName:SynTypar * delegateTypes:SynType list * range:range
+    | WhereTyparIsDelegate of genericName:SynTypar * SynType list * range:range
 
 and
     [<NoEquality; NoComparison;RequireQualifiedAccess>]
     /// The unchecked abstract syntax tree of F# types
     SynType =
     /// F# syntax : A.B.C
-    | LongIdent of LongIdentWithDots
+    | LongIdent of longDotId:LongIdentWithDots
     /// App(typeName, LESSm, typeArgs, commasm, GREATERm, isPostfix, m)
     ///
     /// F# syntax : type<type, ..., type> or type type or (type,...,type) type
     ///   isPostfix: indicates a postfix type application e.g. "int list" or "(int,string) dict"
     ///   commasm: ranges for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
-    | App of typeName:SynType * leftAngleRange:range option * typeArgs:SynType list * commaRanges:range list * rightAngleRange:range option * isPostfix:bool * range:range
+    | App of typeName:SynType * LESSrange:range option * typeArgs:SynType list * commaRanges:range list * GREATERrange:range option * isPostfix:bool * range:range
     /// LongIdentApp(typeName, longId, LESSm, tyArgs, commasm, GREATERm, wholem)
     ///
     /// F# syntax : type.A.B.C<type, ..., type>
     ///   commasm: ranges for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
-    | LongIdentApp of typeName:SynType * dotId:LongIdentWithDots * leftAngleRange:range option * genericNames:SynType list * commaRanges:range list * rightAngleRange:range option * range:range
+    | LongIdentApp of typeName:SynType * longDotId:LongIdentWithDots * LESSRange:range option * typeArgs:SynType list * commaRanges:range list * GREATERrange:range option * range:range
 
     /// F# syntax : type * ... * type
     // the bool is true if / rather than * follows the type
-    | Tuple of (bool*SynType) list * range:range
+    | Tuple of typeNames:(bool*SynType) list * range:range
 
     /// F# syntax : struct (type * ... * type)
     // the bool is true if / rather than * follows the type
-    | StructTuple of (bool*SynType) list * range:range
+    | StructTuple of typeNames:(bool*SynType) list * range:range
 
     /// F# syntax : type[]
     | Array of  int * elementType:SynType * range:range
     /// F# syntax : type -> type
     | Fun of  argType:SynType * returnType:SynType * range:range
     /// F# syntax : 'Var
-    | Var of SynTypar * range:range
+    | Var of genericName:SynTypar * range:range
     /// F# syntax : _
     | Anon of range:range
     /// F# syntax : typ with constraints
     | WithGlobalConstraints of typeName:SynType * constraints:SynTypeConstraint list * range:range
     /// F# syntax : #type
-    | HashConstraint of typeName:SynType * range:range
+    | HashConstraint of SynType * range:range
     /// F# syntax : for units of measure e.g. m / s
-    | MeasureDivide of typeName:SynType * SynType * range:range
+    | MeasureDivide of dividendType:SynType * divisorType:SynType * range:range
     /// F# syntax : for units of measure e.g. m^3, kg^1/2
-    | MeasurePower of typeName:SynType * SynRationalConst * range:range
+    | MeasurePower of measureType:SynType * SynRationalConst * range:range
     /// F# syntax : 1, "abc" etc, used in parameters to type providers
     /// For the dimensionless units i.e. 1 , and static parameters to provided types
     | StaticConstant of constant:SynConst * range:range
     /// F# syntax : const expr, used in static parameters to type providers
     | StaticConstantExpr of expr:SynExpr * range:range
     /// F# syntax : ident=1 etc., used in static parameters to type providers
-    | StaticConstantNamed of SynType * SynType * range:range
+    | StaticConstantNamed of expr:SynType * SynType * range:range
     /// Get the syntactic range of source code covered by this construct.
     member x.Range =
         match x with
@@ -465,6 +466,7 @@ and
         | SynType.MeasureDivide (range=m)
         | SynType.MeasurePower (range=m) -> m
         | SynType.LongIdent(lidwd) -> lidwd.Range
+
 
 
 and
@@ -488,13 +490,13 @@ and
     | Const of constant:SynConst * range:range
 
     /// F# syntax: expr : type
-    | Typed of  expr:SynExpr * typeSig:SynType * range:range
+    | Typed of  expr:SynExpr * typeName:SynType * range:range
 
     /// F# syntax: e1, ..., eN
     | Tuple of  exprs:SynExpr list * commaRanges:range list * range:range  // "range list" is for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
 
     /// F# syntax: struct (e1, ..., eN)
-    | StructTuple of  SynExpr list * range list * range:range  // "range list" is for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
+    | StructTuple of  exprs:SynExpr list * commaRanges:range list * range:range  // "range list" is for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
 
     /// F# syntax: [ e1; ...; en ], [| e1; ...; en |]
     | ArrayOrList of  isList:bool * exprs:SynExpr list * range:range
@@ -513,21 +515,21 @@ and
     /// SynExpr.ObjExpr(objTy,argOpt,binds,extraImpls,mNewExpr,mWholeExpr)
     ///
     /// F# syntax: { new ... with ... }
-    | ObjExpr of objType:SynType * argOpt:(SynExpr * Ident option) option * bindings:SynBinding list * extraImpls:SynInterfaceImpl list * newPos:range * range:range
+    | ObjExpr of objType:SynType * argOptions:(SynExpr * Ident option) option * bindings:SynBinding list * extraImpls:SynInterfaceImpl list * newExprRange:range * range:range
 
     /// F# syntax: 'while ... do ...'
-    | While of spWhile:SequencePointInfoForWhileLoop * whileBody:SynExpr * doBody:SynExpr * range:range
+    | While of whileSeqPoint:SequencePointInfoForWhileLoop * whileExpr:SynExpr * doExpr:SynExpr * range:range
 
     /// F# syntax: 'for i = ... to ... do ...'
-    | For of spFor:SequencePointInfoForForLoop * id:Ident * idBody:SynExpr * bool * toBody:SynExpr * doBody:SynExpr * range:range
+    | For of forSeqPoint:SequencePointInfoForForLoop * ident:Ident * identBody:SynExpr * bool * toBody:SynExpr * doBody:SynExpr * range:range
 
     /// SynExpr.ForEach (spBind, seqExprOnly, isFromSource, pat, enumExpr, bodyExpr, mWholeExpr).
     ///
     /// F# syntax: 'for ... in ... do ...'
-    | ForEach of spFor:SequencePointInfoForForLoop * seqExprOnly:SeqExprOnly * isFromSource:bool * pattern:SynPat * enumExpr:SynExpr * bodyExpr:SynExpr * range:range
+    | ForEach of forSeqPoint:SequencePointInfoForForLoop * seqExprOnly:SeqExprOnly * isFromSource:bool * pat:SynPat * enumExpr:SynExpr * bodyExpr:SynExpr * range:range
 
     /// F# syntax: [ expr ], [| expr |]
-    | ArrayOrListOfSeqExpr of isList:bool * elements:SynExpr * range:range
+    | ArrayOrListOfSeqExpr of isList:bool * expr:SynExpr * range:range
 
     /// CompExpr(isArrayOrList, isNotNakedRefCell, expr)
     ///
@@ -541,10 +543,10 @@ and
     | Lambda of  fromMethod:bool * inLambdaSeq:bool * args:SynSimplePats * body:SynExpr * range:range
 
     /// F# syntax: function pat1 -> expr | ... | patN -> exprN
-    | MatchLambda of bool * range * clauses:SynMatchClause list * spBind:SequencePointInfoForBinding * range:range
+    | MatchLambda of isExnMatch:bool * range * SynMatchClause list * matchSeqPoint:SequencePointInfoForBinding * range:range
 
     /// F# syntax: match expr with pat1 -> expr | ... | patN -> exprN
-    | Match of  spBind:SequencePointInfoForBinding * matchExpr:SynExpr * clauses:SynMatchClause list * isCexprExceptionMatch:bool * range:range (* bool indicates if this is an exception match in a computation expression which throws unmatched exceptions *)
+    | Match of  matchSeqPoint:SequencePointInfoForBinding * expr:SynExpr * clauses:SynMatchClause list * isExnMatch:bool * range:range (* bool indicates if this is an exception match in a computation expression which throws unmatched exceptions *)
 
     /// F# syntax: do expr
     | Do of  expr:SynExpr * range:range
@@ -558,13 +560,13 @@ and
     ///      (or more generally, for higher operator fixities, if App(x,y) is such that y comes before x in the source code, then the node is marked isInfix=true)
     ///
     /// F# syntax: f x
-    | App of exprAtomicFlag:ExprAtomicFlag * isInfix:bool * funcExpr:SynExpr * argExpr:SynExpr * range:range
+    | App of ExprAtomicFlag * isInfix:bool * funcExpr:SynExpr * argExpr:SynExpr * range:range
 
     /// TypeApp(expr, mLessThan, types, mCommas, mGreaterThan, mTypeArgs, mWholeExpr)
     ///     "mCommas" are the ranges for interstitial commas, these only matter for parsing/design-time tooling, the typechecker may munge/discard them
     ///
     /// F# syntax: expr<type1,...,typeN>
-    | TypeApp of expr:SynExpr * leftAngleRange:range * typeNames:SynType list * commaRanges:range list * rightAngleRange:range option * typeArgs:range * range:range
+    | TypeApp of expr:SynExpr * LESSrange:range * typeNames:SynType list * commaRanges:range list * GREATERrange:range option * typeArgsRange:range * range:range
 
     /// LetOrUse(isRecursive, isUse, bindings, body, wholeRange)
     ///
@@ -572,28 +574,28 @@ and
     /// F# syntax: let f pat1 .. patN = expr in expr
     /// F# syntax: let rec f pat1 .. patN = expr in expr
     /// F# syntax: use pat = expr in expr
-    | LetOrUse of isRecursive:bool * isUse:bool * bindings:SynBinding list * exprBody:SynExpr * range:range
+    | LetOrUse of isRecursive:bool * isUse:bool * bindings:SynBinding list * body:SynExpr * range:range
 
     /// F# syntax: try expr with pat -> expr
-    | TryWith of tryExpr:SynExpr * range * SynMatchClause list * range * range:range * spTry:SequencePointInfoForTry * spWith:SequencePointInfoForWith
+    | TryWith of tryExpr:SynExpr * tryRange:range * withCases:SynMatchClause list * withRange:range * range:range * trySeqPoint:SequencePointInfoForTry * withSeqPoint:SequencePointInfoForWith
 
     /// F# syntax: try expr finally expr
-    | TryFinally of tryExpr:SynExpr * finallyExpr:SynExpr * range:range * spTry:SequencePointInfoForTry * spFinally:SequencePointInfoForFinally
+    | TryFinally of tryExpr:SynExpr * finallyExpr:SynExpr * range:range * trySeqPoint:SequencePointInfoForTry * finallySeqPoint:SequencePointInfoForFinally
 
     /// F# syntax: lazy expr
-    | Lazy of expr:SynExpr * range:range
+    | Lazy of SynExpr * range:range
 
     /// Seq(seqPoint, isTrueSeq, e1, e2, m)
     ///  isTrueSeq: false indicates "let v = a in b; v"
     ///
     /// F# syntax: expr; expr
-    | Sequential of spSeq:SequencePointInfoForSeq * isTrueSeq:bool * expr1:SynExpr * expr2:SynExpr * range:range
+    | Sequential of seqPoint:SequencePointInfoForSeq * isTrueSeq:bool * expr1:SynExpr * expr2:SynExpr * range:range
 
     ///  IfThenElse(exprGuard,exprThen,optionalExprElse,spIfToThen,isFromErrorRecovery,mIfToThen,mIfToEndOfLastBranch)
     ///
     /// F# syntax: if expr then expr
     /// F# syntax: if expr then expr else expr
-    | IfThenElse of exprGuard:SynExpr * exprThen:SynExpr * optionalExprElse:SynExpr option * spIfToThen:SequencePointInfoForBinding * isFromErrorRecovery:bool * ifToThen:range * range:range
+    | IfThenElse of ifExpr:SynExpr * thenExpr:SynExpr * elseExpr:SynExpr option * spIfToThen:SequencePointInfoForBinding * isFromErrorRecovery:bool * ifToThenRange:range * range:range
 
     /// F# syntax: ident
     /// Optimized representation, = SynExpr.LongIdent(false,[id],id.idRange)
@@ -603,38 +605,38 @@ and
     /// LongIdent(isOptional, longIdent, altNameRefCell, m)
     ///   isOptional: true if preceded by a '?' for an optional named parameter
     ///   altNameRefCell: Normally 'None' except for some compiler-generated variables in desugaring pattern matching. See SynSimplePat.Id
-    | LongIdent of isOptional:bool * longIdent:LongIdentWithDots * altNameRefCell:SynSimplePatAlternativeIdInfo ref option * range:range
+    | LongIdent of isOptional:bool * longDotId:LongIdentWithDots * altNameRefCell:SynSimplePatAlternativeIdInfo ref option * range:range
 
     /// F# syntax: ident.ident...ident <- expr
-    | LongIdentSet of dotId:LongIdentWithDots * expr:SynExpr * range:range
+    | LongIdentSet of longDotId:LongIdentWithDots * expr:SynExpr * range:range
 
     /// DotGet(expr, rangeOfDot, lid, wholeRange)
     ///
     /// F# syntax: expr.ident.ident
-    | DotGet of expr:SynExpr * rangeOfDot:range * dotId:LongIdentWithDots * range:range
+    | DotGet of expr:SynExpr * rangeOfDot:range * longDotId:LongIdentWithDots * range:range
 
     /// F# syntax: expr.ident...ident <- expr
-    | DotSet of expr:SynExpr * dotId:LongIdentWithDots * exprValue:SynExpr * range:range
+    | DotSet of SynExpr * longDotId:LongIdentWithDots * SynExpr * range:range
 
     /// F# syntax: expr.[expr,...,expr]
-    | DotIndexedGet of expr:SynExpr * indexExprs:SynIndexerArg list * range * range:range
+    | DotIndexedGet of SynExpr * SynIndexerArg list * range * range:range
 
     /// DotIndexedSet (objectExpr, indexExprs, valueExpr, rangeOfLeftOfSet, rangeOfDot, rangeOfWholeExpr)
     ///
     /// F# syntax: expr.[expr,...,expr] <- expr
-    | DotIndexedSet of objectExpr:SynExpr * indexExprs:SynIndexerArg list * valueExpr:SynExpr * rangeOfLeftOfSet:range * rangeOfDot:range * range:range
+    | DotIndexedSet of objectExpr:SynExpr * indexExprs:SynIndexerArg list * valueExpr:SynExpr * leftOfSetRange:range * dotRange:range * range:range
 
     /// F# syntax: Type.Items(e1) <- e2 , rarely used named-property-setter notation, e.g. Foo.Bar.Chars(3) <- 'a'
-    | NamedIndexedPropertySet of LongIdentWithDots * SynExpr * SynExpr * range:range
+    | NamedIndexedPropertySet of longDotId:LongIdentWithDots * SynExpr * SynExpr * range:range
 
     /// F# syntax: expr.Items(e1) <- e2 , rarely used named-property-setter notation, e.g. (stringExpr).Chars(3) <- 'a'
-    | DotNamedIndexedPropertySet of SynExpr * LongIdentWithDots * SynExpr * SynExpr * range:range
+    | DotNamedIndexedPropertySet of SynExpr * longDotId:LongIdentWithDots * SynExpr * SynExpr * range:range
 
     /// F# syntax: expr :? type
     | TypeTest of  expr:SynExpr * typeName:SynType * range:range
 
     /// F# syntax: expr :> type
-    | Upcast of  expr:SynExpr * typeSig:SynType * range:range
+    | Upcast of  expr:SynExpr * typeName:SynType * range:range
 
     /// F# syntax: expr :?> type
     | Downcast of  expr:SynExpr * typeName:SynType * range:range
@@ -649,14 +651,14 @@ and
     | Null of range:range
 
     /// F# syntax: &expr, &&expr
-    | AddressOf of  bool * SynExpr * range * range:range
+    | AddressOf of  isByref:bool * SynExpr * range * range:range
 
     /// F# syntax: ((typar1 or ... or typarN): (member-dig) expr)
     | TraitCall of SynTypar list * SynMemberSig * SynExpr * range:range
 
     /// F# syntax: ... in ...
     /// Computation expressions only, based on JOIN_IN token from lex filter
-    | JoinIn of SynExpr * inPos:range * SynExpr * range:range
+    | JoinIn of SynExpr * range * SynExpr * range:range
 
     /// F# syntax: <implicit>
     /// Computation expressions only, implied by final "do" or "do!"
@@ -677,7 +679,7 @@ and
     /// F# syntax: let! pat = expr in expr
     /// F# syntax: use! pat = expr in expr
     /// Computation expressions only
-    | LetOrUseBang    of spBind:SequencePointInfoForBinding * isUse:bool * isFromSource:bool * pattern:SynPat * rhsExpr:SynExpr * bodyExpr:SynExpr * range:range
+    | LetOrUseBang    of bindSeqPoint:SequencePointInfoForBinding * isUse:bool * isFromSource:bool * SynPat * SynExpr * SynExpr * range:range
 
     /// F# syntax: do! expr
     /// Computation expressions only
@@ -690,7 +692,7 @@ and
     | LibraryOnlyStaticOptimization of SynStaticOptimizationConstraint list * SynExpr * SynExpr * range:range
 
     /// Only used in FSharp.Core
-    | LibraryOnlyUnionCaseFieldGet of SynExpr * longId:LongIdent * int * range:range
+    | LibraryOnlyUnionCaseFieldGet of expr:SynExpr * longId:LongIdent * int * range:range
 
     /// Only used in FSharp.Core
     | LibraryOnlyUnionCaseFieldSet of SynExpr * longId:LongIdent * int * SynExpr * range:range
@@ -702,72 +704,72 @@ and
     | FromParseError  of expr:SynExpr * range:range
 
     /// Inserted for error recovery when there is "expr." and missing tokens or error recovery after the dot
-    | DiscardAfterMissingQualificationAfterDot  of expr:SynExpr * range:range
+    | DiscardAfterMissingQualificationAfterDot  of SynExpr * range:range
 
     /// 'use x = fixed expr'
-    | Fixed of SynExpr * range
+    | Fixed of expr:SynExpr * range:range
 
     /// Get the syntactic range of source code covered by this construct.
     member e.Range =
         match e with
-        | SynExpr.Paren(_,_,_,m)
-        | SynExpr.Quote(_,_,_,_,m)
-        | SynExpr.Const(_,m)
-        | SynExpr.Typed (_,_,m)
-        | SynExpr.Tuple (_,_,m)
-        | SynExpr.StructTuple (_,_,m)
-        | SynExpr.ArrayOrList (_,_,m)
-        | SynExpr.Record (_,_,_,m)
-        | SynExpr.New (_,_,_,m)
-        | SynExpr.ObjExpr (_,_,_,_,_,m)
-        | SynExpr.While (_,_,_,m)
-        | SynExpr.For (_,_,_,_,_,_,m)
-        | SynExpr.ForEach (_,_,_,_,_,_,m)
-        | SynExpr.CompExpr (_,_,_,m)
-        | SynExpr.ArrayOrListOfSeqExpr (_,_,m)
-        | SynExpr.Lambda (_,_,_,_,m)
-        | SynExpr.Match (_,_,_,_,m)
-        | SynExpr.MatchLambda (_,_,_,_,m)
-        | SynExpr.Do (_,m)
-        | SynExpr.Assert (_,m)
-        | SynExpr.App (_,_,_,_,m)
-        | SynExpr.TypeApp (_,_,_,_,_,_,m)
-        | SynExpr.LetOrUse (_,_,_,_,m)
-        | SynExpr.TryWith (_,_,_,_,m,_,_)
-        | SynExpr.TryFinally (_,_,m,_,_)
-        | SynExpr.Sequential (_,_,_,_,m)
-        | SynExpr.ArbitraryAfterError(_,m)
-        | SynExpr.FromParseError (_,m)
-        | SynExpr.DiscardAfterMissingQualificationAfterDot (_,m)
-        | SynExpr.IfThenElse (_,_,_,_,_,_,m)
-        | SynExpr.LongIdent (_,_,_,m)
-        | SynExpr.LongIdentSet (_,_,m)
-        | SynExpr.NamedIndexedPropertySet (_,_,_,m)
-        | SynExpr.DotIndexedGet (_,_,_,m)
-        | SynExpr.DotIndexedSet (_,_,_,_,_,m)
-        | SynExpr.DotGet (_,_,_,m)
-        | SynExpr.DotSet (_,_,_,m)
-        | SynExpr.DotNamedIndexedPropertySet (_,_,_,_,m)
-        | SynExpr.LibraryOnlyUnionCaseFieldGet (_,_,_,m)
-        | SynExpr.LibraryOnlyUnionCaseFieldSet (_,_,_,_,m)
-        | SynExpr.LibraryOnlyILAssembly (_,_,_,_,m)
-        | SynExpr.LibraryOnlyStaticOptimization (_,_,_,m)
-        | SynExpr.TypeTest (_,_,m)
-        | SynExpr.Upcast (_,_,m)
-        | SynExpr.AddressOf (_,_,_,m)
-        | SynExpr.Downcast (_,_,m)
-        | SynExpr.JoinIn (_,_,_,m)
-        | SynExpr.InferredUpcast (_,m)
-        | SynExpr.InferredDowncast (_,m)
-        | SynExpr.Null m
-        | SynExpr.Lazy (_, m)
-        | SynExpr.TraitCall(_,_,_,m)
-        | SynExpr.ImplicitZero (m)
-        | SynExpr.YieldOrReturn (_,_,m)
-        | SynExpr.YieldOrReturnFrom (_,_,m)
-        | SynExpr.LetOrUseBang  (_,_,_,_,_,_,m)
-        | SynExpr.DoBang  (_,m) -> m
-        | SynExpr.Fixed (_,m) -> m
+        | SynExpr.Paren (range=m)
+        | SynExpr.Quote (range=m)
+        | SynExpr.Const (range=m)
+        | SynExpr.Typed (range=m)
+        | SynExpr.Tuple (range=m)
+        | SynExpr.StructTuple (range=m)
+        | SynExpr.ArrayOrList (range=m)
+        | SynExpr.Record (range=m)
+        | SynExpr.New (range=m)
+        | SynExpr.ObjExpr (range=m)
+        | SynExpr.While (range=m)
+        | SynExpr.For (range=m)
+        | SynExpr.ForEach (range=m)
+        | SynExpr.CompExpr (range=m)
+        | SynExpr.ArrayOrListOfSeqExpr (range=m)
+        | SynExpr.Lambda (range=m)
+        | SynExpr.Match (range=m)
+        | SynExpr.MatchLambda (range=m)
+        | SynExpr.Do (range=m)
+        | SynExpr.Assert (range=m)
+        | SynExpr.App (range=m)
+        | SynExpr.TypeApp (range=m)
+        | SynExpr.LetOrUse (range=m)
+        | SynExpr.TryWith (range=m)
+        | SynExpr.TryFinally (range=m)
+        | SynExpr.Sequential (range=m)
+        | SynExpr.ArbitraryAfterError (range=m)
+        | SynExpr.FromParseError (range=m)
+        | SynExpr.DiscardAfterMissingQualificationAfterDot (range=m)
+        | SynExpr.IfThenElse (range=m)
+        | SynExpr.LongIdent (range=m)
+        | SynExpr.LongIdentSet (range=m)
+        | SynExpr.NamedIndexedPropertySet (range=m)
+        | SynExpr.DotIndexedGet (range=m)
+        | SynExpr.DotIndexedSet (range=m)
+        | SynExpr.DotGet (range=m)
+        | SynExpr.DotSet (range=m)
+        | SynExpr.DotNamedIndexedPropertySet (range=m)
+        | SynExpr.LibraryOnlyUnionCaseFieldGet (range=m)
+        | SynExpr.LibraryOnlyUnionCaseFieldSet (range=m)
+        | SynExpr.LibraryOnlyILAssembly (range=m)
+        | SynExpr.LibraryOnlyStaticOptimization (range=m)
+        | SynExpr.TypeTest (range=m)
+        | SynExpr.Upcast (range=m)
+        | SynExpr.AddressOf (range=m)
+        | SynExpr.Downcast (range=m)
+        | SynExpr.JoinIn (range=m)
+        | SynExpr.InferredUpcast (range=m)
+        | SynExpr.InferredDowncast (range=m)
+        | SynExpr.Null (range=m)
+        | SynExpr.Lazy (range=m)
+        | SynExpr.TraitCall (range=m)
+        | SynExpr.ImplicitZero (range=m)
+        | SynExpr.YieldOrReturn (range=m)
+        | SynExpr.YieldOrReturnFrom (range=m)
+        | SynExpr.LetOrUseBang (range=m)
+        | SynExpr.DoBang (range=m)
+        | SynExpr.Fixed (range=m) -> m
         | SynExpr.Ident id -> id.idRange
 
     /// range ignoring any (parse error) extra trailing dots
@@ -826,7 +828,7 @@ and
         | SynExpr.YieldOrReturn (range=m)
         | SynExpr.YieldOrReturnFrom (range=m)
         | SynExpr.LetOrUseBang (range=m)
-        | SynExpr.DoBang  (range=m) -> m
+        | SynExpr.DoBang (range=m) -> m
         | SynExpr.DotGet (expr,_,lidwd,m) -> if lidwd.ThereIsAnExtraDotAtTheEnd then unionRanges expr.Range lidwd.RangeSansAnyExtraDot else m
         | SynExpr.LongIdent (_,lidwd,_,_) -> lidwd.RangeSansAnyExtraDot
         | SynExpr.DiscardAfterMissingQualificationAfterDot (expr,_) -> expr.Range
@@ -887,8 +889,8 @@ and
         | SynExpr.ImplicitZero (range=m)
         | SynExpr.YieldOrReturn (range=m)
         | SynExpr.YieldOrReturnFrom (range=m)
-        | SynExpr.LetOrUseBang  (range=m)
-        | SynExpr.DoBang  (_,m) -> m
+        | SynExpr.LetOrUseBang (range=m)
+        | SynExpr.DoBang (range=m)  -> m
         // these are better than just .Range, and also commonly applicable inside queries
         | SynExpr.Paren(_,m,_,_) -> m
         | SynExpr.Sequential (_,_,e1,_,_)
@@ -928,8 +930,8 @@ and
     ///   isOptArg: true if a '?' is in front of the name
     | Id of  ident:Ident * altNameRefCell:SynSimplePatAlternativeIdInfo ref option * isCompilerGenerated:bool * isThisVar:bool *  isOptArg:bool * range:range
 
-    | Typed of  SynSimplePat * typeName:SynType * range:range
-    | Attrib of  SynSimplePat * attributes:SynAttributes * range:range
+    | Typed of  SynSimplePat * SynType * range:range
+    | Attrib of  SynSimplePat * SynAttributes * range:range
 
 
 and SynSimplePatAlternativeIdInfo =
@@ -960,31 +962,32 @@ and SynConstructorArgs =
 and
     [<NoEquality; NoComparison;RequireQualifiedAccess>]
     SynPat =
-    | Const of constant:SynConst * range:range
+    | Const of SynConst * range:range
     | Wild of range:range
-    | Named of  SynPat * id:Ident *  isThisVar:bool (* true if 'this' variable *)  * accessiblity:SynAccess option * range:range
-    | Typed of  SynPat * typeName:SynType * range:range
-    | Attrib of  SynPat * attributes:SynAttributes * range:range
-    | Or of  SynPat * SynPat * range:range
-    | Ands of  SynPat list * range:range
-    | LongIdent of dotId:LongIdentWithDots * (* holds additional ident for tooling *) Ident option * SynValTyparDecls option (* usually None: temporary used to parse "f<'a> x = x"*) * SynConstructorArgs  * SynAccess option * range:range
-    | Tuple of  SynPat list * range:range
-    | StructTuple of  SynPat list * range:range
-    | Paren of  SynPat * range:range
-    | ArrayOrList of  bool * SynPat list * range:range
-    | Record of fields:((LongIdent * Ident) * SynPat) list * range:range
+    | Named of SynPat * Ident *  isSelfIdentifier:bool (* true if 'this' variable *)  * accessibility:SynAccess option * range:range
+    | Typed of SynPat * SynType * range:range
+    | Attrib of SynPat * SynAttributes * range:range
+    | Or of SynPat * SynPat * range:range
+    | Ands of SynPat list * range:range
+    | LongIdent of longDotId:LongIdentWithDots * (* holds additional ident for tooling *) Ident option * SynValTyparDecls option (* usually None: temporary used to parse "f<'a> x = x"*) * SynConstructorArgs  * accessibility:SynAccess option * range:range
+    | Tuple of SynPat list * range:range
+    | StructTuple of SynPat list * range:range
+    | Paren of SynPat * range:range
+    | ArrayOrList of bool * SynPat list * range:range
+    | Record of ((LongIdent * Ident) * SynPat) list * range:range
     /// 'null'
     | Null of range:range
     /// '?id' -- for optional argument names
     | OptionalVal of Ident * range:range
     /// ':? type '
-    | IsInst of typeName:SynType * range:range
+    | IsInst of SynType * range:range
     /// &lt;@ expr @&gt;, used for active pattern arguments
-    | QuoteExpr of expr:SynExpr * range:range
-    /// Deprecated character ranges
+    | QuoteExpr of SynExpr * range:range
+
+    /// Deprecated character range:ranges
     | DeprecatedCharRange of char * char * range:range
     /// Used internally in the type checker
-    | InstanceMember of  Ident * Ident * (* holds additional ident for tooling *) Ident option * accesiblity:SynAccess option * range:range (* adhoc overloaded method/property *)
+    | InstanceMember of  Ident * Ident * (* holds additional ident for tooling *) Ident option * accessibility:SynAccess option * range:range (* adhoc overloaded method/property *)
 
     /// A pattern arising from a parse error
     | FromParseError of SynPat * range:range
@@ -1015,12 +1018,12 @@ and
 and
     [<NoEquality; NoComparison>]
     SynInterfaceImpl =
-    | InterfaceImpl of SynType * bindings:SynBinding list * range:range
+    | InterfaceImpl of SynType * SynBinding list * range:range
 
 and
     [<NoEquality; NoComparison>]
     SynMatchClause =
-    | Clause of SynPat * SynExpr option *  SynExpr * range:range * spTarget:SequencePointInfoForTarget
+    | Clause of SynPat * SynExpr option *  SynExpr * range:range * SequencePointInfoForTarget
     member this.RangeOfGuardAndRhs =
         match this with
         | Clause(_,eo,e,_,_) ->
@@ -1056,19 +1059,19 @@ and
     [<NoEquality; NoComparison>]
     SynBinding =
     | Binding of
-        access:SynAccess option *
-        bindingKind:SynBindingKind *
-        mustInline:bool  *
-        isMutable:bool  *
-        attributes:SynAttributes *
+        accessibility:SynAccess option *
+        SynBindingKind *
+        mustInline:bool *
+        isMutable:bool *
+        SynAttributes *
         xmlDoc:PreXmlDoc *
         SynValData *
         headPat:SynPat *
         SynBindingReturnInfo option *
-        expr:SynExpr  *
-        lhsRange:range *
-        spBind:SequencePointInfoForBinding
-    // no member just named 'Range', as that would be confusing:
+        SynExpr  *
+        range:range *
+        SequencePointInfoForBinding
+    // no member just named "Range", as that would be confusing:
     //  - for everything else, the 'range' member that appears last/second-to-last is the 'full range' of the whole tree construct
     //  - but for Binding, the 'range' is only the range of the left-hand-side, the right-hand-side range is in the SynExpr
     //  - so we use explicit names to avoid confusion
@@ -1108,11 +1111,11 @@ and
     /// The untyped, unchecked syntax tree for a member signature, used in signature files, abstract member declarations
     /// and member constraints.
     SynMemberSig =
-    | Member of SynValSig  * memberFlags:MemberFlags * range:range
-    | Interface of typeName:SynType  * range:range
+    | Member of SynValSig * MemberFlags * range:range
+    | Interface of typeName:SynType * range:range
     | Inherit of typeName:SynType * range:range
-    | ValField of field:SynField  * range:range
-    | NestedType  of typeDefnSig:SynTypeDefnSig * range:range
+    | ValField of SynField * range:range
+    | NestedType  of SynTypeDefnSig * range:range
 
 and SynMemberSigs = SynMemberSig list
 
@@ -1139,41 +1142,34 @@ and
     SynTypeDefnSimpleRepr =
 
     /// A union type definition, type X = A | B
-    | Union      of accessiblity:SynAccess option * cases:SynUnionCases * range:range
-
+    | Union      of accessibility:SynAccess option * unionCases:SynUnionCases * range:range
     /// An enum type definition, type X = A = 1 | B = 2
-    | Enum       of cases:SynEnumCases * range:range
-
+    | Enum       of SynEnumCases * range:range
     /// A record type definition, type X = { A : int; B : int }
-    | Record     of accessiblity:SynAccess option * fields:SynFields * range:range
-
+    | Record     of accessibility:SynAccess option * recordFields:SynFields * range:range
     /// An object oriented type definition. This is not a parse-tree form, but represents the core
-    /// type representation which the type checker splits out from the 'ObjectModel' cases of type definitions.
+    /// type representation which the type checker splits out from the "ObjectModel" cases of type definitions.
     | General    of SynTypeDefnKind * (SynType * range * Ident option) list * (SynValSig * MemberFlags) list * SynField list  * bool * bool * SynSimplePat list option * range:range
-
     /// A type defined by using an IL assembly representation. Only used in FSharp.Core.
     ///
-    /// F# syntax: type X = (# '...' #)
+    /// F# syntax: "type X = (# "..."#)
     | LibraryOnlyILAssembly of ILType * range:range
-
     /// A type abbreviation, "type X = A.B.C"
     | TypeAbbrev of ParserDetail * SynType * range:range
-
     /// An abstract definition , "type X"
     | None       of range:range
-
     /// An exception definition , "exception E = ..."
     | Exception of SynExceptionDefnRepr
 
     member this.Range =
         match this with
-        | Union(_,_,m)
-        | Enum(_,m)
-        | Record(_,_,m)
-        | General(_,_,_,_,_,_,_,m)
-        | LibraryOnlyILAssembly(_,m)
-        | TypeAbbrev(_,_,m)
-        | None(m) -> m
+        | Union (range=m)
+        | Enum (range=m)
+        | Record (range=m)
+        | General (range=m)
+        | LibraryOnlyILAssembly (range=m)
+        | TypeAbbrev (range=m)
+        | None (range=m) -> m
         | Exception t -> t.Range
 
 and SynEnumCases = SynEnumCase list
@@ -1182,7 +1178,7 @@ and
     [<NoEquality; NoComparison>]
     SynEnumCase =
     /// The untyped, unchecked syntax tree for one case in an enum definition.
-    | EnumCase of attributes:SynAttributes * id:Ident * SynConst * xmlDoc:PreXmlDoc * range:range
+    | EnumCase of SynAttributes * ident:Ident * SynConst * PreXmlDoc * range:range
     member this.Range =
         match this with
         | EnumCase (range=m) -> m
@@ -1193,7 +1189,7 @@ and
     [<NoEquality; NoComparison>]
     SynUnionCase =
     /// The untyped, unchecked syntax tree for one case in a union definition.
-    | UnionCase of attributes:SynAttributes * id:Ident * caseType:SynUnionCaseType * xmlDoc:PreXmlDoc * accessibility:SynAccess option * range:range
+    | UnionCase of SynAttributes * ident:Ident * SynUnionCaseType * PreXmlDoc * accessibility:SynAccess option * range:range
     member this.Range =
         match this with
         | UnionCase (range=m) -> m
@@ -1221,8 +1217,8 @@ and
     | Exception of SynExceptionDefnRepr
     member this.Range =
         match this with
-        | ObjectModel(_,_,m) -> m
-        | Simple(_,m) -> m
+        | ObjectModel (range=m)
+        | Simple (range=m) -> m
         | Exception e -> e.Range
 
 and
@@ -1230,7 +1226,7 @@ and
     /// The untyped, unchecked syntax tree for a type definition in a signature
     SynTypeDefnSig =
     /// The information for a type definition in a signature
-    | TypeDefnSig of SynComponentInfo * SynTypeDefnSigRepr * memberSigs:SynMemberSigs * range:range
+    | TypeDefnSig of SynComponentInfo * SynTypeDefnSigRepr * SynMemberSigs * range:range
 
 and SynFields = SynField list
 
@@ -1238,7 +1234,7 @@ and
     [<NoEquality; NoComparison>]
     /// The untyped, unchecked syntax tree for a field declaration in a record or class
     SynField =
-    | Field of attributes:SynAttributes * isStatic:bool * id:Ident option * typeName:SynType * bool * xmlDoc:PreXmlDoc * accessiblity:SynAccess option * range:range
+    | Field of SynAttributes * isStatic:bool * Ident option * SynType * bool * xmlDoc:PreXmlDoc * accessibility:SynAccess option * range:range
 
 
 and
@@ -1250,7 +1246,7 @@ and
     /// for a type definition or module. For modules, entries such as the type parameters are
     /// always empty.
     SynComponentInfo =
-    | ComponentInfo of attributes:SynAttributes * typeParams:SynTyparDecl list * constraints:SynTypeConstraint list * LongIdent * xmlDoc:PreXmlDoc * preferPostfix:bool * accessiblity:SynAccess option * range:range
+    | ComponentInfo of attribs:SynAttributes * typeParams:SynTyparDecl list * constraints:SynTypeConstraint list * longId:LongIdent * xmlDoc:PreXmlDoc * preferPostfix:bool * accessibility:SynAccess option * range:range
     member this.Range =
         match this with
         | ComponentInfo (range=m) -> m
@@ -1259,20 +1255,20 @@ and
     [<NoEquality; NoComparison>]
     SynValSig =
     | ValSpfn of
-        attributes:SynAttributes *
-        id:Ident *
-        typeParams:SynValTyparDecls *
-        typeName:SynType *
-        valInfo:SynValInfo *
-        bool *
-        isMutable:bool *  (* mutable? *)
+        SynAttributes *
+        ident:Ident *
+        explicitValDecls:SynValTyparDecls *
+        SynType *
+        arity:SynValInfo *
+        isInline:bool *
+        isMutable:bool *
         xmlDoc:PreXmlDoc *
-        accessiblity:SynAccess option *
-        expr:SynExpr option *
+        accessibility:SynAccess option *
+        SynExpr option *
         range:range
 
-    member x.RangeOfId  = let (ValSpfn(id=id)) = x in id.idRange
-    member x.SynInfo = let (ValSpfn(valInfo=v)) = x in v
+    member x.RangeOfId  = let (ValSpfn(_,id,_,_,_,_,_,_,_,_,_)) = x in id.idRange
+    member x.SynInfo = let (ValSpfn(_,_,_,_,v,_,_,_,_,_,_)) = x in v
     member x.SynType = let (ValSpfn(_,_,_,ty,_,_,_,_,_,_,_)) = x in ty
 
 /// The argument names and other metadata for a member or function
@@ -1287,7 +1283,7 @@ and
 and
     [<NoEquality; NoComparison>]
     SynArgInfo =
-    | SynArgInfo of attributes:SynAttributes * optional:bool *  id:Ident option
+    | SynArgInfo of SynAttributes * optional:bool *  Ident option
 
 /// The names and other metadata for the type parameters for a member or function
 and
@@ -1298,28 +1294,28 @@ and
 /// 'exception E = ... '
 and [<NoEquality; NoComparison>]
     SynExceptionDefnRepr =
-    | SynExceptionDefnRepr of SynAttributes * case:SynUnionCase * longId:LongIdent option * xmlDoc:PreXmlDoc * accesibility:SynAccess option * range:range
-    member this.Range = match this with SynExceptionDefnRepr(_,_,_,_,_,m) -> m
+    | SynExceptionDefnRepr of SynAttributes * SynUnionCase * longId:LongIdent option * xmlDoc:PreXmlDoc * accessiblity:SynAccess option * range:range
+    member this.Range = match this with SynExceptionDefnRepr (range=m) -> m
 
 /// 'exception E = ... with ...'
 and
     [<NoEquality; NoComparison>]
     SynExceptionDefn =
-    | SynExceptionDefn of exnRepr:SynExceptionDefnRepr * members:SynMemberDefns * range:range
+    | SynExceptionDefn of SynExceptionDefnRepr * SynMemberDefns * range:range
     member this.Range =
         match this with
-        | SynExceptionDefn(_,_,m) -> m
+        | SynExceptionDefn (range=m) -> m
 
 and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     SynTypeDefnRepr =
-    | ObjectModel  of SynTypeDefnKind * members:SynMemberDefns * range:range
+    | ObjectModel  of SynTypeDefnKind * SynMemberDefns * range:range
     | Simple of SynTypeDefnSimpleRepr * range:range
     | Exception of SynExceptionDefnRepr
     member this.Range =
         match this with
-        | ObjectModel(_,_,m) -> m
-        | Simple(_,m) -> m
+        | ObjectModel (range=m)
+        | Simple (range=m) -> m
         | Exception t -> t.Range
 
 and
@@ -1328,7 +1324,7 @@ and
     | TypeDefn of SynComponentInfo * SynTypeDefnRepr * members:SynMemberDefns * range:range
     member this.Range =
         match this with
-        | TypeDefn(_,_,_,m) -> m
+        | TypeDefn (range=m) -> m
 
 and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
@@ -1342,17 +1338,17 @@ and
     /// LetBindings(bindingList, isStatic, isRecursive, wholeRange)
     ///
     /// localDefns
-    | LetBindings of bindings:SynBinding list * isStatic:bool * isRecursive:bool * range:range
-    | AbstractSlot of valSig:SynValSig * memberFlags:MemberFlags * range:range
-    | Interface of typeName:SynType * interfaceMembers:SynMemberDefns option  * range:range
-    | Inherit of typeName:SynType  * id:Ident option * range:range
-    | ValField of field:SynField  * range:range
+    | LetBindings of SynBinding list * isStatic:bool * isRecursive:bool * range:range
+    | AbstractSlot of SynValSig * MemberFlags * range:range
+    | Interface of SynType * SynMemberDefns option  * range:range
+    | Inherit of SynType  * Ident option * range:range
+    | ValField of SynField  * range:range
     /// A feature that is not implemented
-    | NestedType of typeDefn:SynTypeDefn * accessiblity:SynAccess option * range:range
+    | NestedType of SynTypeDefn * accessibility:SynAccess option * range:range
     /// SynMemberDefn.AutoProperty (attribs,isStatic,id,tyOpt,propKind,memberFlags,xmlDoc,access,synExpr,mGetSet,mWholeAutoProp).
     ///
     /// F# syntax: 'member val X = expr'
-    | AutoProperty of attributes:SynAttributes * isStatic:bool * id:Ident * tyOpt:SynType option * propKind:MemberKind * memberFlags:(MemberKind -> MemberFlags) * xmlDoc:PreXmlDoc * accessibility:SynAccess option * expr:SynExpr * getSetPos:range option * range:range
+    | AutoProperty of attribs:SynAttributes * isStatic:bool * ident:Ident * typeOpt:SynType option * propKind:MemberKind * memberFlags:(MemberKind -> MemberFlags) * xmlDoc:PreXmlDoc * accessiblity:SynAccess option * synExpr:SynExpr * getSetRange:range option * range:range
     member d.Range =
         match d with
         | SynMemberDefn.Member (range=m)
@@ -1372,58 +1368,58 @@ and SynMemberDefns = SynMemberDefn list
 and
     [<NoEquality; NoComparison;RequireQualifiedAccess>]
     SynModuleDecl =
-    | ModuleAbbrev of Ident * LongIdent * range
-    | NestedModule of SynComponentInfo * isRec: bool * SynModuleDecls * bool * range
-    | Let of bool * SynBinding list * range
-    | DoExpr of SequencePointInfoForBinding * SynExpr * range
-    | Types of SynTypeDefn list * range
-    | Exception of SynExceptionDefn * range
-    | Open of LongIdentWithDots * range
-    | Attributes of SynAttributes * range
-    | HashDirective of ParsedHashDirective * range
+    | ModuleAbbrev of ident:Ident * longId:LongIdent * range:range
+    | NestedModule of SynComponentInfo * isRecursive:bool * SynModuleDecls * bool * range:range
+    | Let of bool * SynBinding list * range:range
+    | DoExpr of SequencePointInfoForBinding * SynExpr * range:range
+    | Types of SynTypeDefn list * range:range
+    | Exception of SynExceptionDefn * range:range
+    | Open of longDotId:LongIdentWithDots * range:range
+    | Attributes of SynAttributes * range:range
+    | HashDirective of ParsedHashDirective * range:range
     | NamespaceFragment of SynModuleOrNamespace
     member d.Range =
         match d with
-        | SynModuleDecl.ModuleAbbrev(_,_,m)
-        | SynModuleDecl.NestedModule(_,_,_,_,m)
-        | SynModuleDecl.Let(_,_,m)
-        | SynModuleDecl.DoExpr(_,_,m)
-        | SynModuleDecl.Types(_,m)
-        | SynModuleDecl.Exception(_,m)
-        | SynModuleDecl.Open (_,m)
-        | SynModuleDecl.HashDirective (_,m)
-        | SynModuleDecl.NamespaceFragment(SynModuleOrNamespace(_,_,_,_,_,_,_,m))
-        | SynModuleDecl.Attributes(_,m) -> m
+        | SynModuleDecl.ModuleAbbrev (range=m)
+        | SynModuleDecl.NestedModule (range=m)
+        | SynModuleDecl.Let (range=m)
+        | SynModuleDecl.DoExpr (range=m)
+        | SynModuleDecl.Types (range=m)
+        | SynModuleDecl.Exception (range=m)
+        | SynModuleDecl.Open (range=m)
+        | SynModuleDecl.HashDirective (range=m)
+        | SynModuleDecl.NamespaceFragment (SynModuleOrNamespace (range=m))
+        | SynModuleDecl.Attributes (range=m) -> m
 
 and SynModuleDecls = SynModuleDecl list
 
 and
     [<NoEquality; NoComparison>]
     SynExceptionSig =
-    | SynExceptionSig of exnRepr:SynExceptionDefnRepr * memberSigs:SynMemberSigs * range:range
+    | SynExceptionSig of SynExceptionDefnRepr * SynMemberSigs * range:range
 
 and
     [<NoEquality; NoComparison; RequireQualifiedAccess>]
     SynModuleSigDecl =
-    | ModuleAbbrev      of id:Ident * longId:LongIdent * range:range
-    | NestedModule      of SynComponentInfo * isRec: bool * moduleSigDecls:SynModuleSigDecls * range:range
-    | Val               of valSig:SynValSig * range:range
-    | Types             of typeDefSigs:SynTypeDefnSig list * range:range
-    | Exception         of exnSig:SynExceptionSig * range:range
+    | ModuleAbbrev      of ident:Ident * longId:LongIdent * range:range
+    | NestedModule      of SynComponentInfo * isRecursive:bool * SynModuleSigDecls * range:range
+    | Val               of SynValSig * range:range
+    | Types             of SynTypeDefnSig list * range:range
+    | Exception         of SynExceptionSig * range:range
     | Open              of longId:LongIdent * range:range
-    | HashDirective     of hashDirective:ParsedHashDirective * range:range
+    | HashDirective     of ParsedHashDirective * range:range
     | NamespaceFragment of SynModuleOrNamespaceSig
 
     member d.Range =
         match d with
-        | SynModuleSigDecl.ModuleAbbrev (_,_,m)
-        | SynModuleSigDecl.NestedModule (_,_,_,m)
-        | SynModuleSigDecl.Val      (_,m)
-        | SynModuleSigDecl.Types    (_,m)
-        | SynModuleSigDecl.Exception      (_,m)
-        | SynModuleSigDecl.Open     (_,m)
-        | SynModuleSigDecl.NamespaceFragment (SynModuleOrNamespaceSig(_,_,_,_,_,_,_,m))
-        | SynModuleSigDecl.HashDirective     (_,m) -> m
+        | SynModuleSigDecl.ModuleAbbrev (range=m)
+        | SynModuleSigDecl.NestedModule (range=m)
+        | SynModuleSigDecl.Val (range=m)
+        | SynModuleSigDecl.Types (range=m)
+        | SynModuleSigDecl.Exception (range=m)
+        | SynModuleSigDecl.Open (range=m)
+        | SynModuleSigDecl.NamespaceFragment (SynModuleOrNamespaceSig(range=m))
+        | SynModuleSigDecl.HashDirective (range=m) -> m
 
 and SynModuleSigDecls = SynModuleSigDecl list
 
@@ -1431,15 +1427,15 @@ and SynModuleSigDecls = SynModuleSigDecl list
 and
     [<NoEquality; NoComparison>]
     SynModuleOrNamespace =
-    | SynModuleOrNamespace of id:LongIdent * isRec: bool * isModule:bool * decls:SynModuleDecls * xmlDoc:PreXmlDoc * attributes:SynAttributes * access:SynAccess option * range:range
+    | SynModuleOrNamespace of longId:LongIdent * isRecursive:bool * isModule:bool * decls:SynModuleDecls * xmlDoc:PreXmlDoc * attribs:SynAttributes * accessibility:SynAccess option * range:range
     member this.Range =
         match this with
-        | SynModuleOrNamespace(_,_,_,_,_,_,_,m) -> m
+        | SynModuleOrNamespace (range=m) -> m
 
 and
     [<NoEquality; NoComparison>]
     SynModuleOrNamespaceSig =
-    | SynModuleOrNamespaceSig of id:LongIdent * isRec: bool * isModule:bool * SynModuleSigDecls * xmlDoc:PreXmlDoc * attributes:SynAttributes * SynAccess option * range:range
+    | SynModuleOrNamespaceSig of longId:LongIdent * isRecursive:bool * isModule:bool * SynModuleSigDecls * xmlDoc:PreXmlDoc * attribs:SynAttributes * accessibility:SynAccess option * range:range
 
 and [<NoEquality; NoComparison>]
     ParsedHashDirective =
@@ -1447,15 +1443,15 @@ and [<NoEquality; NoComparison>]
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type ParsedImplFileFragment =
-    | AnonModule of moduleDecls:SynModuleDecls * range:range
+    | AnonModule of SynModuleDecls * range:range
     | NamedModule of SynModuleOrNamespace
-    | NamespaceFragment of longId:LongIdent * bool * bool * moduleDecls:SynModuleDecls * xmlDoc:PreXmlDoc * attributes:SynAttributes * range:range
+    | NamespaceFragment of longId:LongIdent * bool * bool * SynModuleDecls * xmlDoc:PreXmlDoc * SynAttributes * range:range
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type ParsedSigFileFragment =
-    | AnonModule of moduleSigDecl:SynModuleSigDecls * range:range
+    | AnonModule of SynModuleSigDecls * range:range
     | NamedModule of SynModuleOrNamespaceSig
-    | NamespaceFragment of longId:LongIdent * bool * bool * moduleSigDecls:SynModuleSigDecls * xmlDoc:PreXmlDoc * attributes:SynAttributes * range:range
+    | NamespaceFragment of longId:LongIdent * bool * bool * SynModuleSigDecls * xmlDoc:PreXmlDoc * SynAttributes * range:range
 
 [<NoEquality; NoComparison>]
 type ParsedFsiInteraction =
@@ -1490,7 +1486,7 @@ let rangeOfLid (lid: Ident list) =
 
 [<RequireQualifiedAccess>]
 type ScopedPragma =
-   | WarningOff of range * int
+   | WarningOff of range:range * int
    // Note: this type may be extended in the future with optimization on/off switches etc.
 
 // These are the results of parsing + folding in the implicit file name
@@ -1510,11 +1506,11 @@ type QualifiedNameOfFile =
 
 [<NoEquality; NoComparison>]
 type ParsedImplFileInput =
-    | ParsedImplFileInput of filename:string * isScript:bool * QualifiedNameOfFile * ScopedPragma list * ParsedHashDirective list * SynModuleOrNamespace list * (bool * bool)
+    | ParsedImplFileInput of fileName:string * isScript:bool * QualifiedNameOfFile * ScopedPragma list * ParsedHashDirective list * SynModuleOrNamespace list * (bool * bool)
 
 [<NoEquality; NoComparison>]
 type ParsedSigFileInput =
-    | ParsedSigFileInput of filename:string * QualifiedNameOfFile * ScopedPragma list * ParsedHashDirective list * SynModuleOrNamespaceSig list
+    | ParsedSigFileInput of fileName:string * QualifiedNameOfFile * ScopedPragma list * ParsedHashDirective list * SynModuleOrNamespaceSig list
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type ParsedInput =
@@ -1523,10 +1519,10 @@ type ParsedInput =
 
     member inp.Range =
         match inp with
-        | ParsedInput.ImplFile (ParsedImplFileInput(_,_,_,_,_,(SynModuleOrNamespace(_,_,_,_,_,_,_,m) :: _),_))
-        | ParsedInput.SigFile (ParsedSigFileInput(_,_,_,_,(SynModuleOrNamespaceSig(_,_,_,_,_,_,_,m) :: _))) -> m
-        | ParsedInput.ImplFile (ParsedImplFileInput(filename,_,_,_,_,[],_))
-        | ParsedInput.SigFile (ParsedSigFileInput(filename,_,_,_,[])) ->
+        | ParsedInput.ImplFile (ParsedImplFileInput(_,_,_,_,_,(SynModuleOrNamespace(range=m) :: _),_))
+        | ParsedInput.SigFile (ParsedSigFileInput(_,_,_,_,(SynModuleOrNamespaceSig(range=m) :: _))) -> m
+        | ParsedInput.ImplFile (ParsedImplFileInput (fileName=filename))
+        | ParsedInput.SigFile (ParsedSigFileInput (fileName=filename)) ->
 #if DEBUG
             assert("" = "compiler expects ParsedInput.ImplFile and ParsedInput.SigFile to have at least one fragment, 4488")
 #endif
@@ -2052,8 +2048,8 @@ let mkSynBinding (xmlDoc,headPat) (vis,isInline,isMutable,mBind,spBind,retInfo,o
     Binding (vis,NormalBinding,isInline,isMutable,attrs,xmlDoc,info,headPat,retTyOpt,rhsExpr,mBind,spBind)
 
 let NonVirtualMemberFlags k = { MemberKind=k;                           IsInstance=true;  IsDispatchSlot=false; IsOverrideOrExplicitImpl=false; IsFinal=false }
-let CtorMemberFlags =         { MemberKind=MemberKind.Constructor;       IsInstance=false; IsDispatchSlot=false; IsOverrideOrExplicitImpl=false; IsFinal=false }
-let ClassCtorMemberFlags =    { MemberKind=MemberKind.ClassConstructor;  IsInstance=false; IsDispatchSlot=false; IsOverrideOrExplicitImpl=false; IsFinal=false }
+let CtorMemberFlags =         { MemberKind=MemberKind.Constructor;      IsInstance=false; IsDispatchSlot=false; IsOverrideOrExplicitImpl=false; IsFinal=false }
+let ClassCtorMemberFlags =    { MemberKind=MemberKind.ClassConstructor; IsInstance=false; IsDispatchSlot=false; IsOverrideOrExplicitImpl=false; IsFinal=false }
 let OverrideMemberFlags k =   { MemberKind=k;                           IsInstance=true;  IsDispatchSlot=false; IsOverrideOrExplicitImpl=true;  IsFinal=false }
 let AbstractMemberFlags k =   { MemberKind=k;                           IsInstance=true;  IsDispatchSlot=true;  IsOverrideOrExplicitImpl=false; IsFinal=false }
 let StaticMemberFlags k =     { MemberKind=k;                           IsInstance=false; IsDispatchSlot=false; IsOverrideOrExplicitImpl=false; IsFinal=false }
@@ -2099,32 +2095,32 @@ let rec LexerIfdefEval (lookup : string -> bool) = function
 [<RequireQualifiedAccess>]
 [<NoComparison; NoEquality>]
 type LexerWhitespaceContinuation =
-    | Token            of LexerIfdefStackEntries
-    | IfDefSkip        of LexerIfdefStackEntries * int * range:range
-    | String           of LexerIfdefStackEntries * range:range
-    | VerbatimString   of LexerIfdefStackEntries * range:range
-    | TripleQuoteString of LexerIfdefStackEntries * range:range
-    | Comment          of LexerIfdefStackEntries * int * range:range
-    | SingleLineComment of LexerIfdefStackEntries * int * range:range
-    | StringInComment    of LexerIfdefStackEntries * int * range:range
-    | VerbatimStringInComment   of LexerIfdefStackEntries * int * range:range
-    | TripleQuoteStringInComment   of LexerIfdefStackEntries * int * range:range
-    | MLOnly            of LexerIfdefStackEntries * range:range
+    | Token            of ifdef:LexerIfdefStackEntries
+    | IfDefSkip        of ifdef:LexerIfdefStackEntries * int * range:range
+    | String           of ifdef:LexerIfdefStackEntries * range:range
+    | VerbatimString   of ifdef:LexerIfdefStackEntries * range:range
+    | TripleQuoteString of ifdef:LexerIfdefStackEntries * range:range
+    | Comment          of ifdef:LexerIfdefStackEntries * int * range:range
+    | SingleLineComment of ifdef:LexerIfdefStackEntries * int * range:range
+    | StringInComment    of ifdef:LexerIfdefStackEntries * int * range:range
+    | VerbatimStringInComment   of ifdef:LexerIfdefStackEntries * int * range:range
+    | TripleQuoteStringInComment   of ifdef:LexerIfdefStackEntries * int * range:range
+    | MLOnly            of ifdef:LexerIfdefStackEntries * range:range
     | EndLine           of LexerEndlineContinuation
 
     member x.LexerIfdefStack =
         match x with
-        | LexCont.Token ifd
-        | LexCont.IfDefSkip (ifd,_,_)
-        | LexCont.String (ifd,_)
-        | LexCont.VerbatimString (ifd,_)
-        | LexCont.Comment (ifd,_,_)
-        | LexCont.SingleLineComment (ifd,_,_)
-        | LexCont.TripleQuoteString (ifd,_)
-        | LexCont.StringInComment (ifd,_,_)
-        | LexCont.VerbatimStringInComment (ifd,_,_)
-        | LexCont.TripleQuoteStringInComment (ifd,_,_)
-        | LexCont.MLOnly (ifd,_) -> ifd
+        | LexCont.Token (ifdef=ifd)
+        | LexCont.IfDefSkip (ifdef=ifd)
+        | LexCont.String (ifdef=ifd)
+        | LexCont.VerbatimString (ifdef=ifd)
+        | LexCont.Comment (ifdef=ifd)
+        | LexCont.SingleLineComment (ifdef=ifd)
+        | LexCont.TripleQuoteString (ifdef=ifd)
+        | LexCont.StringInComment (ifdef=ifd)
+        | LexCont.VerbatimStringInComment (ifdef=ifd)
+        | LexCont.TripleQuoteStringInComment (ifdef=ifd)
+        | LexCont.MLOnly (ifdef=ifd) -> ifd
         | LexCont.EndLine endl -> endl.LexerIfdefStack
 
 and LexCont = LexerWhitespaceContinuation
@@ -2138,7 +2134,7 @@ and LexCont = LexerWhitespaceContinuation
 /// information about the grammar at the point where the error occured, e.g. what tokens
 /// are valid to shift next at that point in the grammar. This information is processed in CompileOps.fs.
 [<NoEquality; NoComparison>]
-exception SyntaxError of obj (* ParseErrorContext<_> *) * range
+exception SyntaxError of obj (* ParseErrorContext<_> *) * range:range
 
 /// Get an F# compiler position from a lexer position
 let posOfLexPosition (p:Position) =


### PR DESCRIPTION
Field Names for Union Cases improves the clarity of intellisense tooltips and makes pattern matching easier.