### PR TITLE
Make Signature Help look almost like C#/VB

### DIFF
--- a/vsintegration/src/FSharp.Editor/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/SignatureHelp.fs
@@ -172,7 +172,7 @@ type internal FSharpSignatureHelpProvider
 
         for method in methods do
             // Create the documentation. Note, do this on the background thread, since doing it in the documentationBuild fails to build the XML index
-            let methodDocs = XmlDocumentation.BuildMethodOverloadTipText(documentationBuilder, method.Description, true)
+            let methodDocs = XmlDocumentation.BuildMethodOverloadTipText(documentationBuilder, method.Description, false)
 
             let parameters = 
                 let parameters = if isStaticArgTip then method.StaticParameters else method.Parameters

--- a/vsintegration/src/FSharp.LanguageService/XmlDocumentation.fs
+++ b/vsintegration/src/FSharp.LanguageService/XmlDocumentation.fs
@@ -200,11 +200,9 @@ module internal XmlDocumentation =
         match xml with
         | FSharpXmlDoc.None -> ()
         | FSharpXmlDoc.XmlDocFileSignature(filename,signature) -> 
-            segment.Append("\n") |> ignore
             documentationProvider.AppendDocumentation(segment,filename,signature,showExceptions,showParameters, paramName)
         | FSharpXmlDoc.Text(rawXml) ->
             let processedXml = ProcessXml(rawXml)
-            segment.Append("\n") |> ignore
             documentationProvider.AppendDocumentationFromProcessedXML(segment,processedXml,showExceptions,showParameters, paramName)
 
     /// Common sanitation for data tip segment


### PR DESCRIPTION
As per [this comment](https://github.com/Microsoft/visualfsharp/issues/1910#issuecomment-265452848), this is a small change to make tooltips look close to how they look like C#/VB, except for the case when we have parameter comments - I have a newline at the end of the summary doc, whereas C# and VB do not.  I think it's a bit more readable this way.

Here's an example of what it looks like:

![signature-help](https://cloud.githubusercontent.com/assets/6309070/21082374/1a070b38-bf8f-11e6-933d-4875d4a52254.gif)
