### PR TITLE
Give F# Interactive buffer its own content type

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -246,11 +246,3 @@ type internal FSharpSignatureHelpClassifierProvider [<ImportingConstructor>] (ty
     interface IClassifierProvider with
         override __.GetClassifier (buffer: ITextBuffer) =
             buffer.Properties.GetOrCreateSingletonProperty(fun _ -> SignatureHelpClassifier(buffer, typeMap) :> _)
-
-[<Export(typeof<IClassifierProvider>)>]
-[<ContentType("FSharpInteractive")>]
-type internal FSharpInteractiveClassifierProvider [<ImportingConstructor>] (typeMap) =
-    interface IClassifierProvider with
-        override __.GetClassifier (buffer: ITextBuffer) =
-            System.Windows.Forms.MessageBox.Show("OK") |> ignore
-            buffer.Properties.GetOrCreateSingletonProperty(fun _ -> SignatureHelpClassifier(buffer, typeMap) :> _)

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -246,3 +246,11 @@ type internal FSharpSignatureHelpClassifierProvider [<ImportingConstructor>] (ty
     interface IClassifierProvider with
         override __.GetClassifier (buffer: ITextBuffer) =
             buffer.Properties.GetOrCreateSingletonProperty(fun _ -> SignatureHelpClassifier(buffer, typeMap) :> _)
+
+[<Export(typeof<IClassifierProvider>)>]
+[<ContentType("FSharpInteractive")>]
+type internal FSharpInteractiveClassifierProvider [<ImportingConstructor>] (typeMap) =
+    interface IClassifierProvider with
+        override __.GetClassifier (buffer: ITextBuffer) =
+            System.Windows.Forms.MessageBox.Show("OK") |> ignore
+            buffer.Properties.GetOrCreateSingletonProperty(fun _ -> SignatureHelpClassifier(buffer, typeMap) :> _)

--- a/vsintegration/src/FSharp.VS.FSI/FSHarp.VS.FSI.fsproj
+++ b/vsintegration/src/FSharp.VS.FSI/FSHarp.VS.FSI.fsproj
@@ -27,6 +27,19 @@
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludePkgdefInVSIXContainer>true</IncludePkgdefInVSIXContainer>
   </PropertyGroup>
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
+  <Import Project="$(FSharpSourcesRoot)\..\vsintegration\vsintegration.targets" />
+  <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" />
+  <Target Name="GatherBinariesToBeSigned" AfterTargets="Localize" Condition="'$(UseGatherBinaries)' == 'true'">
+    <ItemGroup>
+      <BinariesToBeSigned Include="$(OutDir)$(AssemblyName).dll" />
+      <BinariesToBeSigned Include="$(OutDir)localize\**\$(AssemblyName).resources.dll" />
+      <FilesToSign Include="@(BinariesToBeSigned)">
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
   <ItemGroup>
     <FilesToLocalize Include="$(OutDir)$(AssemblyName).dll">
       <TranslationFile>$(FSharpSourcesRoot)\..\loc\lcl\{Lang}\$(AssemblyName).dll.lcl</TranslationFile>
@@ -34,8 +47,6 @@
       <HasLceComments>false</HasLceComments>
       <InProject>false</InProject>
     </FilesToLocalize>
-  </ItemGroup>
-  <ItemGroup>
     <FsSrGen Include="VFSIstrings.txt" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="srProperties.fs" />
@@ -66,6 +77,7 @@
     <Reference Include="Microsoft.VisualStudio.OLE.Interop.dll" />
     <Reference Include="EnvDTE.dll" />
     <Reference Include="EnvDTE80.dll" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="VSLangProj" />
     <Reference Include="VSLangProj80" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop.dll" />
@@ -146,17 +158,4 @@
       <Project>{d5870cf0-ed51-4cbc-b3d7-6f56da84ac06}</Project>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
-  <Import Project="$(FSharpSourcesRoot)\..\vsintegration\vsintegration.targets" />
-  <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" />
-  <Target Name="GatherBinariesToBeSigned" AfterTargets="Localize" Condition="'$(UseGatherBinaries)' == 'true'">
-    <ItemGroup>
-      <BinariesToBeSigned Include="$(OutDir)$(AssemblyName).dll" />
-      <BinariesToBeSigned Include="$(OutDir)localize\**\$(AssemblyName).resources.dll" />
-      <FilesToSign Include="@(BinariesToBeSigned)">
-         <Authenticode>Microsoft</Authenticode>
-         <StrongName>StrongName</StrongName>
-      </FilesToSign>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/vsintegration/src/FSharp.VS.FSI/fsiBasis.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiBasis.fs
@@ -75,6 +75,9 @@ module internal Guids =
     
     let guidFsharpLanguageService       = Guid("BC6DD5A5-D4D6-4dab-A00D-A51242DBAF1B")  // The F# source file lang service
 
+    [<Literal>]
+    let fsiContentTypeName              = "FSharpInteractive"
+
 module internal Util =
     /// Utility function to create an instance of a class from the local registry. [From Iron Python].
     let CreateObject (globalProvider:System.IServiceProvider) (classType:Type,interfaceType:Type) =

--- a/vsintegration/src/FSharp.VS.FSI/fsiLanguageService.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiLanguageService.fs
@@ -16,6 +16,8 @@ open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.Package
 open Microsoft.VisualStudio.TextManager.Interop
+open System.ComponentModel.Composition
+open Microsoft.VisualStudio.Utilities
 
 open Util
 open System.ComponentModel
@@ -24,6 +26,11 @@ open Microsoft.VisualStudio.FSharp.Interactive.Session
 module SP = Microsoft.VisualStudio.FSharp.Interactive.Session.SessionsProperties
 
 
+module internal ContentType = 
+    [<Export>]
+    [<Name(Guids.fsiContentTypeName)>]
+    [<BaseDefinition("code")>]
+    let FSharpContentTypeDefinition = ContentTypeDefinition()
 
 // FsiPropertyPage
 [<ComVisible(true)>]

--- a/vsintegration/src/FSharp.VS.FSI/fsiTextBufferStream.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiTextBufferStream.fs
@@ -19,14 +19,15 @@ open Util
 open Microsoft.VisualStudio.Editor
 open Microsoft.VisualStudio.Text
 open Microsoft.VisualStudio.Text.Editor
+open Microsoft.VisualStudio.Utilities
 
 // This type wraps the IVsTextLines which contains the FSI session (output and input).
 // It provides the API for writing directly to the read-only part of the buffer.
 // It extends the read-only marker on the buffer (making the written text read-only).
 //
-type internal TextBufferStream(textLines:ITextBuffer) = 
+type internal TextBufferStream(textLines:ITextBuffer, contentTypeRegistry: IContentTypeRegistryService) = 
     do if null = textLines then raise (new ArgumentNullException("textLines"))
-
+    do textLines.ChangeContentType(contentTypeRegistry.GetContentType Guids.fsiContentTypeName, Guid Guids.guidFsiLanguageService)
     let mutable readonlyRegion  = null : IReadOnlyRegion
 
     let extendReadOnlyRegion position =


### PR DESCRIPTION
Fix #512.

This PR introduces `FSharpInteractive` content type for F# Interactive buffer.
A content type is a prerequisite for introducing any advanced editor feature for F# Interactive.

I changed the F# Interactive buffer content type via API. Let me know if there is an easier way of achieving this.