### PR TITLE
Rudimentary support for multi F# projects 

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -76,7 +76,8 @@ type internal FSharpCheckerProvider
 type internal ProjectInfoManager 
     [<ImportingConstructor>]
     (
-        checkerProvider: FSharpCheckerProvider
+        checkerProvider: FSharpCheckerProvider,
+        [<Import(typeof<SVsServiceProvider>)>] serviceProvider: System.IServiceProvider
     ) =
     // A table of information about projects, excluding single-file projects.  
     let projectTable = ConcurrentDictionary<ProjectId, FSharpProjectOptions>()
@@ -101,16 +102,17 @@ type internal ProjectInfoManager
         if SourceFile.MustBeSingleFileProject(fileName) then 
             let! options = checkerProvider.Checker.GetProjectOptionsFromScript(fileName, fileContents, loadTime, [| |], ?extraProjectInfo=extraProjectInfo) 
             let site = ProjectSitesAndFiles.CreateProjectSiteForScript(fileName, options)
-            return ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site,fileName,options.ExtraProjectInfo)
+            return ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site,fileName,options.ExtraProjectInfo,serviceProvider)
         else
             let site = ProjectSitesAndFiles.ProjectSiteOfSingleFile(fileName)
-            return ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site,fileName,extraProjectInfo)
+            return ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site,fileName,extraProjectInfo,serviceProvider)
       }
 
     /// Update the info for a project in the project table
     member this.UpdateProjectInfo(projectId: ProjectId, site: IProjectSite, workspace: Workspace) =
         let extraProjectInfo = Some(box workspace)
-        let options = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site, site.ProjectFileName(), extraProjectInfo)
+        let options = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site, site.ProjectFileName(), extraProjectInfo, serviceProvider)
+        System.Windows.Forms.MessageBox.Show(sprintf "Bp 3: %A\n%A" options.ReferencedProjects options) |> ignore
         checkerProvider.Checker.InvalidateConfiguration(options)
         projectTable.[projectId] <- options
 
@@ -230,35 +232,42 @@ type internal FSharpLanguageService(package : FSharpPackage) as this =
             projectInfoManager.UpdateProjectInfo(project.Id, site, project.Workspace)
 
     member this.SetupProjectFile(siteProvider: IProvideProjectSite, workspace: VisualStudioWorkspaceImpl) =
-        let site = siteProvider.GetProjectSite()
-        let projectGuid = Guid(site.ProjectGuid)
-        let projectFileName = site.ProjectFileName()
+        let  rec setup (site: IProjectSite) =
+            let projectGuid = Guid(site.ProjectGuid)
+            let projectFileName = site.ProjectFileName()
 
-        let projectDisplayName = 
-            if String.IsNullOrWhiteSpace projectFileName then projectFileName
-            else Path.GetFileNameWithoutExtension projectFileName
+            let projectDisplayName = 
+                if String.IsNullOrWhiteSpace projectFileName then projectFileName
+                else Path.GetFileNameWithoutExtension projectFileName
 
-        let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName)
+            let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName)
 
-        projectInfoManager.UpdateProjectInfo(projectId, site, workspace)
+            projectInfoManager.UpdateProjectInfo(projectId, site, workspace)
 
-        match workspace.ProjectTracker.GetProject(projectId) with
-        | null ->
-            let projectContextFactory = this.Package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
-            let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
-            
-            
-            
-            let projectContext = 
-                projectContextFactory.CreateProjectContext(
-                    FSharpCommonConstants.FSharpLanguageName, projectDisplayName, projectFileName, projectGuid, siteProvider, null, errorReporter)
+            match workspace.ProjectTracker.GetProject(projectId) with
+            | null ->
+                let projectContextFactory = this.Package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
+                let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
+                
+                
+                
+                let projectContext = 
+                    projectContextFactory.CreateProjectContext(
+                        FSharpCommonConstants.FSharpLanguageName, projectDisplayName, projectFileName, projectGuid, siteProvider, null, errorReporter)
 
-            let project = projectContext :?> AbstractProject
+                let project = projectContext :?> AbstractProject
 
