### PR TITLE
Fix word-splitting bug in before_install.sh

### DIFF
--- a/before_install.sh
+++ b/before_install.sh
@@ -28,7 +28,11 @@ fi
 
 # Check if SSL certificates have been imported into Mono's certificate store.
 # If certs haven't been installed, some/all of the Nuget packages will fail to restore.
-if [ $('certmgr -list -c Trust | grep -c -F "X.509"') -le 1 ]; then
+# Note, the result of the certmgr and grep commands returns the number of installed X.509 certificates.
+# We need to run the command twice -- on some systems (e.g. macOS) the certs are installed in the user store,
+# and on other systems (e.g., Ubuntu) they're installed to the machine store. certmgr only shows what's in
+# the selected store, which is why we need to check both.
+if [ "$(certmgr -list -c Trust | grep -c -F "X.509")" -le 1 ] && [ "$(certmgr -list -c -m Trust | grep -c -F "X.509")" -le 1 ]; then
   echo "No SSL certificates installed so unable to restore NuGet packages." >&2;
   echo "Run 'mozroots --sync --import' to install certificates to Mono's certificate store." >&2;
   exit 1


### PR DESCRIPTION
There's a bug related to word-splitting in ``before_install.sh`` which was introduced in cc33ee4 and affects at least bash on Mac OS X. I've fixed the script so it's quoted to avoid word-splitting while still adhering to POSIX shell language (thanks shellcheck!).

Related to issue #2125.