### PR TITLE
Give nicer lambda variables

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -9346,7 +9346,14 @@ and TcMethodApplication
                             [domainTy]
                     [argTys],returnTy
                         
-            let lambdaVarsAndExprs = curriedArgTys |> List.mapiSquared (fun i j ty -> mkCompGenLocal mMethExpr ("arg"+string i+string j) ty)
+            let lambdaVarsAndExprs = 
+                match curriedArgTys with
+                | [] -> []
+                | [[ty]] -> [[mkCompGenLocal mMethExpr "x" ty]]
+                | _ ->
+                    curriedArgTys 
+                    |> List.mapiSquared (fun i j ty -> mkCompGenLocal mMethExpr ("arg" + string i + string j) ty)
+
             let unnamedCurriedCallerArgs = lambdaVarsAndExprs |> List.mapSquared (fun (_,e) -> CallerArg(tyOfExpr cenv.g e,e.Range,false,e))
             let namedCurriedCallerArgs = lambdaVarsAndExprs |> List.map (fun _ -> [])
             let lambdaVars = List.mapSquared fst lambdaVarsAndExprs


### PR DESCRIPTION
Since we are in the age of fable, we should care more about generated names.
This is a first attempt to make https://github.com/fable-compiler/Fable/issues/713 nicer