### PR TITLE
Color built-in types as keywords in signature help and quick info

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -2517,7 +2517,8 @@ let fullNameOfEntityRef nmF xref =
     | Some pathText -> pathText +.+ nmF xref
 
 let tagEntityRefName (xref: EntityRef) name =
-    if xref.IsNamespace then tagNamespace name
+    if Set.contains name Lexhelp.Keywords.keywordTypes then tagKeyword name
+    else if xref.IsNamespace then tagNamespace name
     else if xref.IsModule then tagModule name
     else if xref.IsTypeAbbrev then tagAlias name
     else if xref.IsFSharpDelegateTycon then tagDelegate name

--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -298,6 +298,8 @@ module Keywords =
     let keywordNames = 
         keywordList |> List.map (fun (_, w, _) -> w) 
 
+    let keywordTypes = StructuredFormat.TaggedTextOps.keywordTypes
+
     let keywordTable = 
         let tab = System.Collections.Generic.Dictionary<string,token>(100)
         for _,keyword,token in keywordList do 

--- a/src/fsharp/lexhelp.fsi
+++ b/src/fsharp/lexhelp.fsi
@@ -68,3 +68,4 @@ module Keywords =
     val IdentifierToken : lexargs -> UnicodeLexing.Lexbuf -> string -> Parser.token
     val QuoteIdentifierIfNeeded : string -> string
     val keywordNames : string list
+    val keywordTypes : Set<string>

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1112,36 +1112,7 @@ type TypeCheckInfo
             else 
                 items
 
-    let keywordTypes =
-        [
-            "array";
-            "bigint";
-            "bool";
-            "byref";
-            "byte";
-            "char";
-            "decimal";
-            "double";
-            "float";
-            "float32";
-            "int";
-            "int16";
-            "int32";
-            "int64";
-            "list";
-            "nativeint";
-            "obj";
-            "sbyte";
-            "seq";
-            "single";
-            "string";
-            "unit";
-            "uint";
-            "uint16";
-            "uint32";
-            "uint64";
-            "unativeint"
-        ] |> Set.ofSeq
+    static let keywordTypes = Lexhelp.Keywords.keywordTypes
 
     /// Get the auto-complete items at a location
     member x.GetDeclarations (parseResultsOpt, line, lineStr, colAtEndOfNamesAndResidue, qualifyingNames, partialName, hasTextChangedSinceLastTypecheck) =

--- a/src/utils/sformat.fs
+++ b/src/utils/sformat.fs
@@ -194,7 +194,37 @@ namespace Microsoft.FSharp.Text.StructuredFormat
     module TaggedTextOps =
 #endif
         let tagAlias = TaggedText.Alias
-        let tagClass = TaggedText.Class
+        let keywordTypes = 
+          [
+            "array";
+            "bigint";
+            "bool";
+            "byref";
+            "byte";
+            "char";
+            "decimal";
+            "double";
+            "float";
+            "float32";
+            "int";
+            "int16";
+            "int32";
+            "int64";
+            "list";
+            "nativeint";
+            "obj";
+            "sbyte";
+            "seq";
+            "single";
+            "string";
+            "unit";
+            "uint";
+            "uint16";
+            "uint32";
+            "uint64";
+            "unativeint";
+          ] |> Set.ofList
+        let tagClass name = if Set.contains name keywordTypes then TaggedText.Keyword name else TaggedText.Class name
         let tagUnionCase = TaggedText.UnionCase
         let tagDelegate = TaggedText.Delegate
         let tagEnum = TaggedText.Enum
@@ -216,7 +246,7 @@ namespace Microsoft.FSharp.Text.StructuredFormat
         let tagProperty = TaggedText.Property
         let tagSpace = TaggedText.Space
         let tagStringLiteral = TaggedText.StringLiteral
-        let tagStruct = TaggedText.Struct
+        let tagStruct name = if Set.contains name keywordTypes then TaggedText.Keyword name else TaggedText.Struct name
         let tagTypeParameter = TaggedText.TypeParameter
         let tagText = TaggedText.Text
         let tagPunctuation = TaggedText.Punctuation
@@ -1390,5 +1420,5 @@ namespace Microsoft.FSharp.Text.StructuredFormat
 
 #if COMPILER
         /// Called 
-        let fsi_any_to_layout opts x = anyL ShowTopLevelBinding BindingFlags.Public opts x 
+        let fsi_any_to_layout opts x = anyL ShowTopLevelBinding BindingFlags.Public opts x
 #endif  

--- a/src/utils/sformat.fsi
+++ b/src/utils/sformat.fsi
@@ -126,6 +126,7 @@ namespace Microsoft.FSharp.Text.StructuredFormat
 #else
 #endif
             TaggedTextOps =
+        val keywordTypes : Set<string>
         val tagAlias : string -> TaggedText
         val tagClass : string -> TaggedText
         val tagUnionCase : string -> TaggedText


### PR DESCRIPTION
To be consistent with coloring in the editor.

Here is how it looks after this PR:

![image](https://cloud.githubusercontent.com/assets/941060/21655087/cb90fe86-d2b8-11e6-8f57-2aecee613068.png)
