### PR TITLE
Change default color for mutables

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -72,7 +72,7 @@ module internal ClassificationDefinitions =
         inherit ClassificationFormatDefinition()
         
         do self.DisplayName <- SR.FSharpMutableVarsClassificationType.Value
-           self.ForegroundColor <- Nullable Colors.Red
+           self.ForegroundColor <- Nullable (Color.FromRgb(160uy, 128uy, 0uy))
 
     [<Export(typeof<EditorFormatDefinition>)>]
     [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.Printf)>]


### PR DESCRIPTION
Red color with which mutable variables are highlighted is too confusing, see https://github.com/Microsoft/visualfsharp/issues/2446 