### PR TITLE
stop goto definition from going to signature files

### DIFF
--- a/vsintegration/src/FSharp.LanguageService/FSharp.LanguageService.fsproj
+++ b/vsintegration/src/FSharp.LanguageService/FSharp.LanguageService.fsproj
@@ -51,6 +51,7 @@
     <EmbeddedResource Include="VSPackage.resx" />
     <EmbeddedResource Include="FSLangSvcStrings.resx" />
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Pervasive.fs" />
     <Compile Include="Error.fs" />
     <Compile Include="Quickparse.fs" />
     <Compile Include="Vs.fs" />

--- a/vsintegration/src/FSharp.LanguageService/GotoDefinition.fs
+++ b/vsintegration/src/FSharp.LanguageService/GotoDefinition.fs
@@ -8,29 +8,29 @@ open System.Collections.Generic
 open System.Diagnostics
 open Microsoft.VisualStudio
 open Microsoft.VisualStudio.Shell
-open Microsoft.VisualStudio.Shell.Interop 
-open Microsoft.VisualStudio.TextManager.Interop 
+open Microsoft.VisualStudio.Shell.Interop
+open Microsoft.VisualStudio.TextManager.Interop
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Lib
 open Microsoft.FSharp.Compiler.SourceCodeServices
 
 module internal OperatorToken =
-    
+
     let asIdentifier (token : TokenInfo) =
         // Typechecker reports information about all values in the same fashion no matter whether it is named value (let binding) or operator
         // here we piggyback on this fact and just pretend that we need data time for identifier
         let tagOfIdentToken = Microsoft.FSharp.Compiler.Parser.tagOfToken(Microsoft.FSharp.Compiler.Parser.IDENT "")
-        let endCol = token.EndIndex + 1 // EndIndex from GetTokenInfoAt points to the last operator char, but here it should point to column 'after' the last char 
+        let endCol = token.EndIndex + 1 // EndIndex from GetTokenInfoAt points to the last operator char, but here it should point to column 'after' the last char
         tagOfIdentToken, token.StartIndex, endCol
 
 module internal GotoDefinition =
-    
+
     let GotoDefinition (colourizer: FSharpColorizer, typedResults : FSharpCheckFileResults, textView : IVsTextView, line : int, col : int) : GotoDefinitionResult =
-        
+
         let ls = textView.GetBuffer() |> Com.ThrowOnFailure1
         let len = ls.GetLengthOfLine line |> Com.ThrowOnFailure1
         let lineStr = ls.GetLineText(line, 0, line, len) |> Com.ThrowOnFailure1
-        
+
         // in many cases we assume gotodef should work even if we don't stand on the identifier directly
         // treatTokenAsIdentifier governs if we want to have raw value of token (possibly operator) or if should always be considered as identifier
         let rec gotoDefinition alwaysTreatTokenAsIdentifier =
@@ -40,15 +40,15 @@ module internal GotoDefinition =
                     let tag, _, endCol = OperatorToken.asIdentifier token
                     Some(endCol, tag, [""]), true
                 else
-                    match QuickParse.GetCompleteIdentifierIsland true lineStr col with 
-                    | None -> 
+                    match QuickParse.GetCompleteIdentifierIsland true lineStr col with
+                    | None ->
                         Trace.Write("LanguageService", "Goto definition: No identifier found")
                         None, false
-                    | Some (s, colIdent, isQuoted) -> 
+                    | Some (s, colIdent, isQuoted) ->
                         let qualId  = if isQuoted then [s] else s.Split '.' |> Array.toList // chop it up (in case it's a qualified ident)
                         // this is a bit irratiting: `GetTokenInfoAt` won't handle just-past-the-end, so we take the just-past-the-end position and adjust it by the `magicalAdjustmentConstant` to just-*at*-the-end
                         let colIdentAdjusted = colIdent - QuickParse.magicalAdjustmentConstant
-            
+
                         // Corrrect the identifier (e.g. to correctly handle active pattern names that end with "BAR" token)
                         let tag = colourizer.GetTokenInfoAt(VsTextLines.TextColorState(VsTextView.Buffer textView), line, colIdentAdjusted).Token
                         let tag = QuickParse.CorrectIdentifierToken s tag
