### PR TITLE
Separate color themes for dark and light mode

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -78,8 +78,8 @@ module internal ClassificationDefinitions =
         let setColors _ =
             let fontAndColorStorage = serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
             let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager)
-            fontAndColorCacheManager.CheckCache( ref VSKnownGuids.textEditorFontCategory) |> ignore
-            fontAndColorStorage.OpenCategory(ref VSKnownGuids.textEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
+            fontAndColorCacheManager.CheckCache( ref VSKnownGuids.TextEditorFontCategory) |> ignore
+            fontAndColorStorage.OpenCategory(ref VSKnownGuids.TextEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
 
             let formatMap = classificationformatMapService.GetClassificationFormatMap(category = "text")
             for ctype, (light, dark) in colorData do

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -17,7 +17,6 @@ open Microsoft.VisualStudio.Utilities
 open Microsoft.CodeAnalysis.Classification
 
 open Microsoft.FSharp.Compiler.SourceCodeServices
-open Microsoft.VisualStudio.FSharp.LanguageService
 
 [<RequireQualifiedAccess>]
 module internal FSharpClassificationTypes =
@@ -77,9 +76,10 @@ module internal ClassificationDefinitions =
 
         let setColors _ =
             let fontAndColorStorage = serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
-            let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager)
-            fontAndColorCacheManager.CheckCache( ref VSKnownGuids.TextEditorFontCategory) |> ignore
-            fontAndColorStorage.OpenCategory(ref VSKnownGuids.TextEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
+            let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager
+            let textEditor = Guid("A27B4E24-A735-4D1D-B8E7-9716E1E3D8E0")
+            fontAndColorCacheManager.CheckCache( ref textEditor) |> ignore
+            fontAndColorStorage.OpenCategory(ref textEditor, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
 
             let formatMap = classificationformatMapService.GetClassificationFormatMap(category = "text")
             for ctype, (light, dark) in colorData do

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -77,8 +77,8 @@ module internal ClassificationDefinitions =
 
         let setColors _ =
             let fontAndColorStorage = serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
-            let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager)
-            fontAndColorCacheManager.CheckCache( ref VSKnownGuids.textEditorFontCategory) |> ignore
+            let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager
+            fontAndColorCacheManager.CheckCache(ref VSKnownGuids.textEditorFontCategory) |> ignore
             fontAndColorStorage.OpenCategory(ref VSKnownGuids.textEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
 
             let formatMap = classificationformatMapService.GetClassificationFormatMap(category = "text")

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -3,7 +3,6 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
-open System.Composition
 open System.ComponentModel.Composition
 open System.Windows.Media
 
@@ -46,11 +45,9 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Property -> Property
         | SemanticClassificationType.Interface -> Interface
 
-
-
 module internal ClassificationDefinitions =
 
-    [<Export; Shared>]
+    [<Export>]
     type internal ThemeColors
         [<ImportingConstructor>]
         (
@@ -99,7 +96,7 @@ module internal ClassificationDefinitions =
         do VSColorTheme.add_ThemeChanged handler
         interface IDisposable with member __.Dispose() = VSColorTheme.remove_ThemeChanged handler
 
-        member __.getColor(ctype) =
+        member __.GetColor(ctype) =
             let light, dark = colorData |> Map.ofList |> Map.find ctype
             match getCurrentThemeId() with
             | LighTheme -> Nullable light
@@ -127,7 +124,7 @@ module internal ClassificationDefinitions =
         inherit ClassificationFormatDefinition()
 
         do self.DisplayName <- SR.FSharpFunctionsOrMethodsClassificationType.Value
-           self.ForegroundColor <- theme.getColor FSharpClassificationTypes.Function
+           self.ForegroundColor <- theme.GetColor FSharpClassificationTypes.Function
 
     [<Export(typeof<EditorFormatDefinition>)>]
     [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.MutableVar)>]
@@ -138,7 +135,7 @@ module internal ClassificationDefinitions =
         inherit ClassificationFormatDefinition()
 
         do self.DisplayName <- SR.FSharpMutableVarsClassificationType.Value
-           self.ForegroundColor <- theme.getColor FSharpClassificationTypes.MutableVar
+           self.ForegroundColor <- theme.GetColor FSharpClassificationTypes.MutableVar
 
     [<Export(typeof<EditorFormatDefinition>)>]
     [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.Printf)>]
@@ -149,7 +146,7 @@ module internal ClassificationDefinitions =
         inherit ClassificationFormatDefinition()
 
         do self.DisplayName <- SR.FSharpPrintfFormatClassificationType.Value
-           self.ForegroundColor <- theme.getColor FSharpClassificationTypes.Printf
+           self.ForegroundColor <- theme.GetColor FSharpClassificationTypes.Printf
 
     [<Export(typeof<EditorFormatDefinition>)>]
     [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.Property)>]
@@ -160,4 +157,4 @@ module internal ClassificationDefinitions =
         inherit ClassificationFormatDefinition()
 
         do self.DisplayName <- SR.FSharpPropertiesClassificationType.Value
-           self.ForegroundColor <- theme.getColor FSharpClassificationTypes.Property
+           self.ForegroundColor <- theme.GetColor FSharpClassificationTypes.Property

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -78,8 +78,8 @@ module internal ClassificationDefinitions =
         let setColors _ =
             let fontAndColorStorage = serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
             let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager)
