### PR TITLE
Do not throw exception if LanguageDebugInfoService.GetDataTipInfoAsync do not run to completion

### DIFF
--- a/vsintegration/src/FSharp.Editor/CommonRoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CommonRoslynHelpers.fs
@@ -20,7 +20,6 @@ module internal CommonRoslynHelpers =
         let endPosition = sourceText.Lines.[range.EndLine - 1].Start + range.EndColumn
         TextSpan(startPosition, endPosition - startPosition)
 
-
     let GetCompletedTaskResult(task: Task<'TResult>) =
         if task.Status = TaskStatus.RanToCompletion then
             task.Result
@@ -29,8 +28,15 @@ module internal CommonRoslynHelpers =
             raise(task.Exception.GetBaseException())
 
     let StartAsyncAsTask cancellationToken computation =
+        let computation =
+            async {
+                try
+                    return! computation
+                with e ->
+                    Assert.Exception(e)
+                    return Unchecked.defaultof<_>
+            }
         Async.StartAsTask(computation, TaskCreationOptions.None, cancellationToken)
-             .ContinueWith(GetCompletedTaskResult, cancellationToken)
 
     let StartAsyncUnitAsTask cancellationToken (computation:Async<unit>) = 
         StartAsyncAsTask cancellationToken computation  :> Task

--- a/vsintegration/src/FSharp.Editor/LanguageDebugInfoService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageDebugInfoService.fs
@@ -4,29 +4,17 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
 open System.Composition
-open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
-open System.Linq
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Classification
-open Microsoft.CodeAnalysis.Editor
 open Microsoft.CodeAnalysis.Editor.Implementation.Debugging
-open Microsoft.CodeAnalysis.Editor.Implementation
-open Microsoft.CodeAnalysis.Editor.Shared.Utilities
-open Microsoft.CodeAnalysis.Formatting
 open Microsoft.CodeAnalysis.Host.Mef
 open Microsoft.CodeAnalysis.Text
 
 open Microsoft.VisualStudio.FSharp.LanguageService
-open Microsoft.VisualStudio.Text
-open Microsoft.VisualStudio.Text.Tagging
-
-open Microsoft.FSharp.Compiler.Parser
-open Microsoft.FSharp.Compiler.SourceCodeServices
-open Microsoft.FSharp.Compiler.Range
 
 [<Shared>]
 [<ExportLanguageService(typeof<ILanguageDebugInfoService>, FSharpCommonConstants.FSharpLanguageName)>]
@@ -45,10 +33,10 @@ type internal FSharpLanguageDebugInfoService
             let token = tokens.[tokenIndex.Value]
         
             match token.ClassificationType with
-
+        
             | ClassificationTypeNames.StringLiteral ->
                 Some(token.TextSpan)
-
+        
             | ClassificationTypeNames.Identifier ->
                 let textLine = sourceText.Lines.GetLineFromPosition(position)
                 let textLinePos = sourceText.Lines.GetLinePosition(position)
@@ -58,9 +46,8 @@ type internal FSharpLanguageDebugInfoService
                 | Some(island, islandEnd, _) ->
                     let islandDocumentStart = textLine.Start + islandEnd - island.Length
                     Some(TextSpan.FromBounds(islandDocumentStart, islandDocumentStart + island.Length))
-
+        
             | _ -> None
-
 
     interface ILanguageDebugInfoService with
         
@@ -69,16 +56,20 @@ type internal FSharpLanguageDebugInfoService
             Task.FromResult(Unchecked.defaultof<DebugLocationInfo>)
 
         member this.GetDataTipInfoAsync(document: Document, position: int, cancellationToken: CancellationToken): Task<DebugDataTipInfo> =
-            async {
+            let computation =
+                async {
                 let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)  
-                let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                let textSpan = TextSpan.FromBounds(0, sourceText.Length)
-                let tokens = CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.Name), defines, cancellationToken)
-                let result = 
-                    match FSharpLanguageDebugInfoService.GetDataTipInformation(sourceText, position, tokens) with
-                    | None -> DebugDataTipInfo()
-                    | Some(textSpan) -> DebugDataTipInfo(textSpan, sourceText.GetSubText(textSpan).ToString())
-                return result
-            } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken
+                    let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
+                    let textSpan = TextSpan.FromBounds(0, sourceText.Length)
+                    let tokens = CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.Name), defines, cancellationToken)
+                    let result = 
+                         match FSharpLanguageDebugInfoService.GetDataTipInformation(sourceText, position, tokens) with
+                         | None -> 
+                            DebugDataTipInfo()
+                         | Some textSpan -> 
+                            DebugDataTipInfo(textSpan, sourceText.GetSubText(textSpan).ToString())
+                    return result
+                }
+            Async.StartAsTask(computation, TaskCreationOptions.None, cancellationToken)
             
             

--- a/vsintegration/src/FSharp.Editor/LanguageDebugInfoService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageDebugInfoService.fs
@@ -56,20 +56,19 @@ type internal FSharpLanguageDebugInfoService
             Task.FromResult(Unchecked.defaultof<DebugLocationInfo>)
 
         member this.GetDataTipInfoAsync(document: Document, position: int, cancellationToken: CancellationToken): Task<DebugDataTipInfo> =
-            let computation =
-                async {
+            async {
                 let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)  
-                    let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                    let textSpan = TextSpan.FromBounds(0, sourceText.Length)
-                    let tokens = CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.Name), defines, cancellationToken)
-                    let result = 
-                         match FSharpLanguageDebugInfoService.GetDataTipInformation(sourceText, position, tokens) with
-                         | None -> 
-                            DebugDataTipInfo()
-                         | Some textSpan -> 
-                            DebugDataTipInfo(textSpan, sourceText.GetSubText(textSpan).ToString())
-                    return result
-                }
-            Async.StartAsTask(computation, TaskCreationOptions.None, cancellationToken)
+                let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
+                let textSpan = TextSpan.FromBounds(0, sourceText.Length)
+                let tokens = CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.Name), defines, cancellationToken)
+                let result = 
+                     match FSharpLanguageDebugInfoService.GetDataTipInformation(sourceText, position, tokens) with
+                     | None -> 
+                        DebugDataTipInfo()
+                     | Some textSpan -> 
+                        DebugDataTipInfo(textSpan, sourceText.GetSubText(textSpan).ToString())
+                return result
+            }
+            |> CommonRoslynHelpers.StartAsyncAsTask(cancellationToken)
             
             


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/1915

Basically, it turned out we should not (re) throw exceptions if the task has not run to completion. Previously, we ran the async computation with `StartAsyncAsTask` https://github.com/Microsoft/visualfsharp/blob/master/vsintegration/src/FSharp.Editor/CommonRoslynHelpers.fs#L31

```fsharp
let GetCompletedTaskResult(task: Task<'TResult>) =
        if task.Status = TaskStatus.RanToCompletion then
            task.Result
        else
            Assert.Exception(task.Exception.GetBaseException())
            raise(task.Exception.GetBaseException())

let StartAsyncAsTask cancellationToken computation =
        Async.StartAsTask(computation, TaskCreationOptions.None, cancellationToken)
             .ContinueWith(GetCompletedTaskResult, cancellationToken)
```
I'm not sure I understand why we have that `else` branch where we throw the base exception. Could anybody explain this? Should we remove it as it may cause other code misbehavior? 