### PR TITLE
Update DEVGUIDE.md to include note about spaces in the path

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -40,6 +40,9 @@ These steps are tested under the Linux/Mono configuration(s) in ``.travis.yml`` 
 
 ### F# Compiler (Windows)
 
+> **Note:**
+> The path where the visualfsharp repository is on must not have spaces in it for a build to succeed.  For example, if you placed it on "C:\Users\My Name Here\visualfsharp", running `build.cmd` would fail because "My Name Here" has spaces in it.  Place visualfsharp somewhere on disk where there are no spaces in the path.
+
 On Windows you can build the F# compiler for .NET Framework as follows:
 
     build.cmd


### PR DESCRIPTION
I had tried building under "Users\Phillip Carter\repos\visualfsharp" on my personal machine, but because there is a space in that path, running `build.cmd` fails.  This adds a note in the guide to let you know that visualfsharp cannot have spaces in its path.