### PR TITLE
Don't suggest things when the entered identifier is in scope

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -609,8 +609,8 @@ let getErrorString key = SR.GetString key
 
 let (|InvalidArgument|_|) (exn:exn) = match exn with :? ArgumentException as e -> Some e.Message | _ -> None
 
-let OutputPhasedErrorR errorStyle (os:System.Text.StringBuilder) (err:PhasedDiagnostic) =
-    let rec OutputExceptionR (os:System.Text.StringBuilder) error = 
+let OutputPhasedErrorR errorStyle (os:StringBuilder) (err:PhasedDiagnostic) =
+    let rec OutputExceptionR (os:StringBuilder) error = 
       match error with
       | ConstraintSolverTupleDiffLengths(_,tl1,tl2,m,m2) -> 
           os.Append(ConstraintSolverTupleDiffLengthsE().Format tl1.Length tl2.Length) |> ignore

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -610,7 +610,8 @@ let getErrorString key = SR.GetString key
 let (|InvalidArgument|_|) (exn:exn) = match exn with :? ArgumentException as e -> Some e.Message | _ -> None
 
 let OutputPhasedErrorR errorStyle (os:System.Text.StringBuilder) (err:PhasedDiagnostic) =
-    let rec OutputExceptionR (os:System.Text.StringBuilder) = function        
+    let rec OutputExceptionR (os:System.Text.StringBuilder) error = 
+      match error with
       | ConstraintSolverTupleDiffLengths(_,tl1,tl2,m,m2) -> 
           os.Append(ConstraintSolverTupleDiffLengthsE().Format tl1.Length tl2.Length) |> ignore
           if m.StartLine <> m2.StartLine then 

--- a/src/fsharp/ErrorResolutionHints.fs
+++ b/src/fsharp/ErrorResolutionHints.fs
@@ -3,6 +3,8 @@
 /// Functions to format error message details
 module internal Microsoft.FSharp.Compiler.ErrorResolutionHints
 
+open Internal.Utilities
+
 let maxSuggestions = 5
 let minThresholdForSuggestions = 0.7
 let highConfidenceThreshold = 0.85
@@ -11,7 +13,7 @@ let minStringLengthForThreshold = 3
 /// We report a candidate if its edit distance is <= the threshold.
 /// The threshhold is set to about a quarter of the number of characters.
 let IsInEditDistanceProximity idText suggestion =
-    let editDistance = Internal.Utilities.EditDistance.CalcEditDistance(idText,suggestion)
+    let editDistance = EditDistance.CalcEditDistance(idText,suggestion)
     let threshold =
         match idText.Length with
         | x when x < 5 -> 1
