### PR TITLE
optimize IL.prependInstrsToCode with Array.concat

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -2496,7 +2496,7 @@ let prependInstrsToCode (instrs: ILInstr list) (c2: ILCode) =
     // If there is a sequence point as the first instruction then keep it at the front
     | I_seqpoint _ as i0 -> 
         { c2 with Labels = Dictionary.ofList [ for kvp in c2.Labels -> (kvp.Key, if kvp.Value = 0 then 0 else kvp.Value + n) ]
-                  Instrs = Array.concat [| i0 ;instrs; c2.Instrs.[1..] |] }
+                  Instrs = Array.concat [| [|i0|] ; instrs ; c2.Instrs.[1..] |] }
     | _ -> 
         { c2 with Labels = Dictionary.ofList [ for kvp in c2.Labels -> (kvp.Key, kvp.Value + n) ]
                   Instrs = Array.append instrs c2.Instrs }

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -2496,7 +2496,7 @@ let prependInstrsToCode (instrs: ILInstr list) (c2: ILCode) =
     // If there is a sequence point as the first instruction then keep it at the front
     | I_seqpoint _ as i0 -> 
         { c2 with Labels = Dictionary.ofList [ for kvp in c2.Labels -> (kvp.Key, if kvp.Value = 0 then 0 else kvp.Value + n) ]
-                  Instrs = Array.append [| i0 |] (Array.append instrs c2.Instrs.[1..]) }
+                  Instrs = Array.concat [| i0 ;instrs; c2.Instrs.[1..] |] }
     | _ -> 
         { c2 with Labels = Dictionary.ofList [ for kvp in c2.Labels -> (kvp.Key, kvp.Value + n) ]
                   Instrs = Array.append instrs c2.Instrs }


### PR DESCRIPTION
`Array.append a (Array.append b c)` seems to be always slower and more wasteful in allocation than `Array.concat [|a;b;c|]`, it probably shouldn't be used in IL.prependInstrsToCode.

In simple test from FSI (I know it is not proper way), even with empty arrays, we save a good deal of allocation and when arrays are not empty, significant time as well on that operation.

This is a quick fix but it might be worth creating the new array in a single shot because there is still `c2.Instrs.[1..]` which allocates a new array (moreover this array tend to be the biggest one in all the cases it is not empty).

@dsyme I wonder if you can run compiler perf test to check if it has a visible impact in case it doesn't take you long?

Also, I don't have a clue what this code is for, but if someone can put a small sentence in the code explaining why we recreate labels and instructions this way, that would be great.