-            this.SyncProject(project, projectContext, site, forceUpdate=false)
-            site.AdviseProjectSiteChanges(FSharpCommonConstants.FSharpLanguageServiceCallbackName, AdviseProjectSiteChanges(fun () -> this.SyncProject(project, projectContext, site, forceUpdate=true)))
-            site.AdviseProjectSiteClosed(FSharpCommonConstants.FSharpLanguageServiceCallbackName, AdviseProjectSiteChanges(fun () -> projectInfoManager.ClearProjectInfo(project.Id); project.Disconnect()))
-        | _ -> ()
+                this.SyncProject(project, projectContext, site, forceUpdate=false)
+                site.AdviseProjectSiteChanges(FSharpCommonConstants.FSharpLanguageServiceCallbackName, 
+                                              AdviseProjectSiteChanges(fun () -> this.SyncProject(project, projectContext, site, forceUpdate=true)))
+                site.AdviseProjectSiteClosed(FSharpCommonConstants.FSharpLanguageServiceCallbackName, 
+                                             AdviseProjectSiteChanges(fun () -> 
+                                                projectInfoManager.ClearProjectInfo(project.Id)
+                                                project.Disconnect()))
+                for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider) do
+                    setup referencedSite
+            | _ -> ()
+        setup (siteProvider.GetProjectSite())
 
     member this.SetupStandAloneFile(fileName: string, fileContents: string, workspace: VisualStudioWorkspaceImpl, hier: IVsHierarchy) =
 

--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -112,7 +112,6 @@ type internal ProjectInfoManager
     member this.UpdateProjectInfo(projectId: ProjectId, site: IProjectSite, workspace: Workspace) =
         let extraProjectInfo = Some(box workspace)
         let options = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(site, site.ProjectFileName(), extraProjectInfo, serviceProvider)
-        System.Windows.Forms.MessageBox.Show(sprintf "Bp 3: %A\n%A" options.ReferencedProjects options) |> ignore
         checkerProvider.Checker.InvalidateConfiguration(options)
         projectTable.[projectId] <- options
 

--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -248,8 +248,6 @@ type internal FSharpLanguageService(package : FSharpPackage) as this =
                 let projectContextFactory = this.Package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
                 let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
                 
-                
-                
                 let projectContext = 
                     projectContextFactory.CreateProjectContext(
                         FSharpCommonConstants.FSharpLanguageName, projectDisplayName, projectFileName, projectGuid, siteProvider, null, errorReporter)
@@ -264,9 +262,11 @@ type internal FSharpLanguageService(package : FSharpPackage) as this =
                                                 projectInfoManager.ClearProjectInfo(project.Id)
                                                 project.Disconnect()))
                 for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider) do
-                    setup referencedSite
+                    let referencedProjectId = setup referencedSite                    
+                    project.AddProjectReference(ProjectReference referencedProjectId)
             | _ -> ()
-        setup (siteProvider.GetProjectSite())
+            projectId
+        setup (siteProvider.GetProjectSite()) |> ignore
 
     member this.SetupStandAloneFile(fileName: string, fileContents: string, workspace: VisualStudioWorkspaceImpl, hier: IVsHierarchy) =
 

--- a/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
+++ b/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
@@ -84,7 +84,7 @@ type internal FSharpLanguageServiceBackgroundRequests
                     // This portion is executed on the UI thread.
                     let rdt = getServiceProvider().RunningDocumentTable
                     let projectSite = getProjectSitesAndFiles().FindOwningProject(rdt,fileName)
