### PR TITLE
Cleanup System.Bindingflags on coreclr.  Enable more reflect.fs apis on coreclr

### DIFF
--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -263,6 +263,7 @@
     <DefineConstants>$(DefineConstants);FX_NO_REGISTERED_WAIT_HANDLES</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_SECURITY_PERMISSIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_SYSTEM_CONSOLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_SYSTEM_BINDINGFLAGS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_THREAD</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_TYPECODE</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_WEB_CLIENT</DefineConstants>
@@ -297,6 +298,7 @@
     <DefineConstants>$(DefineConstants);FX_NO_REGISTERED_WAIT_HANDLES</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_SECURITY_PERMISSIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_SYSTEM_CONSOLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_SYSTEM_BINDINGFLAGS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_THREAD</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_TPL_PARALLEL</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_TYPECODE</DefineConstants>
@@ -333,6 +335,7 @@
     <DefineConstants>$(DefineConstants);FX_NO_REGISTERED_WAIT_HANDLES</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_SECURITY_PERMISSIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_SYSTEM_CONSOLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_SYSTEM_BINDINGFLAGS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_THREAD</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_TPL_PARALLEL</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_TYPECODE</DefineConstants>

--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -10,6 +10,7 @@ module internal ExtensionTyping =
     open System
     open System.IO
     open System.Collections.Generic
+    open System.Reflection
     open Microsoft.FSharp.Core.CompilerServices
     open Microsoft.FSharp.Compiler.ErrorLogger
     open Microsoft.FSharp.Compiler.Range
@@ -19,8 +20,6 @@ module internal ExtensionTyping =
 
 #if FX_RESHAPED_REFLECTION
     open Microsoft.FSharp.Core.ReflectionAdapters
-#else
-    type BindingFlags = System.Reflection.BindingFlags
 #endif
 
     type TypeProviderDesignation = TypeProviderDesignation of string

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -288,8 +288,9 @@ namespace Microsoft.FSharp.Control
     open System
     open System.Diagnostics
     open System.Diagnostics.CodeAnalysis
-    open System.Threading
     open System.IO
+    open System.Reflection
+    open System.Threading
     open Microsoft.FSharp.Core
     open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
     open Microsoft.FSharp.Core.Operators
@@ -298,9 +299,6 @@ namespace Microsoft.FSharp.Control
 
 #if FX_RESHAPED_REFLECTION
     open ReflectionAdapters
-    type internal BindingFlags = ReflectionAdapters.BindingFlags
-#else
-    type BindingFlags = System.Reflection.BindingFlags
 #endif
 
 #if !FX_NO_TASK

--- a/src/fsharp/FSharp.Core/event.fs
+++ b/src/fsharp/FSharp.Core/event.fs
@@ -13,7 +13,6 @@ namespace Microsoft.FSharp.Control
 
 #if FX_RESHAPED_REFLECTION
     open ReflectionAdapters
-    type internal BindingFlags = ReflectionAdapters.BindingFlags
 #endif
 
 #if !FX_NO_DELEGATE_DYNAMIC_METHOD 

--- a/src/fsharp/FSharp.Core/quotations.fs
+++ b/src/fsharp/FSharp.Core/quotations.fs
@@ -2,8 +2,7 @@
 
 namespace Microsoft.FSharp.Quotations
 
-#if FX_MINIMAL_REFLECTION
-#else
+#if !FX_MINIMAL_REFLECTION
 open System
 open System.IO
 open System.Reflection
@@ -25,7 +24,6 @@ open Microsoft.FSharp.Text.StructuredPrintfImpl.TaggedTextOps
 #if FX_RESHAPED_REFLECTION
 open PrimReflectionAdapters
 open ReflectionAdapters
-type internal BindingFlags = ReflectionAdapters.BindingFlags
 #endif
 
 //--------------------------------------------------------------------------

--- a/src/fsharp/FSharp.Core/reflect.fs
+++ b/src/fsharp/FSharp.Core/reflect.fs
@@ -18,7 +18,7 @@ module internal ReflectionUtils =
 
     open Microsoft.FSharp.Core.Operators
 
