### PR TITLE
Small fixes to FCS members' documentation

### DIFF
--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -415,10 +415,6 @@ type internal FSharpChecker =
     /// <param name="fileversion">An integer that can be used to indicate the version of the file. This will be returned by TryGetRecentCheckResultsForFile when looking up the file.</param>
     /// <param name="source">The full source for the file.</param>
     /// <param name="options">The options for the project or script.</param>
-    /// <param name="isResultObsolete">
-    ///     A callback to check if a requested result is already obsolete, e.g. because of changed 
-    //      source code in the editor. Type checking is abandoned when this returns 'true'.
-    /// </param>
     /// <param name="textSnapshotInfo">
     ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
     ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 
@@ -436,7 +432,7 @@ type internal FSharpChecker =
     /// </para>
     /// <para>
     ///   Return FSharpCheckFileAnswer.Aborted if a parse tree was not available or if the check
-    ////  was abandoned due to isResultObsolete returning 'true' at some checkpoint during type checking.
+    ////  was abandoned due to some checkpoint during type checking.
     /// </para>
     /// </summary>
     ///
@@ -445,10 +441,6 @@ type internal FSharpChecker =
     /// <param name="fileversion">An integer that can be used to indicate the version of the file. This will be returned by TryGetRecentCheckResultsForFile when looking up the file.</param>
     /// <param name="source">The full source for the file.</param>
     /// <param name="options">The options for the project or script.</param>
-    /// <param name="isResultObsolete">
-    ///     A callback to check if a requested result is already obsolete, e.g. because of changed 
-    //      source code in the editor. Type checking is abandoned when this returns 'true'.
-    /// </param>
     /// <param name="textSnapshotInfo">
     ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
     ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 
@@ -466,7 +458,7 @@ type internal FSharpChecker =
     /// </para>
     /// <para>
     ///   Return FSharpCheckFileAnswer.Aborted if a parse tree was not available or if the check
-    ////  was abandoned due to isResultObsolete returning 'true' at some checkpoint during type checking.
+    ////  was abandoned due to some checkpoint during type checking.
     /// </para>
     /// </summary>
     ///
@@ -474,10 +466,6 @@ type internal FSharpChecker =
     /// <param name="fileversion">An integer that can be used to indicate the version of the file. This will be returned by TryGetRecentCheckResultsForFile when looking up the file.</param>
     /// <param name="source">The full source for the file.</param>
     /// <param name="options">The options for the project or script.</param>
-    /// <param name="isResultObsolete">
-    ///     A callback to check if a requested result is already obsolete, e.g. because of changed 
-    //      source code in the editor. Type checking is abandoned when this returns 'true'.
-    /// </param>
     /// <param name="textSnapshotInfo">
     ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
     ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -420,7 +420,7 @@ type internal FSharpChecker =
     //      source code in the editor. Type checking is abandoned when this returns 'true'.
     /// </param>
     /// <param name="textSnapshotInfo">
-    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' to help determine if 
+    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
     ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>
@@ -450,7 +450,7 @@ type internal FSharpChecker =
     //      source code in the editor. Type checking is abandoned when this returns 'true'.
     /// </param>
     /// <param name="textSnapshotInfo">
-    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' to help determine if 
+    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
     ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>
@@ -479,7 +479,7 @@ type internal FSharpChecker =
     //      source code in the editor. Type checking is abandoned when this returns 'true'.
     /// </param>
     /// <param name="textSnapshotInfo">
-    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' to help determine if 
+    ///     An item passed back to 'hasTextChangedSinceLastTypecheck' (from some calls made on 'FSharpCheckFileResults') to help determine if 
     ///     an approximate intellisense resolution is inaccurate because a range of text has changed. This 
     ///     can be used to marginally increase accuracy of intellisense results in some situations.
     /// </param>


### PR DESCRIPTION
* documentation of textSnapshotInfo parameter now mentions that hasTextChangedSinceLastTypecheck is something made available in some members FSharpCheckFileResults
* fixed documentation related to isResultObsolete parameters which were removed (can we get compile error for mismatched documentation?)