### PR TITLE
Update references to Roslyn RC3 bits.

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -14,6 +14,7 @@
     <add key="myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vctools" value="https://vcppdogfooding.azurewebsites.net/nuget/" />
+    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn" />
     <add key="artifacts" value="../artifacts" />
   </packageSources>
 </configuration>

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -121,7 +121,7 @@
     <FsiToolExe>fsi.exe</FsiToolExe>
     <FsLexToolExe>fslex.exe</FsLexToolExe>
     <FsYaccToolExe>fsyacc.exe</FsYaccToolExe>
-    <RoslynVersion>2.0.0-rc2</RoslynVersion>
+    <RoslynVersion>2.0.0-rc3-61225-01</RoslynVersion>
     <RoslynVSBinariesVersion>14.0</RoslynVSBinariesVersion>
     <RoslynVSPackagesVersion>14.3.25407</RoslynVSPackagesVersion>
 

--- a/vsintegration/packages.config
+++ b/vsintegration/packages.config
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Features" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.LanguageServices" version="2.0.0-rc2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.0.0-rc3-61225-01" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.0.0-rc3-61225-01" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.0.0-rc3-61225-01" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Features" version="2.0.0-rc3-61225-01" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.0.0-rc3-61225-01" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.LanguageServices" version="2.0.0-rc3-61225-01" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Package.LanguageService.14.0" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Editor" version="14.3.25407" targetFramework="net46" />

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -55,7 +55,7 @@
     <Compile Include="Navigation\GoToDefinitionService.fs" />
     <Compile Include="Navigation\NavigationBarItemService.fs" />
     <Compile Include="Navigation\NavigateToSearchService.fs" />
-    <Compile Include="Navigation\FindReferencesService.fs" />
+    <Compile Include="Navigation\FindUsagesService.fs" />
     <Compile Include="BlockComment\CommentUncommentService.fs" />
     <Compile Include="Structure\Structure.fs" />
     <Compile Include="Structure\BlockStructureService.fs" />

--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -44,8 +44,8 @@ type internal DocumentLocations =
 
 type internal InlineRenameLocationSet(locationsByDocument: DocumentLocations [], originalSolution: Solution) =
     interface IInlineRenameLocationSet with
-        member __.Locations : IList<InlineRenameLocation> = 
-            [| for doc in locationsByDocument do yield! doc.Locations |] :> _
+        member __.Locations : ImmutableArray<InlineRenameLocation> =
+            [| for doc in locationsByDocument do yield! doc.Locations |].ToImmutableArray()
         
         member this.GetReplacementsAsync(replacementText, _optionSet, cancellationToken) : Task<IInlineRenameReplacementInfo> =
             let rec applyChanges i (solution: Solution) =

--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -10,18 +10,19 @@ open System.Composition
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Host.Mef
 open Microsoft.CodeAnalysis.Editor
+open Microsoft.CodeAnalysis.Editor.FindUsages
 open Microsoft.CodeAnalysis.Editor.Host
 open Microsoft.CodeAnalysis.Navigation
 open Microsoft.CodeAnalysis.FindSymbols
-open Microsoft.CodeAnalysis.FindReferences
+open Microsoft.CodeAnalysis.FindUsages
 
 open Microsoft.VisualStudio.FSharp.LanguageService
 
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler.SourceCodeServices
 
-[<ExportLanguageService(typeof<IStreamingFindReferencesService>, FSharpCommonConstants.FSharpLanguageName); Shared>]
-type internal FSharpFindReferencesService
+[<ExportLanguageService(typeof<IFindUsagesService>, FSharpCommonConstants.FSharpLanguageName); Shared>]
+type internal FSharpFindUsagesService
     [<ImportingConstructor>]
     (
         checkerProvider: FSharpCheckerProvider,
@@ -49,7 +50,7 @@ type internal FSharpFindReferencesService
                 return spans |> Array.choose id |> Array.toList
         }
 
-    let findReferencedSymbolsAsync(document: Document, position: int, context: FindReferencesContext) : Async<unit> =
+    let findReferencedSymbolsAsync(document: Document, position: int, context: IFindUsagesContext, allReferences: bool) : Async<unit> =
         asyncMaybe {
             let! sourceText = document.GetTextAsync(context.CancellationToken)
             let checker = checkerProvider.Checker
@@ -126,20 +127,25 @@ type internal FSharpFindReferencesService
                 match declarationRange with
                 | Some declRange when declRange = symbolUse.RangeAlternate -> ()
                 | _ ->
-                    let! referenceDocSpans = rangeToDocumentSpans(document.Project.Solution, symbolUse.RangeAlternate, context.CancellationToken) |> liftAsync
-                    match referenceDocSpans with
-                    | [] -> ()
-                    | _ ->
-                        for referenceDocSpan in referenceDocSpans do
-                            for definitionItem in definitionItems do
-                                let referenceItem = SourceReferenceItem(definitionItem, referenceDocSpan)
-                                do! context.OnReferenceFoundAsync(referenceItem) |> Async.AwaitTask |> liftAsync
+                    // report a reference if we're interested in all _or_ if we're looking at an implementation
+                    if allReferences || symbolUse.IsFromDispatchSlotImplementation then
+                        let! referenceDocSpans = rangeToDocumentSpans(document.Project.Solution, symbolUse.RangeAlternate, context.CancellationToken) |> liftAsync
+                        match referenceDocSpans with
+                        | [] -> ()
+                        | _ ->
+                            for referenceDocSpan in referenceDocSpans do
+                                for definitionItem in definitionItems do
+                                    let referenceItem = SourceReferenceItem(definitionItem, referenceDocSpan)
+                                    do! context.OnReferenceFoundAsync(referenceItem) |> Async.AwaitTask |> liftAsync
             
-            do! context.OnCompletedAsync() |> Async.AwaitTask |> liftAsync
+            ()
         } |> Async.Ignore
 
-    interface IStreamingFindReferencesService with
+    interface IFindUsagesService with
         member __.FindReferencesAsync(document, position, context) =
-            findReferencedSymbolsAsync(document, position, context)
+            findReferencedSymbolsAsync(document, position, context, true)
+            |> CommonRoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+        member __.FindImplementationsAsync(document, position, context) =
+            findReferencedSymbolsAsync(document, position, context, false)
             |> CommonRoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
  


### PR DESCRIPTION
Thanks to @vasily-kirichenko for doing a lot of the work that I simply cherry-picked here.

Note that this PR is going into `vs2017-rc3` because there was an API change that would break everybody in `master` and once RC3 ships these changes will then be pulled into `master`.

Manual testing of FAR (Find All References) is being done locally to make sure I didn't break anything.

FYI @KevinRansom @dsyme @cartermp