### PR TITLE
Deprecate dictionary.of list

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -2496,14 +2496,14 @@ let prependInstrsToCode (instrs: ILInstr list) (c2: ILCode) =
     // If there is a sequence point as the first instruction then keep it at the front
     | I_seqpoint _ as i0 ->
         let labels = 
-            let dict = Dictionary<_,_>(c2.Labels.Count)
+            let dict = Dictionary.newWithSize c2.Labels.Count
             for kvp in c2.Labels do dict.Add(kvp.Key, if kvp.Value = 0 then 0 else kvp.Value + n)
             dict
         { c2 with Labels = labels
                   Instrs = Array.concat [| [|i0|] ; instrs ; c2.Instrs.[1..] |] }
     | _ ->
         let labels =
-            let dict = Dictionary<_,_>(c2.Labels.Count)
+            let dict = Dictionary.newWithSize c2.Labels.Count
             for kvp in c2.Labels do dict.Add(kvp.Key, kvp.Value + n)
             dict
         { c2 with Labels = labels

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -2494,11 +2494,19 @@ let prependInstrsToCode (instrs: ILInstr list) (c2: ILCode) =
     let n = instrs.Length
     match c2.Instrs.[0] with 
     // If there is a sequence point as the first instruction then keep it at the front
-    | I_seqpoint _ as i0 -> 
-        { c2 with Labels = Dictionary.ofList [ for kvp in c2.Labels -> (kvp.Key, if kvp.Value = 0 then 0 else kvp.Value + n) ]
-                  Instrs = Array.append [| i0 |] (Array.append instrs c2.Instrs.[1..]) }
-    | _ -> 
-        { c2 with Labels = Dictionary.ofList [ for kvp in c2.Labels -> (kvp.Key, kvp.Value + n) ]
+    | I_seqpoint _ as i0 ->
+        let labels = 
+            let dict = Dictionary<_,_>(c2.Labels.Count)
+            for kvp in c2.Labels do dict.Add(kvp.Key, if kvp.Value = 0 then 0 else kvp.Value + n)
+            dict
+        { c2 with Labels = labels
+                  Instrs = Array.concat [| [|i0|] ; instrs ; c2.Instrs.[1..] |] }
+    | _ ->
+        let labels =
+            let dict = Dictionary<_,_>(c2.Labels.Count)
+            for kvp in c2.Labels do dict.Add(kvp.Key, kvp.Value + n)
+            dict
+        { c2 with Labels = labels
                   Instrs = Array.append instrs c2.Instrs }
 
 let prependInstrsToMethod new_code md  = 

--- a/src/absil/ilbinary.fs
+++ b/src/absil/ilbinary.fs
@@ -758,36 +758,40 @@ let isNoArgInstr i =
   | _ -> false
 
 let ILCmpInstrMap = 
-   lazy
-    (Dictionary.ofList
-        [ BI_beq , i_beq
-          BI_bgt , i_bgt
-          BI_bgt_un , i_bgt_un
-          BI_bge , i_bge
-          BI_bge_un , i_bge_un
-          BI_ble , i_ble
-          BI_ble_un , i_ble_un
-          BI_blt , i_blt
-          BI_blt_un , i_blt_un
-          BI_bne_un , i_bne_un
-          BI_brfalse , i_brfalse
-          BI_brtrue , i_brtrue ])
+    lazy (
+        let dict = new System.Collections.Generic.Dictionary<_,_>(12)
+        dict.Add (BI_beq     , i_beq     )
+        dict.Add (BI_bgt     , i_bgt     )
+        dict.Add (BI_bgt_un  , i_bgt_un  )
+        dict.Add (BI_bge     , i_bge     )
+        dict.Add (BI_bge_un  , i_bge_un  )
+        dict.Add (BI_ble     , i_ble     )
+        dict.Add (BI_ble_un  , i_ble_un  )
+        dict.Add (BI_blt     , i_blt     )
+        dict.Add (BI_blt_un  , i_blt_un  )
+        dict.Add (BI_bne_un  , i_bne_un  )
+        dict.Add (BI_brfalse , i_brfalse )
+        dict.Add (BI_brtrue  , i_brtrue  )
+        dict
+    )
 
 let ILCmpInstrRevMap = 
-  lazy
-    (Dictionary.ofList
-        [ BI_beq , i_beq_s
-          BI_bgt , i_bgt_s
-          BI_bgt_un , i_bgt_un_s
-          BI_bge , i_bge_s
-          BI_bge_un , i_bge_un_s
-          BI_ble , i_ble_s
-          BI_ble_un , i_ble_un_s
-          BI_blt , i_blt_s
-          BI_blt_un , i_blt_un_s
-          BI_bne_un , i_bne_un_s
-          BI_brfalse , i_brfalse_s
-          BI_brtrue , i_brtrue_s ])
+  lazy (
+      let dict = new System.Collections.Generic.Dictionary<_,_>(12)
+      dict.Add ( BI_beq     , i_beq_s     )
+      dict.Add ( BI_bgt     , i_bgt_s     )
+      dict.Add ( BI_bgt_un  , i_bgt_un_s  )
+      dict.Add ( BI_bge     , i_bge_s     )
+      dict.Add ( BI_bge_un  , i_bge_un_s  )
+      dict.Add ( BI_ble     , i_ble_s     )
+      dict.Add ( BI_ble_un  , i_ble_un_s  )
+      dict.Add ( BI_blt     , i_blt_s     )
+      dict.Add ( BI_blt_un  , i_blt_un_s  )
+      dict.Add ( BI_bne_un  , i_bne_un_s  )
+      dict.Add ( BI_brfalse , i_brfalse_s )
+      dict.Add ( BI_brtrue  , i_brtrue_s  )
+      dict
+  )
 
 // From corhdr.h 
 

--- a/src/absil/ilbinary.fs
+++ b/src/absil/ilbinary.fs
@@ -759,7 +759,7 @@ let isNoArgInstr i =
 
 let ILCmpInstrMap = 
     lazy (
-        let dict = new System.Collections.Generic.Dictionary<_,_>(12)
+        let dict = Dictionary.newWithSize 12
         dict.Add (BI_beq     , i_beq     )
         dict.Add (BI_bgt     , i_bgt     )
         dict.Add (BI_bgt_un  , i_bgt_un  )
@@ -777,7 +777,7 @@ let ILCmpInstrMap =
 
 let ILCmpInstrRevMap = 
   lazy (
-      let dict = new System.Collections.Generic.Dictionary<_,_>(12)
+      let dict = Dictionary.newWithSize 12
       dict.Add ( BI_beq     , i_beq_s     )
       dict.Add ( BI_bgt     , i_bgt_s     )
       dict.Add ( BI_bgt_un  , i_bgt_un_s  )

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -440,13 +440,6 @@ module String =
 
     let dropSuffix s t = match (tryDropSuffix s t) with Some(res) -> res | None -> failwith "dropSuffix"
 
-module Dictionary = 
-
-    let inline ofList l = 
-        let dict = new System.Collections.Generic.Dictionary<_,_>(List.length l, HashIdentity.Structural)
-        l |> List.iter (fun (k,v) -> dict.Add(k,v))
-        dict
-        
 module Lazy = 
     let force (x: Lazy<'T>) = x.Force()
 

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -440,6 +440,11 @@ module String =
 
     let dropSuffix s t = match (tryDropSuffix s t) with Some(res) -> res | None -> failwith "dropSuffix"
 
+module Dictionary = 
+
+    let inline newWithSize (size: int) = System.Collections.Generic.Dictionary<_,_>(size, HashIdentity.Structural)
+        
+
 module Lazy = 
     let force (x: Lazy<'T>) = x.Force()
 

--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -33,10 +33,14 @@ let code_instr2instrs f (code: ILCode) =
             codebuf.Add instr2
             nw <- nw + 1
         old <- old + 1
-    adjust.[old] <- nw          
+    adjust.[old] <- nw
+    let labels =
+        let dict = new Dictionary<_,_>()
+        for kvp in code.Labels do dict.Add(kvp.Key, adjust.[kvp.Value])
+        dict
     { code with 
          Instrs = codebuf.ToArray()
-         Labels = Dictionary.ofList [ for kvp in code.Labels -> kvp.Key, adjust.[kvp.Value] ] }
+         Labels = labels }
 
 
 

--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -35,7 +35,7 @@ let code_instr2instrs f (code: ILCode) =
         old <- old + 1
     adjust.[old] <- nw
     let labels =
-        let dict = new Dictionary<_,_>(code.Labels.Count)
+        let dict = Dictionary.newWithSize code.Labels.Count
         for kvp in code.Labels do dict.Add(kvp.Key, adjust.[kvp.Value])
         dict
     { code with 

--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -35,7 +35,7 @@ let code_instr2instrs f (code: ILCode) =
         old <- old + 1
     adjust.[old] <- nw
     let labels =
-        let dict = new Dictionary<_,_>()
+        let dict = new Dictionary<_,_>(code.Labels.Count)
         for kvp in code.Labels do dict.Add(kvp.Key, adjust.[kvp.Value])
         dict
     { code with 

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -1459,7 +1459,7 @@ type CodeGenBuffer(m:range,
                 instrs
 
         let codeLabels =
-            let dict = new Dictionary<_,_>(codeLabelToPC.Count + codeLabelToCodeLabel.Count)
+            let dict = Dictionary.newWithSize (codeLabelToPC.Count + codeLabelToCodeLabel.Count)
             for kvp in codeLabelToPC        do dict.Add(kvp.Key, lab2pc 0 kvp.Key)
             for kvp in codeLabelToCodeLabel do dict.Add(kvp.Key, lab2pc 0 kvp.Key)
             dict

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -1457,10 +1457,15 @@ type CodeGenBuffer(m:range,
                 instrs |> Array.mapi (fun idx i2 -> if idx = 0 then i else if i === i2 then AI_nop else i2)
             | _ -> 
                 instrs
+
+        let codeLabels =
+            let dict = new Dictionary<_,_>(codeLabelToPC.Count + codeLabelToCodeLabel.Count)
+            for kvp in codeLabelToPC        do dict.Add(kvp.Key, lab2pc 0 kvp.Key)
+            for kvp in codeLabelToCodeLabel do dict.Add(kvp.Key, lab2pc 0 kvp.Key)
+            dict
         ResizeArray.toList locals ,
         maxStack,
-        (Dictionary.ofList [ for kvp in codeLabelToPC -> (kvp.Key, lab2pc 0 kvp.Key) 
-                             for kvp in codeLabelToCodeLabel -> (kvp.Key, lab2pc 0 kvp.Key) ] ),
+        codeLabels,
         instrs,
         ResizeArray.toList exnSpecs,
         Option.isSome seqpoint

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -919,7 +919,7 @@ module ProvidedMethodCalls =
         let varConv =
             // note: using paramVars.Length as assumed initial size, but this might not 
             // be the optimal value; this wasn't checked before obsoleting Dictionary.ofList
-            let dict = new System.Collections.Generic.Dictionary<_,_>(paramVars.Length)
+            let dict = Dictionary.newWithSize paramVars.Length
             for v,e in Seq.zip (paramVars |> Seq.map (fun x -> x.PUntaint(id,m))) (Option.toList thisArg @ allArgs) do
                 dict.Add(v,(None,e))
             dict

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -916,11 +916,11 @@ module ProvidedMethodCalls =
                                                          paramVars:Tainted<ProvidedVar>[],
                                                          g,amap,mut,isProp,isSuperInit,m,
                                                          expr:Tainted<ProvidedExpr>) = 
-        let varConv = 
-            [ for (v,e) in Seq.zip (paramVars |> Seq.map (fun x -> x.PUntaint(id,m))) (Option.toList thisArg @ allArgs) do
-                 yield (v,(None,e)) ]
-            |> Dictionary.ofList 
-
+        let varConv =
+            let dict = new System.Collections.Generic.Dictionary<_,_>()
+            for v,e in Seq.zip (paramVars |> Seq.map (fun x -> x.PUntaint(id,m))) (Option.toList thisArg @ allArgs) do
+                dict.Add(v,(None,e))
+            dict
         let rec exprToExprAndWitness top (ea:Tainted<ProvidedExpr>) =
             let fail() = error(Error(FSComp.SR.etUnsupportedProvidedExpression(ea.PUntaint((fun etree -> etree.UnderlyingExpressionString), m)),m))
             match ea with

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -917,7 +917,9 @@ module ProvidedMethodCalls =
                                                          g,amap,mut,isProp,isSuperInit,m,
                                                          expr:Tainted<ProvidedExpr>) = 
         let varConv =
-            let dict = new System.Collections.Generic.Dictionary<_,_>()
+            // note: using paramVars.Length as assumed initial size, but this might not 
+            // be the optimal value; this wasn't checked before obsoleting Dictionary.ofList
+            let dict = new System.Collections.Generic.Dictionary<_,_>(paramVars.Length)
             for v,e in Seq.zip (paramVars |> Seq.map (fun x -> x.PUntaint(id,m))) (Option.toList thisArg @ allArgs) do
                 dict.Add(v,(None,e))
             dict

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -679,47 +679,47 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
   let betterTyconRefMap = 
        begin 
         let entries1 = 
-         [ "Int32", v_int_tcr 
-           "IntPtr", v_nativeint_tcr 
-           "UIntPtr", v_unativeint_tcr
-           "Int16", v_int16_tcr 
-           "Int64", v_int64_tcr 
-           "UInt16", v_uint16_tcr
-           "UInt32", v_uint32_tcr
-           "UInt64", v_uint64_tcr
-           "SByte", v_sbyte_tcr
-           "Decimal", v_decimal_tcr
-           "Byte", v_byte_tcr
-           "Boolean", v_bool_tcr
-           "String", v_string_tcr
-           "Object", v_obj_tcr
-           "Exception", v_exn_tcr
-           "Char", v_char_tcr
-           "Double", v_float_tcr
-           "Single", v_float32_tcr] 
-             |> List.map (fun (nm, tcr) -> 
+         [| "Int32"    , v_int_tcr 
+            "IntPtr"   , v_nativeint_tcr 
+            "UIntPtr"  , v_unativeint_tcr
+            "Int16"    , v_int16_tcr 
+            "Int64"    , v_int64_tcr 
+            "UInt16"   , v_uint16_tcr
+            "UInt32"   , v_uint32_tcr
+            "UInt64"   , v_uint64_tcr
+            "SByte"    , v_sbyte_tcr
+            "Decimal"  , v_decimal_tcr
+            "Byte"     , v_byte_tcr
+            "Boolean"  , v_bool_tcr
+            "String"   , v_string_tcr
+            "Object"   , v_obj_tcr
+            "Exception", v_exn_tcr
+            "Char"     , v_char_tcr
+            "Double"   , v_float_tcr
+            "Single"   , v_float32_tcr |] 
+             |> Array.map (fun (nm, tcr) -> 
                    let ty = mkNonGenericTy tcr 
                    nm, findSysTyconRef sys nm, (fun _ -> ty)) 
 
         let entries2 =
-            [ "FSharpFunc`2",    v_fastFunc_tcr, (fun tinst -> mkFunTy (List.item 0 tinst) (List.item 1 tinst))
-              "Tuple`2",       v_ref_tuple2_tcr, decodeTupleTy tupInfoRef
-              "Tuple`3",       v_ref_tuple3_tcr, decodeTupleTy tupInfoRef
-              "Tuple`4",       v_ref_tuple4_tcr, decodeTupleTy tupInfoRef
-              "Tuple`5",       v_ref_tuple5_tcr, decodeTupleTy tupInfoRef
-              "Tuple`6",       v_ref_tuple6_tcr, decodeTupleTy tupInfoRef
-              "Tuple`7",       v_ref_tuple7_tcr, decodeTupleTy tupInfoRef
-              "Tuple`8",       v_ref_tuple8_tcr, decodeTupleTy tupInfoRef
-              "ValueTuple`2",       v_struct_tuple2_tcr, decodeTupleTy tupInfoStruct
-              "ValueTuple`3",       v_struct_tuple3_tcr, decodeTupleTy tupInfoStruct
-              "ValueTuple`4",       v_struct_tuple4_tcr, decodeTupleTy tupInfoStruct
-              "ValueTuple`5",       v_struct_tuple5_tcr, decodeTupleTy tupInfoStruct
-              "ValueTuple`6",       v_struct_tuple6_tcr, decodeTupleTy tupInfoStruct
-              "ValueTuple`7",       v_struct_tuple7_tcr, decodeTupleTy tupInfoStruct
-              "ValueTuple`8",       v_struct_tuple8_tcr, decodeTupleTy tupInfoStruct] 
+            [| 
+              "FSharpFunc`2" ,       v_fastFunc_tcr      , (fun tinst -> mkFunTy (List.item 0 tinst) (List.item 1 tinst))
+              "Tuple`2"      ,       v_ref_tuple2_tcr    , decodeTupleTy tupInfoRef
+              "Tuple`3"      ,       v_ref_tuple3_tcr    , decodeTupleTy tupInfoRef
+              "Tuple`4"      ,       v_ref_tuple4_tcr    , decodeTupleTy tupInfoRef
+              "Tuple`5"      ,       v_ref_tuple5_tcr    , decodeTupleTy tupInfoRef
+              "Tuple`6"      ,       v_ref_tuple6_tcr    , decodeTupleTy tupInfoRef
+              "Tuple`7"      ,       v_ref_tuple7_tcr    , decodeTupleTy tupInfoRef
+              "Tuple`8"      ,       v_ref_tuple8_tcr    , decodeTupleTy tupInfoRef
+              "ValueTuple`2" ,       v_struct_tuple2_tcr , decodeTupleTy tupInfoStruct
+              "ValueTuple`3" ,       v_struct_tuple3_tcr , decodeTupleTy tupInfoStruct
+              "ValueTuple`4" ,       v_struct_tuple4_tcr , decodeTupleTy tupInfoStruct
+              "ValueTuple`5" ,       v_struct_tuple5_tcr , decodeTupleTy tupInfoStruct
+              "ValueTuple`6" ,       v_struct_tuple6_tcr , decodeTupleTy tupInfoStruct
+              "ValueTuple`7" ,       v_struct_tuple7_tcr , decodeTupleTy tupInfoStruct
+              "ValueTuple`8" ,       v_struct_tuple8_tcr , decodeTupleTy tupInfoStruct |] 
 
-        let entries = (entries1 @ entries2)
-        
+        let entries = Array.append entries1 entries2        
         if compilingFslib then 
             // This map is for use when building FSharp.Core.dll. The backing Tycon's may not yet exist for
             // the TyconRef's we have in our hands, hence we can't dereference them to find their stamps.
@@ -728,10 +728,12 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
             //
             // Make it lazy to avoid dereferencing while setting up the base imports. 
             let dict = 
-              lazy
-                entries 
-                |> List.map (fun (nm, tcref, builder) -> nm, (fun tcref2 tinst -> if tyconRefEq tcref tcref2 then Some(builder tinst) else None)) 
-                |> Dictionary.ofList  
+                lazy (
+                    let dict = new Dictionary<_,_>(entries.Length)
+                    for nm, tcref, builder in entries do
+                        dict.Add(nm, fun tcref2 tinst -> if tyconRefEq tcref tcref2 then Some(builder tinst) else None)
+                    dict
+                )
             (fun (tcref: EntityRef) tinst -> 
                  let dict = dict.Value
                  let key = tcref.LogicalName
@@ -746,10 +748,11 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
             // Make it lazy to avoid dereferencing while setting up the base imports. 
             let dict = 
               lazy
-                entries  
-                |> List.filter (fun (_, tcref, _) -> tcref.CanDeref) 
-                |> List.map (fun (_, tcref, builder) -> tcref.Stamp, builder) 
-                |> Dictionary.ofList 
+                let dict = new Dictionary<_,_>(entries.Length)
+                for _, tcref, builder in entries do
+                  if tcref.CanDeref then
+                    dict.Add(tcref.Stamp, builder)
+                dict
             (fun tcref2 tinst -> 
                  let dict = dict.Value
                  let key = tcref2.Stamp

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -719,7 +719,7 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
               "ValueTuple`7" ,       v_struct_tuple7_tcr , decodeTupleTy tupInfoStruct
               "ValueTuple`8" ,       v_struct_tuple8_tcr , decodeTupleTy tupInfoStruct |] 
 
-        let entries = Array.append entries1 entries2        
+        let entries = Array.append entries1 entries2
         if compilingFslib then 
             // This map is for use when building FSharp.Core.dll. The backing Tycon's may not yet exist for
             // the TyconRef's we have in our hands, hence we can't dereference them to find their stamps.

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -729,7 +729,7 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
             // Make it lazy to avoid dereferencing while setting up the base imports. 
             let dict = 
                 lazy (
-                    let dict = new Dictionary<_,_>(entries.Length)
+                    let dict = Dictionary.newWithSize entries.Length
                     for nm, tcref, builder in entries do
                         dict.Add(nm, fun tcref2 tinst -> if tyconRefEq tcref tcref2 then Some(builder tinst) else None)
                     dict
@@ -748,7 +748,7 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
             // Make it lazy to avoid dereferencing while setting up the base imports. 
             let dict = 
               lazy
-                let dict = new Dictionary<_,_>(entries.Length)
+                let dict = Dictionary.newWithSize entries.Length
                 for _, tcref, builder in entries do
                   if tcref.CanDeref then
                     dict.Add(tcref.Stamp, builder)


### PR DESCRIPTION
Addresses #2297

The initial reasoning was when I compared performance of those snippets of code:

```fsharp
let inline ofList l = 
    // original code in compiler
    let dict = new System.Collections.Generic.Dictionary<_,_>(List.length l, HashIdentity.Structural)
    l |> List.iter (fun (k,v) -> dict.Add(k,v))
    dict

let inline ofSeqWithKnownCount (n: int) s  =
    let dict = new System.Collections.Generic.Dictionary<_,_>(n, HashIdentity.Structural)
    for kvp: KeyValuePair<_,_> in s do
      dict.Add(kvp.Key, kvp.Value)      
    dict

let makeDict1 (n:int) =
  [for i in 0 .. n do yield i,i ] |> ofList

let makeDict2 (n: int) =
  // winner
  let dict = Dictionary<_,_>(n)
  for i in 0 .. n do
    dict.Add(i,i)
  dict

let makeDict3 (n: int) =
  seq { for i in 0 .. n do yield KeyValuePair<_,_>(i,i) } |> ofSeqWithKnownCount n

let makeDict4 (n: int) =
  [ for i in 0 .. n do yield KeyValuePair<_,_>(i,i) ] |> ofSeqWithKnownCount n

let makeDict5 (n: int) =
  [| for i in 0 .. n do yield KeyValuePair<_,_>(i,i) |] |> ofSeqWithKnownCount n
```

I compared with populating dictionaries of same size I've noted from evaluating a small set of scripts.

Using FSI and `#time`, the procedural code doesn't generate much garbage and ran about 10x faster of worst one, but this is totally out of context of the compiler workload.

I think it is good to get rid of leaky abstraction:
* call to List.length, some lists were about 1k elements in my test
* procedural code replacing the old code isn't much longer or less readable
* with such helpers available, there is opportunity for getting into pitfalls in new places

The end result of those changes is basically 0% performance change, I've noticed 0.3% variation between master and this (mostly in favor of master) but this was on underpowered laptop (i7 2.1ghz), if you have feeling there is opportunity to do better measurement or think there is a risk with proposed changes, please let me know.