### PR TITLE
update mem perf driver

### DIFF
--- a/build-everything.proj
+++ b/build-everything.proj
@@ -30,6 +30,7 @@
 
   <ItemGroup Condition="'$(BUILD_VS)'=='1'">
     <ProjectsWithNet40 Include="vsintegration/fsharp-vsintegration-src-build.proj" />
+    <ProjectsWithNet40 Include="vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj" />
     <ProjectsWithNet40 Include="vsintegration/fsharp-vsintegration-project-templates-build.proj" />
     <ProjectsWithNet40 Include="vsintegration/fsharp-vsintegration-item-templates-build.proj" />
     <ProjectsWithNet40 Include="vsintegration/fsharp-vsintegration-vsix-build.proj" />

--- a/vsintegration/Utils/LanguageServiceProfiling/App.config
+++ b/vsintegration/Utils/LanguageServiceProfiling/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
 </configuration>

--- a/vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj
+++ b/vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj
@@ -44,22 +44,6 @@
     </DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ProjectCracker.fs" />
@@ -74,7 +58,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -90,11 +74,5 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
 </Project>

--- a/vsintegration/Utils/LanguageServiceProfiling/Options.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Options.fs
@@ -17,15 +17,14 @@ type CompletionPosition = {
 type Options =
     { Options: FSharpProjectOptions
       FileToCheck: string
+      FilesToCheck: string list
       SymbolText: string
       SymbolPos: pos
       CompletionPositions: CompletionPosition list }
          
 
 let FCS (repositoryDir: string) : Options =
-    { Options =
-        {ProjectFileName = repositoryDir </> @"src\fsharp\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj"
-         ProjectFileNames =
+    let files =
           [| @"src\fsharp\FSharp.Compiler.Service\obj\Release\FSComp.fs"
              @"src\fsharp\FSharp.Compiler.Service\obj\Release\FSIstrings.fs"
              @"src\assemblyinfo\assemblyinfo.FSharp.Compiler.Service.dll.fs"
@@ -194,7 +193,10 @@ let FCS (repositoryDir: string) : Options =
              @"src\fsharp\vs\SimpleServices.fs"
              @"src\fsharp\fsi\fsi.fsi"
              @"src\fsharp\fsi\fsi.fs" |]
-             |> Array.map (fun x -> repositoryDir </> x)
+
+    { Options =
+        {ProjectFileName = repositoryDir </> @"src\fsharp\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj"
+         ProjectFileNames = files |> Array.map (fun x -> repositoryDir </> x)
          OtherOptions =
           [|@"-o:obj\Release\FSharp.Compiler.Service.dll"; "-g"; "--noframework";
             @"--baseaddress:0x06800000"; "--define:DEBUG";
@@ -282,6 +284,17 @@ let FCS (repositoryDir: string) : Options =
          UnresolvedReferences = None;
          OriginalLoadReferences = []
          ExtraProjectInfo = None }
+      FilesToCheck = 
+          files 
+          |> Array.filter (fun s -> s.Contains "TypeChecker.fs" || 
+                                    s.Contains "Optimizer.fs" || 
+                                    s.Contains "IlxGen.fs" || 
+                                    s.Contains "TastOps.fs" || 
+                                    s.Contains "TcGlobals.fs" || 
+                                    s.Contains "CompileOps.fs" || 
+                                    s.Contains "CompileOptions.fs") 
+          |>  Array.map (fun x -> repositoryDir </> x) 
+          |> Array.toList
       FileToCheck = repositoryDir </> @"src\fsharp\TypeChecker.fs"
       SymbolText = "Some"
       SymbolPos = mkPos 120 7
@@ -391,6 +404,7 @@ let VFPT (repositoryDir: string) : Options =
          UnresolvedReferences = None
          OriginalLoadReferences = []
          ExtraProjectInfo = None }
+      FilesToCheck = []
       FileToCheck = repositoryDir </> @"src\FSharp.Editing\CodeGeneration\RecordStubGenerator.fs"
       SymbolText = "option"
       SymbolPos = mkPos 19 23 

--- a/vsintegration/Utils/LanguageServiceProfiling/Options.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Options.fs
@@ -1,4 +1,4 @@
-﻿module internal rec LanguageServiceProfiling.Options
+﻿module internal  LanguageServiceProfiling.Options
 
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Range
@@ -21,18 +21,13 @@ type Options =
       SymbolPos: pos
       CompletionPositions: CompletionPosition list }
          
-let get (repositoryDir: string) : Options =
-    match DirectoryInfo(repositoryDir).Name.ToLower() with
-    | "fsharp.compiler.service" -> FCS(repositoryDir)
-    | "fsharpvspowertools" -> VFPT(repositoryDir)
-    | _ -> failwithf "%s is not supported" repositoryDir
 
 let FCS (repositoryDir: string) : Options =
     { Options =
         {ProjectFileName = repositoryDir </> @"src\fsharp\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj"
          ProjectFileNames =
-          [| @"src\fsharp\FSharp.Compiler.Service\obj\Debug\FSComp.fs"
-             @"src\fsharp\FSharp.Compiler.Service\obj\Debug\FSIstrings.fs"
+          [| @"src\fsharp\FSharp.Compiler.Service\obj\Release\FSComp.fs"
+             @"src\fsharp\FSharp.Compiler.Service\obj\Release\FSIstrings.fs"
              @"src\assemblyinfo\assemblyinfo.FSharp.Compiler.Service.dll.fs"
              @"src\assemblyinfo\assemblyinfo.shared.fs"
              @"src\utils\reshapedreflection.fs"
@@ -201,7 +196,7 @@ let FCS (repositoryDir: string) : Options =
              @"src\fsharp\fsi\fsi.fs" |]
              |> Array.map (fun x -> repositoryDir </> x)
          OtherOptions =
-          [|@"-o:obj\Debug\FSharp.Compiler.Service.dll"; "-g"; "--noframework";
+          [|@"-o:obj\Release\FSharp.Compiler.Service.dll"; "-g"; "--noframework";
             @"--baseaddress:0x06800000"; "--define:DEBUG";
             @"--define:CROSS_PLATFORM_COMPILER"; "--define:FX_ATLEAST_45";
             @"--define:FX_ATLEAST_40"; "--define:BE_SECURITY_TRANSPARENT";
@@ -219,6 +214,7 @@ let FCS (repositoryDir: string) : Options =
             @"-r:" + (repositoryDir </> @"packages\Microsoft.DiaSymReader.PortablePdb\lib\net45\Microsoft.DiaSymReader.PortablePdb.dll");
             @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll";
             @"-r:" + (repositoryDir </> @"packages\System.Collections.Immutable\lib\netstandard1.0\System.Collections.Immutable.dll");
+            @"-r:" + (repositoryDir </> @"packages\FSharp.Core\lib\net40\FSharp.Core.dll");
             @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Core.dll";
             @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.dll";
             @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Numerics.dll";
@@ -405,3 +401,11 @@ let VFPT (repositoryDir: string) : Options =
             PartialName = ""
         }]
       }
+
+let get (repositoryDir: string) : Options =
+    let repositoryDir = Path.GetFullPath(repositoryDir)
+    match DirectoryInfo(Path.GetFullPath(repositoryDir)).Name.ToLower() with
+    | "fsharp.compiler.service" -> FCS(repositoryDir)
+    | "fsharpvspowertools" -> VFPT(repositoryDir)
+    | _ -> failwithf "%s is not supported" repositoryDir
+

--- a/vsintegration/Utils/LanguageServiceProfiling/Program.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Program.fs
@@ -1,10 +1,10 @@
 ﻿(*
 
-Background check a project "SCGS" (Stats, Check, GC, Stats)
+Background check a project "CXGSCGS" (Check, Flush, GC, Stats, Check, GC, Stats)
 
-  .\Release\net40\bin\LanguageServiceProfiling.exe ..\FSharp.Compiler.Service SCGS 
+  .\Release\net40\bin\LanguageServiceProfiling.exe ..\FSharp.Compiler.Service CXGSCGS 
 
-Foreground check new versions of multiple files in an already-checked project and keep intellisense info "CGSFGS" (Check, Collect, Stats, File, Collect, Stats)
+Foreground check new versions of multiple files in an already-checked project and keep intellisense info "CGSFGS" (Check, GC, Stats, File, GC, Stats)
 
   .\Release\net40\bin\LanguageServiceProfiling.exe ..\FSharp.Compiler.Service CGSFGS 
 
@@ -29,10 +29,10 @@ Use the following to collect memory usage stats, appending to the existing stats
 Results look like this:
 
   Background FCS project:
-    statistics:     TimeDelta: 26.50     MemDelta:  275     G0:  893     G1:  694     G2:   12
+    master:     TimeDelta: 24.70     MemDelta:  318     G0:  880     G1:  696     G2:    8
 
   Background FCS project (with keepAllBackgroundResolutions=true) :
-    statistics:     TimeDelta: 27.48     MemDelta:  328     G0:  899     G1:  668     G2:   15
+    master:     TimeDelta: 23.84     MemDelta:  448     G0:  877     G1:  702     G2:    6
 
   Multiple foreground files from FCS project keeping all results:
     statistics:     TimeDelta: 8.58     MemDelta:  143     G0:  260     G1:  192     G2:    4
@@ -194,6 +194,7 @@ let main argv =
 <R> for find all references
 <L> for completion lists
 <W> for wasting 100M of memory
+<X> to clear all caches
 <M> to reclaim waste
 <Enter> for exit."""
 
@@ -248,6 +249,9 @@ let main argv =
         | 'S' ->
             stats()
             fileVersion
+        | 'X' ->
+            checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients() 
+            fileVersion
         | _ -> fileVersion
 
     let rec console fileVersion = 
@@ -259,6 +263,7 @@ let main argv =
         | ConsoleKey.L -> processCmd fileVersion 'L' |> console
         | ConsoleKey.W -> processCmd fileVersion 'W' |> console            
         | ConsoleKey.M -> processCmd fileVersion 'M' |> console
+        | ConsoleKey.X -> processCmd fileVersion 'X' |> console
         | ConsoleKey.Enter -> ()
         | _ -> console fileVersion
 

--- a/vsintegration/Utils/LanguageServiceProfiling/Program.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Program.fs
@@ -1,4 +1,38 @@
-﻿open Microsoft.FSharp.Compiler
+﻿(*
+
+
+Use the following to collect memory usage stats, appending to the existing stats files:
+
+  git clone http://github.com/fsharp/FSharp.Compiler.Service  tests\scripts\tmp\FSharp.Compiler.Service
+  pushd tests\scripts\tmp\FSharp.Compiler.Service
+  git checkout  2d51df21ca1d86d4d6676ead3b1fb125b2a0d1ba 
+  .\build Build.NetFx
+  popd
+
+  git rev-parse HEAD > gitrev.txt
+  set /P gitrev=<gitrev.txt
+
+  echo %gitrev%
+
+Check a project "SCGS" (Stats, Check, GC, Stats)
+
+  .\Release\net40\bin\LanguageServiceProfiling.exe tests\scripts\tmp\FSharp.Compiler.Service SCGS %gitrev% >> tests\scripts\service-fcs-project-check-mem-results.txt
+
+Check a file in an already-checked project "CGSFGS" (Check, Collect, Stats, File, Collect, Stats)
+
+  .\Release\net40\bin\LanguageServiceProfiling.exe tests\scripts\tmp\FSharp.Compiler.Service CGSFGS %gitrev% >> tests\scripts\service-fcs-file-check-mem-results.txt
+
+Results look like this:
+
+  a58b5011c989bbca049502bf0759cbde3380d352     TimeDelta: 26.95    MemDelta:  500     G0:  886     G1:  740     G2:   15
+
+or
+
+  a58b5011c989bbca049502bf0759cbde3380d352     TimeDelta: 2.89     MemDelta:   41     G0:   77     G1:   56     G2:    1
+
+*)
+
+open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open System
 open System.IO
@@ -19,49 +53,52 @@ let internal getQuickInfoText (FSharpToolTipText.FSharpToolTipText elements) : s
 [<EntryPoint>]
 let main argv = 
     let rootDir = argv.[0]
+    let scriptOpt = if argv.Length >= 2 then Some argv.[1] else None
+    let msgOpt = if argv.Length >= 3 then Some argv.[2] else None
+    let useConsole = scriptOpt.IsNone
     let options = Options.get rootDir
     let getFileLines () = File.ReadAllLines(options.FileToCheck)
     let getFileText () = File.ReadAllText(options.FileToCheck)
     let getLine line = (getFileLines ()).[line]
 
-    printfn "Found options for %s." options.Options.ProjectFileName
+    eprintfn "Found options for %s." options.Options.ProjectFileName
     let checker = FSharpChecker.Create()
     let waste = new ResizeArray<int array>()
     
     let checkProject() : Async<FSharpCheckProjectResults option> =
         async {
-            printfn "ParseAndCheckProject(%s)..." (Path.GetFileName options.Options.ProjectFileName)
+            eprintfn "ParseAndCheckProject(%s)..." (Path.GetFileName options.Options.ProjectFileName)
             let sw = Stopwatch.StartNew()
             let! result = checker.ParseAndCheckProject(options.Options)
             if result.HasCriticalErrors then
-                printfn "Finished with ERRORS: %+A" result.Errors
+                eprintfn "Finished with ERRORS: %+A" result.Errors
                 return None
             else 
-                printfn "Finished successfully in %O" sw.Elapsed
+                eprintfn "Finished successfully in %O" sw.Elapsed
                 return Some result
         }
 
     let checkFile (fileVersion: int) : Async<FSharpCheckFileResults option> =
         async {
-            printfn "ParseAndCheckFileInProject(%s)..." options.FileToCheck
+            eprintfn "ParseAndCheckFileInProject(%s)..." options.FileToCheck
             let sw = Stopwatch.StartNew()
             let! _, answer = checker.ParseAndCheckFileInProject(options.FileToCheck, fileVersion, File.ReadAllText options.FileToCheck, options.Options)
             match answer with
             | FSharpCheckFileAnswer.Aborted ->
-                printfn "Abortedin %O!" sw.Elapsed
+                eprintfn "Abortedin %O!" sw.Elapsed
                 return None
             | FSharpCheckFileAnswer.Succeeded results ->
                 if results.Errors |> Array.exists (fun x -> x.Severity = FSharpErrorSeverity.Error) then
-                    printfn "Finished with ERRORS in %O: %+A" sw.Elapsed results.Errors
+                    eprintfn "Finished with ERRORS in %O: %+A" sw.Elapsed results.Errors
                     return None
                 else 
-                    printfn "Finished successfully in %O" sw.Elapsed
+                    eprintfn "Finished successfully in %O" sw.Elapsed
                     return Some results
         }
     
     let findAllReferences (fileVersion: int) : Async<FSharpSymbolUse[]> =
         async {
-            printfn "Find all references (symbol = '%s', file = '%s')" options.SymbolText options.FileToCheck
+            eprintfn "Find all references (symbol = '%s', file = '%s')" options.SymbolText options.FileToCheck
             let! projectResults = checkProject()
             match projectResults with
             | Some projectResults ->
@@ -76,19 +113,19 @@ let main argv =
                             [options.SymbolText])
                     match symbolUse with
                     | Some symbolUse ->
-                        printfn "Found symbol %s" symbolUse.Symbol.FullName
+                        eprintfn "Found symbol %s" symbolUse.Symbol.FullName
                         let sw = Stopwatch.StartNew()
                         let! symbolUses = projectResults.GetUsesOfSymbol(symbolUse.Symbol)
-                        printfn "Found %d symbol uses in %O" symbolUses.Length sw.Elapsed
+                        eprintfn "Found %d symbol uses in %O" symbolUses.Length sw.Elapsed
                         return symbolUses
                     | None -> 
-                        printfn "Symbol '%s' was not found at (%d, %d) in %s" options.SymbolText options.SymbolPos.Line options.SymbolPos.Column options.FileToCheck
+                        eprintfn "Symbol '%s' was not found at (%d, %d) in %s" options.SymbolText options.SymbolPos.Line options.SymbolPos.Column options.FileToCheck
                         return [||]
                 | None -> 
-                    printfn "No file check results for %s" options.FileToCheck
+                    eprintfn "No file check results for %s" options.FileToCheck
                     return [||]
              | None -> 
-                printfn "No project results for %s" options.Options.ProjectFileName
+                eprintfn "No project results for %s" options.Options.ProjectFileName
                 return [||]
         }
     let getDeclarations (fileVersion: int) =
@@ -101,7 +138,7 @@ let main argv =
                 | Some fileResults ->
                     let! parseResult = checker.ParseFileInProject(options.FileToCheck, getFileText(), options.Options) 
                     for completion in options.CompletionPositions do
-                        printfn "querying %A %s" completion.QualifyingNames completion.PartialName
+                        eprintfn "querying %A %s" completion.QualifyingNames completion.PartialName
                         let! listInfo =
                             fileResults.GetDeclarationListInfo(
                                 Some parseResult
@@ -112,16 +149,17 @@ let main argv =
                                 , completion.PartialName)
                            
                         for i in listInfo.Items do
-                            printfn "%s" (getQuickInfoText i.DescriptionText)
+                            eprintfn "%s" (getQuickInfoText i.DescriptionText)
 
-                | None -> printfn "no declarations"
-            | None -> printfn "no declarations"
+                | None -> eprintfn "no declarations"
+            | None -> eprintfn "no declarations"
         }
     
     let wasteMemory () =
         waste.Add(Array.zeroCreate (1024 * 1024 * 25))
 
-    printfn """Press:
+    if useConsole then 
+        eprintfn """Press:
 
 <C> for check the project
 <G> for GC.Collect(2)
@@ -132,33 +170,75 @@ let main argv =
 <M> to reclaim waste
 <Enter> for exit."""
 
-    let rec loop (fileVersion: int) =
-        match Console.ReadKey().Key with
-        | ConsoleKey.C -> 
+    let mutable tPrev = None
+    let stats() = 
+        // Note that timing calls are relatively expensive on the startup path so we don't
+        // make this call unless showTimes has been turned on.
+        let uproc = System.Diagnostics.Process.GetCurrentProcess()
+        let timeNow = uproc.UserProcessorTime.TotalSeconds
+        let maxGen = System.GC.MaxGeneration
+        let gcNow = [| for i in 0 .. maxGen -> System.GC.CollectionCount(i) |]
+        let wsNow = uproc.WorkingSet64/1000000L
+
+        match tPrev with
+        | Some (timePrev, gcPrev:int[], wsPrev)->
+            let spanGC = [| for i in 0 .. maxGen -> System.GC.CollectionCount(i) - gcPrev.[i] |]
+            printfn "%s     TimeDelta: %4.2f     MemDelta: %4d     G0: %4d     G1: %4d     G2: %4d" 
+                (match msgOpt with Some msg -> msg | None -> "statistics:")
+                (timeNow - timePrev) 
+                (wsNow - wsPrev)
+                spanGC.[min 0 maxGen] spanGC.[min 1 maxGen] spanGC.[min 2 maxGen]
+
+        | _ -> ()
+        tPrev <- Some (timeNow, gcNow, wsNow)
+
+    let processCmd (fileVersion: int) c =
+        match c with 
+        | 'C' -> 
             checkProject() |> Async.RunSynchronously |> ignore
-            loop fileVersion
-        | ConsoleKey.G -> 
-            printfn "GC is running..."
+            fileVersion
+        | 'G' -> 
+            eprintfn "GC is running..."
             let sw = Stopwatch.StartNew()
             GC.Collect 2
-            printfn "GC is done in %O" sw.Elapsed
-            loop fileVersion
-        | ConsoleKey.F ->
+            eprintfn "GC is done in %O" sw.Elapsed
+            fileVersion
+        | 'F' ->
             checkFile fileVersion |> Async.RunSynchronously |> ignore
-            loop (fileVersion + 1)
-        | ConsoleKey.R ->
+            (fileVersion + 1)
+        | 'R' ->
             findAllReferences fileVersion |> Async.RunSynchronously |> ignore
-            loop fileVersion
-        | ConsoleKey.L ->
+            fileVersion
+        | 'L' ->
             getDeclarations fileVersion |> Async.RunSynchronously
-            loop fileVersion
-        | ConsoleKey.W ->
+            fileVersion
+        | 'W' ->
             wasteMemory()
-            loop fileVersion
-        | ConsoleKey.M ->
+            fileVersion
+        | 'M' ->
             waste.Clear()
-            loop fileVersion
+            fileVersion
+        | 'S' ->
+            stats()
+            fileVersion
+        | _ -> fileVersion
+
+    let rec console fileVersion = 
+        match Console.ReadKey().Key with
+        | ConsoleKey.C -> processCmd fileVersion 'C' |> console
+        | ConsoleKey.G -> processCmd fileVersion 'G' |> console
+        | ConsoleKey.F -> processCmd fileVersion 'F' |> console
+        | ConsoleKey.R -> processCmd fileVersion 'R' |> console
+        | ConsoleKey.L -> processCmd fileVersion 'L' |> console
+        | ConsoleKey.W -> processCmd fileVersion 'W' |> console            
+        | ConsoleKey.M -> processCmd fileVersion 'M' |> console
         | ConsoleKey.Enter -> ()
-        | _ -> loop fileVersion
-    loop 0
+        | _ -> console fileVersion
+
+    let runScript (script:string)  = 
+        (0,script) ||> Seq.fold processCmd |> ignore
+
+    match scriptOpt with 
+    | None ->  console 0
+    | Some s -> runScript  s
     0

--- a/vsintegration/Utils/LanguageServiceProfiling/Program.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Program.fs
@@ -195,6 +195,7 @@ let main argv =
 <L> for completion lists
 <W> for wasting 100M of memory
 <X> to clear all caches
+<P> to pause for key entry
 <M> to reclaim waste
 <Enter> for exit."""
 
@@ -252,6 +253,10 @@ let main argv =
         | 'X' ->
             checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients() 
             fileVersion
+        | 'P' ->
+            eprintfn "pausing (press any key)...";
+            System.Console.ReadKey() |> ignore
+            fileVersion
         | _ -> fileVersion
 
     let rec console fileVersion = 
@@ -264,6 +269,7 @@ let main argv =
         | ConsoleKey.W -> processCmd fileVersion 'W' |> console            
         | ConsoleKey.M -> processCmd fileVersion 'M' |> console
         | ConsoleKey.X -> processCmd fileVersion 'X' |> console
+        | ConsoleKey.P -> processCmd fileVersion 'P' |> console
         | ConsoleKey.Enter -> ()
         | _ -> console fileVersion
 


### PR DESCRIPTION
@vasily-kirichenko This updates the VS memory tester to allow command-line execution.  

    .\Release\net40\bin\LanguageServiceProfiling.exe tests\scripts\tmp\FSharp.Compiler.Service SCGS "commit-number"

where "SCGS" is the script of commands. We print a single line of results to stdout and rest of output to stderr:

  commit-number    TimeDelta: 26.95    MemDelta:  500     G0:  886     G1:  740     G2:   15

The aim is to collect a single line of data to append to a log file. Maybe we do this during CI, I'm not sure, I'm currently doing it manually.

For some reason I also needed to set .NET framework to 4.6 or else I get an unresolvable message that I must install 4.6.2 