-                    let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, fileName, None)                            
+                    let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, fileName, None, getServiceProvider())                            
                     let projectFileName = projectSite.ProjectFileName()
                     let data = 
                         {   ProjectSite = projectSite

--- a/vsintegration/src/FSharp.LanguageService/IProjectSite.fs
+++ b/vsintegration/src/FSharp.LanguageService/IProjectSite.fs
@@ -49,3 +49,5 @@ type internal IProjectSite =
     /// timestamp the site was last loaded
     abstract LoadTime : System.DateTime 
 
+    abstract Parent : obj
+

--- a/vsintegration/src/FSharp.LanguageService/IProjectSite.fs
+++ b/vsintegration/src/FSharp.LanguageService/IProjectSite.fs
@@ -3,11 +3,18 @@
 
 namespace Microsoft.VisualStudio.FSharp.LanguageService
 
+open System
+open System.Runtime.InteropServices
+
 /// Narrow abstraction over the project system.
 type internal AdviseProjectSiteChanges = delegate of unit -> unit  
 
+[<ComImport; InterfaceType(ComInterfaceType.InterfaceIsIUnknown); Guid("ad98f020-bad0-0000-0000-abc037459871")>]
+type internal IProvideProjectSite =
+    abstract GetProjectSite : unit -> IProjectSite
+
 /// Represents known F#-specific information about a project.
-type internal IProjectSite = 
+and internal IProjectSite = 
 
     /// List of files in the project. In the correct order.
     abstract SourceFilesOnDisk : unit -> string[]
@@ -49,5 +56,4 @@ type internal IProjectSite =
     /// timestamp the site was last loaded
     abstract LoadTime : System.DateTime 
 
-    abstract Parent : obj
-
+    abstract ProjectProvider : IProvideProjectSite option

--- a/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
+++ b/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
@@ -37,6 +37,7 @@ type private ProjectSiteOfScriptFile(filename:string, checkOptions : FSharpProje
         override this.TargetFrameworkMoniker = ""
         override this.ProjectGuid = ""
         override this.LoadTime = checkOptions.LoadTime
+        override this.Parent = null
 
     interface IHaveCheckOptions with
         override this.OriginalCheckOptions() = checkOptions
@@ -70,6 +71,7 @@ type private ProjectSiteOfSingleFile(sourceFile) =
         override this.TargetFrameworkMoniker = ""
         override this.ProjectGuid = ""
         override this.LoadTime = new DateTime(2000,1,1)  // any constant time is fine, orphan files do not interact with reloading based on update time
+        override this.Parent = null
     
 /// Information about projects, open files and other active artifacts in visual studio.
 /// Keeps track of the relationship between IVsTextLines buffers, IFSharpSource objects, IProjectSite objects and FSharpProjectOptions
@@ -82,6 +84,60 @@ type internal ProjectSitesAndFiles() =
         | :? IProvideProjectSite as siteFactory -> 
             Some(siteFactory.GetProjectSite())
         | _ -> None
+
+    static let fullOutputAssemblyPath (p:EnvDTE.Project) =
+        let getProperty tag =
+            try Some (p.Properties.[tag].Value.ToString()) with _ -> None
+        getProperty "FullPath"
+        |> Option.bind (fun fullPath ->
+            (try Some (p.ConfigurationManager.ActiveConfiguration.Properties.["OutputPath"].Value.ToString()) with _ -> None)
+            |> Option.bind (fun outputPath -> 
+                getProperty "OutputFileName"
+                |> Option.map (fun outputFileName -> Path.Combine(fullPath, outputPath, outputFileName))))
+        |> Option.bind (fun path -> try Some (Path.GetFullPath path) with _ -> None)
+
+    static let referencedProjects (projectSite:IProjectSite) =
+        match projectSite.Parent with
+        | null -> Seq.empty
+        | :? IVsHierarchy as hier ->                                
+            match hier.GetProperty(VSConstants.VSITEMID_ROOT, int __VSHPROPID.VSHPROPID_ExtObject) with
+            | VSConstants.S_OK, (:? EnvDTE.Project as p) ->
+                (p.Object :?> VSLangProj.VSProject).References
+                |> Seq.cast<VSLangProj.Reference>
+                |> Seq.choose (fun r ->
+                    Option.ofObj r
+                    |> Option.bind (fun r -> try Option.ofObj r.SourceProject with _ -> None))            
+            | _ -> Seq.empty
+        | _ -> Seq.empty
+
+    static let rec referencedProvideProjectSites (projectSite:IProjectSite, solutionService: IVsSolution) =
+        referencedProjects projectSite
+        |> Seq.choose (fun p ->
+            match solutionService.GetProjectOfUniqueName(p.UniqueName) with
+            | VSConstants.S_OK, (:? IProvideProjectSite as ps) ->
+                Some (p, ps)
+            | _ -> None)
+            
+    static let rec referencedProjectsOf (projectSite:IProjectSite, fileName, extraProjectInfo, solutionService: IVsSolution) =
+        referencedProvideProjectSites (projectSite, solutionService)
+        |> Seq.choose (fun (p, ps) ->            
+            fullOutputAssemblyPath p
+            |> Option.map (fun path ->
+                System.Windows.Forms.MessageBox.Show(sprintf "Bp 2: %A" path) |> ignore 
+                path, getProjectOptionsForProjectSite (ps.GetProjectSite(), fileName, extraProjectInfo, solutionService))
+            )
+        |> Seq.toArray
+
+    and getProjectOptionsForProjectSite(projectSite:IProjectSite, fileName, extraProjectInfo, solutionService) =            
+           {ProjectFileName = projectSite.ProjectFileName()
+            ProjectFileNames = projectSite.SourceFilesOnDisk()
+            OtherOptions = projectSite.CompilerFlags()
+            ReferencedProjects = referencedProjectsOf(projectSite, fileName, extraProjectInfo, solutionService)
+            IsIncompleteTypeCheckEnvironment = projectSite.IsIncompleteTypeCheckEnvironment
+            UseScriptResolutionRules = SourceFile.MustBeSingleFileProject fileName
+            LoadTime = projectSite.LoadTime
+            UnresolvedReferences = None
+            ExtraProjectInfo=extraProjectInfo }   
 
     /// Construct a project site for a single file. May be a single file project (for scripts) or an orphan project site (for everything else).
     static member ProjectSiteOfSingleFile(filename:string) : IProjectSite = 
@@ -158,23 +214,21 @@ type internal ProjectSitesAndFiles() =
     member art.FindOwningProject(rdt:IVsRunningDocumentTable, filename) = 
         match art.TryFindOwningProject(rdt, filename) with
         | Some site -> site
-        | None -> ProjectSitesAndFiles.ProjectSiteOfSingleFile(filename)        
+        | None -> ProjectSitesAndFiles.ProjectSiteOfSingleFile(filename)      
+        
+    static member GetReferencedProjectSites(projectSite:IProjectSite, serviceProvider:System.IServiceProvider) =
+        let solutionService = serviceProvider.GetService(typeof<SVsSolution>) :?> IVsSolution
+        referencedProvideProjectSites (projectSite, solutionService)
+        |> Seq.map (fun (_, ps) -> ps.GetProjectSite())
+        |> Seq.toArray
 
     /// Create project options for this project site.
-    static member GetProjectOptionsForProjectSite(projectSite:IProjectSite,filename,extraProjectInfo) = 
-        
+    static member GetProjectOptionsForProjectSite(projectSite:IProjectSite,filename,extraProjectInfo, serviceProvider:System.IServiceProvider) =
         match projectSite with
         | :? IHaveCheckOptions as hco -> hco.OriginalCheckOptions()
         | _ -> 
-            {ProjectFileName = projectSite.ProjectFileName()
-             ProjectFileNames = projectSite.SourceFilesOnDisk()
-             OtherOptions = projectSite.CompilerFlags()
-             ReferencedProjects = [| |]
-             IsIncompleteTypeCheckEnvironment = projectSite.IsIncompleteTypeCheckEnvironment
-             UseScriptResolutionRules = SourceFile.MustBeSingleFileProject(filename)
-             LoadTime = projectSite.LoadTime
-             UnresolvedReferences = None
-             ExtraProjectInfo=extraProjectInfo }      
+            let solutionService = serviceProvider.GetService(typeof<SVsSolution>) :?> IVsSolution
+            getProjectOptionsForProjectSite(projectSite, filename, extraProjectInfo, solutionService)
          
     /// Create project site for these project options
     static member CreateProjectSiteForScript (filename, checkOptions) = ProjectSiteOfScriptFile (filename, checkOptions) :> IProjectSite

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -99,7 +99,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
             member ips.ProjectGuid = inner.ProjectGuid
             member ips.IsIncompleteTypeCheckEnvironment = false
             member ips.LoadTime = inner.LoadTime 
-
+            member ips.Parent = inner.Parent
 
     type internal ProjectSiteOptionLifetimeState =
         | Opening=1  // The project has been opened, but has not yet called Compile() to compute sources/flags
@@ -1443,6 +1443,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     member this.TargetFrameworkMoniker = x.GetTargetFrameworkMoniker()
                     member this.ProjectGuid = x.GetProjectGuid()
                     member this.LoadTime = creationTime
+                    member this.Parent = x :> _
                 }
 
             // Snapshot-capture relevent values from "this", and returns an IProjectSite 
@@ -1474,6 +1475,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     member this.TargetFrameworkMoniker = targetFrameworkMoniker
                     member this.ProjectGuid = x.GetProjectGuid()
                     member this.LoadTime = creationTime
+                    member this.Parent = x :> _
                 }
 
             // let the language service ask us questions

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -99,7 +99,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
             member ips.ProjectGuid = inner.ProjectGuid
             member ips.IsIncompleteTypeCheckEnvironment = false
             member ips.LoadTime = inner.LoadTime 
