### PR TITLE
Fix glyph for local

### DIFF
--- a/before_install.sh
+++ b/before_install.sh
@@ -24,8 +24,8 @@ fi)
 
 #TODO: work out how to avoid the need for this
 chmod u+x packages/FSharp.Compiler.Tools.4.0.1.19/tools/fsi.exe 
-chmod u+x packages/FsLexYacc.7.0.1/build/fslex.exe
-chmod u+x packages/FsLexYacc.7.0.1/build/fsyacc.exe
+chmod u+x packages/FsLexYacc.7.0.3/build/fslex.exe
+chmod u+x packages/FsLexYacc.7.0.3/build/fsyacc.exe
 
 # The FSharp.Compiler.Tools package doesn't work correctly unless a proper install of F# has been done on the machine
 sudo apt-get -y install fsharp

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1201,7 +1201,8 @@ module internal ItemDescriptionsImpl =
             if isAppTy denv.g typ then 
                 let tcref = tcrefOfAppTy denv.g typ
                 tcref.TypeReprInfo |> reprToGlyph 
-            elif isAnyTupleTy denv.g typ then GlyphMajor.Struct
+            elif isStructTupleTy denv.g typ then GlyphMajor.Struct
+            elif isRefTupleTy denv.g typ then GlyphMajor.Class
             elif isFunction denv.g typ then GlyphMajor.Delegate
             elif isTyparTy denv.g typ then GlyphMajor.Struct
             else GlyphMajor.Typedef

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1207,11 +1207,6 @@ module internal ItemDescriptionsImpl =
             else GlyphMajor.Typedef
 
             
-         /// Find the glyph for the given value representation.
-         let ValueToGlyph typ = 
-            if isFunction denv.g typ then GlyphMajor.Method
-            else GlyphMajor.Constant
-              
          /// Find the major glyph of the given named item.       
          let namedItemToMajorGlyph item = 
             // This may explore assemblies that are not in the reference set,
@@ -1219,7 +1214,10 @@ module internal ItemDescriptionsImpl =
             // In this case just use GlyphMajor.Class.
            protectAssemblyExploration  GlyphMajor.Class (fun () ->
               match item with 
-              | Item.Value(vref) | Item.CustomBuilder (_,vref) -> ValueToGlyph(vref.Type)
+              | Item.Value(vref) | Item.CustomBuilder (_,vref) -> 
+                    if isFunction denv.g vref.Type then GlyphMajor.Method
+                    elif vref.LiteralValue.IsSome then  GlyphMajor.Constant
+                    else GlyphMajor.Variable
               | Item.Types(_,typ::_) -> typeToGlyph (stripTyEqns denv.g typ)    
               | Item.UnionCase _
               | Item.ActivePatternCase _ -> GlyphMajor.EnumMember   


### PR DESCRIPTION
For F# values we incorrectly used Glyph.Constant for non-literal values.
