### PR TITLE
VS2017 RC - Get correct options for scripts

### DIFF
--- a/src/fsharp/vs/IncrementalBuild.fsi
+++ b/src/fsharp/vs/IncrementalBuild.fsi
@@ -122,7 +122,7 @@ type internal IncrementalBuilder =
       /// Raised just before a file is type-checked, to invalidate the state of the file in VS and force VS to request a new direct typecheck of the file.
       /// The incremental builder also typechecks the file (error and intellisense results from the backgroud builder are not
       /// used by VS). 
-      member BeforeTypeCheckFile : IEvent<string>
+      member BeforeFileChecked : IEvent<string>
 
       /// Raised just after a file is parsed
       member FileParsed : IEvent<string>

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -318,6 +318,8 @@ type internal FSharpProjectOptions =
       LoadTime : DateTime
       /// Unused in this API and should be 'None'
       UnresolvedReferences : UnresolvedReferencesSet option
+      /// Extra information passed back on event trigger
+      ExtraProjectInfo : obj option
     }
          
           
@@ -473,7 +475,7 @@ type internal FSharpChecker =
     /// <param name="loadedTimeStamp">Indicates when the script was loaded into the editing environment,
     /// so that an 'unload' and 'reload' action will cause the script to be considered as a new project,
     /// so that references are re-resolved.</param>
-    member GetProjectOptionsFromScript : filename: string * source: string * ?loadedTimeStamp: DateTime * ?otherFlags: string[] * ?useFsiAuxLib: bool -> Async<FSharpProjectOptions>
+    member GetProjectOptionsFromScript : filename: string * source: string * ?loadedTimeStamp: DateTime * ?otherFlags: string[] * ?useFsiAuxLib: bool * ?extraProjectInfo: obj -> Async<FSharpProjectOptions>
 
     /// <summary>
     /// <para>Get the FSharpProjectOptions implied by a set of command line arguments.</para>
@@ -484,7 +486,7 @@ type internal FSharpChecker =
     /// <param name="loadedTimeStamp">Indicates when the script was loaded into the editing environment,
     /// so that an 'unload' and 'reload' action will cause the script to be considered as a new project,
     /// so that references are re-resolved.</param>
-    member GetProjectOptionsFromCommandLineArgs : projectFileName: string * argv: string[] * ?loadedTimeStamp: DateTime -> FSharpProjectOptions
+    member GetProjectOptionsFromCommandLineArgs : projectFileName: string * argv: string[] * ?loadedTimeStamp: DateTime * ?extraProjectInfo: obj -> FSharpProjectOptions
            
     /// <summary>
     /// <para>Like ParseFileInProject, but uses results from the background builder.</para>
@@ -558,17 +560,17 @@ type internal FSharpChecker =
     /// and that the file has become eligible to be re-typechecked for errors.
     ///
     /// The event will be raised on a background thread.
-    member BeforeBackgroundFileCheck : IEvent<string>
+    member BeforeBackgroundFileCheck : IEvent<string * obj option>
 
     /// Raised after a parse of a file in the background analysis.
     ///
     /// The event will be raised on a background thread.
-    member FileParsed : IEvent<string>
+    member FileParsed : IEvent<string * obj option>
 
     /// Raised after a check of a file in the background analysis.
     ///
     /// The event will be raised on a background thread.
-    member FileChecked : IEvent<string>
+    member FileChecked : IEvent<string * obj option>
     
     /// Get or set a flag which controls if background work is started implicitly. 
     ///
@@ -583,7 +585,7 @@ type internal FSharpChecker =
     /// Notify the host that a project has been fully checked in the background (using file contents provided by the file system API)
     ///
     /// The event may be raised on a background thread.
-    member ProjectChecked : IEvent<string>
+    member ProjectChecked : IEvent<string * obj option>
 
     // For internal use only 
     member internal ReactorOps : IReactorOperations

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -101,7 +101,8 @@ let ``FileSystem compilation test``() =
           IsIncompleteTypeCheckEnvironment = false
           UseScriptResolutionRules = true 
           LoadTime = System.DateTime.Now // Not 'now', we don't want to force reloading
