### PR TITLE
simplify NonLocalEntityRef.Path.Length check in tastops

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -2488,11 +2488,11 @@ let fullNameOfPubPath (PubPath(p)) = textOfPath p
 let fullNameOfPubPathAsLayout (PubPath(p)) = layoutOfPath (Array.toList p)
 
 let fullNameOfParentOfNonLocalEntityRef (nlr: NonLocalEntityRef) = 
-    if nlr.Path.Length = 0 || nlr.Path.Length = 1 then None
+    if nlr.Path.Length < 2 then None
     else Some (textOfPath nlr.EnclosingMangledPath)  // <--- BAD BAD BAD: this is a mangled path. This is wrong for nested modules
 
 let fullNameOfParentOfNonLocalEntityRefAsLayout (nlr: NonLocalEntityRef) = 
-    if nlr.Path.Length = 0 || nlr.Path.Length = 1 then None
+    if nlr.Path.Length < 2 then None
     else Some (layoutOfPath (List.ofArray nlr.EnclosingMangledPath))  // <--- BAD BAD BAD: this is a mangled path. This is wrong for nested modules
 
 let fullNameOfParentOfEntityRef eref = 


### PR DESCRIPTION
Tastops.fullNameOfParentOfNonLocalEntityRef and Tastops.fullNameOfParentOfNonLocalEntityRefAsLayout used to perform two comparison by accessing nested properties (up to 4 get per call: `nlr.Path.Length = 0 || nlr.Path.Length = 1`)

replaced with `nlr.Path.Length < 2`