### PR TITLE
don't keep parse results in background builder

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1391,15 +1391,20 @@ type TcResolutions
 
 /// Represents container for all name resolutions that were met so far when typechecking some particular file
 type TcSymbolUses(g, capturedNameResolutions : ResizeArray<CapturedNameResolution>, formatSpecifierLocations: range[]) = 
+    
+    // Make sure we only capture the information we really need to report symbol uses
+    let cnrs = [| for cnr in capturedNameResolutions  -> cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.Range |]
+    let capturedNameResolutions = () 
+    do ignore capturedNameResolutions // don't capture this!
 
     member this.GetUsesOfSymbol(item) = 
-        [| for cnr in capturedNameResolutions do
-               if protectAssemblyExploration false (fun () -> ItemsAreEffectivelyEqual g item cnr.Item) then
-                  yield cnr.ItemOccurence, cnr.DisplayEnv, cnr.Range |]
+        [| for (cnrItem,occ,denv,m) in cnrs do
+               if protectAssemblyExploration false (fun () -> ItemsAreEffectivelyEqual g item cnrItem) then
+                  yield occ, denv, m |]
 
     member this.GetAllUsesOfSymbols() = 
-        [| for cnr in capturedNameResolutions do
-              yield (cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.Range) |]
+        [| for (cnrItem,occ,denv,m) in cnrs do
+              yield (cnrItem, occ, denv, m) |]
 
     member this.GetFormatSpecifierLocations() =  formatSpecifierLocations
 

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1393,17 +1393,17 @@ type TcResolutions
 type TcSymbolUses(g, capturedNameResolutions : ResizeArray<CapturedNameResolution>, formatSpecifierLocations: range[]) = 
     
     // Make sure we only capture the information we really need to report symbol uses
-    let cnrs = [| for cnr in capturedNameResolutions  -> cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.Range |]
+    let cnrs = [| for cnr in capturedNameResolutions  -> struct (cnr.Item, cnr.ItemOccurence, cnr.DisplayEnv, cnr.Range) |]
     let capturedNameResolutions = () 
     do ignore capturedNameResolutions // don't capture this!
 
     member this.GetUsesOfSymbol(item) = 
