### PR TITLE
Add OSX to OS list for Jenkins CI builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -4,7 +4,7 @@ import jobs.generation.JobReport;
 def project = GithubProject
 def branch = GithubBranchName
 
-def osList = ['Windows_NT', 'Ubuntu14.04' ] //, 'OSX', 'CentOS7.1'
+def osList = ['Windows_NT', 'Ubuntu14.04', 'OSX' ] //, 'CentOS7.1'
 
 def static getBuildJobName(def configuration, def os) {
     return configuration.toLowerCase() + '_' + os.toLowerCase()


### PR DESCRIPTION
This change adds OSX to the list of operating systems to run Jenkins CI builds on.