### PR TITLE
fixed: CommonHelpers.tryClassifyAtPosition return wrong result at the end position

### DIFF
--- a/vsintegration/src/FSharp.Editor/CommonHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CommonHelpers.fs
@@ -59,7 +59,7 @@ module CommonHelpers =
         | FSharpTokenColorKind.PreprocessorKeyword -> ClassificationTypeNames.PreprocessorKeyword 
         | FSharpTokenColorKind.Operator -> ClassificationTypeNames.Operator
         | FSharpTokenColorKind.TypeName  -> ClassificationTypeNames.ClassName
-        | FSharpTokenColorKind.Default 
+        | FSharpTokenColorKind.Default
         | _ -> ClassificationTypeNames.Text
 
     let private scanSourceLine(sourceTokenizer: FSharpSourceTokenizer, textLine: TextLine, lineContents: string, lexState: FSharpTokenizerLexState) : SourceLineData =
@@ -70,7 +70,11 @@ module CommonHelpers =
             let tokenInfoOption, nextLexState = lineTokenizer.ScanToken(lexState.Value)
             lexState.Value <- nextLexState
             if tokenInfoOption.IsSome then
-                let classificationType = compilerTokenToRoslynToken(tokenInfoOption.Value.ColorClass)
+                let classificationType = 
+                    if tokenInfoOption.Value.CharClass = FSharpTokenCharKind.WhiteSpace then
+                        ClassificationTypeNames.WhiteSpace 
+                    else 
+                        compilerTokenToRoslynToken(tokenInfoOption.Value.ColorClass)
                 for i = tokenInfoOption.Value.LeftColumn to tokenInfoOption.Value.RightColumn do
                     Array.set colorMap i classificationType
             tokenInfoOption
@@ -158,14 +162,21 @@ module CommonHelpers =
             Assert.Exception(ex)
             List<ClassifiedSpan>()
 
-    let tryClassifyAtPosition (documentKey, sourceText: SourceText, filePath, defines, position: int, cancellationToken) =
+    let tryClassifyAtPosition (documentKey, sourceText: SourceText, filePath, defines, position: int, includeRightColumn: bool, cancellationToken) =
         let textLine = sourceText.Lines.GetLineFromPosition(position)
         let textLinePos = sourceText.Lines.GetLinePosition(position)
         let textLineColumn = textLinePos.Character
 
         let classifiedSpanOption =
             getColorizationData(documentKey, sourceText, textLine.Span, Some(filePath), defines, cancellationToken)
-            |> Seq.tryFind(fun classifiedSpan -> classifiedSpan.TextSpan.Contains(position))
+            |> Seq.tryFind(fun classifiedSpan ->
+                if includeRightColumn then
+                    classifiedSpan.ClassificationType <> ClassificationTypeNames.WhiteSpace &&
+                    (classifiedSpan.TextSpan.Contains(position) ||
+                    // TextSpan.Contains returns `false` for `position` equals its right bound, 
+                    // so we have to check if it contains `position - 1`.
+                     (position > 0 && classifiedSpan.TextSpan.Contains(position - 1)))
+                else classifiedSpan.TextSpan.Contains(position))
 
         match classifiedSpanOption with
         | Some(classifiedSpan) ->

--- a/vsintegration/src/FSharp.Editor/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/GoToDefinitionService.fs
@@ -53,29 +53,20 @@ type internal FSharpGoToDefinitionService
             let textLine = sourceText.Lines.GetLineFromPosition(position)
             let textLinePos = sourceText.Lines.GetLinePosition(position)
             let fcsTextLineNumber = textLinePos.Line + 1 // Roslyn line numbers are zero-based, FSharp.Compiler.Service line numbers are 1-based
-            let textLineColumn = textLinePos.Character
-            let tryGotoAtPosition position = 
-              async { 
-                match CommonHelpers.tryClassifyAtPosition(documentKey, sourceText, filePath, defines, position, cancellationToken) with 
-                | Some (islandColumn, qualifiers, _) -> 
-                    let! _parseResults, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, textVersionHash, sourceText.ToString(), options)
-                    match checkFileAnswer with
-                    | FSharpCheckFileAnswer.Aborted -> return None
-                    | FSharpCheckFileAnswer.Succeeded(checkFileResults) -> 
             
-                    let! declarations = checkFileResults.GetDeclarationLocationAlternate (fcsTextLineNumber, islandColumn, textLine.ToString(), qualifiers, false)
+            match CommonHelpers.tryClassifyAtPosition(documentKey, sourceText, filePath, defines, position, true, cancellationToken) with 
+            | Some (islandColumn, qualifiers, _) -> 
+                let! _parseResults, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, textVersionHash, sourceText.ToString(), options)
+                match checkFileAnswer with
+                | FSharpCheckFileAnswer.Aborted -> return None
+                | FSharpCheckFileAnswer.Succeeded(checkFileResults) -> 
             
-                    match declarations with
-                    | FSharpFindDeclResult.DeclFound(range) -> return Some(range)
-                    | _ -> return None
-                | None -> return None
-               }
-
-            // Tolerate being on the right of the identifier
-            let! attempt1 = tryGotoAtPosition position
-            match attempt1 with 
-            | None when textLineColumn > 0 -> return! tryGotoAtPosition (position - 1) 
-            | res -> return res
+                let! declarations = checkFileResults.GetDeclarationLocationAlternate (fcsTextLineNumber, islandColumn, textLine.ToString(), qualifiers, false)
+            
+                match declarations with
+                | FSharpFindDeclResult.DeclFound(range) -> return Some(range)
+                | _ -> return None
+            | None -> return None
         }
     
     // FSROSLYNTODO: Since we are not integrated with the Roslyn project system yet, the below call

--- a/vsintegration/src/FSharp.Editor/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfoProvider.fs
@@ -80,17 +80,9 @@ type internal FSharpQuickInfoProvider
           
             let textLine = sourceText.Lines.GetLineFromPosition(position)
             let textLineNumber = textLine.LineNumber + 1 // Roslyn line numbers are zero-based
-            let textLinePos = sourceText.Lines.GetLinePosition(position)
-            let textLineColumn = textLinePos.Character
             //let qualifyingNames, partialName = QuickParse.GetPartialLongNameEx(textLine.ToString(), textLineColumn - 1)
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing(filePath, options.OtherOptions |> Seq.toList)
-            let tryClassifyAtPosition position = 
-                CommonHelpers.tryClassifyAtPosition(documentId, sourceText, filePath, defines, position, cancellationToken)
-            
-            let quickParseInfo = 
-                match tryClassifyAtPosition position with 
-                | None when textLineColumn > 0 -> tryClassifyAtPosition (position - 1) 
-                | res -> res
+            let quickParseInfo = CommonHelpers.tryClassifyAtPosition(documentId, sourceText, filePath, defines, position, false, cancellationToken)
 
             match quickParseInfo with 
             | Some (islandColumn, qualifiers, textSpan) -> 
@@ -107,7 +99,7 @@ type internal FSharpQuickInfoProvider
             async {
                 let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                 let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)  
-                let classification = CommonHelpers.tryClassifyAtPosition(document.Id, sourceText, document.FilePath, defines, position, cancellationToken)
+                let classification = CommonHelpers.tryClassifyAtPosition(document.Id, sourceText, document.FilePath, defines, position, false, cancellationToken)
 
                 match classification with
                 | Some _ ->


### PR DESCRIPTION
This remove the ugly `tryGotoAtPosition` and the similar stuff from QuickInfo service. Same should be done for Inline Rename and Highlight Document after merging this.