-          UnresolvedReferences = None }
+          UnresolvedReferences = None 
+          ExtraProjectInfo = None }
 
     let results = checker.ParseAndCheckProject(projectOptions) |> Async.RunSynchronously
 

--- a/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
+++ b/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
@@ -23,7 +23,7 @@ type internal FSharpBraceMatchingService() =
     interface IBraceMatcher with
         member this.FindBracesAsync(document, position, cancellationToken) = 
             async {
-                match FSharpLanguageService.GetOptions(document.Project.Id) with
+                match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
                 | Some(options) ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                     let! result = FSharpBraceMatchingService.GetBraceMatchingResult(sourceText, document.Name, options, position)

--- a/vsintegration/src/FSharp.Editor/BreakpointResolutionService.fs
+++ b/vsintegration/src/FSharp.Editor/BreakpointResolutionService.fs
@@ -48,7 +48,7 @@ type internal FSharpBreakpointResolutionService() =
     interface IBreakpointResolutionService with
         member this.ResolveBreakpointAsync(document: Document, textSpan: TextSpan, cancellationToken: CancellationToken): Task<BreakpointResolutionResult> =
             async {
-                match FSharpLanguageService.GetOptions(document.Project.Id) with
+                match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
                 | Some(options) ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                     let! location = FSharpBreakpointResolutionService.GetBreakpointLocation(sourceText, document.Name, textSpan, options)

--- a/vsintegration/src/FSharp.Editor/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/ColorizationService.fs
@@ -36,18 +36,14 @@ type internal FSharpColorizationService() =
         
         member this.AddSyntacticClassificationsAsync(document: Document, textSpan: TextSpan, result: List<ClassifiedSpan>, cancellationToken: CancellationToken) =
             async {
+                let defines = FSharpLanguageService.GetCompilationDefinesForEditingDocument(document)  
                 let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                match FSharpLanguageService.GetOptions(document.Project.Id) with
-                | Some(options) ->
-                    let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.Name, options.OtherOptions |> Seq.toList)
-                    result.AddRange(CommonHelpers.getColorizationData(
-                                      document.Id, sourceText, textSpan, Some(document.FilePath), defines, cancellationToken))
-                | None -> ()
+                result.AddRange(CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.FilePath), defines, cancellationToken))
             } |> CommonRoslynHelpers.StartAsyncUnitAsTask(cancellationToken)
 
         member this.AddSemanticClassificationsAsync(document: Document, textSpan: TextSpan, result: List<ClassifiedSpan>, cancellationToken: CancellationToken) =
             async {
-                match FSharpLanguageService.GetOptions(document.Project.Id) with
+                match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
                 | Some(options) ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                     let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask

--- a/vsintegration/src/FSharp.Editor/CommonHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CommonHelpers.fs
@@ -152,7 +152,9 @@ module CommonHelpers =
                 | None -> ()
 
             result
-        with ex -> 
+        with 
+        | :? System.OperationCanceledException -> reraise()
+        |  ex -> 
             Assert.Exception(ex)
             List<ClassifiedSpan>()
 

--- a/vsintegration/src/FSharp.Editor/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentDiagnosticAnalyzer.fs
@@ -25,6 +25,8 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
     inherit DocumentDiagnosticAnalyzer()
 
     static member GetDiagnostics(filePath: string, sourceText: SourceText, textVersionHash: int, options: FSharpProjectOptions, addSemanticErrors: bool) = async {
+
+
         let! parseResults = FSharpLanguageService.Checker.ParseFileInProject(filePath, sourceText.ToString(), options) 
         let! errors = async {
             if addSemanticErrors then
@@ -57,7 +59,7 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
 
     override this.AnalyzeSyntaxAsync(document: Document, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         async {
-            match FSharpLanguageService.GetOptions(document.Project.Id) with
+            match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
             | Some(options) ->
                 let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                 let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask
@@ -68,7 +70,8 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
 
     override this.AnalyzeSemanticsAsync(document: Document, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         async {
-            match FSharpLanguageService.GetOptions(document.Project.Id) with
+            let! optionsOpt = FSharpLanguageService.TryGetOptionsForDocumentOrProject(document) 
+            match optionsOpt with 
             | Some(options) ->
                 let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                 let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask

--- a/vsintegration/src/FSharp.Editor/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/GoToDefinitionService.fs
@@ -79,7 +79,7 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>] ([<ImportMany
     member this.FindDefinitionsAsyncAux(document: Document, position: int, cancellationToken: CancellationToken) =
         async {
             let results = List<INavigableItem>()
-            match FSharpLanguageService.GetOptions(document.Project.Id) with
+            match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
             | Some(options) ->
                 let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                 let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask

--- a/vsintegration/src/FSharp.Editor/LanguageDebugInfoService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageDebugInfoService.fs
@@ -66,16 +66,15 @@ type internal FSharpLanguageDebugInfoService() =
 
         member this.GetDataTipInfoAsync(document: Document, position: int, cancellationToken: CancellationToken): Task<DebugDataTipInfo> =
             async {
-                match FSharpLanguageService.GetOptions(document.Project.Id) with
-                | Some(options) ->
-                    let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.Name, options.OtherOptions |> Seq.toList)
-                    let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                    let textSpan = TextSpan.FromBounds(0, sourceText.Length)
-                    let tokens = CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.Name), defines, cancellationToken)
-                    return match FSharpLanguageDebugInfoService.GetDataTipInformation(sourceText, position, tokens) with
-                           | None -> Unchecked.defaultof<DebugDataTipInfo>
-                           | Some(textSpan) -> new DebugDataTipInfo(textSpan, sourceText.GetSubText(textSpan).ToString())
-                | None -> return Unchecked.defaultof<DebugDataTipInfo>
+                let defines = FSharpLanguageService.GetCompilationDefinesForEditingDocument(document)  
+                let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
+                let textSpan = TextSpan.FromBounds(0, sourceText.Length)
+                let tokens = CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.Name), defines, cancellationToken)
+                let result = 
+                    match FSharpLanguageDebugInfoService.GetDataTipInformation(sourceText, position, tokens) with
+                    | None -> DebugDataTipInfo()
+                    | Some(textSpan) -> DebugDataTipInfo(textSpan, sourceText.GetSubText(textSpan).ToString())
+                return result
             } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken
             
             

--- a/vsintegration/src/FSharp.Editor/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService.fs
@@ -3,6 +3,7 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
+open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Runtime.InteropServices
 open System.Linq
@@ -48,20 +49,95 @@ type internal SVsSettingsPersistenceManager = class end
 type internal FSharpLanguageService(package : FSharpPackage) =
     inherit AbstractLanguageService<FSharpPackage, FSharpLanguageService>(package)
 
-    static let optionsCache = Dictionary<ProjectId, FSharpProjectOptions>()
-    static let checker = lazy FSharpChecker.Create()
-    static member Checker with get() = checker.Value
+    // A table of information about projects, excluding single-file projects.  
+    static let projectTable = ConcurrentDictionary<ProjectId, FSharpProjectOptions>()
 
-    static member GetOptions(projectId: ProjectId) =
-        if optionsCache.ContainsKey(projectId) then
-            Some(optionsCache.[projectId])
+    // A table of information about single-file projects.  Currently we only need the load time of each such file, plus
+    // the original options for editing
+    static let singleFileProjectTable = ConcurrentDictionary<ProjectId, DateTime * FSharpProjectOptions>()
+
+    static let checker =  lazy FSharpChecker.Create()
+
+
+    /// Update the info for a proejct in the project table
+    static let UpdateProjectInfo(projectId: ProjectId, site: IProjectSite, workspace: Workspace) =
+        let extraProjectInfo = Some(box workspace)
+        let options = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site, site.ProjectFileName(), extraProjectInfo)
+        checker.Value.InvalidateConfiguration(options)
+        projectTable.[projectId] <- options
+
+    /// Clear a project from the project table
+    static let ClearProjectInfo(projectId: ProjectId) =
+        projectTable.TryRemove(projectId) |> ignore
+        
+    /// Get the exact options for a single-file script
+    static let ComputeSingleFileOptions (fileName, loadTime, fileContents, workspace: Workspace) = async {
+        let extraProjectInfo = Some(box workspace)
+        if SourceFile.MustBeSingleFileProject(fileName) then 
+            let! options = checker.Value.GetProjectOptionsFromScript(fileName, fileContents, loadTime, [| |], ?extraProjectInfo=extraProjectInfo) 
+            let site = ProjectSitesAndFiles.CreateProjectSiteForScript(fileName, options)
+            return ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site,fileName,options.ExtraProjectInfo)
+        else
+            let site = ProjectSitesAndFiles.ProjectSiteOfSingleFile(fileName)
+            return ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site,fileName,extraProjectInfo)
+      }
+
+    /// Get the options for a project
+    static member TryGetOptionsForProject(projectId: ProjectId) = 
+        if projectTable.ContainsKey(projectId) then
+            Some(projectTable.[projectId])
         else
             None
 
-    static member UpdateOptions(projectId: ProjectId, options: FSharpProjectOptions) =
-        optionsCache.[projectId] <- options
+    /// Get the exact options for a document or project
+    static member TryGetOptionsForDocumentOrProject(document: Document) = async { 
+        let projectId = document.Project.Id
+        
+        // The options for a single-file script project are re-requested each time the file is analyzed.  This is because the
+        // single-file project may contain #load and #r references which are changing as the user edits, and we may need to re-analyze
+        // to determine the latest settings.  FCS keeps a cache to help ensure these are up-to-date.
+        if singleFileProjectTable.ContainsKey(projectId) then 
+          try
+            let loadTime,_ = singleFileProjectTable.[projectId]
+            let fileName = document.FilePath
+            let! cancellationToken = Async.CancellationToken
+            let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
+            let! options = ComputeSingleFileOptions (fileName, loadTime, sourceText.ToString(), document.Project.Solution.Workspace)
+            singleFileProjectTable.[projectId] <- (loadTime, options)
+            return Some options
+          with ex -> 
+            Assert.Exception(ex)
+            return None
+        else return FSharpLanguageService.TryGetOptionsForProject(projectId) 
+     }
 
+    /// Get the options for a document or project relevant for syntax processing.
+    /// Quicker then TryGetOptionsForDocumentOrProject as it doesn't need to recompute the exact project options for a script.
+    static member TryGetOptionsForEditingDocumentOrProject(document: Document) = 
+        let projectId = document.Project.Id
+        if singleFileProjectTable.ContainsKey(projectId) then 
+            let _loadTime, originalOptions = singleFileProjectTable.[projectId]
+            Some originalOptions
+        else 
+            FSharpLanguageService.TryGetOptionsForProject(projectId) 
+
+    /// Get compilation defines relevant for syntax processing.  
+    /// Quicker then TryGetOptionsForDocumentOrProject as it doesn't need to recompute the exact project 
+    /// options for a script.
+    static member GetCompilationDefinesForEditingDocument(document: Document) = 
+        let projectOptionsOpt = FSharpLanguageService.TryGetOptionsForProject(document.Project.Id)  
+        let otherOptions = 
+            match projectOptionsOpt with 
+            | None -> []
+            | Some(options) -> options.OtherOptions |> Array.toList
+        CompilerEnvironment.GetCompilationDefinesForEditing(document.Name, otherOptions)
+
+    /// Get the global FSharpChecker component
+    static member Checker with get() = checker.Value
+
+    /// Sync the information for the project 
     member this.SyncProject(project: AbstractProject, projectContext: IWorkspaceProjectContext, site: IProjectSite) =
+
         let hashSetIgnoreCase x = new HashSet<string>(x, StringComparer.OrdinalIgnoreCase)
         let updatedFiles = site.SourceFilesOnDisk() |> hashSetIgnoreCase
         let workspaceFiles = project.GetCurrentDocuments() |> Seq.map(fun file -> file.FilePath) |> hashSetIgnoreCase
@@ -78,8 +154,50 @@ type internal FSharpLanguageService(package : FSharpPackage) =
 
         // update the cached options
         if updated then
-            let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site, "")
-            FSharpLanguageService.UpdateOptions(project.Id, checkOptions)
+            UpdateProjectInfo(project.Id, site, project.Workspace)
+
+    member this.SetupProjectFile(siteProvider: IProvideProjectSite, workspace: VisualStudioWorkspaceImpl) =
+        let site = siteProvider.GetProjectSite()
+        let projectGuid = Guid(site.ProjectGuid)
+        let projectFileName = site.ProjectFileName()
+        let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectFileName)
+
+        UpdateProjectInfo(projectId, site, workspace)
+
+        match workspace.ProjectTracker.GetProject(projectId) with
+        | null ->
+            let projectContextFactory = this.Package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
+            let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
+
+            let projectContext = projectContextFactory.CreateProjectContext(FSharpCommonConstants.FSharpLanguageName, projectFileName, projectFileName, projectGuid, siteProvider, null, errorReporter)
+            let project = projectContext :?> AbstractProject
+
+            this.SyncProject(project, projectContext, site)
+            site.AdviseProjectSiteChanges(FSharpCommonConstants.FSharpLanguageServiceCallbackName, AdviseProjectSiteChanges(fun () -> this.SyncProject(project, projectContext, site)))
+            site.AdviseProjectSiteClosed(FSharpCommonConstants.FSharpLanguageServiceCallbackName, AdviseProjectSiteChanges(fun () -> ClearProjectInfo(project.Id); project.Disconnect()))
+        | _ -> ()
+
+    member this.SetupStandAloneFile(fileName: string, fileContents: string, workspace: VisualStudioWorkspaceImpl, hier: IVsHierarchy) =
+
+        let loadTime = DateTime.Now
+        let options = ComputeSingleFileOptions (fileName, loadTime, fileContents, workspace) |> Async.RunSynchronously
+
+        let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(options.ProjectFileName, options.ProjectFileName)
+        singleFileProjectTable.[projectId] <- (loadTime, options)
+
+        if obj.ReferenceEquals(workspace.ProjectTracker.GetProject(projectId), null) then
+            let projectContextFactory = this.Package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
+            let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
+
+            let projectContext = projectContextFactory.CreateProjectContext(FSharpCommonConstants.FSharpLanguageName, options.ProjectFileName, options.ProjectFileName, projectId.Id, hier, null, errorReporter)
+            projectContext.AddSourceFile(fileName)
+            
+            let project = projectContext :?> AbstractProject
+            let document = project.GetCurrentDocumentFromPath(fileName)
+
+            document.Closing.Add(fun _ ->  
+                singleFileProjectTable.TryRemove(projectId) |> ignore; 
+                project.Disconnect())
 
     override this.ContentTypeName = FSharpCommonConstants.FSharpContentTypeName
     override this.LanguageName = FSharpCommonConstants.FSharpLanguageName
