### PR TITLE
Update references to rc3 roslyn bits

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -11,7 +11,8 @@
     <add key="myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <add key="myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="myget.org roslyn-tools"  value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="dotnet.myget.org roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vctools" value="https://vcppdogfooding.azurewebsites.net/nuget/" />
     <add key="artifacts" value="../artifacts" />

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -121,7 +121,7 @@
     <FsiToolExe>fsi.exe</FsiToolExe>
     <FsLexToolExe>fslex.exe</FsLexToolExe>
     <FsYaccToolExe>fsyacc.exe</FsYaccToolExe>
-    <RoslynVersion>2.0.0-rc2</RoslynVersion>
+    <RoslynVersion>2.0.0-rc3-61324-01</RoslynVersion>
     <RoslynVSBinariesVersion>14.0</RoslynVSBinariesVersion>
     <RoslynVSPackagesVersion>14.3.25407</RoslynVSPackagesVersion>
 

--- a/vsintegration/packages.config
+++ b/vsintegration/packages.config
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Features" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.0.0-rc2" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.LanguageServices" version="2.0.0-rc2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.0.0-rc3-61324-01" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.0.0-rc3-61324-01" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.0.0-rc3-61324-01" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Features" version="2.0.0-rc3-61324-01" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.0.0-rc3-61324-01" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.LanguageServices" version="2.0.0-rc3-61324-01" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Package.LanguageService.14.0" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Editor" version="14.3.25407" targetFramework="net46" />
@@ -21,7 +21,7 @@
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Language.Intellisense" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Designer.Interfaces" version="1.1.4322" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25929-RC2" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26124-RC3" />
   <package id="Roslyn.Microsoft.VisualStudio.ComponentModelHost" version="0.0.2" targetFramework="net46" />
   <package id="Microsoft.VisualFSharp.Microsoft.VisualStudio.Shell.UI.Internal" version="14.0.25420" targetFramework="net46" />
   <package id="RoslynDependencies.Microsoft.VisualStudio.Text.Internal" version="14.3.25407" targetFramework="net45" />

--- a/vsintegration/vsintegration.targets
+++ b/vsintegration/vsintegration.targets
@@ -2,6 +2,6 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="RestoreVsIntegrationPackages" BeforeTargets="Build" Condition="'$(RestorePackages)' == ''">
-	<Exec Command=".\.nuget\NuGet.exe restore vsintegration\packages.config -PackagesDirectory packages -ConfigFile .\.nuget\NuGet.Config" WorkingDirectory="$(FSharpSourcesRoot)\.." />
+    <Exec Command=".\.nuget\NuGet.exe restore vsintegration\packages.config -PackagesDirectory packages -ConfigFile .\.nuget\NuGet.Config" WorkingDirectory="$(FSharpSourcesRoot)\.." />
   </Target>
 </Project>


### PR DESCRIPTION
@vasily-kirichenko  @CyrusNajmabadi  @cartermp 

This PR contains the latest roslyn bits.  It seems as if between RC2 and RC3 there was a breaking change ...

https://github.com/Microsoft/visualfsharp/blob/master/vsintegration/src/FSharp.Editor/Navigation/FindReferencesService.fs#L144

IStreamingFindReferencesService was removed here: https://github.com/dotnet/roslyn/commit/1db055b7776c3c80b93f5fa00f371beee131a3fe

and replaced with IFindUsagesService.

I guess to re-enable FindAllReferences with the latest bits we need to make some changes, @vasily-kirichenko would you take this PR and make the necessary changes to the editor please?

Thanks

Kevin


