### PR TITLE
Make deployed vsix use F#.core.dll

### DIFF
--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -13,6 +13,7 @@
 "OldVersion"="2.0.0.0-4.4.0.0"
 "NewVersion"="4.4.1.0"
 "Culture"="neutral"
+"codeBase"="$PackageFolder$\FSharp.Core.dll"
 
 [$RootKey$\Projects\{A1591282-1198-4647-A2B1-27E5FF5F6F3B}\LanguageTemplates]
 "{F2A71F9B-5D33-465A-A702-920D77279786}"="{76B279E8-36ED-494E-B145-5344F8DEFCB6}"


### PR DESCRIPTION
Fixes: https://github.com/Microsoft/visualfsharp/issues/2063

Teeny weeny but quite effective.
