### PR TITLE
Ensure that fsharp sdk msi uses correct component guids.

### DIFF
--- a/setup/FSharp.SDK/component-groups/Runtime_Redist.wxs
+++ b/setup/FSharp.SDK/component-groups/Runtime_Redist.wxs
@@ -78,7 +78,7 @@
     <!-- F# 4.0 -->
 
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.4.0.0">
-      <Component Id="Runtime_Redist_4.4.0.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_4.4.0.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_4.4.0.0_FSharp.Core" Transitive="yes" Guid="DA07D2FE-8B67-566A-A48C-88AB3188BBCA">
         <File Id="Runtime_Redist_4.4.0.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.4.0.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_4.4.0.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.4.0.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_4.4.0.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.4.0.0\FSharp.Core.sigdata" />
@@ -86,7 +86,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_3.47.4.0">
-      <Component Id="Runtime_Redist_3.47.4.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_3.47.4.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_3.47.4.0_FSharp.Core" Transitive="yes" Guid="37873912-7DAC-5992-9FEA-92CF91857AA8">
         <File Id="Runtime_Redist_3.47.4.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\3.47.4.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_3.47.4.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\3.47.4.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_3.47.4.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\3.47.4.0\FSharp.Core.sigdata" />
@@ -94,7 +94,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.7.4.0">
-      <Component Id="Runtime_Redist_3.7.4.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_3.7.4.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_3.7.4.0_FSharp.Core" Transitive="yes" Guid="1574403D-39A7-5946-A982-AF82AAC8D7EB">
         <File Id="Runtime_Redist_3.7.4.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.7.4.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_3.7.4.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.7.4.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_3.7.4.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.7.4.0\FSharp.Core.sigdata" />
@@ -102,7 +102,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.4.0">
-      <Component Id="Runtime_Redist_3.78.4.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_3.78.4.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_3.78.4.0_FSharp.Core" Transitive="yes" Guid="38863225-7332-5676-B315-D075D92EE7B3">
         <File Id="Runtime_Redist_3.78.4.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.78.4.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_3.78.4.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.78.4.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_3.78.4.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.78.4.0\FSharp.Core.sigdata" />
@@ -110,7 +110,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.4.0">
-      <Component Id="Runtime_Redist_3.259.4.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_3.259.4.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_3.259.4.0_FSharp.Core" Transitive="yes" Guid="DCD97222-B0CF-5CA6-AFED-E12CA45E3A50">
         <File Id="Runtime_Redist_3.259.4.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.259.4.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_3.259.4.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.259.4.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_3.259.4.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.259.4.0\FSharp.Core.sigdata" />
@@ -121,7 +121,7 @@
     <!-- F# 3.1 -->
 
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.1.0">
-      <Component Id="Runtime_Redist_4.3.1.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_4.3.1.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_4.3.1.0_FSharp.Core" Transitive="yes" Guid="4A1993AA-FA5A-45E5-A08C-7A1887DA52B9">
         <File Id="Runtime_Redist_4.3.1.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.3.1.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_4.3.1.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.3.1.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_4.3.1.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.3.1.0\FSharp.Core.sigdata" />
@@ -129,7 +129,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.1">
-      <Component Id="Runtime_Redist_2.3.5.1_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_2.3.5.1_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_2.3.5.1_FSharp.Core" Transitive="yes" Guid="32033C8F-1065-453D-B97F-382FA8E47711">
         <File Id="Runtime_Redist_2.3.5.1_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\2.3.5.1\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_2.3.5.1_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\2.3.5.1\FSharp.Core.xml" />
         <File Id="Runtime_Redist_2.3.5.1_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\2.3.5.1\FSharp.Core.sigdata" />
@@ -137,7 +137,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.3.1.0">
-      <Component Id="Runtime_Redist_3.3.1.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_3.3.1.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_3.3.1.0_FSharp.Core" Transitive="yes" Guid="66247184-2DBA-45FC-8F6C-620DB406D01E">
         <File Id="Runtime_Redist_3.3.1.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.3.1.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_3.3.1.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.3.1.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_3.3.1.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.3.1.0\FSharp.Core.sigdata" />
@@ -145,7 +145,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.78.3.1">
-      <Component Id="Runtime_Redist_3.78.3.1_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_3.78.3.1_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_3.78.3.1_FSharp.Core" Transitive="yes" Guid="4E980E06-B1D8-4CE1-AA06-8BECA0CE042F">
         <File Id="Runtime_Redist_3.78.3.1_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.78.3.1\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_3.78.3.1_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.78.3.1\FSharp.Core.xml" />
         <File Id="Runtime_Redist_3.78.3.1_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.78.3.1\FSharp.Core.sigdata" />
@@ -153,7 +153,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETCore_3.259.3.1">
-      <Component Id="Runtime_Redist_3.259.3.1_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_3.259.3.1_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_3.259.3.1_FSharp.Core" Transitive="yes" Guid="F0C04DA6-86D2-49DF-9348-E8A69B95EA70">
         <File Id="Runtime_Redist_3.259.3.1_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.259.3.1\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_3.259.3.1_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.259.3.1\FSharp.Core.xml" />
         <File Id="Runtime_Redist_3.259.3.1_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETCore\3.259.3.1\FSharp.Core.sigdata" />
@@ -164,7 +164,7 @@
     <!-- F# 3.0 -->
 
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETFramework_4.0_4.3.0.0">
-      <Component Id="Runtime_Redist_4.3.0.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_4.3.0.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_4.3.0.0_FSharp.Core" Transitive="yes" Guid="A0608A0C-5B4A-439E-B058-5930433BF254">
         <File Id="Runtime_Redist_4.3.0.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_4.3.0.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.3.0.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_4.3.0.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETFramework\v4.0\4.3.0.0\FSharp.Core.sigdata" />
@@ -172,7 +172,7 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="ReferenceAssemblies_Microsoft_FSharp_NETPortable_2.3.5.0">
-      <Component Id="Runtime_Redist_2.3.5.0_FSharp.Core" Transitive="yes" Guid="$(fsharp.guid(Runtime_Redist_2.3.5.0_FSharp.Core, $(var.LocaleCode)))">
+      <Component Id="Runtime_Redist_2.3.5.0_FSharp.Core" Transitive="yes" Guid="AFE254E7-FC12-4F7D-A804-9DF009BFBD8E">
         <File Id="Runtime_Redist_2.3.5.0_FSharp.Core.dll" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\2.3.5.0\FSharp.Core.dll" KeyPath="yes" />
         <File Id="Runtime_Redist_2.3.5.0_FSharp.Core.xml" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\2.3.5.0\FSharp.Core.xml" />
         <File Id="Runtime_Redist_2.3.5.0_FSharp.Core.sigdata" Source="$(var.NugetPackagesDir)\Microsoft.VisualFSharp.Core.Redist.1.0.0\content\.NETPortable\2.3.5.0\FSharp.Core.sigdata" />


### PR DESCRIPTION
* Fix fscorelocation on coreclr when no fsharp.core dll was provided
* Ensure that the installer has the correct component guids for SDK items shipped previously

FYI @KevinRansom