@@ -96,7 +214,7 @@ type internal FSharpLanguageService(package : FSharpPackage) =
 
         // FSROSLYNTODO: Hide navigation bars for now. Enable after adding tests
         workspace.Options <- workspace.Options.WithChangedOption(NavigationBarOptions.ShowNavigationBar, FSharpCommonConstants.FSharpLanguageName, false)
-
+        
         match textView.GetBuffer() with
         | (VSConstants.S_OK, textLines) ->
             let filename = VsTextLines.GetFilename textLines
@@ -111,46 +229,6 @@ type internal FSharpLanguageService(package : FSharpPackage) =
                     this.SetupStandAloneFile(filename, fileContents, workspace, hier)
             | _ -> ()
         | _ -> ()
-
-    member this.SetupProjectFile(siteProvider: IProvideProjectSite, workspace: VisualStudioWorkspaceImpl) =
-        let site = siteProvider.GetProjectSite()
-        let projectGuid = Guid(site.ProjectGuid)
-        let projectFileName = site.ProjectFileName()
-        let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectFileName)
-
-        let options = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site, site.ProjectFileName())
-        FSharpLanguageService.UpdateOptions(projectId, options)
-
-        match workspace.ProjectTracker.GetProject(projectId) with
-        | null ->
-            let projectContextFactory = this.Package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
-            let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
-
-            let projectContext = projectContextFactory.CreateProjectContext(FSharpCommonConstants.FSharpLanguageName, projectFileName, projectFileName, projectGuid, siteProvider, null, errorReporter)
-            let project = projectContext :?> AbstractProject
-
-            this.SyncProject(project, projectContext, site)
-            site.AdviseProjectSiteChanges(FSharpCommonConstants.FSharpLanguageServiceCallbackName, AdviseProjectSiteChanges(fun () -> this.SyncProject(project, projectContext, site)))
-            site.AdviseProjectSiteClosed(FSharpCommonConstants.FSharpLanguageServiceCallbackName, AdviseProjectSiteChanges(fun () -> project.Disconnect()))
-        | _ -> ()
-
-    member this.SetupStandAloneFile(fileName: string, fileContents: string, workspace: VisualStudioWorkspaceImpl, hier: IVsHierarchy) =
-        let options = FSharpLanguageService.Checker.GetProjectOptionsFromScript(fileName, fileContents, DateTime.Now, [| |]) |> Async.RunSynchronously
-        let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(options.ProjectFileName, options.ProjectFileName)
-
-        FSharpLanguageService.UpdateOptions(projectId, options)
-
-        if obj.ReferenceEquals(workspace.ProjectTracker.GetProject(projectId), null) then
-            let projectContextFactory = this.Package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
-            let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
-
-            let projectContext = projectContextFactory.CreateProjectContext(FSharpCommonConstants.FSharpLanguageName, options.ProjectFileName, options.ProjectFileName, projectId.Id, hier, null, errorReporter)
-            projectContext.AddSourceFile(fileName)
-            
-            let project = projectContext :?> AbstractProject
-            let document = project.GetCurrentDocumentFromPath(fileName)
-
-            document.Closing.Add(fun _ -> project.Disconnect())
 
 
 and [<Guid(FSharpCommonConstants.packageGuidString)>]

