### PR TITLE
fix semantic colors

### DIFF
--- a/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
+++ b/vsintegration/src/FSharp.Editor/BraceMatchingService.fs
@@ -11,20 +11,18 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 [<ExportBraceMatcher(FSharpCommonConstants.FSharpLanguageName)>]
 type internal FSharpBraceMatchingService() =
 
-    static member GetBraceMatchingResult(sourceText, fileName, options, position) = async {
-        let isPositionInRange(range) =
-            let span = CommonRoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
-            span.Start <= position && position < span.End
+    static member GetBraceMatchingResult(sourceText, fileName, options, position: int) = async {
         let! matchedBraces = FSharpLanguageService.Checker.MatchBracesAlternate(fileName, sourceText.ToString(), options)
 
-        return matchedBraces |> Seq.tryFind(fun(left, right) -> isPositionInRange(left) || isPositionInRange(right))
+        let isPositionInRange range = CommonRoslynHelpers.FSharpRangeToTextSpan(sourceText, range).Contains(position)
+        return matchedBraces |> Array.tryFind(fun (left, right) -> isPositionInRange left || isPositionInRange right)
     }
         
     interface IBraceMatcher with
         member this.FindBracesAsync(document, position, cancellationToken) = 
             async {
                 match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
-                | Some(options) ->
+                | Some options ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                     let! result = FSharpBraceMatchingService.GetBraceMatchingResult(sourceText, document.Name, options, position)
                     return match result with

--- a/vsintegration/src/FSharp.Editor/BreakpointResolutionService.fs
+++ b/vsintegration/src/FSharp.Editor/BreakpointResolutionService.fs
@@ -49,7 +49,7 @@ type internal FSharpBreakpointResolutionService() =
         member this.ResolveBreakpointAsync(document: Document, textSpan: TextSpan, cancellationToken: CancellationToken): Task<BreakpointResolutionResult> =
             async {
                 match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
-                | Some(options) ->
+                | Some options ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                     let! location = FSharpBreakpointResolutionService.GetBreakpointLocation(sourceText, document.Name, textSpan, options)
                     return match location with

--- a/vsintegration/src/FSharp.Editor/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CompletionProvider.fs
@@ -144,7 +144,7 @@ type internal FSharpCompletionProvider(workspace: Workspace, serviceProvider: SV
     override this.ProvideCompletionsAsync(context: Microsoft.CodeAnalysis.Completion.CompletionContext) =
         async {
             match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(context.Document)  with 
-            | Some(options) ->
+            | Some options ->
                 let! sourceText = context.Document.GetTextAsync(context.CancellationToken) |> Async.AwaitTask
                 let! textVersion = context.Document.GetTextVersionAsync(context.CancellationToken) |> Async.AwaitTask
                 let! results = FSharpCompletionProvider.ProvideCompletionsAsyncAux(sourceText, context.Position, options, context.Document.FilePath, textVersion.GetHashCode())

--- a/vsintegration/src/FSharp.Editor/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentDiagnosticAnalyzer.fs
@@ -60,7 +60,7 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
     override this.AnalyzeSyntaxAsync(document: Document, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         async {
             match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
-            | Some(options) ->
+            | Some options ->
                 let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                 let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask
                 return! FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(document.FilePath, sourceText, textVersion.GetHashCode(), options, false)
@@ -72,7 +72,7 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
         async {
             let! optionsOpt = FSharpLanguageService.TryGetOptionsForDocumentOrProject(document) 
             match optionsOpt with 
-            | Some(options) ->
+            | Some options ->
                 let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                 let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask
                 return! FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(document.FilePath, sourceText, textVersion.GetHashCode(), options, true)

--- a/vsintegration/src/FSharp.Editor/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/GoToDefinitionService.fs
@@ -80,7 +80,7 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>] ([<ImportMany
         async {
             let results = List<INavigableItem>()
             match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
-            | Some(options) ->
+            | Some options ->
                 let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                 let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask
                 let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.Name, options.OtherOptions |> Seq.toList)

--- a/vsintegration/src/FSharp.Editor/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService.fs
@@ -129,7 +129,7 @@ type internal FSharpLanguageService(package : FSharpPackage) =
         let otherOptions = 
             match projectOptionsOpt with 
             | None -> []
-            | Some(options) -> options.OtherOptions |> Array.toList
+            | Some options -> options.OtherOptions |> Array.toList
         CompilerEnvironment.GetCompilationDefinesForEditing(document.Name, otherOptions)
 
     /// Get the global FSharpChecker component

--- a/vsintegration/src/FSharp.Editor/ProjectDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/ProjectDiagnosticAnalyzer.fs
@@ -48,7 +48,7 @@ type internal FSharpProjectDiagnosticAnalyzer() =
     override this.AnalyzeProjectAsync(project: Project, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         async {
             match FSharpLanguageService.GetOptionsForProject(project.Id) with
-            | Some(options) -> return! FSharpProjectDiagnosticAnalyzer.GetDiagnostics(options)
+            | Some options -> return! FSharpProjectDiagnosticAnalyzer.GetDiagnostics(options)
             | None -> return ImmutableArray<Diagnostic>.Empty
         } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken
 #endif

--- a/vsintegration/src/FSharp.Editor/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfoProvider.fs
@@ -107,7 +107,7 @@ type internal FSharpQuickInfoProvider [<System.ComponentModel.Composition.Import
                 match classification with
                 | Some _ ->
                     match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
-                    | Some(options) ->
+                    | Some options ->
                         let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask
                         let! quickInfoResult = FSharpQuickInfoProvider.ProvideQuickInfo(document.Id, sourceText, document.FilePath, position, options, textVersion.GetHashCode(), cancellationToken)
                         match quickInfoResult with

--- a/vsintegration/src/FSharp.Editor/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/SignatureHelp.fs
@@ -191,7 +191,7 @@ type FSharpSignatureHelpProvider [<ImportingConstructor>]  (serviceProvider: SVs
             async {
               try
                 match FSharpLanguageService.TryGetOptionsForEditingDocumentOrProject(document)  with 
-                | Some(options) ->
+                | Some options ->
                     let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                     let! textVersion = document.GetTextVersionAsync(cancellationToken) |> Async.AwaitTask
 


### PR DESCRIPTION
Semantic color information was not being provided correctly because the wrong source text was passed in

Fix is here: https://github.com/Microsoft/visualfsharp/pull/1877/files#diff-de5bdafb119bed995860757094ee328eR50