### PR TITLE
fix memory capture by TcSymbolUses

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1391,15 +1391,20 @@ type TcResolutions
 
 /// Represents container for all name resolutions that were met so far when typechecking some particular file
 type TcSymbolUses(g, capturedNameResolutions : ResizeArray<CapturedNameResolution>, formatSpecifierLocations: range[]) = 
+    
+    // Make sure we only capture the information we really need to report symbol uses
+    let cnrs = [| for cnr in capturedNameResolutions  -> cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.Range |]
+    let capturedNameResolutions = () 
+    do ignore capturedNameResolutions // don't capture this!
 
     member this.GetUsesOfSymbol(item) = 
-        [| for cnr in capturedNameResolutions do
-               if protectAssemblyExploration false (fun () -> ItemsAreEffectivelyEqual g item cnr.Item) then
-                  yield cnr.ItemOccurence, cnr.DisplayEnv, cnr.Range |]
+        [| for (cnrItem,occ,denv,m) in cnrs do
+               if protectAssemblyExploration false (fun () -> ItemsAreEffectivelyEqual g item cnrItem) then
+                  yield occ, denv, m |]
 
     member this.GetAllUsesOfSymbols() = 
-        [| for cnr in capturedNameResolutions do
-              yield (cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.Range) |]
+        [| for (cnrItem,occ,denv,m) in cnrs do
+              yield (cnrItem, occ, denv, m) |]
 
     member this.GetFormatSpecifierLocations() =  formatSpecifierLocations
 


### PR DESCRIPTION
This fixes memory capture by the retained TcSymbolUses structure, which was unnecessarily capturing the NameResolutionEnv objects for each symbol use 

@vasily-kirichenko Here are the memory usage statistics reported by LanguageServiceProfiling.exe for CXGSCGS script:

```
master:     TimeDelta: 24.70     MemDelta:  318     G0:  880     G1:  696     G2:    8
mem-capture-1:    TimeDelta: 25.27     MemDelta:  233     G0:  881     G1:  743     G2:    8
```
So the retained memory is reduced by 26% (that's all memory retained by  the BackgroundBuilder-->IncrementalBuilder for the background check of the project)