--- a/vsintegration/src/FSharp.Editor/ProjectDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/ProjectDiagnosticAnalyzer.fs
@@ -47,7 +47,7 @@ type internal FSharpProjectDiagnosticAnalyzer() =
 
     override this.AnalyzeProjectAsync(project: Project, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         async {
-            match FSharpLanguageService.GetOptions(project.Id) with
+            match FSharpLanguageService.GetOptionsForProject(project.Id) with
             | Some(options) -> return! FSharpProjectDiagnosticAnalyzer.GetDiagnostics(options)
             | None -> return ImmutableArray<Diagnostic>.Empty
         } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken

--- a/vsintegration/src/FSharp.Editor/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfoProvider.fs
@@ -100,14 +100,14 @@ type internal FSharpQuickInfoProvider [<System.ComponentModel.Composition.Import
     interface IQuickInfoProvider with
         override this.GetItemAsync(document: Document, position: int, cancellationToken: CancellationToken): Task<QuickInfoItem> =
             async {
-                match FSharpLanguageService.GetOptions(document.Project.Id) with
-                | Some(options) ->
-                    let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                    let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.Name, options.OtherOptions |> Seq.toList)
-                    let classification = CommonHelpers.tryClassifyAtPosition(document.Id, sourceText, document.FilePath, defines, position, cancellationToken)
+                let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
+                let defines = FSharpLanguageService.GetCompilationDefinesForEditingDocument(document)  
+                let classification = CommonHelpers.tryClassifyAtPosition(document.Id, sourceText, document.FilePath, defines, position, cancellationToken)
 
-                    match classification with
-                    | Some _ ->
+                match classification with
+                | Some _ ->
+                    match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
+                    | Some(options) ->
                         let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask
                         let! quickInfoResult = FSharpQuickInfoProvider.ProvideQuickInfo(document.Id, sourceText, document.FilePath, position, options, textVersion.GetHashCode(), cancellationToken)
                         match quickInfoResult with

--- a/vsintegration/src/FSharp.Editor/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/SignatureHelp.fs
@@ -190,7 +190,7 @@ type FSharpSignatureHelpProvider [<ImportingConstructor>]  (serviceProvider: SVs
         member this.GetItemsAsync(document, position, triggerInfo, cancellationToken) = 
             async {
               try
-                match FSharpLanguageService.GetOptions(document.Project.Id) with
+                match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
                 | Some(options) ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                     let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask

--- a/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
+++ b/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
@@ -84,7 +84,7 @@ type internal FSharpLanguageServiceBackgroundRequests
                     // This portion is executed on the UI thread.
                     let rdt = getServiceProvider().RunningDocumentTable
                     let projectSite = getProjectSitesAndFiles().FindOwningProject(rdt,fileName)
-                    let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, fileName)                            
+                    let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, fileName, None)                            
                     let projectFileName = projectSite.ProjectFileName()
                     let data = 
                         {   ProjectSite = projectSite

--- a/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
@@ -328,7 +328,8 @@ type internal FSharpSource(service:LanguageService, textLines, colorizer, vsFile
                   IsIncompleteTypeCheckEnvironment = true
                   UseScriptResolutionRules = false
                   LoadTime = new System.DateTime(2000,1,1)   // dummy data, just enough to get a parse
-                  UnresolvedReferences = None }
+                  UnresolvedReferences = None
+                  ExtraProjectInfo=None }
 
             ic.ParseFileInProject(fileName, source.GetText(), co) |> Async.RunSynchronously
 

--- a/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
+++ b/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
@@ -161,7 +161,7 @@ type internal ProjectSitesAndFiles() =
         | None -> ProjectSitesAndFiles.ProjectSiteOfSingleFile(filename)        
 
     /// Create project options for this project site.
-    static member GetProjectOptionsForProjectSite(projectSite:IProjectSite,filename)= 
+    static member GetProjectOptionsForProjectSite(projectSite:IProjectSite,filename,extraProjectInfo) = 
         
         match projectSite with
         | :? IHaveCheckOptions as hco -> hco.OriginalCheckOptions()
@@ -173,7 +173,8 @@ type internal ProjectSitesAndFiles() =
              IsIncompleteTypeCheckEnvironment = projectSite.IsIncompleteTypeCheckEnvironment
              UseScriptResolutionRules = SourceFile.MustBeSingleFileProject(filename)
              LoadTime = projectSite.LoadTime
-             UnresolvedReferences = None }      
+             UnresolvedReferences = None
+             ExtraProjectInfo=extraProjectInfo }      
          
     /// Create project site for these project options
     static member CreateProjectSiteForScript (filename, checkOptions) = ProjectSiteOfScriptFile (filename, checkOptions) :> IProjectSite

