### PR TITLE
Colorize modules & fix namespace colorization

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1425,6 +1425,13 @@ type TypeCheckInfo
                      | ItemOccurence.Binding _
                      | ItemOccurence.Pattern _), _, _, _, m) ->
                 Some (m, FSharpTokenColorKind.TypeName)
+            | CNR(_, Item.ModuleOrNamespaces refs, 
+                     ( ItemOccurence.UseInType   
+                     | ItemOccurence.UseInAttribute
+                     | ItemOccurence.Use _
+                     | ItemOccurence.Binding _
+                     | ItemOccurence.Pattern _), _, _, _, m) when refs |> List.exists (fun x -> x.IsModule) ->
+                Some (m, FSharpTokenColorKind.TypeName)
             | _ -> None)
         |> Seq.toArray
 

--- a/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
@@ -59,7 +59,7 @@ type internal FSharpColorizationService
                         | FSharpCheckFileAnswer.Aborted -> [| |]
                         | FSharpCheckFileAnswer.Succeeded(results) -> 
                             [| for (range, tokenColorKind)  in results.GetExtraColorizationsAlternate() do
-                                  let span = CommonRoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
+                                  let span = CommonHelpers.fixupSpan(sourceText, CommonRoslynHelpers.FSharpRangeToTextSpan(sourceText, range))
                                   if textSpan.Contains(span.Start) || textSpan.Contains(span.End - 1) || span.Contains(textSpan) then
                                       yield ClassifiedSpan(span, CommonHelpers.compilerTokenToRoslynToken(tokenColorKind)) |]
 


### PR DESCRIPTION
It also fixes wrong namespaces colorization when they are used as part of qualified names.

Before

![image](https://cloud.githubusercontent.com/assets/873919/21287679/757a4ffa-c482-11e6-9cf5-35eaa100a4d9.png)

After

![image](https://cloud.githubusercontent.com/assets/873919/21287663/0b9159ee-c482-11e6-8404-1c4c211fbad7.png)
