### PR TITLE
Fix #2308 -- Struct tuples do not work in FSI / VS FSI 

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -319,6 +319,7 @@ if /i '%ARG%' == 'test-net40-fsharp' (
 
 if /i '%ARG%' == 'test-coreclr-fsharp' (
     set BUILD_NET40=1
+    set BUILD_PROTO_WITH_CORECLR_LKG=1
     set BUILD_CORECLR=1
     set TEST_CORECLR_FSHARP_SUITE=1
 )

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1683,6 +1683,7 @@ let DefaultReferencesForScriptsAndOutOfProjectSources(assumeDotNetFramework) =
           yield "System.Collections" // System.Collections.Generic.List<T>
           yield "System.Runtime.Numerics" // BigInteger
           yield "System.Threading"  // OperationCanceledException
+          yield "System.ValueTuple"
 
           yield "System.Web"
           yield "System.Web.Services"

--- a/tests/fsharp/regression/struct-tuple-bug-1/test.fsx
+++ b/tests/fsharp/regression/struct-tuple-bug-1/test.fsx
@@ -1,0 +1,14 @@
+// #Regression 
+let failures = ref false
+let report_failure () = 
+  System.Console.Error.WriteLine "NO"; failures := true
+
+let struct (_x,_y) = struct (1,2)
+
+let _ = 
+  if !failures then (System.Console.Out.WriteLine "Test Failed"; exit 1) 
+  else
+      (System.Console.Out.WriteLine "Test Passed"; 
+       System.IO.File.WriteAllText("test.ok", "ok"); 
+       exit 0)
+

--- a/tests/fsharp/regression/struct-tuple-bug-1/test.fsx
+++ b/tests/fsharp/regression/struct-tuple-bug-1/test.fsx
@@ -1,14 +1,20 @@
 // #Regression 
 let failures = ref false
-let report_failure () = 
-  System.Console.Error.WriteLine "NO"; failures := true
+let report_failure msg = 
+  printfn "%A" msg
+  failures := true
 
-let struct (_x,_y) = struct (1,2)
+try
+    let struct (_x,_y) = struct (1,2)
+    ()
+with ex -> report_failure (ex.ToString())
 
-let _ = 
-  if !failures then (System.Console.Out.WriteLine "Test Failed"; exit 1) 
-  else
-      (System.Console.Out.WriteLine "Test Passed"; 
-       System.IO.File.WriteAllText("test.ok", "ok"); 
-       exit 0)
-
+let _ =
+    if !failures then 
+        printfn "Test Failed"
+        exit 1
+    else
+        printfn "Test Passed"
+        System.IO.File.WriteAllText("test.ok", "ok")
+        exit 0
+()

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1432,6 +1432,10 @@ module RegressionTests =
     [<Test >]
     let ``tuple-bug-1`` () = singleTestBuildAndRun "regression/tuple-bug-1" FSC_BASIC
 
+    [<Test >]
+    let ``struct tuple-bug-1`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
+
+
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
 module OptimizationTests =

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1433,7 +1433,7 @@ module RegressionTests =
     let ``tuple-bug-1`` () = singleTestBuildAndRun "regression/tuple-bug-1" FSC_BASIC
 
     [<Test >]
-    let ``struct tuple-bug-1`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
+    let ``struct-tuple-bug-1`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
 
 
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1433,7 +1433,10 @@ module RegressionTests =
     let ``tuple-bug-1`` () = singleTestBuildAndRun "regression/tuple-bug-1" FSC_BASIC
 
     [<Test >]
-    let ``struct-tuple-bug-1`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
+    let ``struct-tuple-bug-1-FSC_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSC_BASIC
+
+    [<Test >]
+    let ``struct-tuple-bug-1=FSI_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
 
 
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1378,6 +1378,13 @@ module ToolsTests =
 
 
 module RegressionTests = 
+
+    [<Test >]
+    let ``struct-tuple-bug-1-FSC_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSC_BASIC
+
+    [<Test >]
+    let ``tuple-bug-1`` () = singleTestBuildAndRun "regression/tuple-bug-1" FSC_BASIC
+
     [<Test>]
     let ``26`` () = singleTestBuildAndRun "regression/26" FSC_BASIC
 
@@ -1425,20 +1432,12 @@ module RegressionTests =
         fsc cfg "%s -r:Category.dll -a -o:petshop.dll" cfg.fsc_flags ["Category.ml"]
 
         peverify cfg "petshop.dll"
-                
+
     [<Test >]
     let ``86`` () = singleTestBuildAndRun "regression/86" FSC_BASIC
 
     [<Test >]
-    let ``tuple-bug-1`` () = singleTestBuildAndRun "regression/tuple-bug-1" FSC_BASIC
-
-    [<Test >]
-    let ``struct-tuple-bug-1-FSC_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSC_BASIC
-
-    [<Test >]
-    let ``struct-tuple-bug-1=FSI_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
-
-
+    let ``struct-tuple-bug-1-FSI_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
 module OptimizationTests =

--- a/tests/scripts/fsci.fsx
+++ b/tests/scripts/fsci.fsx
@@ -56,8 +56,8 @@ let executeFsi references =
     let arguments2 = sprintf @"%s %s" fsiExe (String.concat " " arguments)
     if isVerbose then 
         log "%s %s" coreRunExe arguments2
-        log "%s %s @fsc.cmd.args" coreRunExe fsiExe
-    File.WriteAllLines(OutputDir ++ "fsc.cmd.args", arguments)
+        log "%s %s @fsi.cmd.args" coreRunExe fsiExe
+    File.WriteAllLines(OutputDir ++ "fsi.cmd.args", arguments)
     File.WriteAllLines(OutputDir ++ (TestName + ".runtimeconfig.json"), runtimeConfigLines)
     CopyDlls.Split(';') |> Array.iter(fun s -> if not (System.String.IsNullOrWhiteSpace(s)) then File.Copy(s, OutputDir ++ Path.GetFileName(s), true))
     executeProcess coreRunExe arguments2


### PR DESCRIPTION
Fixes #2308 -- Struct tuples do not work in FSI / VS FSI 
Ensure:
            that FSI pre-loads system.valuetuple.dll.

Also adds fsi_basic test case because all of the tuple test cases are in nunit or fsharpqa, which have rather more configuration and so didn't catch this case.