### PR TITLE
Colorize F# signature help

### DIFF
--- a/vsintegration/src/FSharp.Editor/CommonConstants.fs
+++ b/vsintegration/src/FSharp.Editor/CommonConstants.fs
@@ -20,4 +20,6 @@ module internal FSharpCommonConstants =
     [<Literal>]
     let FSharpContentTypeName = "F#"
     [<Literal>]
+    let FSharpSignatureHelpContentTypeName = "F# Signature Help"
+    [<Literal>]
     let FSharpLanguageServiceCallbackName = "F# Language Service"

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -3,6 +3,7 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
+open System.Text.RegularExpressions
 open System.Composition
 open System.Collections.Concurrent
 open System.Collections.Generic
@@ -181,20 +182,49 @@ type internal FSharpSignatureHelpProvider
                       let paramDoc = XmlDocumentation.BuildMethodParamText(documentationBuilder, method.XmlDoc, p.ParameterName) 
                       let doc = if String.IsNullOrWhiteSpace(paramDoc) then [||]
                                 else [| TaggedText(TextTags.Text, paramDoc) |]
-                      yield (p.ParameterName,p.IsOptional,doc,[| TaggedText(TextTags.Text,p.Display) |]) |]
+                      let parameterParts =
+                          if isStaticArgTip then
+                              [| TaggedText(TextTags.Class, p.Display) |]                                
+                          else
+                              let str = p.Display
+                              match str.IndexOf(':') with
+                              | -1 -> [| TaggedText(TextTags.Parameter, str) |]                                
+                              | 0 -> 
+                                [| TaggedText(TextTags.Punctuation, ":"); 
+                                   TaggedText(TextTags.Class, str.[1..]) |]
+                              | i -> 
+                                [| TaggedText(TextTags.Parameter, str.[..i-1]); 
+                                   TaggedText(TextTags.Punctuation, ":"); 
+                                   TaggedText(TextTags.Class, str.[i+1..]) |]
+                      yield (p.ParameterName, p.IsOptional, doc, parameterParts) 
+                |]
 
             let hasParamComments (pcs: (string*bool*TaggedText[]*TaggedText[])[]) =
                 pcs |> Array.exists (fun (_, _, doc, _) -> doc.Length > 0)
 
-            let summaryText = if String.IsNullOrWhiteSpace(summaryDoc) then [| TaggedText() |]
-                              elif (hasParamComments parameters) then [| TaggedText(TextTags.Text, summaryDoc + "\n") |]
-                              else [| TaggedText(TextTags.Text, summaryDoc) |]
-
+            let summaryText =                 
+                let doc = 
+                    if String.IsNullOrWhiteSpace summaryDoc then
+                        String.Empty
+                    elif hasParamComments parameters then 
+                        summaryDoc + "\n" 
+                    else 
+                        summaryDoc
+                [| TaggedText(TextTags.Text, doc) |]
+                
             // Prepare the text to display
-            let descriptionParts = [| TaggedText(TextTags.Text, method.TypeText) |]
-            let prefixParts = [| TaggedText(TextTags.Text, methodGroup.MethodName);  TaggedText(TextTags.Punctuation,  (if isStaticArgTip then "<" else "(")) |]
+            let descriptionParts = 
+                let str = method.TypeText
+                if str.StartsWith(": ", StringComparison.OrdinalIgnoreCase) then
+                    [| TaggedText(TextTags.Punctuation, ": "); 
+                       TaggedText(TextTags.Class, str.[2..]) |]
+                else
+                    [| TaggedText(TextTags.Text, str) |]
+            let prefixParts = 
+                [| TaggedText(TextTags.Method, methodGroup.MethodName);  
+                   TaggedText(TextTags.Punctuation, (if isStaticArgTip then "<" else "(")) |]
             let separatorParts = [| TaggedText(TextTags.Punctuation, ", ") |]
-            let suffixParts = [| TaggedText(TextTags.Text, (if isStaticArgTip then ">" else ")")) |]
+            let suffixParts = [| TaggedText(TextTags.Punctuation, (if isStaticArgTip then ">" else ")")) |]
 
             let completionItem = (method.HasParamArrayArg, summaryText, prefixParts, separatorParts, suffixParts, parameters, descriptionParts)
             // FSROSLYNTODO: Do we need a cache like for completion?
@@ -234,7 +264,7 @@ type internal FSharpSignatureHelpProvider
                                     let parameters = parameters 
                                                      |> Array.map (fun (paramName, isOptional, paramDoc, displayParts) -> 
                                                         SignatureHelpParameter(paramName,isOptional,documentationFactory=(fun _ -> paramDoc :> seq<_>),displayParts=displayParts))
