### PR TITLE
Fix fscorelocation on coreclr when no fsharp.core dll was provided

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1640,7 +1640,7 @@ let GetFSharpCoreReferenceUsedByCompiler(useSimpleResolution) =
     let fscCoreLocation = 
         let fscLocation = typeof<TypeInThisAssembly>.Assembly.Location
         Path.Combine(Path.GetDirectoryName(fscLocation), fsCoreName + ".dll")
-    if File.Exists(fscCoreLocation) then fsCoreName + ".dll"
+    if File.Exists(fscCoreLocation) then fscCoreLocation
     else failwithf "Internal error: Could not find %s" fsCoreName
 #else
     // TODO:  Remove this when we do out of GAC for DEV 15 because above code will work everywhere.


### PR DESCRIPTION
Ensure that the coreclr compiler looks alongside the compiler as a last resort.