--- a/vsintegration/tests/Salsa/FSharpLanguageServiceTestable.fs
+++ b/vsintegration/tests/Salsa/FSharpLanguageServiceTestable.fs
@@ -69,7 +69,7 @@ type internal FSharpLanguageServiceTestable() as this =
         if this.Unhooked then raise Error.UseOfUnhookedLanguageServiceState        
         artifacts <- Some (ProjectSitesAndFiles())
         let checker = FSharpChecker.Create()
-        checker.BeforeBackgroundFileCheck.Add (fun filename -> UIThread.Run(fun () -> this.NotifyFileTypeCheckStateIsDirty(filename)))
+        checker.BeforeBackgroundFileCheck.Add (fun (filename,_) -> UIThread.Run(fun () -> this.NotifyFileTypeCheckStateIsDirty(filename)))
         checkerContainerOpt <- Some (checker)
         serviceProvider <- Some sp
         isInitialized <- true
@@ -126,7 +126,7 @@ type internal FSharpLanguageServiceTestable() as this =
 
     /// Respond to project being cleaned/rebuilt (any live type providers in the project should be refreshed)
     member this.OnProjectCleaned(projectSite:IProjectSite) = 
-        let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, "")
+        let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, "",None)
         this.FSharpChecker.NotifyProjectCleaned(checkOptions)
 
     member this.OnActiveViewChanged(textView) =
