### PR TITLE
PrefixUnusedValueWithUnderscore Code Fix does not trigger on operators and backticked identifiers

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/PrefixUnusedValueWithUnderscore.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/PrefixUnusedValueWithUnderscore.fs
@@ -12,6 +12,8 @@ open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
 open Microsoft.CodeAnalysis.CodeActions
 
+open Microsoft.FSharp.Compiler
+
 [<ExportCodeFixProvider(FSharpCommonConstants.FSharpLanguageName, Name = "PrefixUnusedValueWithUnderscore"); Shared>]
 type internal FSharpPrefixUnusedValueWithUnderscoreCodeFixProvider() =
     inherit CodeFixProvider()
@@ -30,8 +32,14 @@ type internal FSharpPrefixUnusedValueWithUnderscoreCodeFixProvider() =
     override __.FixableDiagnosticIds = fixableDiagnosticIds.ToImmutableArray()
 
     override __.RegisterCodeFixesAsync context : Task =
-       async {
-           let diagnostics = (context.Diagnostics |> Seq.filter (fun x -> fixableDiagnosticIds |> List.contains x.Id)).ToImmutableArray()
-           context.RegisterCodeFix(createCodeFix(SR.PrefixValueNameWithUnderscore.Value, context, TextChange(TextSpan(context.Span.Start, 0), "_")), diagnostics)
-           context.RegisterCodeFix(createCodeFix(SR.RenameValueToUnderscore.Value, context, TextChange(context.Span, "_")), diagnostics)
+        async {
+            let! sourceText = context.Document.GetTextAsync()
+            let ident = sourceText.ToString(context.Span)
+            // Prefixing operators and backticked identifiers does not make sense.
+            // We have to use the additional check for backtickes because `IsOperatorOrBacktickedName` operates on display names
+            // where backtickes are replaced with parens.
+            if not (PrettyNaming.IsOperatorOrBacktickedName ident) && not (ident.StartsWith "``") then
+                let diagnostics = (context.Diagnostics |> Seq.filter (fun x -> fixableDiagnosticIds |> List.contains x.Id)).ToImmutableArray()
+                context.RegisterCodeFix(createCodeFix(SR.PrefixValueNameWithUnderscore.Value, context, TextChange(TextSpan(context.Span.Start, 0), "_")), diagnostics)
+                context.RegisterCodeFix(createCodeFix(SR.RenameValueToUnderscore.Value, context, TextChange(context.Span, "_")), diagnostics)
         } |> CommonRoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)

--- a/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
@@ -15,6 +15,7 @@ open Microsoft.CodeAnalysis.Host.Mef
 open Microsoft.CodeAnalysis.Text
 
 open Microsoft.FSharp.Compiler.SourceCodeServices
+open Microsoft.FSharp.Compiler.Range
 
 type internal FSharpHighlightSpan =
     { IsDefinition: bool
@@ -56,7 +57,7 @@ type internal FSharpDocumentHighlightsService [<ImportingConstructor>] (checkerP
         asyncMaybe {
             let textLine = sourceText.Lines.GetLineFromPosition(position)
             let textLinePos = sourceText.Lines.GetLinePosition(position)
-            let fcsTextLineNumber = textLinePos.Line + 1
+            let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let! symbol = CommonHelpers.getSymbolAtPosition(documentKey, sourceText, position, filePath, defines, SymbolLookupKind.Greedy)
             let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults = true)
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland)


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/2207