### PR TITLE
Improve nuget package versioning

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -24,6 +24,7 @@ echo           ^<debug^|release^>
 echo           ^<diag^|publicsign^>
 echo           ^<test^|test-net40-coreunit^|test-coreclr-coreunit^|test-compiler-unit^|test-pcl-coreunit^|test-net40-fsharp^|test-coreclr-fsharp^|test-net40-fsharpqa^>
 echo           ^<include tag^>
+echo           ^<init^>
 echo.
 echo No arguments default to 'default', meaning this (no testing)
 echo.
@@ -177,7 +178,7 @@ if /i '%ARG%' == 'microbuild' (
     set BUILD_PORTABLE=1
     set BUILD_VS=1
     set BUILD_SETUP=%FSC_BUILD_SETUP%
-    
+
     set TEST_NET40_COMPILERUNIT_SUITE=1
     set TEST_NET40_COREUNIT_SUITE=1
     set TEST_NET40_FSHARP_SUITE=1
@@ -188,7 +189,6 @@ if /i '%ARG%' == 'microbuild' (
     set TEST_VS_IDEUNIT_SUITE=1
     set CI=1
 )
-
 
 REM These divide 'ci' into two chunks which can be done in parallel
 if /i '%ARG%' == 'ci_part1' (
@@ -204,7 +204,6 @@ if /i '%ARG%' == 'ci_part1' (
     set TEST_NET40_FSHARPQA_SUITE=1
     set TEST_VS_IDEUNIT_SUITE=1
     set CI=1
-
 )
 
 if /i '%ARG%' == 'ci_part2' (
@@ -326,6 +325,10 @@ if /i '%ARG%' == 'test-coreclr-fsharp' (
 
 if /i '%ARG%' == 'publicsign' (
     set BUILD_PUBLICSIGN=1
+)
+
+if /i '%ARG%' == 'init' (
+    set BUILD_PROTO_WITH_CORECLR_LKG=1
 )
 
 goto :EOF
@@ -477,6 +480,7 @@ if '%BUILD_PROTO_WITH_CORECLR_LKG%' == '1' (
 )
 
 set _dotnetexe=%~dp0Tools\dotnetcli\dotnet.exe
+set NUGET_PACKAGES=%~dp0Packages
 
 set _fsiexe="packages\FSharp.Compiler.Tools.4.0.1.19\tools\fsi.exe"
 if not exist %_fsiexe% echo Error: Could not find %_fsiexe% && goto :failure
@@ -494,7 +498,6 @@ if NOT EXIST Proto\net40\bin\fsc-proto.exe (
 
 set _dotnetexe=%~dp0Tools\dotnetcli\dotnet.exe
 set _architecture=win7-x64
-
 
 rem Build Proto
 if '%BUILD_PROTO%' == '1' (

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -18,7 +18,6 @@
     <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
   </PropertyGroup>
 
-  <!-- Nuget Package properties -->
   <PropertyGroup>
     <!-- Settings used all the time -->
     <Tailcalls>true</Tailcalls>
@@ -106,12 +105,15 @@
     <DefineConstants Condition="'$(VisualStudioVersion)'=='' AND '$(ProjectLanguage)' != 'VisualBasic'">$(DefineConstants);VS_VERSION_DEV14</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup> 
+  <!-- Nuget Package properties -->
+  <PropertyGroup>
     <BuildRevision>$([System.DateTime]::Now.ToString(`yyMMdd`))</BuildRevision>
-    <NuGetReleaseVersion>1.0.0</NuGetReleaseVersion> 
+    <NuGetReleaseVersion>1.0.0</NuGetReleaseVersion>
     <NuGetPreReleaseVersion>$(NuGetReleaseVersion)-rc</NuGetPreReleaseVersion>
-    <NuGetPerBuildPreReleaseVersion Condition="'$(BuildRevision)' != ''">$(NuGetPreReleaseVersion)-$(BuildRevision.Trim())</NuGetPerBuildPreReleaseVersion> 
-  </PropertyGroup> 
+    <NuGetPerBuildPreReleaseVersion Condition="'$(BuildRevision)' != ''">$(NuGetPreReleaseVersion)-$(BuildRevision.Trim())</NuGetPerBuildPreReleaseVersion>
+    <NUGET_PACKAGES Condition=" '$(NUGET_PACKAGES)' == '' ">$(MSBuildThisFileDirectory)..\packages</NUGET_PACKAGES>
+    <RestorePackagesPath>$(NUGET_PACKAGES)</RestorePackagesPath>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- Compiler tool locations.		-->
@@ -129,6 +131,8 @@
     <!-- The LKG FSI.EXE requires MSBuild 15 to be installed, which is painful -->
     <FsiToolPath>$(FSharpSourcesRoot)\..\packages\FSharp.Compiler.Tools.4.0.1.19\tools</FsiToolPath>
   </PropertyGroup>
+
   <Import Project="../Tools/Build.Common.props" Condition="'$(TargetFramework)'=='coreclr'"/>
+  <Import Project="$(BuildVersionFilePath)"     Condition="Exists('$(BuildVersionFilePath)')" />
 
 </Project>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -491,7 +491,7 @@
   </Target>
 
   <Target Name="dotnetpublishfsicompiler" AfterTargets="CopyFilesToOutputDirectory" Condition=" '$(DOTNET_PUBLISH_FSI)' == 'true' ">
-    <SetEnvtVar Name="NUGET_PACKAGES" Value="$(NUGET_PACKAGES)" />
+    <SetEnvVar Name="NUGET_PACKAGES" Value="$(NUGET_PACKAGES)" />
     <Exec Command="$(MSBuildThisFileDirectory)..\Tools\dotnetcli\dotnet.exe restore DeployCompiler\fsi\project.json"/>
     <Exec Command="$(MSBuildThisFileDirectory)..\Tools\dotnetcli\dotnet.exe --verbose publish --no-build DeployCompiler\fsi\project.json -r $(DOTNET_PUBLISH_PLATFORM) -c $(Configuration) -o $(DOTNET_PUBLISH_FSI_PATH)"/>
   </Target>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -412,18 +412,16 @@
 
   <!-- Hook up .NET Core to enable solution refresh of packages -->
   <PropertyGroup Condition="'$(TargetFramework)'=='coreclr'">
-    
-    <NuGetPackagesPath Condition="'$(NuGetPackagesPath)' == ''">$(FSharpSourcesRoot)\..\packages</NuGetPackagesPath>
 
     <!-- Implicitly needed by packageresolve.targets.  Should file a bug for a better error message here -->
-    <PackagesDir>$(NuGetPackagesPath)\</PackagesDir>
+    <PackagesDir>$(NUGET_PACKAGES)</PackagesDir>
 
     <NuGetToolPath Condition="'$(NuGetToolPath)' == ''">$(FSharpSourcesRoot)\..\.nuget\</NuGetToolPath>
     <NuGetConfigCommandLine>-ConfigFile "$(NuGetConfigFile)"</NuGetConfigCommandLine>
 
-    <NugetRestoreCommand>"$(NuGetToolPath)NuGet.exe install -OutputDirectory "$(NuGetPackagesPath)" -Config "$(NuGetToolPath)NuGet.Config"</NugetRestoreCommand>
+    <NugetRestoreCommand>"$(NuGetToolPath)NuGet.exe install -OutputDirectory "$(PackagesDir)" -Config "$(NuGetToolPath)NuGet.Config"</NugetRestoreCommand>
 
-    <DnuRestoreCommand>"$(NuGetToolPath)NuGet.exe" restore -OutputDirectory "$(NuGetPackagesPath)" -Config "$(NuGetToolPath)NuGet.Config"</DnuRestoreCommand>
+    <DnuRestoreCommand>"$(NuGetToolPath)NuGet.exe" restore -OutputDirectory "$(PackagesDir)" -Config "$(NuGetToolPath)NuGet.Config"</DnuRestoreCommand>
 
     <!-- Current version of .NET Core does not support all semantics used in our packages, 
          so we ignore the pre-calculation in the lock file and calculate asset applicability in the build task -->
@@ -473,32 +471,27 @@
   </Target>
 
   <Target Name="dotnetrestore" BeforeTargets="Build" Condition=" '$(TargetFramework)' == 'coreclr' ">
-    <Exec Command="$(MSBuildThisFileDirectory)..\.nuget\nuget.exe restore -PackagesDirectory $(MSBuildThisFileDirectory)..\packages -Config $(MSBuildThisFileDirectory)..\.nuget\NuGet.Config project.json" />
-  </Target>
-
-  <Target Name="nugetpack" AfterTargets="Build" Condition="'$(TargetFramework)' == 'coreclr' "
-          Inputs="@(PackageNuspec)" Outputs='$(OutputPath.TrimEnd("\"))\nuget\"%(PackageNuspec.Filename)).nupkg'>
-    <PropertyGroup>
-      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
-    </PropertyGroup>
-
-    <Exec Command='$(MSBuildThisFileDirectory)..\.nuget\nuget.exe pack %(PackageNuspec.Filename)%(PackageNuspec.Extension) -BasePath "$(OutputPath.TrimEnd("\"))" -ExcludeEmptyDirectories $(PackageProperties) -OutputDirectory "$(MSBuildThisFileDirectory)..\artifacts' />
+   <Exec Command="$(MSBuildThisFileDirectory)..\.nuget\nuget.exe restore -PackagesDirectory $(PackagesDir) -Config $(MSBuildThisFileDirectory)..\.nuget\NuGet.Config project.json" />
   </Target>
 
   <Target Name="dotnetrestore" BeforeTargets="Build" Condition=" '$(DOTNET_PUBLISH)' == 'true' ">
+    <SetEnvVar Name="NUGET_PACKAGES" Value="$(NUGET_PACKAGES)" />
     <Exec Command="$(MSBuildThisFileDirectory)..\Tools\dotnetcli\dotnet.exe restore --configfile $(MSBuildThisFileDirectory)..\.nuget\NuGet.Config project.json"/>
   </Target>
 
   <Target Name="dotnetpublish" AfterTargets="Build" Condition=" '$(DOTNET_PUBLISH)' == 'true' ">
+    <SetEnvVar Name="NUGET_PACKAGES" Value="$(NUGET_PACKAGES)" />
     <Exec Command="$(MSBuildThisFileDirectory)..\Tools\dotnetcli\dotnet.exe --verbose publish --no-build project.json -r $(DOTNET_PUBLISH_PLATFORM) -c $(Configuration) -o $(DOTNET_PUBLISH_PATH)"/>
   </Target>
 
   <Target Name="dotnetpublishfsccompiler" AfterTargets="CopyFilesToOutputDirectory" Condition=" '$(DOTNET_PUBLISH_FSC)' == 'true' ">
+    <SetEnvVar Name="NUGET_PACKAGES" Value="$(NUGET_PACKAGES)" />
     <Exec Command="$(MSBuildThisFileDirectory)..\Tools\dotnetcli\dotnet.exe restore DeployCompiler\fsc\project.json"/>
     <Exec Command="$(MSBuildThisFileDirectory)..\Tools\dotnetcli\dotnet.exe --verbose publish --no-build DeployCompiler\fsc\project.json -r $(DOTNET_PUBLISH_PLATFORM) -c $(Configuration) -o $(DOTNET_PUBLISH_FSC_PATH)"/>
   </Target>
 
   <Target Name="dotnetpublishfsicompiler" AfterTargets="CopyFilesToOutputDirectory" Condition=" '$(DOTNET_PUBLISH_FSI)' == 'true' ">
+    <SetEnvtVar Name="NUGET_PACKAGES" Value="$(NUGET_PACKAGES)" />
     <Exec Command="$(MSBuildThisFileDirectory)..\Tools\dotnetcli\dotnet.exe restore DeployCompiler\fsi\project.json"/>
     <Exec Command="$(MSBuildThisFileDirectory)..\Tools\dotnetcli\dotnet.exe --verbose publish --no-build DeployCompiler\fsi\project.json -r $(DOTNET_PUBLISH_PLATFORM) -c $(Configuration) -o $(DOTNET_PUBLISH_FSI_PATH)"/>
   </Target>
@@ -516,6 +509,68 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="LatestCommit" />
     </Exec>
     <WriteLinesToFile File="$(IntermediateOutputPath)source_link.json" Overwrite="true" Lines='{"documents": { "$(SrcRootDirectory)/*" : "$(RemoteUri.Replace(".git", "").Replace("github.com", "raw.githubusercontent.com"))/$(LatestCommit)/*" }}' />
+  </Target>
+
+    <!-- If BuildVersionFilePath not specified then do nothing  -->
+  <Target Name="CleanVersionFile" Condition ="'$(BuildVersionFilePath)' != '' ">
+    <PropertyGroup>
+        <BuildVersionFileDir>$([System.IO.Path]::GetDirectoryName($(BuildVersionFilePath)))</BuildVersionFileDir>
+    </PropertyGroup>
+    <RemoveDir Condition="Exists('$(BuildVersionFileDir)')" Directories="$(BuildVersionFileDir)" />
+  </Target>
+
+    <!-- If BuildVersionFilePath not specified then do nothing  -->
+  <Target Name="CreateOrUpdateBuildVersionFile" Condition ="'$(BuildVersionFilePath)' != '' ">
+    <PropertyGroup>
+        <BuildVersionFileDir>$([System.IO.Path]::GetDirectoryName($(BuildVersionFilePath)))</BuildVersionFileDir>
+        <PackageVersionMajor Condition="'$(PackageVersionMajor)' == ''" >$(NuGetPerBuildPreReleaseVersion)</PackageVersionMajor>
+        <PackageVersionMinor Condition="'$(PackageVersionMinor)' != ''" >$([MSBuild]::Add($(PackageVersionMinor), 1))</PackageVersionMinor>
+        <PackageVersionMinor Condition="'$(PackageVersionMinor)' == ''" >1</PackageVersionMinor>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <CurrentVersionLines Include="%3C%3Fxml version=%221.0%22 encoding=%22utf-8%22%3F%3E" />
+      <CurrentVersionLines Include="%3C!-- This is a generated file. $(VersionSeedSourceComment) Seed Date is $(VersionSeedDate). --%3E" />
+      <CurrentVersionLines Include="%3CProject xmlns=%22http://schemas.microsoft.com/developer/msbuild/2003%22%3E" />
+      <CurrentVersionLines Include="%3CPropertyGroup%3E" />
+      <CurrentVersionLines Include="%3CPackageVersionMajor Condition=%22%27%24(PackageVersionMajor)%27==%27%27%22%3E$(NuGetPerBuildPreReleaseVersion)%3C/PackageVersionMajor%3E" />
+      <CurrentVersionLines Include="%3CPackageVersionMinor Condition=%22%27%24(PackageVersionMinor)%27==%27%27%22%3E$(PackageVersionMinor)%3C/PackageVersionMinor%3E" />
+      <CurrentVersionLines Include="%3C/PropertyGroup%3E" />
+      <CurrentVersionLines Include="%3C/Project%3E" />
+    </ItemGroup>
+
+    <!-- Since by default the file will get dropped at the obj dir, make sure that the dir is created already or else WriteLinesToFile will error. -->
+    <MakeDir Condition="!Exists('$(BuildVersionFileDir)')" Directories="$(BuildVersionFileDir)" />
+
+    <WriteLinesToFile
+      ContinueOnError="WarnAndContinue"
+      File="$(BuildVersionFilePath)"
+      Lines="@(CurrentVersionLines)"
+      Overwrite="true" />
+
+    <!-- Delete old BuildVersion.props files -->
+    <ItemGroup>
+      <OldBuildVersionFiles Include="$(BuildVersionFilePath)BuildVersions-*.props" Exclude="$(BuildVersionFilePath)%(BuildVersionFileItem.Filename).props" />
+    </ItemGroup>
+    <Delete Files="@(OldBuildVersionFiles)" TreatErrorsAsWarnings="true"/>
+  </Target>
+
+  <Target Name="nugetpack"
+          DependsOnTargets="CreateOrUpdateBuildVersionFile"
+          AfterTargets="Build"
+          Condition="'$(TargetFramework)' == 'coreclr' "
+          Inputs="@(PackageNuspec)" 
+          Outputs='$(FSharpSourcesRoot.TrimEnd("\"))\..\$(Configuration)\artifacts\"%(PackageNuspec.Filename)).nupkg'>
+
+    <PropertyGroup>
+      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(FSharpSourcesRoot.TrimEnd('\'))\..\$(Configuration)\artifacts" />
+    <MakeDir Directories="$(FSharpSourcesRoot.TrimEnd('\'))\..\artifacts" />
+    <SetEnvVar Name="NUGET_PACKAGES" Value="$(NUGET_PACKAGES)" />
+    <Exec Command='$(MSBuildThisFileDirectory)..\.nuget\nuget.exe pack @(PackageNuspec) -BasePath $(OutputPath.TrimEnd("\")) -ExcludeEmptyDirectories $(PackageProperties) -OutputDirectory $(FSharpSourcesRoot.TrimEnd("\"))\..\$(Configuration)\artifacts' />
+    <Exec Command='$(MSBuildThisFileDirectory)..\.nuget\nuget.exe pack @(PackageNuspec) -BasePath $(OutputPath.TrimEnd("\")) -ExcludeEmptyDirectories $(PackageProperties) -OutputDirectory $(FSharpSourcesRoot.TrimEnd("\"))\..\artifacts' />
   </Target>
 
   <UsingTask TaskName="ReplaceFileText" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
@@ -541,4 +596,19 @@
     </Task>
   </UsingTask>
 
-</Project>
+  <UsingTask TaskName="SetEnvVar" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <Name  ParameterType="System.String" Required="true" />
+      <Value ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+          Environment.SetEnvironmentVariable(Name, Value);
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  </Project>

--- a/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
+++ b/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
@@ -28,7 +28,6 @@
     <Compile Include="..\FSharp.Build\CreateFSharpManifestResourceName.fs" >
        <Link>CreateFSharpManifestResourceName.fs</Link>
     </Compile>
-
     <Compile Include="..\FSharp.Build\Fsc.fsi">
       <Link>Fsc.fsi</Link>
     </Compile>
@@ -36,16 +35,16 @@
       <Link>Fsc.fs</Link>
     </Compile>
     <CopyAndSubstituteText Include="..\FSharp.Build\Microsoft.FSharp.targets">
-		<Link>Microsoft.FSharp-proto.targets</Link>
-		<TargetFilename>Microsoft.FSharp-proto.targets</TargetFilename>
-		<Pattern1>{BuildSuffix}</Pattern1>
-		<Replacement1>-proto</Replacement1>
-	</CopyAndSubstituteText>
-	<CopyAndSubstituteText Include="..\FSharp.Build\Microsoft.Portable.FSharp.targets">
-		<Link>Microsoft.Portable.FSharp-proto.targets</Link>
-		<TargetFilename>Microsoft.Portable.FSharp-proto.targets</TargetFilename>
-		<Pattern1>{BuildSuffix}</Pattern1>
-		<Replacement1>-proto</Replacement1>
+      <Link>Microsoft.FSharp-proto.targets</Link>
+      <TargetFilename>Microsoft.FSharp-proto.targets</TargetFilename>
+      <Pattern1>{BuildSuffix}</Pattern1>
+      <Replacement1>-proto</Replacement1>
+    </CopyAndSubstituteText>
+    <CopyAndSubstituteText Include="..\FSharp.Build\Microsoft.Portable.FSharp.targets">
+      <Link>Microsoft.Portable.FSharp-proto.targets</Link>
+      <TargetFilename>Microsoft.Portable.FSharp-proto.targets</TargetFilename>
+      <Pattern1>{BuildSuffix}</Pattern1>
+      <Replacement1>-proto</Replacement1>
     </CopyAndSubstituteText>
   </ItemGroup>
   <ItemGroup>

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -21,8 +21,18 @@
       <HasLceComments>false</HasLceComments>
       <InProject>false</InProject>
     </FilesToLocalize>
+  </ItemGroup>
+
+  <!-- Nuget packaging configuration -->
+  <ItemGroup>
     <PackageNuspec Include="FSharp.Build.netcore.nuspec" Condition="'$(TargetFramework)' == 'coreclr'" />
   </ItemGroup>
+  <PropertyGroup>
+    <PackageVersion    Condition="'$(PreReleaseLabel)'     == ''">$(NuGeReleaseVersion)</PackageVersion>
+    <PackageVersion    Condition="'$(PackageVersionMinor)' != ''">$(PackageVersionMajor)-$(PackageVersionMinor)</PackageVersion>
+    <PackageVersion    Condition="'$(PackageVersionMinor)' == ''">$(NuGetPerBuildPreReleaseVersion)-0</PackageVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <FsSrGen Include="FSBuild.txt">
       <Link>FSBuild.txt</Link>
@@ -40,14 +50,14 @@
     <Compile Include="CreateFSharpManifestResourceName.fsi" />
     <Compile Include="CreateFSharpManifestResourceName.fs" />
     <CopyAndSubstituteText Include="Microsoft.FSharp.targets">
-		<TargetFilename>Microsoft.FSharp.targets</TargetFilename>
-		<Pattern1>{BuildSuffix}</Pattern1>
-		<Replacement1></Replacement1>
-	</CopyAndSubstituteText>
-	<CopyAndSubstituteText Include="Microsoft.Portable.FSharp.targets">
-		<TargetFilename>Microsoft.Portable.FSharp.targets</TargetFilename>
-		<Pattern1>{BuildSuffix}</Pattern1>
-		<Replacement1></Replacement1>
+      <TargetFilename>Microsoft.FSharp.targets</TargetFilename>
+      <Pattern1>{BuildSuffix}</Pattern1>
+      <Replacement1></Replacement1>
+    </CopyAndSubstituteText>
+    <CopyAndSubstituteText Include="Microsoft.Portable.FSharp.targets">
+    <TargetFilename>Microsoft.Portable.FSharp.targets</TargetFilename>
+      <Pattern1>{BuildSuffix}</Pattern1>
+      <Replacement1></Replacement1>
     </CopyAndSubstituteText>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'coreclr' ">

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.targets
@@ -19,7 +19,6 @@ this file.
 
     <UsingTask TaskName="Fsc" AssemblyFile="FSharp.Build{BuildSuffix}.dll"/>
     <UsingTask TaskName="CreateFSharpManifestResourceName" AssemblyFile="FSharp.Build{BuildSuffix}.dll"/>
-    <UsingTask TaskName="SetEnv" AssemblyFile="FSharp.Build{BuildSuffix}.dll"/>
 
   <PropertyGroup>
         <ImportByWildcardBeforeMicrosoftFSharpTargets Condition="'$(ImportByWildcardBeforeMicrosoftFSharpTargets)' == ''">true</ImportByWildcardBeforeMicrosoftFSharpTargets>

--- a/src/fsharp/FSharp.Compiler.Host.netcore.nuget/FSharp.Compiler.Host.proj
+++ b/src/fsharp/FSharp.Compiler.Host.netcore.nuget/FSharp.Compiler.Host.proj
@@ -1,6 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
+    <PreReleaseLabel>rc</PreReleaseLabel>
+    <BuildVersionFilePath Condition="'$(BuildVersionFilePath)'==''" >obj\BuildVersionFile.props</BuildVersionFilePath>
   </PropertyGroup>
 
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.targets" />
@@ -8,7 +10,9 @@
   <PropertyGroup>
     <PackageLicenceUrl Condition="'$(PackageLicenceUrl)' == ''">https://github.com/Microsoft/visualfsharp/blob/master/License.txt</PackageLicenceUrl>
     <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://github.com/Microsoft/visualfsharp</PackageProjectUrl>
-    <PackageVersion    Condition="'$(PackageVersion)' == ''"   >$(NuGetPerBuildPreReleaseVersion)</PackageVersion>
+    <PackageVersion    Condition="'$(PreReleaseLabel)' == ''">$(NuGeReleaseVersion)</PackageVersion>
+    <PackageVersion    Condition="'$(PackageVersionMinor)' != ''">$(PackageVersionMajor)-$(PackageVersionMinor)</PackageVersion>
+    <PackageVersion    Condition="'$(PackageVersionMinor)' == ''">$(NuGetPerBuildPreReleaseVersion)-0</PackageVersion>
     <PackageAuthors    Condition="'$(PackageAuthors)' == ''"   >Microsoft</PackageAuthors>
     <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp coreclr functional programming</PackageTags>
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\coreclr\bin</OutputPath>
@@ -39,20 +43,9 @@
     </ProjectReference>
   </ItemGroup>
 
-  <Target Name="Build" Outputs="$(TargetPath)"  DependsOnTargets="$(nugetpack)" />
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
+
+  <Target Name="Build" Outputs="$(TargetPath)" DependsOnTargets="$(nugetpack)" />
   <Target Name="Rebuild"  DependsOnTargets="$(nugetpack)" />
-
-  <Target Name="nugetpack" AfterTargets="Build" 
-          Condition="'$(TargetFramework)' == 'coreclr' "
-          Inputs="@(PackageNuspec)" 
-          Outputs='$(FSharpSourcesRoot.TrimEnd("\"))\..\$(Configuration)\artifacts\"%(PackageNuspec.Filename)).nupkg'>
-    <PropertyGroup>
-      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
-    </PropertyGroup>
-    <MakeDir Directories="$(FSharpSourcesRoot.TrimEnd('\'))\..\$(Configuration)\artifacts" />
-    <MakeDir Directories="$(FSharpSourcesRoot.TrimEnd('\'))\..\artifacts" />
-    <Exec Command='$(MSBuildThisFileDirectory)..\..\..\.nuget\nuget.exe pack @(PackageNuspec) -BasePath $(OutputPath.TrimEnd("\")) -ExcludeEmptyDirectories $(PackageProperties) -OutputDirectory $(FSharpSourcesRoot.TrimEnd("\"))\..\$(Configuration)\artifacts' />
-    <Exec Command='$(MSBuildThisFileDirectory)..\..\..\.nuget\nuget.exe pack @(PackageNuspec) -BasePath $(OutputPath.TrimEnd("\")) -ExcludeEmptyDirectories $(PackageProperties) -OutputDirectory $(FSharpSourcesRoot.TrimEnd("\"))\..\artifacts' />
-  </Target>
-
+  <Target Name="Clean"    DependsOnTargets="CleanVersionFile" />
 </Project>

--- a/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj
+++ b/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj
@@ -29,8 +29,18 @@
       <HasLceComments>false</HasLceComments>
       <InProject>false</InProject>
     </FilesToLocalize>
+  </ItemGroup>
+
+  <!-- Nuget packaging configuration -->
+  <ItemGroup>
     <PackageNuspec Include="FSharp.Compiler.netcore.nuspec" Condition="'$(TargetFramework)' == 'coreclr'" />
   </ItemGroup>
+  <PropertyGroup>
+    <PackageVersion    Condition="'$(PreReleaseLabel)' == ''">$(NuGeReleaseVersion)</PackageVersion>
+    <PackageVersion    Condition="'$(PackageVersionMinor)' != ''">$(PackageVersionMajor)-$(PackageVersionMinor)</PackageVersion>
+    <PackageVersion    Condition="'$(PackageVersionMinor)' == ''">$(NuGetPerBuildPreReleaseVersion)-0</PackageVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Compiler.dll.fs">
       <Link>assemblyinfo.FSharp.Compiler.dll.fs</Link>

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -23,10 +23,18 @@
     <OtherFlags Condition=" '$(TargetFramework)'=='portable78'">$(OtherFlags)  --compiling-fslib-40 --compiling-fslib-nobigint</OtherFlags>
     <OtherFlags Condition=" '$(TargetFramework)'=='portable259'">$(OtherFlags) --compiling-fslib-40 --compiling-fslib-nobigint</OtherFlags>
   </PropertyGroup>
+
+  <!-- Nuget packaging configuration -->
   <ItemGroup>
     <PackageNuspec Include="FSharp.Core.netcore.nuspec" Condition="'$(TargetFramework)' == 'coreclr'" />
     <None Include="FSharp.Core.runtimeconfig.json"      Condition="'$(TargetFramework)' == 'coreclr'" ><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
   </ItemGroup>
+  <PropertyGroup>
+    <PackageVersion    Condition="'$(PreReleaseLabel)' == ''">$(NuGeReleaseVersion)</PackageVersion>
+    <PackageVersion    Condition="'$(PackageVersionMinor)' != ''">$(PackageVersionMajor)-$(PackageVersionMinor)</PackageVersion>
+    <PackageVersion    Condition="'$(PackageVersionMinor)' == ''">$(NuGetPerBuildPreReleaseVersion)-0</PackageVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <FilesToLocalize Include="$(OutDir)$(AssemblyName).dll">
       <TranslationFile>$(FSharpSourcesRoot)\..\loc\lcl\{Lang}\$(AssemblyName).dll.lcl</TranslationFile>
@@ -231,7 +239,6 @@
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
 
   <!-- Hook compilation phase to do custom work -->
-
   <Target Name="CopyToBuiltBin" BeforeTargets="AfterCompile" AfterTargets="CoreCompile" >
     <ItemGroup>
       <BuiltProjectOutputGroupKeyOutput Include="$(IntermediateOutputPath)\FSharp.Core.sigdata" />


### PR DESCRIPTION

* The nuget package versioning we did, did not increment per build, which interfered with caching.
* Revert to using   /packages as the package cache

