### PR TITLE
Use Roslyn dependency graphs

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/CommonRoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CommonRoslynHelpers.fs
@@ -206,6 +206,5 @@ module internal RoslynExtensions =
     type Project with
         /// The list of all other projects within the same solution that reference this project.
         member this.GetDependentProjects() =
-            [ for project in this.Solution.Projects do
-                if project.ProjectReferences |> Seq.exists (fun ref -> ref.ProjectId = this.Id) then 
-                    yield project ]
+            this.Solution.GetProjectDependencyGraph().GetProjectsThatDirectlyDependOnThisProject(this.Id)
+            |> Seq.map this.Solution.GetProject

--- a/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs
@@ -104,6 +104,7 @@ type internal FSharpFindReferencesService
                             [ for declProject in declProjects do
                                 yield declProject
                                 yield! declProject.GetDependentProjects() ]
+                            |> List.distinct
                         | Some (SymbolDeclarationLocation.Projects (declProjects, true)) -> declProjects
                         // The symbol is declared in .NET framework, an external assembly or in a C# project within the solution.
                         // In order to find all its usages we have to check all F# projects.


### PR DESCRIPTION
It doesn't matter much if we compute dependent projects once.
However, on repeated queries (via Find All References, Rename, etc.), Roslyn dependency graph may be faster thanks to efficient lookup.