### PR TITLE
fix for #2346

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -348,11 +348,15 @@ and
             projectContext.AddSourceFile(fileName)
             
             let project = projectContext :?> AbstractProject
-            let document = project.GetCurrentDocumentFromPath(fileName)
+            let id = project.GetCurrentDocumentFromPath(fileName).Id
 
-            document.Closing.Add(fun _ ->  
-                projectInfoManager.RemoveSingleFileProject(projectId)
-                project.Disconnect())
+            let rec onDocumentClosed = EventHandler<DocumentEventArgs> (fun _ args ->
+                if args.Document.Id = id then
+                    projectInfoManager.RemoveSingleFileProject(projectId)
+                    project.Disconnect()
+                    workspace.DocumentClosed.RemoveHandler(onDocumentClosed)
+            )
+            workspace.DocumentClosed.AddHandler(onDocumentClosed)
 
     override this.ContentTypeName = FSharpCommonConstants.FSharpContentTypeName
     override this.LanguageName = FSharpCommonConstants.FSharpLanguageName

--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -348,10 +348,10 @@ and
             projectContext.AddSourceFile(fileName)
             
             let project = projectContext :?> AbstractProject
-            let id = project.GetCurrentDocumentFromPath(fileName).Id
+            let documentId = project.GetCurrentDocumentFromPath(fileName).Id
 
             let rec onDocumentClosed = EventHandler<DocumentEventArgs> (fun _ args ->
-                if args.Document.Id = id then
+                if args.Document.Id = documentId then
                     projectInfoManager.RemoveSingleFileProject(projectId)
                     project.Disconnect()
                     workspace.DocumentClosed.RemoveHandler(onDocumentClosed)


### PR DESCRIPTION
This fixes the puzzling symptoms of #2346 but not the underlying cause of which I'm not sure.
I suspect somewhere in `AbstractProject.Disconnect()` in Roslyn there is some kind of race as giving it a bit of a breather with e.g. 
```
async { do! Async.Sleep 1000
        project.Disconnect() } |> Async.StartImmediate
```
fixes the symptoms, too.

This PR is more an indication of the problem, in this way I hope it may help somewhat.

