### PR TITLE
Enable zooming in F# Interactive window

### DIFF
--- a/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -98,14 +98,7 @@ type internal FsiToolWindow() as this =
     do  textLines.InitializeContent("", 0) |> throwOnFailure0
     let textView       = Util.CreateObjectT<VsTextViewClass,IVsTextView> provider
     do  setSiteForObjectWithSite textView  providerNative
-
-    // We want to disable zooming in the VFSI window. This code does that.
-    let userData = textView :?> IVsUserData
-    do if userData <> null then
-           let roles = "ANALYZABLE,INTERACTIVE"
-           let mutable guid_VsTextViewRoles = new Guid("{297078ff-81a2-43d8-9ca3-4489c53c99ba}")
-           userData.SetData(&guid_VsTextViewRoles, roles) |> throwOnFailure0
-
+    
     do  textView.Initialize(textLines,
                             IntPtr.Zero,
                             uint32 TextViewInitFlags.VIF_VSCROLL ||| uint32 TextViewInitFlags.VIF_HSCROLL ||| uint32 TextViewInitFlags3.VIF_NO_HWND_SUPPORT,


### PR DESCRIPTION
Following #1840, I gave it a try by removing zooming disability in F# Interactive.

It seems to work fine during a testing session. Zooming in/out using `Ctrl + Shift ./,` works. There is also a drop down to choose zoom level.

![image](https://cloud.githubusercontent.com/assets/941060/20817803/0e693222-b82a-11e6-96ef-bfb70ec101ce.png)


Would you consider to accept the changes?