-            member ips.Parent = inner.Parent
+            member ips.ProjectProvider = inner.ProjectProvider
 
     type internal ProjectSiteOptionLifetimeState =
         | Opening=1  // The project has been opened, but has not yet called Compile() to compute sources/flags
@@ -1443,7 +1443,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     member this.TargetFrameworkMoniker = x.GetTargetFrameworkMoniker()
                     member this.ProjectGuid = x.GetProjectGuid()
                     member this.LoadTime = creationTime
-                    member this.Parent = x :> _
+                    member this.ProjectProvider = Some (x :> IProvideProjectSite)
                 }
 
             // Snapshot-capture relevent values from "this", and returns an IProjectSite 
@@ -1475,7 +1475,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     member this.TargetFrameworkMoniker = targetFrameworkMoniker
                     member this.ProjectGuid = x.GetProjectGuid()
                     member this.LoadTime = creationTime
-                    member this.Parent = x :> _
+                    member this.ProjectProvider = Some (x :> IProvideProjectSite)
                 }
 
             // let the language service ask us questions

--- a/vsintegration/tests/Salsa/FSharpLanguageServiceTestable.fs
+++ b/vsintegration/tests/Salsa/FSharpLanguageServiceTestable.fs
@@ -126,7 +126,7 @@ type internal FSharpLanguageServiceTestable() as this =
 
     /// Respond to project being cleaned/rebuilt (any live type providers in the project should be refreshed)
     member this.OnProjectCleaned(projectSite:IProjectSite) = 