-            fontAndColorCacheManager.CheckCache( ref VSKnownGuids.TextEditorFontCategory) |> ignore
-            fontAndColorStorage.OpenCategory(ref VSKnownGuids.TextEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
+            fontAndColorCacheManager.CheckCache( ref VSKnownGuids.textEditorFontCategory) |> ignore
+            fontAndColorStorage.OpenCategory(ref VSKnownGuids.textEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
 
             let formatMap = classificationformatMapService.GetClassificationFormatMap(category = "text")
             for ctype, (light, dark) in colorData do

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -46,6 +46,9 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Interface -> Interface
 
 module internal ClassificationDefinitions =
+    let private guidVSLightTheme = Guid "de3dbbcd-f642-433c-8353-8f1df4370aba"
+    let private guidVSBlueTheme = Guid "a4d6a176-b948-4b29-8c66-53c97a1ed7d0"
+    let private guidVSDarkTheme = Guid "1ded0138-47ce-435e-84ef-9ec1f439b749"
 
     [<Export>]
     type internal ThemeColors
@@ -56,10 +59,9 @@ module internal ClassificationDefinitions =
             [<Import(typeof<SVsServiceProvider>)>] serviceProvider: IServiceProvider
         ) =
 
-        let (| LighTheme | DarkTheme | UnknownTheme |) id =
-            if id = Guid("de3dbbcd-f642-433c-8353-8f1df4370aba") ||
-               id = Guid("a4d6a176-b948-4b29-8c66-53c97a1ed7d0") then LighTheme 
-            elif id = Guid("1ded0138-47ce-435e-84ef-9ec1f439b749") then DarkTheme
+        let (| LightTheme | DarkTheme | UnknownTheme |) id =
+            if id = guidVSLightTheme || id = guidVSBlueTheme then LightTheme 
+            elif id = guidVSDarkTheme then DarkTheme
             else UnknownTheme
     
         let getCurrentThemeId() =
@@ -86,7 +88,7 @@ module internal ClassificationDefinitions =
                     let ict = classificationTypeRegistry.GetClassificationType(ctype)
                     let oldProps = formatMap.GetTextProperties(ict)
                     let newProps = match getCurrentThemeId() with
-                                    | LighTheme -> oldProps.SetForeground light
+                                    | LightTheme -> oldProps.SetForeground light
                                     | DarkTheme -> oldProps.SetForeground dark
                                     | UnknownTheme -> oldProps
                     formatMap.SetTextProperties(ict, newProps)
@@ -99,7 +101,7 @@ module internal ClassificationDefinitions =
         member __.GetColor(ctype) =
             let light, dark = colorData |> Map.ofList |> Map.find ctype
             match getCurrentThemeId() with
-            | LighTheme -> Nullable light
+            | LightTheme -> Nullable light
             | DarkTheme -> Nullable dark
             | UnknownTheme -> Nullable()
 

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -77,8 +77,8 @@ module internal ClassificationDefinitions =
 
         let setColors _ =
             let fontAndColorStorage = serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
-            let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager
-            fontAndColorCacheManager.CheckCache(ref VSKnownGuids.textEditorFontCategory) |> ignore
+            let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager)
+            fontAndColorCacheManager.CheckCache( ref VSKnownGuids.textEditorFontCategory) |> ignore
             fontAndColorStorage.OpenCategory(ref VSKnownGuids.textEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
 
             let formatMap = classificationformatMapService.GetClassificationFormatMap(category = "text")

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -7,6 +7,7 @@ open System.ComponentModel.Composition
 open System.Windows.Media
 
 open Microsoft.VisualStudio
+open Microsoft.VisualStudio.Editor
 open Microsoft.VisualStudio.PlatformUI
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
@@ -77,9 +78,8 @@ module internal ClassificationDefinitions =
         let setColors _ =
             let fontAndColorStorage = serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
             let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager
-            let textEditor = Guid("A27B4E24-A735-4D1D-B8E7-9716E1E3D8E0")
-            fontAndColorCacheManager.CheckCache( ref textEditor) |> ignore
-            fontAndColorStorage.OpenCategory(ref textEditor, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
+            fontAndColorCacheManager.CheckCache( ref DefGuidList.guidTextEditorFontCategory) |> ignore
+            fontAndColorStorage.OpenCategory(ref DefGuidList.guidTextEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
 
             let formatMap = classificationformatMapService.GetClassificationFormatMap(category = "text")
             for ctype, (light, dark) in colorData do

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -47,9 +47,6 @@ module internal FSharpClassificationTypes =
         | SemanticClassificationType.Interface -> Interface
 
 module internal ClassificationDefinitions =
-    let private guidVSLightTheme = Guid "de3dbbcd-f642-433c-8353-8f1df4370aba"
-    let private guidVSBlueTheme = Guid "a4d6a176-b948-4b29-8c66-53c97a1ed7d0"
-    let private guidVSDarkTheme = Guid "1ded0138-47ce-435e-84ef-9ec1f439b749"
 
     [<Export>]
     type internal ThemeColors
@@ -61,8 +58,8 @@ module internal ClassificationDefinitions =
         ) =
 
         let (| LightTheme | DarkTheme | UnknownTheme |) id =
-            if id = guidVSLightTheme || id = guidVSBlueTheme then LightTheme 
-            elif id = guidVSDarkTheme then DarkTheme
+            if id = KnownColorThemes.Light || id = KnownColorThemes.Blue then LightTheme 
+            elif id = KnownColorThemes.Dark then DarkTheme
             else UnknownTheme
     
         let getCurrentThemeId() =

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -17,6 +17,7 @@ open Microsoft.VisualStudio.Utilities
 open Microsoft.CodeAnalysis.Classification
 
 open Microsoft.FSharp.Compiler.SourceCodeServices
+open Microsoft.VisualStudio.FSharp.LanguageService
 
 [<RequireQualifiedAccess>]
 module internal FSharpClassificationTypes =
@@ -76,10 +77,9 @@ module internal ClassificationDefinitions =
 
         let setColors _ =
             let fontAndColorStorage = serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
-            let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager
-            let textEditor = Guid("A27B4E24-A735-4D1D-B8E7-9716E1E3D8E0")
-            fontAndColorCacheManager.CheckCache( ref textEditor) |> ignore
-            fontAndColorStorage.OpenCategory(ref textEditor, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
+            let fontAndColorCacheManager = serviceProvider.GetService(typeof<SVsFontAndColorCacheManager>) :?> IVsFontAndColorCacheManager)
+            fontAndColorCacheManager.CheckCache( ref VSKnownGuids.TextEditorFontCategory) |> ignore
+            fontAndColorStorage.OpenCategory(ref VSKnownGuids.TextEditorFontCategory, uint32 __FCSTORAGEFLAGS.FCSF_READONLY) |> ignore
 
             let formatMap = classificationformatMapService.GetClassificationFormatMap(category = "text")
             for ctype, (light, dark) in colorData do

--- a/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
@@ -181,15 +181,15 @@ type internal FSharpSourceTestable
                 lastDependencies.Clear()
 
 module internal VSKnownGuids =
-        let StatementCompletionFC = Guid "C1614BB1-734F-4a31-BD42-5AE6275E16D2" // GUID_StatementCompletionFC
-        let TextEditorFontCategory = Guid "A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0" // Guid for the code editor font and color category. GUID_TextEditorFC
+        let statementCompletionFC = Guid "C1614BB1-734F-4a31-BD42-5AE6275E16D2" // GUID_StatementCompletionFC
+        let textEditorFontCategory = Guid "A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0" // Guid for the code editor font and color category. GUID_TextEditorFC
 
 [<AllowNullLiteralAttribute>]
 type internal VSFontsAndColorsHelper private(fontFamily, pointSize, excludedCodeForegroundColorBrush, backgroundBrush) =
         static let Compute(site:System.IServiceProvider) =
             UIThread.MustBeCalledFromUIThread()
             let vsFontAndColorStorage = site.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
-            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.TextEditorFontCategory, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
+            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.textEditorFontCategory, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
             let itemInfo : ColorableItemInfo[] = Array.zeroCreate 1  
             vsFontAndColorStorage.GetItem("Excluded Code", itemInfo) |> ignore
             let fgColorInfo = itemInfo.[0].crForeground 
@@ -202,7 +202,7 @@ type internal VSFontsAndColorsHelper private(fontFamily, pointSize, excludedCode
             let color = System.Windows.Media.Color.FromArgb(winFormColor.A, winFormColor.R, winFormColor.G, winFormColor.B)
             let backgroundBrush = new System.Windows.Media.SolidColorBrush(color)
             vsFontAndColorStorage.CloseCategory() |> ignore
-            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.StatementCompletionFC, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
+            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.statementCompletionFC, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
             let fontInfo : FontInfo[] = Array.zeroCreate 1
             vsFontAndColorStorage.GetFont(null, fontInfo) |> ignore
             let fontFamily = fontInfo.[0].bstrFaceName 

--- a/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
@@ -181,15 +181,15 @@ type internal FSharpSourceTestable
                 lastDependencies.Clear()
 
 module internal VSKnownGuids =
-        let statementCompletionFC = Guid "C1614BB1-734F-4a31-BD42-5AE6275E16D2" // GUID_StatementCompletionFC
-        let textEditorFontCategory = Guid "A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0" // Guid for the code editor font and color category. GUID_TextEditorFC
+        let StatementCompletionFC = Guid "C1614BB1-734F-4a31-BD42-5AE6275E16D2" // GUID_StatementCompletionFC
+        let TextEditorFontCategory = Guid "A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0" // Guid for the code editor font and color category. GUID_TextEditorFC
 
 [<AllowNullLiteralAttribute>]
 type internal VSFontsAndColorsHelper private(fontFamily, pointSize, excludedCodeForegroundColorBrush, backgroundBrush) =
         static let Compute(site:System.IServiceProvider) =
             UIThread.MustBeCalledFromUIThread()
             let vsFontAndColorStorage = site.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
-            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.textEditorFontCategory, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
+            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.TextEditorFontCategory, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
             let itemInfo : ColorableItemInfo[] = Array.zeroCreate 1  
             vsFontAndColorStorage.GetItem("Excluded Code", itemInfo) |> ignore
             let fgColorInfo = itemInfo.[0].crForeground 
@@ -202,7 +202,7 @@ type internal VSFontsAndColorsHelper private(fontFamily, pointSize, excludedCode
             let color = System.Windows.Media.Color.FromArgb(winFormColor.A, winFormColor.R, winFormColor.G, winFormColor.B)
             let backgroundBrush = new System.Windows.Media.SolidColorBrush(color)
             vsFontAndColorStorage.CloseCategory() |> ignore
-            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.statementCompletionFC, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
+            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.StatementCompletionFC, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
             let fontInfo : FontInfo[] = Array.zeroCreate 1
             vsFontAndColorStorage.GetFont(null, fontInfo) |> ignore
             let fontFamily = fontInfo.[0].bstrFaceName 

--- a/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
@@ -180,16 +180,15 @@ type internal FSharpSourceTestable
                         vsFileWatch.UnadviseFileChange(cookie) |> ignore
                 lastDependencies.Clear()
 
-module internal VSKnownGuids =
-        let StatementCompletionFC = Guid "C1614BB1-734F-4a31-BD42-5AE6275E16D2" // GUID_StatementCompletionFC
-        let TextEditorFontCategory = Guid "A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0" // Guid for the code editor font and color category. GUID_TextEditorFC
 
 [<AllowNullLiteralAttribute>]
 type internal VSFontsAndColorsHelper private(fontFamily, pointSize, excludedCodeForegroundColorBrush, backgroundBrush) =
         static let Compute(site:System.IServiceProvider) =
             UIThread.MustBeCalledFromUIThread()
+            let mutable guidStatementCompletionFC = new Guid("C1614BB1-734F-4a31-BD42-5AE6275E16D2") // GUID_StatementCompletionFC
             let vsFontAndColorStorage = site.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
-            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.TextEditorFontCategory, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
+            let mutable guidTextEditorFontCategory = new Guid("A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0") // Guid for the code editor font and color category. GUID_TextEditorFC
+            vsFontAndColorStorage.OpenCategory(&guidTextEditorFontCategory, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
             let itemInfo : ColorableItemInfo[] = Array.zeroCreate 1  
             vsFontAndColorStorage.GetItem("Excluded Code", itemInfo) |> ignore
             let fgColorInfo = itemInfo.[0].crForeground 
@@ -202,7 +201,7 @@ type internal VSFontsAndColorsHelper private(fontFamily, pointSize, excludedCode
             let color = System.Windows.Media.Color.FromArgb(winFormColor.A, winFormColor.R, winFormColor.G, winFormColor.B)
             let backgroundBrush = new System.Windows.Media.SolidColorBrush(color)
             vsFontAndColorStorage.CloseCategory() |> ignore
-            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.StatementCompletionFC, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
+            vsFontAndColorStorage.OpenCategory(&guidStatementCompletionFC, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
             let fontInfo : FontInfo[] = Array.zeroCreate 1
             vsFontAndColorStorage.GetFont(null, fontInfo) |> ignore
             let fontFamily = fontInfo.[0].bstrFaceName 

--- a/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
@@ -180,15 +180,16 @@ type internal FSharpSourceTestable
                         vsFileWatch.UnadviseFileChange(cookie) |> ignore
                 lastDependencies.Clear()
 
+module internal VSKnownGuids =
+        let StatementCompletionFC = Guid "C1614BB1-734F-4a31-BD42-5AE6275E16D2" // GUID_StatementCompletionFC
+        let TextEditorFontCategory = Guid "A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0" // Guid for the code editor font and color category. GUID_TextEditorFC
 
 [<AllowNullLiteralAttribute>]
 type internal VSFontsAndColorsHelper private(fontFamily, pointSize, excludedCodeForegroundColorBrush, backgroundBrush) =
         static let Compute(site:System.IServiceProvider) =
             UIThread.MustBeCalledFromUIThread()
-            let mutable guidStatementCompletionFC = new Guid("C1614BB1-734F-4a31-BD42-5AE6275E16D2") // GUID_StatementCompletionFC
             let vsFontAndColorStorage = site.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
-            let mutable guidTextEditorFontCategory = new Guid("A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0") // Guid for the code editor font and color category. GUID_TextEditorFC
-            vsFontAndColorStorage.OpenCategory(&guidTextEditorFontCategory, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
+            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.TextEditorFontCategory, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
             let itemInfo : ColorableItemInfo[] = Array.zeroCreate 1  
             vsFontAndColorStorage.GetItem("Excluded Code", itemInfo) |> ignore
             let fgColorInfo = itemInfo.[0].crForeground 
@@ -201,7 +202,7 @@ type internal VSFontsAndColorsHelper private(fontFamily, pointSize, excludedCode
             let color = System.Windows.Media.Color.FromArgb(winFormColor.A, winFormColor.R, winFormColor.G, winFormColor.B)
             let backgroundBrush = new System.Windows.Media.SolidColorBrush(color)
             vsFontAndColorStorage.CloseCategory() |> ignore
-            vsFontAndColorStorage.OpenCategory(&guidStatementCompletionFC, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
+            vsFontAndColorStorage.OpenCategory(ref VSKnownGuids.StatementCompletionFC, (uint32 __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS) ||| (uint32 __FCSTORAGEFLAGS.FCSF_READONLY)) |> ignore
             let fontInfo : FontInfo[] = Array.zeroCreate 1
             vsFontAndColorStorage.GetFont(null, fontInfo) |> ignore
             let fontFamily = fontInfo.[0].bstrFaceName 


### PR DESCRIPTION
I took most of the theme change listener and colors from [Vasily's PR #2348](https://github.com/Microsoft/visualfsharp/pull/2348/commits/b0c82b0bc41d4314e4b86b3f77c0e9b54baaaecb)

Theme changer doesn't overwrite per-mode customizations made by the user.
Enclosed dark and light modes are adjusted according to the recent commits but obviously WIP.