### PR TITLE
Show project name instead of full project file path in Navigation Bar

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService.fs
@@ -241,8 +241,15 @@ type internal FSharpLanguageService(package : FSharpPackage) as this =
         | null ->
             let projectContextFactory = this.Package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
             let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
+            
+            let projectDisplayName = 
+                if String.IsNullOrWhiteSpace projectFileName then projectFileName
+                else Path.GetFileNameWithoutExtension projectFileName
+            
+            let projectContext = 
+                projectContextFactory.CreateProjectContext(
+                    FSharpCommonConstants.FSharpLanguageName, projectDisplayName, projectFileName, projectGuid, siteProvider, null, errorReporter)
 
-            let projectContext = projectContextFactory.CreateProjectContext(FSharpCommonConstants.FSharpLanguageName, projectFileName, projectFileName, projectGuid, siteProvider, null, errorReporter)
             let project = projectContext :?> AbstractProject
 
             this.SyncProject(project, projectContext, site, forceUpdate=false)

--- a/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
+++ b/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
@@ -97,6 +97,8 @@ type internal FSharpBlockStructureService(checker: FSharpChecker, projectInfoMan
                 | Some parsedInput ->
                     let blockSpans =
                         Structure.getOutliningRanges (sourceText.Lines |> Seq.map (fun x -> x.ToString()) |> Seq.toArray) parsedInput
+                        // it's crucial to not return more than one BlockSpan, othewise Roslyn crashes Visual Studio when user hover 
+                        // mouse over guide lines.
                         |> Seq.distinctBy (fun x -> x.Range.StartLine)
                         |> Seq.choose (fun range -> 
                             CommonRoslynHelpers.TryFSharpRangeToTextSpan(sourceText, range.Range)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/873919/21292233/94d70f78-c50e-11e6-9e0c-a9bbaf15a275.png)

This is what C# and VB do.