### PR TITLE
color intrinsic types as keywords

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1098,6 +1098,7 @@ type TypeCheckInfo
 
     let keywordTypes =
         [
+            "array";
             "bigint";
             "bool";
             "byref";
@@ -1111,9 +1112,11 @@ type TypeCheckInfo
             "int16";
             "int32";
             "int64";
+            "list";
             "nativeint";
             "obj";
             "sbyte";
+            "seq";
             "single";
             "string";
             "unit";


### PR DESCRIPTION
With the change to the Roslyn-based language service, type aliases into the .NET framework are colored as types (teal) instead of keywords (blue).  This is a (probably poor) attempt at fixing that.

This solution is certainly less than ideal, because I wasn't able to find something that I could easily call to determine if a type's token is an alias to a .NET framework type (e.g., `int` -> `System.Int32`).  The closest I could find was [this](https://github.com/Microsoft/visualfsharp/blob/696c6f7e3882caa7b7efcd58b7df70f5a138204d/src/fsharp/NicePrint.fs#L116-L133), but even then, the list wasn't complete; it lacked the `byref` keyword so I had to copy the items into another member function to cover everything.

The diff looks more painful than it really is; I just added one case to the `match` expression:

``` F#
// well known type aliases get colored as keywords 
| CNR(_, (Item.Types (n, _)), _, _, _, _, m) when TypeCheckInfo.IsKeywordType(n) -> 
    Some (m, FSharpTokenColorKind.Keyword) 
```

and the `IsKeywordType()` method itself.

Fixes #1809.