### PR TITLE
Rollback changing VS FSI tool window content type

### DIFF
--- a/vsintegration/src/FSharp.VS.FSI/fsiTextBufferStream.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiTextBufferStream.fs
@@ -27,7 +27,11 @@ open Microsoft.VisualStudio.Utilities
 //
 type internal TextBufferStream(textLines:ITextBuffer, contentTypeRegistry: IContentTypeRegistryService) = 
     do if null = textLines then raise (new ArgumentNullException("textLines"))
-    do textLines.ChangeContentType(contentTypeRegistry.GetContentType Guids.fsiContentTypeName, Guid Guids.guidFsiLanguageService)
+    // The following line causes unhandled excepiton on a background thread, see https://github.com/Microsoft/visualfsharp/issues/2318#issuecomment-279340343
+    // It seems we should provide a Quick Info Provider at the same time as uncommenting it.
+    
+    //do textLines.ChangeContentType(contentTypeRegistry.GetContentType Guids.fsiContentTypeName, Guid Guids.guidFsiLanguageService)
+    
     let mutable readonlyRegion  = null : IReadOnlyRegion
 
     let extendReadOnlyRegion position =


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/2318

A distinct content type was given to VS FSI window as a first step in adding syntax highlighting to it, see https://github.com/Microsoft/visualfsharp/pull/2192 

We should return to this in the future, as we are implementing the coloring. 