@@ -29,7 +31,7 @@ let FilterPredictions (idText:string) (suggestionF:ErrorLogger.Suggestions) =
     allSuggestions
     |> Seq.choose (fun suggestion ->
         let suggestedText = suggestion.ToUpperInvariant()
-        let similarity = Internal.Utilities.EditDistance.JaroWinklerDistance uppercaseText suggestedText
+        let similarity = EditDistance.JaroWinklerDistance uppercaseText suggestedText
         if similarity >= highConfidenceThreshold || suggestion.EndsWith ("." + idText) then
             Some(similarity,suggestion)
         elif similarity < minThresholdForSuggestions && suggestedText.Length > minStringLengthForThreshold then

--- a/src/fsharp/ErrorResolutionHints.fs
+++ b/src/fsharp/ErrorResolutionHints.fs
@@ -33,9 +33,17 @@ let FilterPredictions (idText:string) (suggestionF:ErrorLogger.Suggestions) =
             cleanName
         else nm
 
+    /// Returns `true` if given string is an operator display name, e.g. ( |>> )
+    let IsOperatorName (name: string) =
+        if not (name.StartsWith "( " && name.EndsWith " )") then false else
+        let name =  name.[2..name.Length - 3]
+        let res = name |> Seq.forall (fun c -> c <> ' ')
+        res        
+
     if allSuggestions.Contains idText then [] else // some other parsing error occurred
     allSuggestions
     |> Seq.choose (fun suggestion ->
+        if IsOperatorName suggestion then None else
         let suggestion:string = demangle suggestion
         let suggestedText = suggestion.ToUpperInvariant()
         let similarity = EditDistance.JaroWinklerDistance uppercaseText suggestedText

--- a/src/fsharp/ErrorResolutionHints.fs
+++ b/src/fsharp/ErrorResolutionHints.fs
@@ -27,9 +27,16 @@ let FilterPredictions (idText:string) (suggestionF:ErrorLogger.Suggestions) =
     let uppercaseText = idText.ToUpperInvariant()
     let allSuggestions = suggestionF()
 
+    let demangle (nm:string) =
+        if nm.StartsWith "( " && nm.EndsWith " )" then
+            let cleanName = nm.[2..nm.Length - 3]
+            cleanName
+        else nm
+
     if allSuggestions.Contains idText then [] else // some other parsing error occurred
     allSuggestions
     |> Seq.choose (fun suggestion ->
+        let suggestion:string = demangle suggestion
         let suggestedText = suggestion.ToUpperInvariant()
         let similarity = EditDistance.JaroWinklerDistance uppercaseText suggestedText
         if similarity >= highConfidenceThreshold || suggestion.EndsWith ("." + idText) then

--- a/src/fsharp/ErrorResolutionHints.fs
+++ b/src/fsharp/ErrorResolutionHints.fs
@@ -9,11 +9,11 @@ let highConfidenceThreshold = 0.85
 let minStringLengthForThreshold = 3
 
 /// We report a candidate if its edit distance is <= the threshold.
-/// The threshhold is set to about a quarter of the number of characters the user entered.
-let IsInEditDistanceProximity userEntered suggestion =
-    let editDistance = Internal.Utilities.EditDistance.CalcEditDistance(userEntered,suggestion)
+/// The threshhold is set to about a quarter of the number of characters.
+let IsInEditDistanceProximity idText suggestion =
+    let editDistance = Internal.Utilities.EditDistance.CalcEditDistance(idText,suggestion)
     let threshold =
-        match userEntered.Length with
+        match idText.Length with
         | x when x < 5 -> 1
         | x when x < 7 -> 2
         | x -> x / 4 + 1
@@ -21,16 +21,16 @@ let IsInEditDistanceProximity userEntered suggestion =
     editDistance <= threshold
 
 /// Filters predictions based on edit distance to the given unknown identifier.
-let FilterPredictions (userEntered:string) (suggestionF:ErrorLogger.Suggestions) =    
-    let uppercaseText = userEntered.ToUpperInvariant()
+let FilterPredictions (idText:string) (suggestionF:ErrorLogger.Suggestions) =    
+    let uppercaseText = idText.ToUpperInvariant()
     let allSuggestions = suggestionF()
 
-    if allSuggestions.Contains userEntered then [] else // some other parsing error occurred
+    if allSuggestions.Contains idText then [] else // some other parsing error occurred
     allSuggestions
     |> Seq.choose (fun suggestion ->
         let suggestedText = suggestion.ToUpperInvariant()
         let similarity = Internal.Utilities.EditDistance.JaroWinklerDistance uppercaseText suggestedText
-        if similarity >= highConfidenceThreshold || suggestion.EndsWith ("." + userEntered) then
+        if similarity >= highConfidenceThreshold || suggestion.EndsWith ("." + idText) then
             Some(similarity,suggestion)
         elif similarity < minThresholdForSuggestions && suggestedText.Length > minStringLengthForThreshold then
             None

--- a/src/fsharp/ErrorResolutionHints.fs
+++ b/src/fsharp/ErrorResolutionHints.fs
@@ -23,9 +23,11 @@ let IsInEditDistanceProximity userEntered suggestion =
 /// Filters predictions based on edit distance to the given unknown identifier.
 let FilterPredictions (userEntered:string) (suggestionF:ErrorLogger.Suggestions) =    
     let uppercaseText = userEntered.ToUpperInvariant()
-    suggestionF()
+    let allSuggestions = suggestionF()
+
+    if allSuggestions.Contains userEntered then [] else // some other parsing error occurred
+    allSuggestions
     |> Seq.choose (fun suggestion ->
-        if suggestion = userEntered then None else
         let suggestedText = suggestion.ToUpperInvariant()
         let similarity = Internal.Utilities.EditDistance.JaroWinklerDistance uppercaseText suggestedText
         if similarity >= highConfidenceThreshold || suggestion.EndsWith ("." + userEntered) then

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -2303,6 +2303,13 @@ let rec ResolveExprLongIdentPrim sink (ncenv:NameResolver) fullyQualified m ad n
                                       |> Seq.map (fun e -> e.Value.DisplayName)
                                       |> Set.ofSeq
 
+                                  let suggestedModulesAndNamespaces =
+                                      nenv.ModulesAndNamespaces fullyQualified
+                                      |> Seq.collect (fun kv -> kv.Value)
+                                      |> Seq.filter (fun modref -> IsEntityAccessible ncenv.amap m ad modref)
+                                      |> Seq.collect (fun e -> [e.DisplayName; e.DemangledModuleOrNamespaceName])
+                                      |> Set.ofSeq
+
                                   let unions =
                                       // check if the user forgot to use qualified access
                                       nenv.eTyconsByDemangledNameAndArity
@@ -2320,6 +2327,7 @@ let rec ResolveExprLongIdentPrim sink (ncenv:NameResolver) fullyQualified m ad n
                                 
                                   suggestedNames
                                   |> Set.union suggestedTypes
+                                  |> Set.union suggestedModulesAndNamespaces
                                   |> Set.union unions
 
                               raze (UndefinedName(0,FSComp.SR.undefinedNameValueOfConstructor,id,suggestNamesAndTypes))
@@ -2407,7 +2415,7 @@ let rec ResolveExprLongIdentPrim sink (ncenv:NameResolver) fullyQualified m ad n
 
                       search +++ moduleSearch +++ tyconSearch
 
-                  let suggestEverythingInScope() = 
+                  let suggestEverythingInScope() =
                       let suggestedModulesAndNamespaces =
                           nenv.ModulesAndNamespaces fullyQualified
                           |> Seq.collect (fun kv -> kv.Value)

--- a/tests/fsharp/typecheck/sigs/neg06.bsl
+++ b/tests/fsharp/typecheck/sigs/neg06.bsl
@@ -93,15 +93,15 @@ neg06.fs(128,53,128,61): typecheck error FS0043: A type parameter is missing a c
 
 neg06.fs(141,10,141,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(148,13,148,21): typecheck error FS0039: The value or constructor 'BadType1' is not defined. Maybe you want one of the following: BadType0
+neg06.fs(148,13,148,21): typecheck error FS0039: The value or constructor 'BadType1' is not defined.
 
 neg06.fs(150,10,150,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(157,13,157,21): typecheck error FS0039: The value or constructor 'BadType2' is not defined. Maybe you want one of the following: BadType0, BadType1
+neg06.fs(157,13,157,21): typecheck error FS0039: The value or constructor 'BadType2' is not defined.
 
 neg06.fs(159,10,159,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(166,13,166,21): typecheck error FS0039: The value or constructor 'BadType3' is not defined. Maybe you want one of the following: BadType0, BadType1, BadType2
+neg06.fs(166,13,166,21): typecheck error FS0039: The value or constructor 'BadType3' is not defined.
 
 neg06.fs(195,10,195,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
@@ -109,11 +109,11 @@ neg06.fs(203,13,203,21): typecheck error FS0039: The value or constructor 'BadTy
 
 neg06.fs(205,10,205,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(213,13,213,21): typecheck error FS0039: The value or constructor 'BadType2' is not defined. Maybe you want one of the following: BadType1
+neg06.fs(213,13,213,21): typecheck error FS0039: The value or constructor 'BadType2' is not defined.
 
 neg06.fs(215,10,215,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(223,13,223,21): typecheck error FS0039: The value or constructor 'BadType3' is not defined. Maybe you want one of the following: BadType1, BadType2
+neg06.fs(223,13,223,21): typecheck error FS0039: The value or constructor 'BadType3' is not defined.
 
 neg06.fs(294,10,294,12): typecheck error FS0009: Uses of this construct may result in the generation of unverifiable .NET IL code. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'.
 

--- a/tests/fsharpqa/Source/Warnings/DontSuggestWhenThingsAreOpen.fs
+++ b/tests/fsharpqa/Source/Warnings/DontSuggestWhenThingsAreOpen.fs
@@ -1,5 +1,5 @@
 // #Warnings
-//<Expects status="Error" id="FS0039">The value or constructor 'N' is not defined.$</Expects>
+//<Expects status="Error" id="FS0599">Missing qualification after '.'</Expects>
 
 module N =
     let name = "hallo"

--- a/tests/fsharpqa/Source/Warnings/DontSuggestWhenThingsAreOpen.fs
+++ b/tests/fsharpqa/Source/Warnings/DontSuggestWhenThingsAreOpen.fs
@@ -1,0 +1,13 @@
+// #Warnings
+//<Expects status="Error" id="FS0039">The value or constructor 'N' is not defined.$</Expects>
+
+module N =
+    let name = "hallo"
+
+type T =
+    static member myMember = 1
+
+let x = N.
+
+
+exit 0

--- a/tests/fsharpqa/Source/Warnings/SuggestDoubleBacktickIdentifiers.fs
+++ b/tests/fsharpqa/Source/Warnings/SuggestDoubleBacktickIdentifiers.fs
@@ -1,5 +1,5 @@
 // #Warnings
-//<Expects status="Error" span="(7,11,7,25)" id="FS0039">The value, constructor, namespace or type 'longe name' is not defined.</Expects>
+//<Expects status="Error" span="(7,11,7,25)" id="FS0039">The value, constructor, namespace or type 'longe name' is not defined. Maybe you want one of the following: longer name$</Expects>
 
 module N =
     let ``longer name`` = "hallo"

--- a/tests/fsharpqa/Source/Warnings/env.lst
+++ b/tests/fsharpqa/Source/Warnings/env.lst
@@ -38,6 +38,7 @@
 	SOURCE=DontSuggestCompletelyWrongStuff.fs SCFLAGS="--vserrors" # DontSuggestCompletelyWrongStuff.fs
 	SOURCE=SuggestTypesInNamespaceVS.fs SCFLAGS="--vserrors" # SuggestTypesInNamespaceVS.fs
 	SOURCE=SuggestAsyncModule.fs SCFLAGS="--vserrors" # SuggestAsyncModule.fs
+	SOURCE=DontSuggestWhenThingsAreOpen.fs SCFLAGS="--vserrors" # DontSuggestWhenThingsAreOpen.fs
 	SOURCE=SuggestDoubleBacktickIdentifiers.fs SCFLAGS="--vserrors" # SuggestDoubleBacktickIdentifiers.fs
 	SOURCE=ElseBranchHasWrongType.fs # ElseBranchHasWrongType.fs
 	SOURCE=ElseBranchHasWrongType2.fs # ElseBranchHasWrongType2.fs

--- a/vsintegration/src/FSharp.Editor/CodeFix/ReplaceWithSuggestion.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ReplaceWithSuggestion.fs
@@ -40,16 +40,17 @@ type internal FSharpReplaceWithSuggestionCodeFixProvider() =
                 let parts = message.Split([| maybeString |], StringSplitOptions.None)
                 if parts.Length > 1 then
                     let suggestions = 
-                        parts.[1].Split([|' '; '\r'; '\n'|], StringSplitOptions.RemoveEmptyEntries) 
+                        parts.[1].Split([| '\r'; '\n'|], StringSplitOptions.RemoveEmptyEntries) 
                         |> Array.map (fun s -> s.Trim())
                     
                     let diagnostics = [| diagnostic |].ToImmutableArray()
 
                     for suggestion in suggestions do
+                        let replacement = if suggestion.Contains " " then "``" + suggestion + "``" else suggestion
                         let codefix = 
                             createCodeFix(
                                 FSComp.SR.replaceWithSuggestion suggestion, 
                                 context,
-                                TextChange(context.Span, suggestion))
+                                TextChange(context.Span, replacement))
                         context.RegisterCodeFix(codefix, diagnostics))
         } |> CommonRoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)


### PR DESCRIPTION
this is a partial fix for #2214 

When we detect that the identifier itself is in scope, then we don't suggest stuff since there are good chances that something else went wrong.
In this case we don't suggest anything since quickfix tooling interfers with autocomplete.