-        let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, "",None)
+        let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, "" ,None, serviceProvider.Value)
         this.FSharpChecker.NotifyProjectCleaned(checkOptions)
 
     member this.OnActiveViewChanged(textView) =
@@ -168,7 +168,7 @@ type internal FSharpLanguageServiceTestable() as this =
     interface IDependencyFileChangeNotify with
         member this.DependencyFileCreated projectSite = 
             // Invalidate the configuration if we notice any add for any DependencyFiles 
-            let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, "", None)
+            let checkOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(projectSite, "", None, this.ServiceProvider)
             this.FSharpChecker.InvalidateConfiguration(checkOptions)
 
         member this.DependencyFileChanged (filename) = 

--- a/vsintegration/tests/Salsa/salsa.fs
+++ b/vsintegration/tests/Salsa/salsa.fs
@@ -296,7 +296,7 @@ module internal Salsa =
           member this.ProjectGuid = 
                 let projectObj, projectObjFlags = MSBuild.CrackProject(projectfile, configurationFunc(), platformFunc())
                 projectObj.GetProperty(ProjectFileConstants.ProjectGuid).EvaluatedValue
-          member this.Parent = null
+          member this.ProjectProvider = None
 
     // Attempt to treat as MSBuild project.
     let internal NewMSBuildProjectSite(configurationFunc, platformFunc, msBuildProjectName) = 

--- a/vsintegration/tests/Salsa/salsa.fs
+++ b/vsintegration/tests/Salsa/salsa.fs
@@ -296,7 +296,8 @@ module internal Salsa =
           member this.ProjectGuid = 
                 let projectObj, projectObjFlags = MSBuild.CrackProject(projectfile, configurationFunc(), platformFunc())
                 projectObj.GetProperty(ProjectFileConstants.ProjectGuid).EvaluatedValue
-        
+          member this.Parent = null
+
     // Attempt to treat as MSBuild project.
     let internal NewMSBuildProjectSite(configurationFunc, platformFunc, msBuildProjectName) = 
         let newProjectSite = new MSBuildProjectSite(msBuildProjectName,configurationFunc,platformFunc)


### PR DESCRIPTION
Related to #1975.

This PR adds simple support for multiple F# projects in a solution. It makes sure that `ReferencedProjects` field in `FSharpProjectOptions` is populated correctly. All referenced projects are registered with Roslyn; however, there is no real integration with Roslyn workspaces yet.

Ideally most of the changes in `ProjectSitesAndFiles.fs` should be done in the F# project system i.e. figuring out referenced projects directly from `FSharpProjectNode`. I need some pointers to do it in a better way. This is currently done similar to VFPT where we rely on `Project` and `VSProject` to find referenced projects.

After this PR, go to definition seems to work for those symbols defined in a referenced project.