### PR TITLE
Address issue with being unable to install VisualFSharpOpenSource .vsix

### DIFF
--- a/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
+++ b/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
@@ -36,7 +36,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <IsProductComponent>true</IsProductComponent>
+    <IsProductComponent>false</IsProductComponent>
     <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
     <ExtensionInstallationFolder>Microsoft\FSharp</ExtensionInstallationFolder>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>


### PR DESCRIPTION
So ...

Visual FSharp tools is a slightly unusual vsix inasmuch as ... it ships with VS and yet we want to be able to install it the VSIX from an OSS build too.

VSCore have a scenario to ensure that this works, however, as part of the new installer work uninstall of vs shipped vsix' replaced in this way got broken.  And so the feature has been disabled until it can be fixed in a future update.

Which leaves us with a bit of a problem ...

This PR has a work-around until we can install vsix' properly again.

The fix is simple ... tell the build we are not building an internal component.


How to use:

In a VS 2017 command shell by typing 
````
vsixinstaller release\net40\bin\VisualFSharpOpenSource.vsix
````
to uninstall type:
````
vsixinstaller /uninstall:VisualFSharp
````
**Note:**
You need to uninstall an earlier installation of the vsix before installing an updated VisualFsharpOpenSource.vsix










