### PR TITLE
Bring back OnIdle registration for Error List processing

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -189,6 +189,24 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
 
             // FSI-LINKAGE-POINT: unsited init
             do Microsoft.VisualStudio.FSharp.Interactive.Hooks.fsiConsoleWindowPackageCtorUnsited (this :> Package)
+
+            let mutable mgr : IOleComponentManager = null
+            let mutable componentID = 0u
+
+            member this.RegisterForIdleTime() =
+                mgr <- this.GetService(typeof<SOleComponentManager>) :?> IOleComponentManager
+                if componentID = 0u && mgr <> null then
+                    let crinfo = Array.zeroCreate<OLECRINFO>(1)
+                    let mutable crinfo0 = crinfo.[0]
+                    crinfo0.cbSize <- Marshal.SizeOf(typeof<OLECRINFO>) |> uint32
+                    crinfo0.grfcrf <- uint32 (_OLECRF.olecrfNeedIdleTime ||| _OLECRF.olecrfNeedPeriodicIdleTime)
+                    crinfo0.grfcadvf <- uint32 (_OLECADVF.olecadvfModal ||| _OLECADVF.olecadvfRedrawOff ||| _OLECADVF.olecadvfWarningsOff)
+                    crinfo0.uIdleTimeInterval <- 1000u
+                    crinfo.[0] <- crinfo0 
+                    let componentID_out = ref componentID
+                    let _hr = mgr.FRegisterComponent(this, crinfo, componentID_out)
+                    componentID <- componentID_out.Value
+                    ()
                 
             /// This method loads a localized string based on the specified resource.
 
@@ -289,6 +307,8 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                 Microsoft.VisualStudio.FSharp.Interactive.Hooks.fsiConsoleWindowPackageInitalizeSited (this :> Package) commandService
                 // FSI-LINKAGE-POINT: private method GetDialogPage forces fsi options to be loaded
                 let _fsiPropertyPage = this.GetDialogPage(typeof<Microsoft.VisualStudio.FSharp.Interactive.FsiPropertyPage>)
+
+                this.RegisterForIdleTime()
                 ()
 
             /// This method is called during Devenv /Setup to get the bitmap to
@@ -340,7 +360,37 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     GetToolWindowAsITestVFSI().SendTextInteraction(s)
                 member this.GetMostRecentLines(n:int) : string[] =
                     GetToolWindowAsITestVFSI().GetMostRecentLines(n)
+            
+            interface IOleComponent with
+                override this.FContinueMessageLoop(_uReason:uint32, _pvLoopData:IntPtr, _pMsgPeeked:MSG[]) = 
+                    1
 
+                override this.FDoIdle(grfidlef:uint32) =
+                    // see e.g "C:\Program Files\Microsoft Visual Studio 2008 SDK\VisualStudioIntegration\Common\IDL\olecm.idl" for details
+                    //Trace.Print("CurrentDirectoryDebug", (fun () -> sprintf "curdir='%s'\n" (System.IO.Directory.GetCurrentDirectory())))  // can be useful for watching how GetCurrentDirectory changes
+                    let periodic = (grfidlef &&& (uint32 _OLEIDLEF.oleidlefPeriodic)) <> 0u                        
+                    if periodic && mgr.FContinueIdle() <> 0 then
+                        TaskReporterIdleRegistration.DoIdle(mgr)
+                    else
+                        0
+
+                override this.FPreTranslateMessage(_pMsg) = 0
+
+                override this.FQueryTerminate(_fPromptUser) = 1
+
+                override this.FReserved1(_dwReserved, _message, _wParam, _lParam) = 1
+
+                override this.HwndGetWindow(_dwWhich, _dwReserved) = 0n
+
+                override this.OnActivationChange(_pic, _fSameComponent, _pcrinfo, _fHostIsActivating, _pchostinfo, _dwReserved) = ()
+
+                override this.OnAppActivate(_fActive, _dwOtherThreadID) = ()
+
+                override this.OnEnterState(_uStateID, _fEnter)  = ()
+        
+                override this.OnLoseActivation() = ()
+
+                override this.Terminate() = ()
 
     /// Factory for creating our editor, creates FSharp Projects
     [<Guid(GuidList.guidFSharpProjectFactoryString)>]

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -195,7 +195,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
 
             member this.RegisterForIdleTime() =
                 mgr <- this.GetService(typeof<SOleComponentManager>) :?> IOleComponentManager
-                if componentID = 0u && mgr <> null then
+                if componentID = 0u && not (isNull mgr) then
                     let crinfo = Array.zeroCreate<OLECRINFO>(1)
                     let mutable crinfo0 = crinfo.[0]
                     crinfo0.cbSize <- Marshal.SizeOf(typeof<OLECRINFO>) |> uint32
@@ -369,7 +369,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     // see e.g "C:\Program Files\Microsoft Visual Studio 2008 SDK\VisualStudioIntegration\Common\IDL\olecm.idl" for details
                     //Trace.Print("CurrentDirectoryDebug", (fun () -> sprintf "curdir='%s'\n" (System.IO.Directory.GetCurrentDirectory())))  // can be useful for watching how GetCurrentDirectory changes
                     let periodic = (grfidlef &&& (uint32 _OLEIDLEF.oleidlefPeriodic)) <> 0u                        
-                    if periodic && mgr.FContinueIdle() <> 0 then
+                    if periodic && not (isNull mgr) && mgr.FContinueIdle() <> 0 then
                         TaskReporterIdleRegistration.DoIdle(mgr)
                     else
                         0


### PR DESCRIPTION
Fix #1988.

While compiling F# projects, `IDEBuildLogger` put all errors and warnings into a work queue to be processed when VS is in idle mode.

Idle processing used to be registered and triggered at https://github.com/dsyme/old-visualfsharp-clones/blob/8130b1429d3fd83a77a07df1bdc07751a6ee6577/vsintegration/src/vs/FsPkgs/FSharp.LanguageService/servicem.fs#L2093. This seems to get lost when we moved to the new F# language service.

Build errors are back :)

![image](https://cloud.githubusercontent.com/assets/941060/21293698/6d222b0c-c52c-11e6-8363-f3ef29de10f7.png)
