### PR TITLE
Breakpoints should be faster

### DIFF
--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -107,9 +107,11 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
             (fun _ -> NavigationImpl.empty)   
             
     member private scope.ValidateBreakpointLocationImpl(pos) =
+        let isMatchRange m = rangeContainsPos m pos || m.StartLine = pos.Line
+
         // Process let-binding
         let findBreakPoints () = 
-            let checkRange m = [ if rangeContainsPos m pos || m.StartLine = pos.Line then yield m ]
+            let checkRange m = [ if isMatchRange m then yield m ]
             let walkBindSeqPt sp = [ match sp with SequencePointAtBinding m -> yield! checkRange m | _ -> () ]
             let walkForSeqPt sp = [ match sp with SequencePointAtForLoop m -> yield! checkRange m | _ -> () ]
             let walkWhileSeqPt sp = [ match sp with SequencePointAtWhileLoop m -> yield! checkRange m | _ -> () ]
@@ -140,13 +142,24 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
 
             and walkExprOpt (spAlways:bool) eOpt = [ match eOpt with Some e -> yield! walkExpr spAlways e | _ -> () ]
             
+            and IsBreakableExpression e =
+                match e with
+                | SynExpr.Match _
+                | SynExpr.IfThenElse _
+                | SynExpr.For _
+                | SynExpr.ForEach _
+                | SynExpr.While _ -> true
+                | _ -> not (IsControlFlowExpression e)
+
             // Determine the breakpoint locations for an expression. spAlways indicates we always
             // emit a breakpoint location for the expression unless it is a syntactic control flow construct
-            and walkExpr (spAlways:bool)  e = 
-                [ if spAlways && not (IsControlFlowExpression e) then 
-                      yield! checkRange e.Range
-                  match e with 
+            and walkExpr (spAlways:bool)  e =
+                let m = e.Range
+                if not (isMatchRange m) then [] else
+                [ if spAlways && IsBreakableExpression e then 
+                      yield! checkRange m
 
+                  match e with
                   | SynExpr.ArbitraryAfterError _ 
                   | SynExpr.LongIdent _
                   | SynExpr.LibraryOnlyILAssembly _
@@ -280,7 +293,7 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
             
             // Process a class declaration or F# type declaration
             let rec walkTycon (TypeDefn(ComponentInfo(_, _, _, _, _, _, _, _), repr, membDefns, m)) =
-                if not (rangeContainsPos m pos) then [] else
+                if not (isMatchRange m) then [] else
                 [ for memb in membDefns do yield! walkMember memb
                   match repr with
                   | SynTypeDefnRepr.ObjectModel(_, membDefns, _) -> 
@@ -305,24 +318,24 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
             // (such as type declarations, nested modules etc.)                            
             let rec walkDecl decl = 
                 [ match decl with 
-                  | SynModuleDecl.Let(_, binds, m) when rangeContainsPos m pos -> 
+                  | SynModuleDecl.Let(_, binds, m) when isMatchRange m -> 
                       yield! walkBinds binds
-                  | SynModuleDecl.DoExpr(spExpr,expr, m) when rangeContainsPos m pos ->  
+                  | SynModuleDecl.DoExpr(spExpr,expr, m) when isMatchRange m ->  
                       yield! walkBindSeqPt spExpr
                       yield! walkExpr false expr
                   | SynModuleDecl.ModuleAbbrev _ -> ()
-                  | SynModuleDecl.NestedModule(_, _isRec, decls, _, m) when rangeContainsPos m pos ->
+                  | SynModuleDecl.NestedModule(_, _isRec, decls, _, m) when isMatchRange m ->
                       for d in decls do yield! walkDecl d
-                  | SynModuleDecl.Types(tydefs, m) when rangeContainsPos m pos -> 
+                  | SynModuleDecl.Types(tydefs, m) when isMatchRange m -> 
                       for d in tydefs do yield! walkTycon d
                   | SynModuleDecl.Exception(SynExceptionDefn(SynExceptionDefnRepr(_, _, _, _, _, _), membDefns, _), m) 
-                        when rangeContainsPos m pos ->
+                        when isMatchRange m ->
                       for m in membDefns do yield! walkMember m
                   | _ -> () ] 
                       
             // Collect all the items in a module  
             let walkModule (SynModuleOrNamespace(_,_,_,decls,_,_,_,m)) =
-                if rangeContainsPos m pos then
+                if isMatchRange m then
                     List.collect walkDecl decls
                 else
                     []
@@ -339,11 +352,13 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
             (fun () -> 
                 let locations = findBreakPoints()
                 
-                printfn "%A" locations
                 match locations |> List.filter (fun m -> rangeContainsPos m pos) with
-                | [] -> Seq.tryHead locations
-                | locations -> Seq.tryLast locations)
-            (fun _msg -> None)  
+                | [] ->
+                    match locations |> List.filter (fun m -> rangeBeforePos m pos |> not) with
+                    | [] -> Seq.tryHead locations
+                    | locationsAfterPos -> Seq.tryHead locationsAfterPos
+                | coveringLocations -> Seq.tryLast coveringLocations)
+            (fun _msg -> None)
             
     /// When these files appear or disappear the configuration for the current project is invalidated.
     member scope.DependencyFiles = dependencyFiles


### PR DESCRIPTION
This does the following:

* Expressions are filtered so that we don't evaluate parts of the tree that don't matter
* We allow breakpoints to be set from more positions