### PR TITLE
Highlight structs and use a higher contrast colour scheme in FSI

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -162,7 +162,6 @@ module internal Utilities =
                         | TaggedText.Alias _
                         | TaggedText.Class _ 
                         | TaggedText.Module _
-                        | TaggedText.ModuleBinding _
                         | TaggedText.Interface _
                         | TaggedText.Record _
                         | TaggedText.Struct _

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -157,13 +157,20 @@ module internal Utilities =
                 member r.AddText z s =
                     let color =
                         match s with
-                        | Keyword _ -> ConsoleColor.Blue
-                        | TypeParameter _
-                        | Alias _
-                        | Struct _
-                        | Class _ -> ConsoleColor.Cyan
-                        | StringLiteral _ -> ConsoleColor.Red
-                        | NumericLiteral _ -> ConsoleColor.Magenta
+                        | TaggedText.Keyword _ -> ConsoleColor.White
+                        | TaggedText.TypeParameter _
+                        | TaggedText.Alias _
+                        | TaggedText.Class _ 
+                        | TaggedText.Module _
+                        | TaggedText.ModuleBinding _
+                        | TaggedText.Interface _
+                        | TaggedText.Record _
+                        | TaggedText.Struct _
+                        | TaggedText.Union _ -> ConsoleColor.Cyan
+                        | TaggedText.UnionCase _
+                        | TaggedText.ActivePatternCase _ -> ConsoleColor.Magenta
+                        | TaggedText.StringLiteral _ -> ConsoleColor.Yellow
+                        | TaggedText.NumericLiteral _ -> ConsoleColor.Green
                         | _ -> Console.ForegroundColor
 
                     DoWithColor color (fun () -> outWriter.Write s.Value)

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -160,6 +160,7 @@ module internal Utilities =
                         | Keyword _ -> ConsoleColor.Blue
                         | TypeParameter _
                         | Alias _
+                        | Struct _
                         | Class _ -> ConsoleColor.Cyan
                         | StringLiteral _ -> ConsoleColor.Red
                         | NumericLiteral _ -> ConsoleColor.Magenta

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -166,7 +166,7 @@ module internal Utilities =
                         | TaggedText.Record _
                         | TaggedText.Struct _
                         | TaggedText.Union _
-                        | TaggedText.UnknownType -> ConsoleColor.Cyan
+                        | TaggedText.UnknownType _ -> ConsoleColor.Cyan
                         | TaggedText.UnionCase _
                         | TaggedText.ActivePatternCase _ -> ConsoleColor.Magenta
                         | TaggedText.StringLiteral _ -> ConsoleColor.Yellow

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -166,7 +166,8 @@ module internal Utilities =
                         | TaggedText.Interface _
                         | TaggedText.Record _
                         | TaggedText.Struct _
-                        | TaggedText.Union _ -> ConsoleColor.Cyan
+                        | TaggedText.Union _
+                        | TaggedText.UnknownType -> ConsoleColor.Cyan
                         | TaggedText.UnionCase _
                         | TaggedText.ActivePatternCase _ -> ConsoleColor.Magenta
                         | TaggedText.StringLiteral _ -> ConsoleColor.Yellow


### PR DESCRIPTION
Comparison of Windows, Mac and Ubuntu: https://imgur.com/a/q0zUA

Windows:
![image](https://cloud.githubusercontent.com/assets/64654/21750016/5464403e-d5a1-11e6-88bb-41824405cbea.png)


Prior to this PR, "DateTime" would not be highlighted.

Closes #2193 and #2194.