@@ -58,29 +58,41 @@ module internal GotoDefinition =
                 Strings.Errors.GotoDefinitionFailed_NotIdentifier ()
                 |> GotoDefinitionResult.MakeError
             | Some(colIdent, tag, qualId) ->
-                if typedResults.HasFullTypeCheckInfo then 
-                    if Parser.tokenTagToTokenId tag <> Parser.TOKEN_IDENT then 
+                if typedResults.HasFullTypeCheckInfo then
+                    if Parser.tokenTagToTokenId tag <> Parser.TOKEN_IDENT then
                         Strings.Errors.GotoDefinitionFailed_NotIdentifier ()
                         |> GotoDefinitionResult.MakeError
                     else
+                      match typedResults.GetSymbolUseAtLocation (line+1,colIdent,lineStr,qualId) |> Async.RunSynchronously with
+                      // if the symbol was defined in a signature, go to its implementation
+                      | Some fsSymbol when fsSymbol.Symbol.ImplementationLocation.IsSome  ->
+                            let m = fsSymbol.Symbol.ImplementationLocation.Value
+                            let span = fsharpRangeToTextSpan m
+                            GotoDefinitionResult.MakeSuccess(m.FileName, span)
+                      // if the symbol isn't in a signature, go to its declaration
+                      | Some fsSymbol when fsSymbol.Symbol.DeclarationLocation.IsSome  ->
+                            let m = fsSymbol.Symbol.DeclarationLocation.Value
+                            let span = fsharpRangeToTextSpan m
+                            GotoDefinitionResult.MakeSuccess(m.FileName, span)
+                      | _ ->
                       match typedResults.GetDeclarationLocationAlternate (line+1, colIdent, lineStr, qualId, false) |> Async.RunSynchronously with
-                      | FSharpFindDeclResult.DeclFound m -> 
-                          let span = TextSpan (iStartLine = m.StartLine-1, iEndLine = m.StartLine-1, iStartIndex = m.StartColumn, iEndIndex = m.StartColumn) 
+                      | FSharpFindDeclResult.DeclFound m ->
+                          let span = fsharpRangeToTextSpan m
                           GotoDefinitionResult.MakeSuccess(m.FileName, span)
                       | FSharpFindDeclResult.DeclNotFound(reason) ->
                           if makeAnotherAttempt then gotoDefinition true
                           else
                           Trace.Write("LanguageService", sprintf "Goto definition failed: Reason %+A" reason)
-                          let text = 
-                              match reason with                    
+                          let text =
+                              match reason with
                               | FSharpFindDeclFailureReason.Unknown -> Strings.Errors.GotoDefinitionFailed()
                               | FSharpFindDeclFailureReason.NoSourceCode -> Strings.Errors.GotoDefinitionFailed_NoSourceCode()
                               | FSharpFindDeclFailureReason.ProvidedType(typeName) -> Strings.Errors.GotoDefinitionFailed_ProvidedType(typeName)
                               | FSharpFindDeclFailureReason.ProvidedMember(name) -> Strings.Errors.GotoFailed_ProvidedMember(name)
                           GotoDefinitionResult.MakeError text
-                else 
+                else
                     Trace.Write("LanguageService", "Goto definition: No 'TypeCheckInfo' available")
                     Strings.Errors.GotoDefinitionFailed_NoTypecheckInfo()
                     |> GotoDefinitionResult.MakeError
-            
+
         gotoDefinition false

--- a/vsintegration/src/FSharp.LanguageService/Pervasive.fs
+++ b/vsintegration/src/FSharp.LanguageService/Pervasive.fs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.VisualStudio.FSharp.LanguageService
+
+open Microsoft.VisualStudio.TextManager.Interop
+open Microsoft.FSharp.Compiler
+open Microsoft.FSharp.Compiler.SourceCodeServices
+
+[<AutoOpen>]
+module internal Pervasive =
+
+    let fsharpRangeToTextSpan (m:Range.range) =
+        TextSpan (iStartLine = m.StartLine-1, iEndLine = m.StartLine-1, iStartIndex = m.StartColumn, iEndIndex = m.StartColumn)
+


### PR DESCRIPTION
going to the signature file when using goto definition is a constant annoyance, this makes it use the symbol location to go to the implementation of a construct when it was declared in a signature file.

`goto-signature` can be added as a separate command either in this repo or as a part of VFPT

