### PR TITLE
Fixes a build caused by merging the find-references PR?

### DIFF
--- a/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs
@@ -67,7 +67,7 @@ type internal FSharpFindReferencesService
                 let lineNumber = sourceText.Lines.GetLinePosition(position).Line + 1
                 let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.FilePath, options.OtherOptions |> Seq.toList)
                 
-                match CommonHelpers.tryClassifyAtPosition(document.Id, sourceText, document.FilePath, defines, position, true, context.CancellationToken) with
+                match CommonHelpers.tryClassifyAtPosition(document.Id, sourceText, document.FilePath, defines, position, context.CancellationToken) with
                 | Some (islandColumn, qualifiers, _) -> 
                     let! symbolUse = checkFileResults.GetSymbolUseAtLocation(lineNumber, islandColumn, textLine, qualifiers)
                     match symbolUse with


### PR DESCRIPTION
Local builds were [broken for me](https://github.com/Microsoft/visualfsharp/pull/1985#issuecomment-267463872) after this commit: https://github.com/Microsoft/visualfsharp/commit/a5cee6035b498d83b68defa1d4149f88786a0b85

I'm not sure if CI is updated or if my machine is just messed up, but after this change I can finally build the tools locally.

cc @KevinRansom 