### PR TITLE
Use ConcurrentDictionary instead of Dictionary for ForeachAction.seen

### DIFF
--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -507,11 +507,11 @@ module internal IncrementalBuild =
     /// Visit each executable action necessary to evaluate the given output (with an optional slot in a
     /// vector output). Call actionFunc with the given accumulator.
     let ForeachAction (Target(output, optSlot)) bt (actionFunc:Action->'acc->'acc) (acc:'acc) =
-        let seen = Dictionary<Id,bool>()
+        let seen = System.Collections.Concurrent.ConcurrentDictionary<Id, unit>()
         let isSeen id = 
             if seen.ContainsKey id then true
             else 
-                seen.[id] <- true
+                seen.[id] <- ()
                 false
                  
         let shouldEvaluate(bt,currentsig:InputSignature,id) =


### PR DESCRIPTION
This fixes exceptions and one core 100% load when a project is opening, like this:

![image](https://cloud.githubusercontent.com/assets/873919/22456353/f04f1a60-e7a2-11e6-9b4f-dcaf24c7ee65.png)
