### PR TITLE
Move to new VS SDK build tools

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -371,7 +371,7 @@ echo .
 echo .
 
 echo ---------------- Done with arguments, starting preparation -----------------
-set BuildToolsPackage=Microsoft.VSSDK.BuildTools.15.0.25929-RC2
+set BuildToolsPackage=Microsoft.VSSDK.BuildTools.15.0.26124-RC3
 if '%VSSDKInstall%'=='' (
      set VSSDKInstall=%~dp0packages\%BuildToolsPackage%\tools\vssdk
 )

--- a/packages.config
+++ b/packages.config
@@ -29,7 +29,7 @@
   <package id="VisualCppTools" version="14.0.24519-Pre"/>
   <package id="Newtonsoft.Json" version="6.0.8"/>
   <package id="Microsoft.FSharp.TupleSample" version="1.0.0-alpha-161121"/>
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25929-RC2" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26124-RC3" />
 
   <!-- Annoyingly the build of FSharp.Compiler.Server.Shared references a Visual Studio-specific attribute -->
   <!-- That DLL is logically part of the F# Compiler and F# Interactive but is shipped as part of the Visual F# IDE Tools -->

--- a/setup/packages.config
+++ b/setup/packages.config
@@ -7,7 +7,7 @@
   <package id="FsSrGen" version="2.0.0" targetFramework="net46" />
   <package id="MicroBuild.Core" version="0.2.0" />
   <package id="MicroBuild.Core.Sentinel" version="1.0.0" />
-  <package id="MicroBuild.Plugins.SwixBuild" version="1.0.101" />
+  <package id="MicroBuild.Plugins.SwixBuild" version="1.1.0-g0701ee829f" />
   <package id="WiX.Toolset.2015" version="3.10.0.1503" />
   <package id="Microsoft.VisualFSharp.Core.Redist" version="1.0.0" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net46" />

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -32,7 +32,7 @@
     <WarningsAsErrors />
 
     <FX_NO_LOADER Condition=" '$(FX_NO_LOADER)'==''">false</FX_NO_LOADER>
-    <VSSDK_BUILDTOOLS_VERSION>Microsoft.VSSDK.BuildTools.15.0.25929-RC2</VSSDK_BUILDTOOLS_VERSION>
+    <VSSDK_BUILDTOOLS_VERSION>Microsoft.VSSDK.BuildTools.15.0.26124-RC3</VSSDK_BUILDTOOLS_VERSION>
 
     <!-- Always qualify the IntermediateOutputPath by the TargetFramework if any exists -->
     <IntermediateOutputPath>obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>

--- a/vsintegration/packages.config
+++ b/vsintegration/packages.config
@@ -21,7 +21,7 @@
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Language.Intellisense" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Designer.Interfaces" version="1.1.4322" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.25929-RC2" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26124-RC3" />
   <package id="Roslyn.Microsoft.VisualStudio.ComponentModelHost" version="0.0.2" targetFramework="net46" />
   <package id="Microsoft.VisualFSharp.Microsoft.VisualStudio.Shell.UI.Internal" version="14.0.25420" targetFramework="net46" />
   <package id="RoslynDependencies.Microsoft.VisualStudio.Text.Internal" version="14.3.25407" targetFramework="net45" />


### PR DESCRIPTION
**Pulling this into vs2017-rtm, too**

Recent changes to the VS SDK / VS detouring layer are forcing us to move to a new SDK in order to continue building / dogfooding.

This is the peer of the Roslyn change:

https://github.com/dotnet/roslyn/pull/16858

closes #2356