### PR TITLE
append a timestamp to the VSIX version number

### DIFF
--- a/src/Microbuild.Settings.targets
+++ b/src/Microbuild.Settings.targets
@@ -226,6 +226,28 @@
       <Compile Include="@(TempCompile)" />
     </ItemGroup>
   </Target>
-  
+
+  <Target Name="GetVsixPackageVersion" Outputs="$(VsixPackageVersion)">
+   <PropertyGroup>
+     <!--
+
+     Given $(BUILD_BUILDNUMBER) = '20161225.1'
+     Given $(MicroBuildAssemblyVersion) = '15.4.1.0'
+
+     Then $(BuildTimeStamp_Day) = 161225
+     Then $(BuildTimeStamp_Number) = 01
+     Then $(BuildTimeStamp) = 16122501
+     Then $(MicroBuildAssemblyVersion_WithoutRevision) = 15.4.1
+     Then $(VsixPackageVersion) = 15.4.1.16122501
+
+     -->
+     <BuildTimeStamp_Day>$(BUILD_BUILDNUMBER.Split('.')[0].Substring(2))</BuildTimeStamp_Day>
+     <BuildTimeStamp_Number>$(BUILD_BUILDNUMBER.Split('.')[1].PadLeft(2, '0'))</BuildTimeStamp_Number>
+     <BuildTimeStamp>$(BuildTimeStamp_Day)$(BuildTimeStamp_Number)</BuildTimeStamp>
+     <MicroBuildAssemblyVersion_WithoutRevision>$(MicroBuildAssemblyVersion.Substring(0, $(MicroBuildAssemblyVersion.LastIndexOf('.'))))</MicroBuildAssemblyVersion_WithoutRevision>
+     <VsixPackageVersion>$(MicroBuildAssemblyVersion_WithoutRevision).$(BuildTimeStamp)</VsixPackageVersion>
+   </PropertyGroup>
+ </Target>
+
   <Import Project="..\packages\MicroBuild.Core.$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
 </Project>

--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="VisualFSharp" Version="15.4.1.0" Language="en-US" Publisher="Microsoft.VisualFSharpTools" />
+    <Identity Id="VisualFSharp" Version="|%CurrentProject%;GetVsixPackageVersion|" Language="en-US" Publisher="Microsoft.VisualFSharpTools" />
     <DisplayName>Visual F# Tools</DisplayName>
     <Description xml:space="preserve">Deploy Visual F# Tools templates to Visual Studio</Description>
     <PackageId>Microsoft.FSharp.VSIX.Full.Core</PackageId>

--- a/vsintegration/Vsix/VisualFSharpOpenSource/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpOpenSource/Source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="VisualFSharp" Version="15.4.1.9055" Language="en-US" Publisher="Microsoft.VisualFSharpTools" />
+    <Identity Id="VisualFSharp" Version="42.42.42.42" Language="en-US" Publisher="Microsoft.VisualFSharpTools" />
     <DisplayName>Visual F# Tools</DisplayName>
     <Description xml:space="preserve">Deploy Visual F# Tools templates to Visual Studio</Description>
     <PackageId>Microsoft.FSharp.VSIX.OpenSource.Core</PackageId>


### PR DESCRIPTION
The result of this is that the version of VisualFSharpFull.vsix will now be 15.4.1.17011201 instead of 15.4.1.0.  Assembly versions are staying the same.