-#if FX_RESHAPED_REFLECTION
+#if FX_NO_SYSTEM_BINDINGFLAGS
     type BindingFlags = Microsoft.FSharp.Core.ReflectionAdapters.BindingFlags
 #else
     type BindingFlags = System.Reflection.BindingFlags
@@ -709,7 +709,6 @@ module internal Impl =
 
 #if FX_RESHAPED_REFLECTION
 open ReflectionAdapters
-type internal BindingFlags = ReflectionAdapters.BindingFlags
 #endif
         
 [<Sealed>]

--- a/src/fsharp/FSharp.Core/reflect.fsi
+++ b/src/fsharp/FSharp.Core/reflect.fsi
@@ -70,8 +70,8 @@ type FSharpValue =
     /// <returns>A function to read the specified field from the record.</returns>
     static member PreComputeRecordFieldReader : info:PropertyInfo -> (obj -> obj)
 
-#if FX_RESHAPED_REFLECTION
-#else
+// These APIs are only internal for portable profile, 7,78 and 259 of FSHarp.Core.dll --- those profiles System.Reflection.BindingFlags
+#if !FX_NO_SYSTEM_BINDINGFLAGS
     /// <summary>Creates an instance of a record type.</summary>
     ///
     /// <remarks>Assumes the given input is a record type.</remarks>
@@ -263,8 +263,7 @@ type FSharpValue =
 /// <summary>Contains operations associated with constructing and analyzing F# types such as records, unions and tuples</summary>
 type FSharpType =
 
-#if FX_RESHAPED_REFLECTION
-#else
+#if !FX_NO_SYSTEM_BINDINGFLAGS
     /// <summary>Reads all the fields from a record value, in declaration order</summary>
     ///
     /// <remarks>Assumes the given input is a record value. If not, ArgumentException is raised.</remarks>
@@ -530,8 +529,8 @@ namespace Microsoft.FSharp.Reflection
 open Microsoft.FSharp.Core
 
 module internal ReflectionUtils = 
-#if FX_RESHAPED_REFLECTION
-    type internal BindingFlags = ReflectionAdapters.BindingFlags
+#if FX_NO_SYSTEM_BINDINGFLAGS
+    type BindingFlags = ReflectionAdapters.BindingFlags
 #else
     type BindingFlags = System.Reflection.BindingFlags
 #endif

--- a/src/utils/reshapedreflection.fs
+++ b/src/utils/reshapedreflection.fs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 namespace Microsoft.FSharp.Core
+open System.Reflection
 
 //Replacement for: System.Security.SecurityElement.Escape(line) All platforms
 module internal XmlAdapters =
@@ -23,7 +24,6 @@ module internal XmlAdapters =
 #if FX_RESHAPED_REFLECTION
 module internal ReflectionAdapters = 
     open System
-    open System.Reflection
 #if FX_RESHAPED_REFLECTION_CORECLR
     open System.Runtime.Loader
 #endif
@@ -31,6 +31,7 @@ module internal ReflectionAdapters =
     open Microsoft.FSharp.Collections
     open PrimReflectionAdapters
 
+#if FX_NO_SYSTEM_BINDINGFLAGS
     [<System.FlagsAttribute>]
     type BindingFlags =
     | DeclaredOnly = 2
@@ -39,6 +40,7 @@ module internal ReflectionAdapters =
     | Public = 16
     | NonPublic = 32
     | InvokeMethod = 0x100
+#endif
 
     let inline hasFlag (flag : BindingFlags) f  = (f &&& flag) = flag
     let isDeclaredFlag  f    = hasFlag BindingFlags.DeclaredOnly f


### PR DESCRIPTION
1. Fixes #2455
    The coreclr build of FSharp.Core was missing some apis from reflect.  They were internal rather than public.

2.  Clean up System.BindingFlags on coreclr by adding FX_NO_SYSTEM_BINDINGFLAGS 





