### PR TITLE
Suggest opening namespaces on attributes again

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -397,7 +397,12 @@ and FSharpEntity(cenv:cenv, entity:EntityRef) =
         [ for ty in AllInterfacesOfType  cenv.g cenv.amap range0 AllowMultiIntfInstantiations.Yes (generalizedTyconRef entity) do 
              yield FSharpType(cenv,  ty) ]
         |> makeReadOnlyCollection
-
+    
+    member x.IsAttributeType =
+        if isUnresolved() then false else
+        let ty = generalizedTyconRef entity
+        Infos.ExistsHeadTypeInEntireHierarchy cenv.g cenv.amap range0 ty cenv.g.tcref_System_Attribute
+        
     member x.BaseType = 
         checkIsResolved()        
         GetSuperTypeOfType cenv.g cenv.amap range0 (generalizedTyconRef entity) 

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -244,6 +244,9 @@ and [<Class>] internal FSharpEntity =
     /// Get all the interface implementations, by walking the type hierarchy
     member AllInterfaces : IList<FSharpType>  
 
+    /// Check if the entity inherits from System.Attribute in its type hierarchy
+    member IsAttributeType : bool
+
     /// Get the base type, if any 
     member BaseType : FSharpType option
 

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -191,7 +191,7 @@ type internal FSharpAddOpenCodeFixProvider
                                  [ yield e.TopRequireQualifiedAccessParent, e.AutoOpenParent, e.Namespace, e.CleanedIdents
                                    if isAttribute then
                                        let lastIdent = e.CleanedIdents.[e.CleanedIdents.Length - 1]
-                                       if e.Kind = EntityKind.Attribute && lastIdent.EndsWith "Attribute" then
+                                       if lastIdent.EndsWith "Attribute" && e.Kind LookupType.Precise = EntityKind.Attribute then
                                            yield 
                                                e.TopRequireQualifiedAccessParent, 
                                                e.AutoOpenParent,


### PR DESCRIPTION
This also fixes https://github.com/Microsoft/visualfsharp/issues/2080.

The assertion dialog might still appear in very rare cases (e.g. there is a hidden type defined with Attribute suffix in an implicitly referenced assembly).
