### PR TITLE
Refactor help context service

### DIFF
--- a/vsintegration/src/FSharp.Editor/Commands/HelpContextService.fs
+++ b/vsintegration/src/FSharp.Editor/Commands/HelpContextService.fs
@@ -46,65 +46,63 @@ type internal FSharpHelpContextService
                        content = "." -> true
                 | _ -> false
           
-            let keyword =
-                let tokenInformation, col =
-                    let col = 
-                        if caretColumn = lineText.Length && caretColumn > 0 then
-                            // if we are at the end of the line, we always step back one character
-                            caretColumn - 1
-                        else
-                            caretColumn
+            let tokenInformation, col =
+                let col = 
+                    if caretColumn = lineText.Length && caretColumn > 0 then
+                        // if we are at the end of the line, we always step back one character
+                        caretColumn - 1
+                    else
+                        caretColumn
 
-                    let getTokenAt line col = 
-                       if col < 0 || line < 0 then None else
-                       let start = textLines.[line].Start + col
-                       let span = TextSpan.FromBounds(start, start + 1)
-                       tokens 
-                       |> Seq.tryFindIndex(fun t -> t.TextSpan.Contains(span))
-                       |> Option.map (fun i -> tokens.[i])
+                let getTokenAt line col = 
+                    if col < 0 || line < 0 then None else
+                    let start = textLines.[line].Start + col
+                    let span = TextSpan.FromBounds(start, start + 1)
+                    tokens 
+                    |> Seq.tryFindIndex(fun t -> t.TextSpan.Contains(span))
+                    |> Option.map (fun i -> tokens.[i])
           
-                    match getTokenAt line col with
-                    | Some t as original -> // when col > 0 && shouldTryToFindSurroundingIdent t ->
-                        if shouldTryToFindSurroundingIdent t then
-                            match getTokenAt line (col - 1) with
-                            | Some t as newInfo when not (shouldTryToFindSurroundingIdent t) -> newInfo, col - 1
-                            | _ -> 
+                match getTokenAt line col with
+                | Some t as original -> // when col > 0 && shouldTryToFindSurroundingIdent t ->
+                    if shouldTryToFindSurroundingIdent t then
+                        match getTokenAt line (col - 1) with
+                        | Some t as newInfo when not (shouldTryToFindSurroundingIdent t) -> newInfo, col - 1
+                        | _ -> 
                             match getTokenAt line (col + 1) with
                             | Some t as newInfo when not (shouldTryToFindSurroundingIdent t) -> newInfo, col + 1
                             | _ -> original, col
-                        else original, col
-                    | otherwise -> otherwise, col
+                    else original, col
+                | otherwise -> otherwise, col
 
-                match tokenInformation with
-                |   None -> None
-                |   Some token ->
-                        match token.ClassificationType with
-                        |   ClassificationTypeNames.Keyword
-                        |   ClassificationTypeNames.Operator
-                        |   ClassificationTypeNames.PreprocessorKeyword ->
-                                sourceText.GetSubText(token.TextSpan).ToString() + "_FS" |> Some
-                        |   ClassificationTypeNames.Comment -> Some "comment_FS"
-                        |   ClassificationTypeNames.Identifier ->
-                                try
-                                    let possibleIdentifier = QuickParse.GetCompleteIdentifierIsland false lineText col
-                                    match possibleIdentifier with
-                                    |   None -> None
-                                    |   Some(s,colAtEndOfNames, _) ->
-                                            if check.HasFullTypeCheckInfo then 
-                                                let qualId = PrettyNaming.GetLongNameFromString s
-                                                check.GetF1KeywordAlternate(Line.fromZ line, colAtEndOfNames, lineText, qualId)
-                                                |> Async.RunSynchronously
-                                            else None
-                                with e ->
-                                    Assert.Exception (e)
-                                    reraise()
-                        | _ -> None
-            return keyword
+            match tokenInformation with
+            |   None -> return None
+            |   Some token ->
+                    match token.ClassificationType with
+                    |   ClassificationTypeNames.Keyword
+                    |   ClassificationTypeNames.Operator
+                    |   ClassificationTypeNames.PreprocessorKeyword ->
+                            return Some (sourceText.GetSubText(token.TextSpan).ToString() + "_FS")
+                    |   ClassificationTypeNames.Comment -> return Some "comment_FS"
+                    |   ClassificationTypeNames.Identifier ->
+                            try
+                                let possibleIdentifier = QuickParse.GetCompleteIdentifierIsland false lineText col
+                                match possibleIdentifier with
+                                |   None -> return None
+                                |   Some(s,colAtEndOfNames, _) ->
+                                        if check.HasFullTypeCheckInfo then 
+                                            let qualId = PrettyNaming.GetLongNameFromString s
+                                            return! check.GetF1KeywordAlternate(Line.fromZ line, colAtEndOfNames, lineText, qualId)
+                                        else 
+                                            return None
+                            with e ->
+                                Assert.Exception e
+                                return None
+                    | _ -> return None
     }
 
     interface IHelpContextService with
-        member this.Language with get () = "fsharp"
-        member this.Product with get () = "fsharp"
+        member this.Language = "fsharp"
+        member this.Product = "fsharp"
 
         member this.GetHelpTermAsync(document, textSpan, cancellationToken) = 
             async {
@@ -116,11 +114,8 @@ type internal FSharpHelpContextService
                     let textLine = sourceText.Lines.GetLineFromPosition(textSpan.Start)
                     let tokens = CommonHelpers.getColorizationData(document.Id, sourceText, textLine.Span, Some document.Name, defines, cancellationToken)
                     let! keyword = FSharpHelpContextService.GetHelpTerm(checkerProvider.Checker, sourceText, document.FilePath, options, textSpan, tokens, textVersion.GetHashCode())
-
-                    return match keyword with 
-                           | Some k -> k
-                           | None   -> ""
-                | None -> return ""
+                    return defaultArg keyword String.Empty
+                | None -> return String.Empty
             } |> CommonRoslynHelpers.StartAsyncAsTask cancellationToken
 
         member this.FormatSymbol(_symbol) = Unchecked.defaultof<_>


### PR DESCRIPTION
 - Remove the use of `Async.RunSynchronously` inside async computation expressions.
 - Remove `reraise()` usage. We should not reraise exceptions without knowing anyone catching it (especially for non-critical services).