-                                    SignatureHelpItem(isVariadic=hasParamArrayArg ,documentationFactory=(fun _ -> doc :> seq<_>),prefixParts=prefixParts,separatorParts=separatorParts,suffixParts=suffixParts,parameters=parameters,descriptionParts=descriptionParts))
+                                    AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem(null, isVariadic=hasParamArrayArg ,documentationFactory=(fun _ -> doc :> seq<_>),prefixParts=prefixParts,separatorParts=separatorParts,suffixParts=suffixParts,parameters=parameters,descriptionParts=descriptionParts) :> SignatureHelpItem)
 
                         return SignatureHelpItems(items,applicableSpan,argumentIndex,argumentCount,Option.toObj argumentName)
                 | None -> 
@@ -244,3 +274,17 @@ type internal FSharpSignatureHelpProvider
                 return null
             } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken
 
+open System.ComponentModel.Composition
+open Microsoft.VisualStudio.Utilities
+open Microsoft.VisualStudio.Text
+open Microsoft.VisualStudio.Text.Classification
+open Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp.Presentation
+
+// Enable colorized signature help for F# buffers
+
+[<Export(typeof<IClassifierProvider>)>]
+[<ContentType(FSharpCommonConstants.FSharpSignatureHelpContentTypeName)>]
+type FSharpSignatureHelpClassifierProvider [<ImportingConstructor>] (typeMap) =
+    interface IClassifierProvider with
+        override __.GetClassifier (buffer: ITextBuffer) =
+            buffer.Properties.GetOrCreateSingletonProperty(fun _ -> SignatureHelpClassifier(buffer, typeMap) :> _)

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -215,9 +215,9 @@ type internal FSharpSignatureHelpProvider
             // Prepare the text to display
             let descriptionParts = 
                 let str = method.TypeText
-                if str.StartsWith(": ", StringComparison.OrdinalIgnoreCase) then
-                    [| TaggedText(TextTags.Punctuation, ": "); 
-                       TaggedText(TextTags.Class, str.[2..]) |]
+                if str.StartsWith(":", StringComparison.OrdinalIgnoreCase) then
+                    [| TaggedText(TextTags.Punctuation, ":"); 
+                       TaggedText(TextTags.Class, str.[1..]) |]
                 else
                     [| TaggedText(TextTags.Text, str) |]
             let prefixParts = 
@@ -264,7 +264,7 @@ type internal FSharpSignatureHelpProvider
                                     let parameters = parameters 
                                                      |> Array.map (fun (paramName, isOptional, paramDoc, displayParts) -> 
                                                         SignatureHelpParameter(paramName,isOptional,documentationFactory=(fun _ -> paramDoc :> seq<_>),displayParts=displayParts))
-                                    AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem(null, isVariadic=hasParamArrayArg ,documentationFactory=(fun _ -> doc :> seq<_>),prefixParts=prefixParts,separatorParts=separatorParts,suffixParts=suffixParts,parameters=parameters,descriptionParts=descriptionParts) :> SignatureHelpItem)
+                                    SignatureHelpItem(isVariadic=hasParamArrayArg ,documentationFactory=(fun _ -> doc :> seq<_>),prefixParts=prefixParts,separatorParts=separatorParts,suffixParts=suffixParts,parameters=parameters,descriptionParts=descriptionParts))
 
                         return SignatureHelpItems(items,applicableSpan,argumentIndex,argumentCount,Option.toObj argumentName)
                 | None -> 

--- a/vsintegration/src/FSharp.Editor/ContentType.fs
+++ b/vsintegration/src/FSharp.Editor/ContentType.fs
@@ -15,6 +15,11 @@ module FSharpStaticTypeDefinitions =
     [<BaseDefinition(ContentTypeNames.RoslynContentType)>]
     let FSharpContentTypeDefinition = ContentTypeDefinition()
 
+    [<Export>]
+    [<Name(FSharpCommonConstants.FSharpSignatureHelpContentTypeName)>]
+    [<BaseDefinition("sighelp")>]
+    let FSharpSignatureHelpContentTypeDefinition = ContentTypeDefinition()
+
 [<ExportContentTypeLanguageService(FSharpCommonConstants.FSharpContentTypeName, FSharpCommonConstants.FSharpLanguageName)>]
 type FSharpContentType [<System.Composition.ImportingConstructor>](contentTypeRegistry : IContentTypeRegistryService) =  
     member this.contentTypeRegistryService = contentTypeRegistry

--- a/vsintegration/tests/unittests/VisualFSharp.Unittests.fsproj
+++ b/vsintegration/tests/unittests/VisualFSharp.Unittests.fsproj
@@ -164,6 +164,9 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0.dll" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0.dll" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.dll" />
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=$(RoslynVSBinariesVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Text.Logic.$(RoslynVSPackagesVersion)\lib\net45\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+    </Reference>    
     <Reference Include="Microsoft.VisualStudio.Threading, Version=$(RoslynVSBinariesVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Threading.14.1.131\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Screenshot:

![image](https://cloud.githubusercontent.com/assets/941060/21286296/3ea70522-c450-11e6-94df-158cc25621f9.png)

The text parsing part is ad hoc. I imagine we can make use of structured data for precise coloring once these changes landed https://github.com/Microsoft/visualfsharp/compare/master...vladima:vladima/classification