### PR TITLE
[TEMP] Log roslyn calls

### DIFF
--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -764,6 +764,7 @@ module internal IncrementalBuild =
     ///
     /// Will throw OperationCanceledException if the cancellation ctok has been set.
     let ExecuteApply (ctok: CompilationThreadToken) save (ct: CancellationToken) (action:Action) bt = 
+        if ct.IsCancellationRequested then Diagnostics.Debug.Assert(false, "!!! ThrowIfCancellationRequested !!!")
         ct.ThrowIfCancellationRequested()
         if (injectCancellationFault) then raise (OperationCanceledException("injected fault"))
         let actionResult = action.Execute(ctok)

--- a/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
@@ -30,18 +30,16 @@ type internal FSharpColorizationService
         member this.AddLexicalClassifications(_: SourceText, _: TextSpan, _: List<ClassifiedSpan>, _: CancellationToken) = ()
         
         member this.AddSyntacticClassificationsAsync(document: Document, textSpan: TextSpan, result: List<ClassifiedSpan>, cancellationToken: CancellationToken) =
-            Logging.Logging.logInfof "=> FSharpColorizationService.GetItemsAsync\n%s" Environment.StackTrace
+            Cancellation.track "FSharpColorizationService.AddSyntacticClassificationsAsync" cancellationToken
             async {
-                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpColorizationService.AddSyntacticClassificationsAsync\n%s" Environment.StackTrace)
                 let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)  
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 result.AddRange(CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.FilePath), defines, cancellationToken))
             } |> CommonRoslynHelpers.StartAsyncUnitAsTask cancellationToken
 
         member this.AddSemanticClassificationsAsync(document: Document, textSpan: TextSpan, result: List<ClassifiedSpan>, cancellationToken: CancellationToken) =
-            Logging.Logging.logInfof "=> FSharpColorizationService.AddSemanticClassificationsAsync\n%s" Environment.StackTrace
+            Cancellation.track "FSharpColorizationService.AddSemanticClassificationsAsync" cancellationToken
             asyncMaybe {
-                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpColorizationService.AddSemanticClassificationsAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! _, _, checkResults = checkerProvider.Checker.ParseAndCheckDocument(document, options, sourceText = sourceText, allowStaleResults = false) 

--- a/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
@@ -30,14 +30,18 @@ type internal FSharpColorizationService
         member this.AddLexicalClassifications(_: SourceText, _: TextSpan, _: List<ClassifiedSpan>, _: CancellationToken) = ()
         
         member this.AddSyntacticClassificationsAsync(document: Document, textSpan: TextSpan, result: List<ClassifiedSpan>, cancellationToken: CancellationToken) =
+            Logging.Logging.logInfof "=> FSharpColorizationService.GetItemsAsync\n%s" Environment.StackTrace
             async {
+                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpColorizationService.AddSyntacticClassificationsAsync\n%s" Environment.StackTrace)
                 let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)  
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 result.AddRange(CommonHelpers.getColorizationData(document.Id, sourceText, textSpan, Some(document.FilePath), defines, cancellationToken))
             } |> CommonRoslynHelpers.StartAsyncUnitAsTask cancellationToken
 
         member this.AddSemanticClassificationsAsync(document: Document, textSpan: TextSpan, result: List<ClassifiedSpan>, cancellationToken: CancellationToken) =