@@ -168,7 +168,7 @@ type internal FSharpLanguageServiceTestable() as this =
     interface IDependencyFileChangeNotify with
         member this.DependencyFileCreated projectSite = 
             // Invalidate the configuration if we notice any add for any DependencyFiles 
-            let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, "")
+            let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, "", None)
             this.FSharpChecker.InvalidateConfiguration(checkOptions)
 
         member this.DependencyFileChanged (filename) = 

--- a/vsintegration/tests/unittests/BraceMatchingServiceTests.fs
+++ b/vsintegration/tests/unittests/BraceMatchingServiceTests.fs
@@ -25,6 +25,7 @@ type BraceMatchingServiceTests()  =
         UseScriptResolutionRules = false
         LoadTime = DateTime.MaxValue
         UnresolvedReferences = None
+        ExtraProjectInfo = None
     }
 
     member private this.VerifyNoBraceMatch(fileContents: string, marker: string) =

--- a/vsintegration/tests/unittests/BreakpointResolutionService.fs
+++ b/vsintegration/tests/unittests/BreakpointResolutionService.fs
@@ -29,6 +29,7 @@ type BreakpointResolutionServiceTests()  =
         UseScriptResolutionRules = false
         LoadTime = DateTime.MaxValue
         UnresolvedReferences = None