-        [| for (cnrItem,occ,denv,m) in cnrs do
+        [| for (struct (cnrItem,occ,denv,m)) in cnrs do
                if protectAssemblyExploration false (fun () -> ItemsAreEffectivelyEqual g item cnrItem) then
                   yield occ, denv, m |]
 
     member this.GetAllUsesOfSymbols() = 
-        [| for (cnrItem,occ,denv,m) in cnrs do
+        [| for (struct (cnrItem,occ,denv,m)) in cnrs do
               yield (cnrItem, occ, denv, m) |]
 
     member this.GetFormatSpecifierLocations() =  formatSpecifierLocations

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1600,10 +1600,14 @@ type IncrementalBuilder(frameworkTcImportsCache: FrameworkImportsCache, tcConfig
         
     // Build
     let stampedFileNamesNode        = Vector.Stamp "SourceFileTimeStamps" StampFileNameTask fileNamesNode
-    let parseTreesNode              = Vector.Map "ParseTrees" ParseTask stampedFileNamesNode
     let stampedReferencedAssembliesNode = Vector.Stamp "TimestampReferencedAssembly" TimestampReferencedAssemblyTask referencedAssembliesNode
     let initialTcAccNode            = Vector.Demultiplex "CombineImportedAssemblies" CombineImportedAssembliesTask stampedReferencedAssembliesNode
-    let tcStatesNode                = Vector.ScanLeft "TypeCheckingStates" TypeCheckTask initialTcAccNode parseTreesNode
+#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
+    let parseTreesNode              = Vector.Map "ParseTrees" ParseTask stampedFileNamesNode
+    let tcStatesNode                = Vector.ScanLeft "TypeCheckingStates" TypeCheckTask initialTcAccNode stampedFileNamesNode
+#else
+    let tcStatesNode                = Vector.ScanLeft "TypeCheckingStates" (fun tcAcc n -> TypeCheckTask tcAcc (ParseTask n)) initialTcAccNode stampedFileNamesNode
+#endif
     let finalizedTypeCheckNode      = Vector.Demultiplex "FinalizeTypeCheck" FinalizeTypeCheckTask tcStatesNode
 
     // Outputs
@@ -1611,7 +1615,9 @@ type IncrementalBuilder(frameworkTcImportsCache: FrameworkImportsCache, tcConfig
 
     do buildDescription.DeclareVectorOutput stampedFileNamesNode
     do buildDescription.DeclareVectorOutput stampedReferencedAssembliesNode
+#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
     do buildDescription.DeclareVectorOutput parseTreesNode
+#endif
     do buildDescription.DeclareVectorOutput tcStatesNode
     do buildDescription.DeclareScalarOutput initialTcAccNode
     do buildDescription.DeclareScalarOutput finalizedTypeCheckNode
@@ -1760,6 +1766,7 @@ type IncrementalBuilder(frameworkTcImportsCache: FrameworkImportsCache, tcConfig
       
     member ib.GetParseResultsForFile (filename, ct) =
         let slotOfFile = ib.GetSlotOfFileName filename
+#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
         match GetVectorResultBySlot(parseTreesNode,slotOfFile,partialBuild) with
         | Some (results, _) -> results
         | None -> 
@@ -1767,6 +1774,18 @@ type IncrementalBuilder(frameworkTcImportsCache: FrameworkImportsCache, tcConfig
             match GetVectorResultBySlot(parseTreesNode,slotOfFile,build) with
             | Some (results, _) -> results
             | None -> failwith "Build was not evaluated, expcted the results to be ready after 'Eval'."
+#else
+        let results = 
+            match GetVectorResultBySlot(stampedFileNamesNode,slotOfFile,partialBuild) with
+            | Some (results, _) ->  results
+            | None -> 
+                let build = IncrementalBuild.EvalUpTo SavePartialBuild ct (stampedFileNamesNode, slotOfFile) partialBuild  
+                match GetVectorResultBySlot(stampedFileNamesNode,slotOfFile,build) with
+                | Some (results, _) -> results
+                | None -> failwith "Build was not evaluated, expcted the results to be ready after 'Eval'."
+        // re-parse on demand instead of retaining
+        ParseTask results
+#endif
 
     member __.ProjectFileNames  = sourceFiles  |> List.map (fun (_,f,_) -> f)
 

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -4817,7 +4817,11 @@ let ``Test request for parse and check doesn't check whole project`` () =
     backgroundCheckCount.Value |> shouldEqual 0
     let checkResults1 = checker.CheckFileInProject(parseResults1, ProjectBig.fileNames.[5], 0, ProjectBig.fileSources2.[5], ProjectBig.options)  |> Async.RunSynchronously
     let pD, tD = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
-    backgroundParseCount.Value |> shouldEqual 10 // This could be reduced to 5 - the whole project gets parsed 
+#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
+    backgroundParseCount.Value |> shouldEqual 10
+#else
+    backgroundParseCount.Value |> shouldEqual 5
+#endif
     backgroundCheckCount.Value |> shouldEqual 5
     (pD - pC) |> shouldEqual 0
     (tD - tC) |> shouldEqual 1
@@ -4826,7 +4830,11 @@ let ``Test request for parse and check doesn't check whole project`` () =
     let pE, tE = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
     (pE - pD) |> shouldEqual 0
     (tE - tD) |> shouldEqual 1
+#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
     backgroundParseCount.Value |> shouldEqual 10 // but note, the project does not get reparsed
+#else
+    backgroundParseCount.Value |> shouldEqual 7 // but note, the project does not get reparsed
+#endif
     backgroundCheckCount.Value |> shouldEqual 7 // only two extra typechecks of files
 
     // A subsequent ParseAndCheck of identical source code doesn't do any more anything
@@ -4834,7 +4842,11 @@ let ``Test request for parse and check doesn't check whole project`` () =
     let pF, tF = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
     (pF - pE) |> shouldEqual 0  // note, no new parse of the file
     (tF - tE) |> shouldEqual 0  // note, no new typecheck of the file
+#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
     backgroundParseCount.Value |> shouldEqual 10 // but note, the project does not get reparsed
+#else
+    backgroundParseCount.Value |> shouldEqual 7 // but note, the project does not get reparsed
+#endif
     backgroundCheckCount.Value |> shouldEqual 7 // only two extra typechecks of files
 
     ()

--- a/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
@@ -4218,7 +4218,11 @@ let x = query { for bbbb in abbbbc(*D0*) do
         SaveFileToDisk file2      
         TakeCoffeeBreak(this.VS)
         
+#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
         gpatcc.AssertExactly(notAA[file2], notAA[file2;file3])
+#else
+        gpatcc.AssertExactly(notAA[file2; file3], notAA[file2;file3])
+#endif
 
     /// FEATURE: References added to the project bring corresponding new .NET and F# items into scope.
     [<Test;Category("ReproX")>]


### PR DESCRIPTION
Like https://github.com/Microsoft/visualfsharp/pull/2377 this eliminates a source of unnecessarily retained memory - the parse trees from the background build.  These are unused in the Visual F# Tools and even if they were needed it is easy to recreate them on-demand.  

The original code is being kept #if because the FSharp.Compiler.Service buget package component might choose to optionally allow the storage of these, so there's no need to delete the original code path yet

Memory stats:

```
this branch     TimeDelta: 25.86     MemDelta:  242     G0:  876     G1:  745     G2:    7
master:        TimeDelta: 24.70     MemDelta:  318     G0:  880     G1:  696     G2:    8
```

which indicates a 24% reduction in retained memory

When combined with #2377 this gives

```
this branch:     TimeDelta: 26.03     MemDelta:  145     G0:  897     G1:  745     G2:   27
```

which is a 54% reduction in retained memory for the background incremental build.