+            Logging.Logging.logInfof "=> FSharpColorizationService.AddSemanticClassificationsAsync\n%s" Environment.StackTrace
             asyncMaybe {
+                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpColorizationService.AddSemanticClassificationsAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! _, _, checkResults = checkerProvider.Checker.ParseAndCheckDocument(document, options, sourceText = sourceText, allowStaleResults = false) 

--- a/vsintegration/src/FSharp.Editor/Common/CommonHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CommonHelpers.fs
@@ -635,3 +635,9 @@ module internal Extensions =
                 | _ -> Glyph.StructurePublic
             | GlyphMajor.Error -> Glyph.Error
             | _ -> Glyph.None
+
+module Cancellation =
+    let track method (ct: CancellationToken) =
+        Logging.Logging.logInfof "=> %s\n%s" method Environment.StackTrace
+        let __ = ct.Register((fun () -> Logging.Logging.logInfof "CANCELLED %s\n%s" method Environment.StackTrace), true)
+        ()

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -112,9 +112,8 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
 
     override this.AnalyzeSyntaxAsync(document: Document, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         let projectInfoManager = getProjectInfoManager document
-        Logging.Logging.logInfof "=> DocumentDiagnosticAnalyzer.AnalyzeSyntaxAsync\n%s" Environment.StackTrace
+        Cancellation.track "DocumentDiagnosticAnalyzer.AnalyzeSyntaxAsync" cancellationToken
         asyncMaybe {
-            use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED DocumentDiagnosticAnalyzer.AnalyzeSyntaxAsync\n%s" Environment.StackTrace) |> liftAsync
             let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
             let! sourceText = document.GetTextAsync(cancellationToken)
             let! textVersion = document.GetTextVersionAsync(cancellationToken)
@@ -127,9 +126,8 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
 
     override this.AnalyzeSemanticsAsync(document: Document, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         let projectInfoManager = getProjectInfoManager document
-        Logging.Logging.logInfof "=> DocumentDiagnosticAnalyzer.AnalyzeSemanticsAsync\n%s" Environment.StackTrace
         asyncMaybe {
-            use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED DocumentDiagnosticAnalyzer.AnalyzeSemanticsAsync\n%s" Environment.StackTrace) |> liftAsync
+            Cancellation.track "DocumentDiagnosticAnalyzer.AnalyzeSyntaxAsync" cancellationToken
             let! options = projectInfoManager.TryGetOptionsForDocumentOrProject(document) 
             let! sourceText = document.GetTextAsync(cancellationToken)
             let! textVersion = document.GetTextVersionAsync(cancellationToken)

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -112,7 +112,9 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
 
     override this.AnalyzeSyntaxAsync(document: Document, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         let projectInfoManager = getProjectInfoManager document
+        Logging.Logging.logInfof "=> DocumentDiagnosticAnalyzer.AnalyzeSyntaxAsync\n%s" Environment.StackTrace
         asyncMaybe {
+            use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED DocumentDiagnosticAnalyzer.AnalyzeSyntaxAsync\n%s" Environment.StackTrace) |> liftAsync
             let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
             let! sourceText = document.GetTextAsync(cancellationToken)
             let! textVersion = document.GetTextVersionAsync(cancellationToken)
@@ -125,7 +127,9 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
 
     override this.AnalyzeSemanticsAsync(document: Document, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =
         let projectInfoManager = getProjectInfoManager document
+        Logging.Logging.logInfof "=> DocumentDiagnosticAnalyzer.AnalyzeSemanticsAsync\n%s" Environment.StackTrace
         asyncMaybe {
+            use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED DocumentDiagnosticAnalyzer.AnalyzeSemanticsAsync\n%s" Environment.StackTrace) |> liftAsync
             let! options = projectInfoManager.TryGetOptionsForDocumentOrProject(document) 
             let! sourceText = document.GetTextAsync(cancellationToken)
             let! textVersion = document.GetTextVersionAsync(cancellationToken)

--- a/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
@@ -70,9 +70,8 @@ type internal FSharpDocumentHighlightsService [<ImportingConstructor>] (checkerP
 
     interface IDocumentHighlightsService with
         member __.GetDocumentHighlightsAsync(document, position, _documentsToSearch, cancellationToken) : Task<ImmutableArray<DocumentHighlights>> =
-            Logging.Logging.logInfof "=> FSharpDocumentHighlightsService.GetDocumentHighlightsAsync\n%s" Environment.StackTrace
+            Cancellation.track "FSharpDocumentHighlightsService.GetDocumentHighlightsAsync" cancellationToken
             asyncMaybe {
-                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpDocumentHighlightsService.GetDocumentHighlightsAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! textVersion = document.GetTextVersionAsync(cancellationToken) 

--- a/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
@@ -70,7 +70,9 @@ type internal FSharpDocumentHighlightsService [<ImportingConstructor>] (checkerP
 
     interface IDocumentHighlightsService with
         member __.GetDocumentHighlightsAsync(document, position, _documentsToSearch, cancellationToken) : Task<ImmutableArray<DocumentHighlights>> =
+            Logging.Logging.logInfof "=> FSharpDocumentHighlightsService.GetDocumentHighlightsAsync\n%s" Environment.StackTrace
             asyncMaybe {
+                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpDocumentHighlightsService.GetDocumentHighlightsAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! textVersion = document.GetTextVersionAsync(cancellationToken) 

--- a/vsintegration/src/FSharp.Editor/Formatting/BraceMatchingService.fs
+++ b/vsintegration/src/FSharp.Editor/Formatting/BraceMatchingService.fs
@@ -26,7 +26,9 @@ type internal FSharpBraceMatchingService
         
     interface IBraceMatcher with
         member this.FindBracesAsync(document, position, cancellationToken) = 
+            Logging.Logging.logInfof "=> FSharpBraceMatchingService.FindBracesAsync\n%s" Environment.StackTrace
             asyncMaybe {
+                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpBraceMatchingService.FindBracesAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! (left, right) = FSharpBraceMatchingService.GetBraceMatchingResult(checkerProvider.Checker, sourceText, document.Name, options, position)

--- a/vsintegration/src/FSharp.Editor/Formatting/BraceMatchingService.fs
+++ b/vsintegration/src/FSharp.Editor/Formatting/BraceMatchingService.fs
@@ -28,7 +28,6 @@ type internal FSharpBraceMatchingService
         member this.FindBracesAsync(document, position, cancellationToken) = 
             Logging.Logging.logInfof "=> FSharpBraceMatchingService.FindBracesAsync\n%s" Environment.StackTrace
             asyncMaybe {
-                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpBraceMatchingService.FindBracesAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! (left, right) = FSharpBraceMatchingService.GetBraceMatchingResult(checkerProvider.Checker, sourceText, document.Name, options, position)

--- a/vsintegration/src/FSharp.Editor/Formatting/IndentationService.fs
+++ b/vsintegration/src/FSharp.Editor/Formatting/IndentationService.fs
@@ -46,13 +46,15 @@ type internal FSharpIndentationService() =
 
     interface ISynchronousIndentationService with
         member this.GetDesiredIndentation(document: Document, lineNumber: int, cancellationToken: CancellationToken): Nullable<IndentationResult> =
+            Logging.Logging.logInfof "=> FSharpIndentationService.GetDesiredIndentation\n%s" Environment.StackTrace
             async {
-                 let! sourceText = document.GetTextAsync(cancellationToken)
-                 let! options = document.GetOptionsAsync(cancellationToken)
-                 let tabSize = options.GetOption(FormattingOptions.TabSize, FSharpCommonConstants.FSharpLanguageName)
-                 
-                 return 
-                    match FSharpIndentationService.GetDesiredIndentation(sourceText, lineNumber, tabSize) with
-                    | None -> Nullable()
-                    | Some(indentation) -> Nullable<IndentationResult>(IndentationResult(sourceText.Lines.[lineNumber].Start, indentation))
+                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpIndentationService.GetDesiredIndentation\n%s" Environment.StackTrace)
+                let! sourceText = document.GetTextAsync(cancellationToken)
+                let! options = document.GetOptionsAsync(cancellationToken)
+                let tabSize = options.GetOption(FormattingOptions.TabSize, FSharpCommonConstants.FSharpLanguageName)
+                
+                return 
+                   match FSharpIndentationService.GetDesiredIndentation(sourceText, lineNumber, tabSize) with
+                   | None -> Nullable()
+                   | Some(indentation) -> Nullable<IndentationResult>(IndentationResult(sourceText.Lines.[lineNumber].Start, indentation))
             } |> Async.RunSynchronously

--- a/vsintegration/src/FSharp.Editor/Formatting/IndentationService.fs
+++ b/vsintegration/src/FSharp.Editor/Formatting/IndentationService.fs
@@ -46,9 +46,8 @@ type internal FSharpIndentationService() =
 
     interface ISynchronousIndentationService with
         member this.GetDesiredIndentation(document: Document, lineNumber: int, cancellationToken: CancellationToken): Nullable<IndentationResult> =
-            Logging.Logging.logInfof "=> FSharpIndentationService.GetDesiredIndentation\n%s" Environment.StackTrace
+            Cancellation.track "FSharpIndentationService.GetDesiredIndentation" cancellationToken
             async {
-                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpIndentationService.GetDesiredIndentation\n%s" Environment.StackTrace)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! options = document.GetOptionsAsync(cancellationToken)
                 let tabSize = options.GetOption(FormattingOptions.TabSize, FSharpCommonConstants.FSharpLanguageName)

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigationBarItemService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigationBarItemService.fs
@@ -42,8 +42,10 @@ type internal FSharpNavigationBarItemService
     static let emptyResult: IList<NavigationBarItem> = upcast [||]
 
     interface INavigationBarItemService with
-        member __.GetItemsAsync(document, cancellationToken) : Task<IList<NavigationBarItem>> = 
+        member __.GetItemsAsync(document, cancellationToken) : Task<IList<NavigationBarItem>> =
+            Logging.Logging.logInfof "=> FSharpNavigationBarItemService.GetItemsAsync\n%s" Environment.StackTrace
             asyncMaybe {
+                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpNavigationBarItemService.GetItemsAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! parsedInput = checkerProvider.Checker.ParseDocument(document, options, sourceText)

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigationBarItemService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigationBarItemService.fs
@@ -43,9 +43,8 @@ type internal FSharpNavigationBarItemService
 
     interface INavigationBarItemService with
         member __.GetItemsAsync(document, cancellationToken) : Task<IList<NavigationBarItem>> =
-            Logging.Logging.logInfof "=> FSharpNavigationBarItemService.GetItemsAsync\n%s" Environment.StackTrace
+            Cancellation.track "FSharpNavigationBarItemService.GetItemsAsync" cancellationToken
             asyncMaybe {
-                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpNavigationBarItemService.GetItemsAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! parsedInput = checkerProvider.Checker.ParseDocument(document, options, sourceText)

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -54,7 +54,9 @@ type internal FSharpQuickInfoProvider
     
     interface IQuickInfoProvider with
         override this.GetItemAsync(document: Document, position: int, cancellationToken: CancellationToken): Task<QuickInfoItem> =
+            Logging.Logging.logInfof "=> FSharpQuickInfoProvider.GetItemAsync\n%s" Environment.StackTrace
             asyncMaybe {
+                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpQuickInfoProvider.GetItemAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)  
                 let! _ = CommonHelpers.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Precise)

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -54,9 +54,8 @@ type internal FSharpQuickInfoProvider
     
     interface IQuickInfoProvider with
         override this.GetItemAsync(document: Document, position: int, cancellationToken: CancellationToken): Task<QuickInfoItem> =
-            Logging.Logging.logInfof "=> FSharpQuickInfoProvider.GetItemAsync\n%s" Environment.StackTrace
+            Cancellation.track "FSharpQuickInfoProvider.GetItemAsync" cancellationToken
             asyncMaybe {
-                use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED FSharpQuickInfoProvider.GetItemAsync\n%s" Environment.StackTrace) |> liftAsync
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)  
                 let! _ = CommonHelpers.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Precise)

--- a/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
+++ b/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
@@ -110,7 +110,9 @@ type internal FSharpBlockStructureService(checker: FSharpChecker, projectInfoMan
     override __.Language = FSharpCommonConstants.FSharpLanguageName
  
     override __.GetBlockStructureAsync(document, cancellationToken) : Task<BlockStructure> =
+        Logging.Logging.logInfof "=> BlockStructureService.GetBlockStructureAsync\n%s" Environment.StackTrace
         asyncMaybe {
+            use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED BlockStructureService.GetBlockStructureAsync\n%s" Environment.StackTrace) |> liftAsync
             let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
             let! sourceText = document.GetTextAsync(cancellationToken)
             let! parsedInput = checker.ParseDocument(document, options, sourceText)

--- a/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
+++ b/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
@@ -110,9 +110,8 @@ type internal FSharpBlockStructureService(checker: FSharpChecker, projectInfoMan
     override __.Language = FSharpCommonConstants.FSharpLanguageName
  
     override __.GetBlockStructureAsync(document, cancellationToken) : Task<BlockStructure> =
-        Logging.Logging.logInfof "=> BlockStructureService.GetBlockStructureAsync\n%s" Environment.StackTrace
+        Cancellation.track "BlockStructureService.GetBlockStructureAsync" cancellationToken
         asyncMaybe {
-            use! __ = Async.OnCancel(fun () -> Logging.Logging.logInfof "CANCELLED BlockStructureService.GetBlockStructureAsync\n%s" Environment.StackTrace) |> liftAsync
             let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
             let! sourceText = document.GetTextAsync(cancellationToken)
             let! parsedInput = checker.ParseDocument(document, options, sourceText)

--- a/vsintegration/tests/unittests/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.QuickInfo.fs
@@ -3,7 +3,7 @@
 namespace Tests.LanguageService.QuickInfo
 
 open System
-open NUnit.Framework
+open NUnit.Framework 
 open Salsa.Salsa
 open Salsa.VsOpsUtils
 open UnitTests.TestLib.Salsa


### PR DESCRIPTION
Output: https://gist.github.com/vasily-kirichenko/2c7eba7a11348ef4d71f915c5b9fa65b

Stack trace on `if ct.IsCancellationRequested then Diagnostics.Debug.Assert(false, "!!! ThrowIfCancellationRequested !!!"`:

```
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.ExecuteApply(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild, Microsoft.FSharp.Core.Unit>> save, System.Threading.CancellationToken ct, Microsoft.FSharp.Compiler.IncrementalBuild.Action action, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild bt) Line 767	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.newBt@786.Invoke(Microsoft.FSharp.Compiler.IncrementalBuild.Action action, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild bt) Line 786	F#
FSharp.Core.dll!Microsoft.FSharp.Collections.ListModule.loop@220-16<int, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild>.Invoke(Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild s, Microsoft.FSharp.Collections.FSharpList<int> xs) Line 222	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.visitVector@539-1<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild>.Invoke(Microsoft.FSharp.Core.FSharpOption<int> optSlot, Microsoft.FSharp.Compiler.IncrementalBuild.VectorBuildRule ve, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild acc) Line 635	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.visitVector@539-1<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild>.Invoke(Microsoft.FSharp.Core.FSharpOption<int> optSlot, Microsoft.FSharp.Compiler.IncrementalBuild.VectorBuildRule ve, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild acc) Line 578	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.eval@784.Invoke(System.Tuple<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild, int> tupledArg) Line 786	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.Eval(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild, Microsoft.FSharp.Core.Unit>> save, System.Threading.CancellationToken ct, Microsoft.FSharp.Compiler.IncrementalBuild.INode node, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild bt) Line 807	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuilder.GetCheckResultsAndImplementationsForProject(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, System.Threading.CancellationToken ct) Line 1749	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.SourceCodeServices.BackgroundCompiler.ParseAndCheckProjectImpl(Microsoft.FSharp.Compiler.SourceCodeServices.FSharpProjectOptions options, Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, System.Threading.CancellationToken ct) Line 2652	F#
FSharp.LanguageService.Compiler.dll!<StartupCode$FSharp-LanguageService-Compiler>.$Service.projectReferences@2235-1.Microsoft.FSharp.Compiler.CompileOps.IProjectReference.Microsoft-FSharp-Compiler-CompileOps-IProjectReference-EvaluateRawContents() Line 2237	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.CompileOps.TcImports.RegisterAndPrepareToImportReferencedDll(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution r) Line 4253	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.CompileOps.RegisterAndImportReferencedAssemblies@4301.Invoke(Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution nm) Line 4303	F#
FSharp.Core.dll!Microsoft.FSharp.Primitives.Basics.List.chooseToFreshConsTail<System.Tuple<Microsoft.FSharp.Compiler.CompileOps.ImportedBinary, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AvailableImportedAssembly>>>, Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution>(Microsoft.FSharp.Collections.FSharpList<System.Tuple<Microsoft.FSharp.Compiler.CompileOps.ImportedBinary, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AvailableImportedAssembly>>>> cons, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution, Microsoft.FSharp.Core.FSharpOption<System.Tuple<Microsoft.FSharp.Compiler.CompileOps.ImportedBinary, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AvailableImportedAssembly>>>>> f, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution> xs) Line 184	F#
FSharp.Core.dll!Microsoft.FSharp.Primitives.Basics.List.choose<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution, System.Tuple<Microsoft.FSharp.Compiler.CompileOps.ImportedBinary, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AvailableImportedAssembly>>>>(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution, Microsoft.FSharp.Core.FSharpOption<System.Tuple<Microsoft.FSharp.Compiler.CompileOps.ImportedBinary, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AvailableImportedAssembly>>>>> f, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution> xs) Line 199	F#
FSharp.Core.dll!Microsoft.FSharp.Collections.ListModule.Choose<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution, System.Tuple<Microsoft.FSharp.Compiler.CompileOps.ImportedBinary, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AvailableImportedAssembly>>>>(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution, Microsoft.FSharp.Core.FSharpOption<System.Tuple<Microsoft.FSharp.Compiler.CompileOps.ImportedBinary, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AvailableImportedAssembly>>>>> chooser, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution> list) Line 155	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.CompileOps.TcImports.RegisterAndImportReferencedAssemblies(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution> nms) Line 4299	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.CompileOps.TcImports.DoRegisterAndImportReferencedAssemblies(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution> nms) Line 4313	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.CompileOps.TcImports.BuildNonFrameworkTcImports(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, Microsoft.FSharp.Compiler.CompileOps.TcConfigProvider tcConfigP, Microsoft.FSharp.Compiler.TcGlobals.TcGlobals tcGlobals, Microsoft.FSharp.Compiler.CompileOps.TcImports baseTcImports, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.AssemblyResolution> nonFrameworkReferences, Microsoft.FSharp.Collections.FSharpList<Microsoft.FSharp.Compiler.CompileOps.UnresolvedAssemblyReference> knownUnresolved) Line 4508	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuilder.CombineImportedAssembliesTask<System.Tuple<Microsoft.FSharp.Core.FSharpChoice<string, Microsoft.FSharp.Compiler.CompileOps.IProjectReference>, System.DateTime>[]>(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, System.Tuple<Microsoft.FSharp.Core.FSharpChoice<string, Microsoft.FSharp.Compiler.CompileOps.IProjectReference>, System.DateTime>[] _arg1) Line 1416	F#
FSharp.LanguageService.Compiler.dll!<StartupCode$FSharp-LanguageService-Compiler>.$IncrementalBuild.-ctor@1612-80.Invoke(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, System.Tuple<Microsoft.FSharp.Core.FSharpChoice<string, Microsoft.FSharp.Compiler.CompileOps.IProjectReference>, System.DateTime>[] _arg1) Line 1612	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.Vector.BoxingDemultiplex@922T<System.Tuple<Microsoft.FSharp.Core.FSharpChoice<string, Microsoft.FSharp.Compiler.CompileOps.IProjectReference>, System.DateTime>, Microsoft.FSharp.Compiler.TypeCheckAccumulator, object>.Invoke(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, object[] i) Line 923	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.Action.Execute(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok) Line 306	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.ExecuteApply(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild, Microsoft.FSharp.Core.Unit>> save, System.Threading.CancellationToken ct, Microsoft.FSharp.Compiler.IncrementalBuild.Action action, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild bt) Line 770	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.newBt@786.Invoke(Microsoft.FSharp.Compiler.IncrementalBuild.Action action, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild bt) Line 786	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.visitScalar@654-1<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild>.Invoke(Microsoft.FSharp.Compiler.IncrementalBuild.ScalarBuildRule se, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild acc) Line 668	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.visitVector@539-1<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild>.Invoke(Microsoft.FSharp.Core.FSharpOption<int> optSlot, Microsoft.FSharp.Compiler.IncrementalBuild.VectorBuildRule ve, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild acc) Line 578	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.eval@784.Invoke(System.Tuple<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild, int> tupledArg) Line 786	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuild.EvalUpTo(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken, Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild, Microsoft.FSharp.Core.Unit>> save, System.Threading.CancellationToken ct, Microsoft.FSharp.Compiler.IncrementalBuild.INode node, int n, Microsoft.FSharp.Compiler.IncrementalBuild.PartialBuild bt) Line 813	F#
FSharp.LanguageService.Compiler.dll!Microsoft.FSharp.Compiler.IncrementalBuilder.GetCheckResultsBeforeSlotInProject(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok, int slotOfFile, System.Threading.CancellationToken ct) Line 1738	F#
FSharp.LanguageService.Compiler.dll!<StartupCode$FSharp-LanguageService-Compiler>.$Reactor.EnqueueAndAwaitOpAsync@146-2<Microsoft.FSharp.Compiler.PartialCheckResults>.Invoke(Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CompilationThreadToken ctok) Line 149	F#
FSharp.LanguageService.Compiler.dll!<StartupCode$FSharp-LanguageService-Compiler>.$Reactor.loop@67-90.Invoke(Microsoft.FSharp.Core.FSharpOption<Microsoft.FSharp.Compiler.SourceCodeServices.ReactorCommands> _arg2) Line 77	F#
FSharp.Core.dll!Microsoft.FSharp.Control.AsyncBuilderImpl.cont@825<Microsoft.FSharp.Core.FSharpOption<Microsoft.FSharp.Compiler.SourceCodeServices.ReactorCommands>, Microsoft.FSharp.Core.Unit>.Invoke(Microsoft.FSharp.Core.FSharpOption<Microsoft.FSharp.Compiler.SourceCodeServices.ReactorCommands> a) Line 825	F#
FSharp.Core.dll!<StartupCode$FSharp-Core>.$Control.loop@428-38.Invoke(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Control.FakeUnitValue> action) Line 428	F#
FSharp.Core.dll!Microsoft.FSharp.Control.Trampoline.ExecuteAction(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Control.FakeUnitValue> firstAction) Line 443	F#
FSharp.Core.dll!Microsoft.FSharp.Control.TrampolineHolder.Protect(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.Unit, Microsoft.FSharp.Control.FakeUnitValue> firstAction) Line 555	F#
FSharp.Core.dll!<StartupCode$FSharp-Core>.$Control.-ctor@511-1.Invoke(object state) Line 513	F#
[External Code]	
```