+        ExtraProjectInfo = None
     }
     let code = "
 // This is a comment

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -49,6 +49,7 @@ let internal options = {
     UseScriptResolutionRules = false
     LoadTime = DateTime.MaxValue
     UnresolvedReferences = None
+    ExtraProjectInfo = None
 }
 
 let VerifyCompletionList(fileContents: string, marker: string, expected: string list, unexpected: string list) =

--- a/vsintegration/tests/unittests/DocumentDiagnosticAnalyzerTests.fs
+++ b/vsintegration/tests/unittests/DocumentDiagnosticAnalyzerTests.fs
@@ -31,6 +31,7 @@ type DocumentDiagnosticAnalyzerTests()  =
         UseScriptResolutionRules = false
         LoadTime = DateTime.MaxValue
         UnresolvedReferences = None
+        ExtraProjectInfo = None
     }
 
     member private this.VerifyNoErrors(fileContents: string, ?additionalFlags: string[]) =

--- a/vsintegration/tests/unittests/GoToDefinitionServiceTests.fs
+++ b/vsintegration/tests/unittests/GoToDefinitionServiceTests.fs
@@ -91,6 +91,7 @@ let _ = Module1.foo 1
             UseScriptResolutionRules = false
             LoadTime = DateTime.MaxValue
             UnresolvedReferences = None
