### PR TITLE
Optimize Mapfold

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -334,7 +334,8 @@ module List =
     let mapFold (f:'a -> 'b -> 'c * 'a) (s:'a) (l:'b list) : 'c list * 'a = 
         match l with
         | [] -> [], s
-        | [h] -> let h',s' = f s h
+        | [h] -> let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
+                 let h',s' = f.Invoke(s, h)
                  [h'], s'
         | _ -> 
             List.mapFold f s l

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -332,14 +332,12 @@ module List =
 
     // must be tail recursive 
     let mapFold (f:'a -> 'b -> 'c * 'a) (s:'a) (l:'b list) : 'c list * 'a = 
-        // microbenchmark suggested this implementation is faster than the simpler recursive one, and this function is called a lot
-        let mutable s = s
-        let mutable r = []
-        for x in l do
-            let x',s' = f s x
-            s <- s'
-            r <- x' :: r
-        List.rev r, s
+        match l with
+        | [] -> [], s
+        | [h] -> let h',s' = f s h
+                 [h'], s'
+        | _ -> 
+            List.mapFold f s l
 
     // Not tail recursive 
     let rec mapFoldBack f l s = 


### PR DESCRIPTION
@dsyme 
Can you run the compilerperf script to see if this makes a difference?

This is attempt to optimize the `mapFold` function in `illib`, which is called a lot. 

I first measured the size of the lists that get passed into it by using `fsc` to compile the `FSharp.Core` library and having it output to console the size of the lists. I found that around 42% of all the lists passed in are empty, 39% of all the lists passed in have size 1, and 14% of all lists passed in have size 2. Here's a graph displaying it (note the log scale). 
![a](https://cloud.githubusercontent.com/assets/13482895/22029726/70ba2ba4-dca9-11e6-8497-8ab52fff81fb.png)


Because of this I added in extra conditions to optimize for the null and size 1 cases. For larger lists, I use `List.mapFold` because that prevents us having to use `List.rev`, which is quite expensive. Below are my benchmark results and the [script ](https://gist.github.com/liboz/b17cc1740f5bdfdd0bc516df72b55081)I used to generate it. It is marginally faster for size 0 and 1 lists and much faster for lists larger than that.


|         Method |       Jit | Platform | count |        Mean |    StdDev |  Gen 0 | Allocated |    Gen 0 |
|--------------- |---------- |--------- |------ |------------ |---------- |------- |---------- |--------- |
| mapFoldLibrary | LegacyJit |      X86 |     0 |   **7.9820 ns** | 0.1351 ns | 0.0084 |      28 B |   232.09 |
|            old | LegacyJit |      X86 |     0 |  10.2546 ns | 0.0811 ns | 0.0081 |      28 B |   197.42 |
| mapFoldLibrary |    RyuJit |      X64 |     0 |   **9.8685 ns** | 0.2399 ns | 0.0170 |      56 B |   372.15 |
|            old |    RyuJit |      X64 |     0 |  12.6970 ns | 0.3386 ns | 0.0170 |      56 B |   342.35 |
| mapFoldLibrary | LegacyJit |      X86 |     1 |  **36.0709 ns** | 0.6886 ns | 0.0173 |      60 B |   476.19 |
|            old | LegacyJit |      X86 |     1 |  38.5328 ns | 0.4145 ns | 0.0174 |      60 B |   412.70 |
| mapFoldLibrary |    RyuJit |      X64 |     1 |  **22.1181 ns** | 0.1698 ns | 0.0339 |     112 B |   774.00 |
|            old |    RyuJit |      X64 |     1 |  25.6891 ns | 0.3070 ns | 0.0339 |     112 B |   684.60 |
| mapFoldLibrary | LegacyJit |      X86 |     2 |  **50.4253 ns** | 0.4492 ns | 0.0259 |      92 B |   609.00 |
|            old | LegacyJit |      X86 |     2 |  76.3954 ns | 0.3959 ns | 0.0361 |     124 B |   953.79 |
| mapFoldLibrary |    RyuJit |      X64 |     2 |  **40.0407 ns** | 0.2898 ns | 0.0518 |     168 B | 1,100.36 |
|            old |    RyuJit |      X64 |     2 |  49.3331 ns | 0.1614 ns | 0.0706 |     232 B | 1,543.40 |
| mapFoldLibrary | LegacyJit |      X86 |     3 |  **58.8695 ns** | 0.4564 ns | 0.0364 |     124 B |   947.50 |
|            old | LegacyJit |      X86 |     3 | 106.5111 ns | 1.2117 ns | 0.0483 |     172 B | 1,047.20 |
| mapFoldLibrary |    RyuJit |      X64 |     3 |  **50.3711 ns** | 0.7742 ns | 0.0680 |     224 B | 1,488.60 |
|            old |    RyuJit |      X64 |     3 |  67.6240 ns | 0.3922 ns | 0.0985 |     320 B | 2,128.60 |
| mapFoldLibrary | LegacyJit |      X86 |     4 |  **67.2295 ns** | 0.1917 ns | 0.0464 |     156 B |   950.80 |
|            old | LegacyJit |      X86 |     4 | 136.2848 ns | 0.5413 ns | 0.0634 |     220 B | 1,750.15 |
| mapFoldLibrary |    RyuJit |      X64 |     4 |  **61.6003 ns** | 0.2595 ns | 0.0859 |     280 B | 1,714.00 |
|            old |    RyuJit |      X64 |     4 |  86.0856 ns | 0.6507 ns | 0.1234 |     408 B | 3,057.18 |
| mapFoldLibrary | LegacyJit |      X86 |     5 |  **76.8845 ns** | 0.3080 ns | 0.0565 |     188 B | 1,248.60 |
|            old | LegacyJit |      X86 |     5 | 167.2817 ns | 2.7596 ns | 0.0786 |     268 B | 1,905.00 |
| mapFoldLibrary |    RyuJit |      X64 |     5 |  **71.2625 ns** | 0.4908 ns | 0.1035 |     336 B | 2,296.93 |
|            old |    RyuJit |      X64 |     5 | 104.8573 ns | 0.6288 ns | 0.1507 |     496 B | 4,261.38 |
| mapFoldLibrary | LegacyJit |      X86 |    10 | **124.1846 ns** | 3.7853 ns | 0.1039 |     348 B | 2,373.00 |
|            old | LegacyJit |      X86 |    10 | 327.2854 ns | 4.6879 ns | 0.1485 |     508 B | 4,220.00 |
| mapFoldLibrary |    RyuJit |      X64 |    10 | **120.4639 ns** | 1.4605 ns | 0.1894 |     616 B | 4,213.29 |
|            old |    RyuJit |      X64 |    10 | 205.6105 ns | 3.1472 ns | 0.2851 |     936 B | 5,714.40 |
