### PR TITLE
SemanticClassificationType should not be internal

### DIFF
--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -149,7 +149,7 @@ type internal FSharpSymbolUse =
     member RangeAlternate: range
 
 [<RequireQualifiedAccess>]
-type internal SemanticClassificationType =
+type SemanticClassificationType =
     | ReferenceType
     | ValueType
     | UnionCase


### PR DESCRIPTION
This is needed downstream for ionide and FSAC.
Already merged to fsharp/FSharp.Compiler.Service (see https://github.com/fsharp/FSharp.Compiler.Service/pull/696)