+            ExtraProjectInfo = None
         }
 
         File.WriteAllText(filePath, fileContents)

--- a/vsintegration/tests/unittests/QuickInfoProviderTests.fs
+++ b/vsintegration/tests/unittests/QuickInfoProviderTests.fs
@@ -47,6 +47,7 @@ let internal options = {
     UseScriptResolutionRules = false
     LoadTime = DateTime.MaxValue
     UnresolvedReferences = None
+    ExtraProjectInfo = None
 }
 
 let private normalizeLineEnds (s: string) = s.Replace("\r\n", "\n").Replace("\n\n", "\n")

--- a/vsintegration/tests/unittests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/unittests/SignatureHelpProviderTests.fs
@@ -18,7 +18,6 @@
 // Technique 3: 
 // 
 //    Use F# Interactive.  This only works for FSharp.Compiler.Service.dll which has a public API
-
 module Microsoft.VisualStudio.FSharp.Editor.Tests.Roslyn.SignatureHelpProvider
 
 open System
@@ -59,6 +58,7 @@ let internal options = {
     UseScriptResolutionRules = false
     LoadTime = DateTime.MaxValue
     UnresolvedReferences = None
+    ExtraProjectInfo = None
 }
 
 [<Test>]


### PR DESCRIPTION

Prior to this, we never update the compiler options stored for scripts.  This means that as you add ``#r`` or ``#load`` the compilation options aren't updated.

This PR updates the options in the semantic analysis phase.  We can't update them on every request for options because it is too expensive.  

This fixes some aspects of https://github.com/Microsoft/visualfsharp/issues/1808  but the underlying problem of not reacting to file update events in dependencies is not fixed.


