### PR TITLE
Fix autocomplete after integer literals

### DIFF
--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -458,6 +458,7 @@ module UntypedParseImpl =
                     // also want it for e.g. [|arr|].(0)
                     Some(expr.Range) 
                 | x -> x  // we found the answer deeper somewhere in the lhs
+            | SynExpr.Const(SynConst.Double(_), range) -> Some(range) 
             | _ -> defaultTraverse expr
         })
     
@@ -582,6 +583,13 @@ module UntypedParseImpl =
                               dive exprIndexer exprIndexer.Range traverseSynExpr
                               dive exprRhs exprRhs.Range traverseSynExpr
                             ] |> pick expr
+                        | SynExpr.Const (SynConst.Double(_), m) ->
+                            if posEq m.End pos then
+                                // the cursor is at the dot
+                                Some(m.End, false)
+                            else
+                                // the cursor is left of the dot
+                                None
                         | SynExpr.DiscardAfterMissingQualificationAfterDot(e,m) ->
                             match traverseSynExpr(e) with
                             | None -> 

--- a/vsintegration/src/FSharp.Editor/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CompletionProvider.fs
@@ -57,7 +57,12 @@ type internal FSharpCompletionProvider(workspace: Workspace, serviceProvider: SV
         else
           let triggerPosition = caretPosition - 1
           let c = sourceText.[triggerPosition]
+          
           if not (completionTriggers |> Array.contains c) then
+            false
+          
+          // do not trigger completion if it's not single dot, i.e. range expression
+          elif triggerPosition > 0 && sourceText.[triggerPosition - 1] = '.' then
             false
 
           // Trigger completion if we are on a valid classification type


### PR DESCRIPTION
...and do not trigger autocomple after double dot.

before

![1](https://cloud.githubusercontent.com/assets/873919/20860456/d6fee21c-b989-11e6-9e3e-6cc70d47f3e7.gif)

after

![1](https://cloud.githubusercontent.com/assets/873919/20860448/9a73f332-b989-11e6-96bb-314b2306fca0.gif)
