### PR TITLE
Turn off KeywordCompletionProvider

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionService.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionService.fs
@@ -30,8 +30,10 @@ type internal FSharpCompletionService
 
     let builtInProviders = 
         ImmutableArray.Create<CompletionProvider>(
-            FSharpCompletionProvider(workspace, serviceProvider, checkerProvider, projectInfoManager),
-            FSharpKeywordCompletionProvider(workspace, projectInfoManager))
+            FSharpCompletionProvider(workspace, serviceProvider, checkerProvider, projectInfoManager)
+            // we've turned off keyword completion because it does not filter suggestion depending on context.
+            // FSharpKeywordCompletionProvider(workspace, projectInfoManager)
+            )
 
     let completionRules = 
         CompletionRules.Default

--- a/vsintegration/src/FSharp.Editor/Completion/KeywordCompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/KeywordCompletionProvider.fs
@@ -28,7 +28,8 @@ type internal FSharpKeywordCompletionProvider
 
     let completionItems =
         Lexhelp.Keywords.keywordsWithDescription
-        |> List.map (fun (keyword, description) -> 
+        |> List.filter (fun (keyword, _) -> not (PrettyNaming.IsOperatorName keyword))
+        |> List.map (fun (keyword, description) ->
              CommonCompletionItem.Create(keyword, Nullable(Glyph.Keyword)).AddProperty("description", description))
 
     static member ShouldTriggerCompletionAux(sourceText: SourceText, caretPosition: int, trigger: CompletionTriggerKind, getInfo: (unit -> DocumentId * string * string list)) =


### PR DESCRIPTION
Due to the lack of context filtering, keyword completion is very obtrusive. Adding such a filtering is quite a lot of work, so I turn it off for now.