### PR TITLE
Modify before_install.sh for OSX compatibility

### DIFF
--- a/before_install.sh
+++ b/before_install.sh
@@ -1,9 +1,39 @@
+#!/bin/sh
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
-sudo apt-get update
-sudo apt-get -y install mono-devel
+# OS detection
 
+OSName=$(uname -s)
+case $OSName in
+    Darwin)
+        OS=OSX
+        ;;
+
+    Linux)
+        OS=Linux
+        ;;
+
+    *)
+        echo "Unsupported OS '$OSName' detected. Cannot continue with build, the scripts must be updated to support this OS."
+        exit 1
+        ;;
+esac
+
+# On Linux (or at least, Ubuntu), when building with Mono, need to install the mono-devel package first.
+if [ $OS == "Linux" ]; then
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+    echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+    sudo apt-get update
+    sudo apt-get -y install mono-devel
+fi
+
+# Check if SSL certificates have been imported into Mono's certificate store.
+# If certs haven't been installed, some/all of the Nuget packages will fail to restore.
+if [ `certmgr -list -c Trust | grep -c -F "X.509"` -le 1 ]; then
+  echo "No SSL certificates installed so unable to restore NuGet packages.\nRun 'mozroots --sync --import' to install certificates to Mono's certificate store." >&2;
+  exit 1
+fi
+
+# Restore NuGet packages (needed for compiler bootstrap and tests).
 mono .nuget/NuGet.exe restore packages.config -PackagesDirectory packages -ConfigFile .nuget/NuGet.Config
 
 (if test x-$BUILD_CORECLR = x-1; then \
@@ -27,16 +57,23 @@ chmod u+x packages/FSharp.Compiler.Tools.4.0.1.19/tools/fsi.exe
 chmod u+x packages/FsLexYacc.7.0.3/build/fslex.exe
 chmod u+x packages/FsLexYacc.7.0.3/build/fsyacc.exe
 
-# The FSharp.Compiler.Tools package doesn't work correctly unless a proper install of F# has been done on the machine
-sudo apt-get -y install fsharp
+# The FSharp.Compiler.Tools package doesn't work correctly unless a proper install of F# has been done on the machine.
+# OSX can skip this because the OSX Mono installer includes F#.
+if [ $OS != "OSX" ]; then
+    sudo apt-get -y install fsharp
+fi
 
 # "access to the path /etc/mono/registry/last-time is denied"
-sudo mkdir /etc/mono/registry
-sudo chmod uog+rw /etc/mono/registry
-
-
-
-  
-
-
-
+# On non-OSX systems, may need to create Mono's registry folder to avoid exceptions during builds.
+# This doesn't seem to be necessary on OSX, as the folder is created by the installer.
+if [ $OS != "OSX" ]; then
+    # This registry folder path is correct for Linux;
+    # on OSX the folder is /Library/Frameworks/Mono.framework/Versions/Current/etc/mono/registry
+    # and may be different for *BSD systems.
+    __MonoRegistryDir="/etc/mono/registry"
+    if [ ! -d "$__MonoRegistryDir" ]; then
+      echo "Mono registry directory does not exist (it may not have been created yet)."
+      echo "The directory needs to be created now; superuser permissions are required for this."
+      { sudo -- sh -c "mkdir -p $__MonoRegistryDir && chmod uog+rw $__MonoRegistryDir"; } || { echo "Unable to create/chmod Mono registry directory '$__MonoRegistryDir'." >&2; }
+    fi
+fi

--- a/before_install.sh
+++ b/before_install.sh
@@ -19,7 +19,7 @@ case $OSName in
 esac
 
 # On Linux (or at least, Ubuntu), when building with Mono, need to install the mono-devel package first.
-if [ $OS == "Linux" ]; then
+if [ $OS = 'Linux' ]; then
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
     echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
     sudo apt-get update
@@ -28,8 +28,9 @@ fi
 
 # Check if SSL certificates have been imported into Mono's certificate store.
 # If certs haven't been installed, some/all of the Nuget packages will fail to restore.
-if [ `certmgr -list -c Trust | grep -c -F "X.509"` -le 1 ]; then
-  echo "No SSL certificates installed so unable to restore NuGet packages.\nRun 'mozroots --sync --import' to install certificates to Mono's certificate store." >&2;
+if [ $('certmgr -list -c Trust | grep -c -F "X.509"') -le 1 ]; then
+  echo "No SSL certificates installed so unable to restore NuGet packages." >&2;
+  echo "Run 'mozroots --sync --import' to install certificates to Mono's certificate store." >&2;
   exit 1
 fi
 
@@ -59,14 +60,14 @@ chmod u+x packages/FsLexYacc.7.0.3/build/fsyacc.exe
 
 # The FSharp.Compiler.Tools package doesn't work correctly unless a proper install of F# has been done on the machine.
 # OSX can skip this because the OSX Mono installer includes F#.
-if [ $OS != "OSX" ]; then
+if [ $OS != 'OSX' ]; then
     sudo apt-get -y install fsharp
 fi
 
 # "access to the path /etc/mono/registry/last-time is denied"
 # On non-OSX systems, may need to create Mono's registry folder to avoid exceptions during builds.
 # This doesn't seem to be necessary on OSX, as the folder is created by the installer.
-if [ $OS != "OSX" ]; then
+if [ $OS != 'OSX' ]; then
     # This registry folder path is correct for Linux;
     # on OSX the folder is /Library/Frameworks/Mono.framework/Versions/Current/etc/mono/registry
     # and may be different for *BSD systems.

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,16 @@
+#!/bin/sh
 
 # At the moment all we build is the Mono version of the F# compiler
 export BUILD_NET40=1
 
+# Perform any necessary setup prior to running builds
+# (e.g., restoring NuGet packages).
 ./before_install.sh
+rc=$?;
+if [ $rc -ne 0 ]; then
+    echo "before_install script failed."
+    exit $rc
+fi
 
 # This is a very, very limited build script for Mono which bootstraps the compiler
 xbuild src/fsharp-proto-build.proj 


### PR DESCRIPTION
Modify before_install.sh so it works on OSX. The script now performs rudimentary OS detection, and Linux-specific commands are only executed when running on Linux.

Related to #2114.