### PR TITLE
Trigger add open for FS0043

### DIFF
--- a/src/fsharp/vs/ServiceAssemblyContent.fs
+++ b/src/fsharp/vs/ServiceAssemblyContent.fs
@@ -437,7 +437,8 @@ type internal Entity =
     { FullRelativeName: LongIdent
       Qualifier: LongIdent
       Namespace: LongIdent option
-      Name: LongIdent }
+      Name: LongIdent
+      LastIdent: string }
     override x.ToString() = sprintf "%A" x
 
 [<CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
@@ -512,7 +513,8 @@ module internal Entity =
                           { FullRelativeName = String.concat "." fullRelativeName //.[0..fullRelativeName.Length - identCount - 1]
                             Qualifier = String.concat "." qualifier
                             Namespace = ns
-                            Name = match restIdents with [|_|] -> "" | _ -> String.concat "." restIdents }) 
+                            Name = match restIdents with [|_|] -> "" | _ -> String.concat "." restIdents 
+                            LastIdent = Array.tryLast restIdents |> Option.defaultValue "" }) 
 
 type internal ScopeKind =
     | Namespace

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -131,16 +131,16 @@ type internal FSharpAddOpenCodeFixProvider
                 openNamespaceFix context ctx name ns multipleNames)
             |> Seq.toList
             
-        let quilifySymbolFixes =
+        let qualifiedSymbolFixes =
             candidates
-            |> Seq.filter (fun (entity,_) -> not(entity.FullRelativeName.Contains("op_"))) // Don't include fully-qualified operator names. The resultant suggestion makes the code not compile.
+            |> Seq.filter (fun (entity,_) -> not(entity.FullRelativeName.StartsWith("op_"))) // Don't include qualified operator names. The resultant codefix won't compile because it won't be an infix operator anymore.
             |> Seq.map (fun (entity, _) -> entity.FullRelativeName, entity.Qualifier)
             |> Seq.distinct
             |> Seq.sort
             |> Seq.map (qualifySymbolFix context)
             |> Seq.toList
 
-        for codeFix in openNamespaceFixes @ quilifySymbolFixes do
+        for codeFix in openNamespaceFixes @ qualifiedSymbolFixes do
             context.RegisterCodeFix(codeFix, (context.Diagnostics |> Seq.filter (fun x -> fixableDiagnosticIds |> List.contains x.Id)).ToImmutableArray())
 
     override __.FixableDiagnosticIds = fixableDiagnosticIds.ToImmutableArray()

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -85,7 +85,7 @@ type internal FSharpAddOpenCodeFixProvider
         assemblyContentProvider: AssemblyContentProvider
     ) =
     inherit CodeFixProvider()
-    let fixableDiagnosticIds = ["FS0039"]
+    let fixableDiagnosticIds = ["FS0039"; "FS0043"]
 
     let checker = checkerProvider.Checker
     let fixUnderscoresInMenuText (text: string) = text.Replace("_", "__")
@@ -133,6 +133,7 @@ type internal FSharpAddOpenCodeFixProvider
             
         let quilifySymbolFixes =
             candidates
+            |> Seq.filter (fun (entity,_) -> not(entity.FullRelativeName.Contains("op_"))) // Don't include fully-qualified operator names. The resultant suggestion makes the code not compile.
             |> Seq.map (fun (entity, _) -> entity.FullRelativeName, entity.Qualifier)
             |> Seq.distinct
             |> Seq.sort
@@ -181,9 +182,9 @@ type internal FSharpAddOpenCodeFixProvider
                     longIdent
                     |> List.map (fun ident ->
                         { Ident = ident.idText
-                          Resolved = not (ident.idRange = unresolvedIdentRange) })
+                          Resolved = not (ident.idRange = unresolvedIdentRange)})
                     |> List.toArray)
-            
+                                                    
             let createEntity = ParsedInput.tryFindInsertionContext unresolvedIdentRange.StartLine parsedInput maybeUnresolvedIdents
             return entities |> Seq.map createEntity |> Seq.concat |> Seq.toList |> getSuggestions context
         } 

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -133,7 +133,7 @@ type internal FSharpAddOpenCodeFixProvider
             
         let qualifiedSymbolFixes =
             candidates
-            |> Seq.filter (fun (entity,_) -> not(entity.FullRelativeName.StartsWith("op_"))) // Don't include qualified operator names. The resultant codefix won't compile because it won't be an infix operator anymore.
+            |> Seq.filter (fun (entity,_) -> not(entity.LastIdent.StartsWith "op_")) // Don't include qualified operator names. The resultant codefix won't compile because it won't be an infix operator anymore.
             |> Seq.map (fun (entity, _) -> entity.FullRelativeName, entity.Qualifier)
             |> Seq.distinct
             |> Seq.sort


### PR DESCRIPTION
I'm not sure if this is a good solution, but this does fix #2473.  I can now do a full Suave app by using codefixes with this change:

![ops-lightbulbs](https://cloud.githubusercontent.com/assets/6309070/23240041/cc5f5f5a-f91f-11e6-8669-68bf1f840493.gif)
