### PR TITLE
Fix find all references

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
@@ -2,8 +2,6 @@
 
 namespace Microsoft.VisualStudio.FSharp.Editor
 
-#nowarn "1182"
-
 open System
 open System.Composition
 open System.Collections.Generic

--- a/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs
@@ -14,6 +14,7 @@ open Microsoft.CodeAnalysis.Editor.Host
 open Microsoft.CodeAnalysis.Navigation
 open Microsoft.CodeAnalysis.FindSymbols
 open Microsoft.CodeAnalysis.FindReferences
+open Microsoft.CodeAnalysis.Completion
 
 open Microsoft.VisualStudio.FSharp.LanguageService
 
@@ -62,6 +63,7 @@ type internal FSharpFindReferencesService
             let! symbol = CommonHelpers.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Fuzzy)
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(lineNumber, symbol.RightColumn, textLine, [symbol.Text])
             let! declaration = checkFileResults.GetDeclarationLocationAlternate (lineNumber, symbol.RightColumn, textLine, [symbol.Text], false) |> liftAsync
+            let tags = GlyphTags.GetTags(CommonRoslynHelpers.GetGlyphForSymbol symbolUse.Symbol)
             
             let declarationRange = 
                 match declaration with
@@ -77,14 +79,14 @@ type internal FSharpFindReferencesService
                 match declarationSpans with 
                 | [] -> 
                     [ DefinitionItem.CreateNonNavigableItem(
-                          ImmutableArray<string>.Empty, 
+                          tags,
                           [TaggedText(TextTags.Text, symbolUse.Symbol.FullName)].ToImmutableArray(),
                           [TaggedText(TextTags.Assembly, symbolUse.Symbol.Assembly.SimpleName)].ToImmutableArray()) ]
                 | _ ->
                     declarationSpans
                     |> List.map (fun span ->
                         DefinitionItem.Create(
-                            ImmutableArray<string>.Empty, 
+                            tags, 
                             [TaggedText(TextTags.Text, symbolUse.Symbol.FullName)].ToImmutableArray(), 
                             span))
             

--- a/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs
@@ -80,15 +80,12 @@ type internal FSharpFindReferencesService
                 | [] -> 
                     [ DefinitionItem.CreateNonNavigableItem(
                           tags,
-                          [TaggedText(TextTags.Text, symbolUse.Symbol.FullName)].ToImmutableArray(),
-                          [TaggedText(TextTags.Assembly, symbolUse.Symbol.Assembly.SimpleName)].ToImmutableArray()) ]
+                          ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Text)),
+                          ImmutableArray.Create(TaggedText(TextTags.Assembly, symbolUse.Symbol.Assembly.SimpleName))) ]
                 | _ ->
                     declarationSpans
                     |> List.map (fun span ->
-                        DefinitionItem.Create(
-                            tags, 
-                            [TaggedText(TextTags.Text, symbolUse.Symbol.FullName)].ToImmutableArray(), 
-                            span))
+                        DefinitionItem.Create(tags, ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Text)), span))
             
             for definitionItem in definitionItems do
                 do! context.OnDefinitionFoundAsync(definitionItem) |> Async.AwaitTask |> liftAsync


### PR DESCRIPTION
`ColorizationService` returned duplicated spans in some cases which caused `FindReferencesService` to crash somewhere in Roslyn code as it checks given spans for overlapping.

It also added a glyph for a definition symbol in Find References results window:

![image](https://cloud.githubusercontent.com/assets/873919/21693127/c7ee1718-d390-11e6-874d-c1e8f4f23226.png)
