### PR TITLE
Make breakpoints break again

### DIFF
--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -345,12 +345,7 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
                 
                 match locations |> List.filter (fun m -> rangeContainsPos m pos) with
                 | [] -> Seq.tryHead locations
-                | first::rest -> 
-                    let smallest = ref first
-                    for current in rest do
-                        if rangeContainsRange !smallest current then
-                            smallest := current
-                    Some !smallest)
+                | locations -> Seq.tryLast locations)
             (fun _msg -> None)  
             
     /// When these files appear or disappear the configuration for the current project is invalidated.

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -340,8 +340,18 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
  
         ErrorScope.Protect 
             Range.range0 
-            (fun () -> findBreakPoints() |> List.tryLast)
-            (fun _msg -> None)   
+            (fun () -> 
+                let locations = findBreakPoints()
+                
+                match locations |> List.filter (fun m -> rangeContainsPos m pos) with
+                | [] -> Seq.tryHead locations
+                | first::rest -> 
+                    let smallest = ref first
+                    for current in rest do
+                        if rangeContainsRange !smallest current then
+                            smallest := current
+                    Some !smallest)
+            (fun _msg -> None)  
             
     /// When these files appear or disappear the configuration for the current project is invalidated.
     member scope.DependencyFiles = dependencyFiles


### PR DESCRIPTION
fixes #2229

I made two changes:

1) from all locations that are emitted we take the first that full covers our range (and not just is in the same line)
2) I made the AST traversal lazy, since we don't need to scan the whole tree
