### PR TITLE
#I completion, proper glyph for assemblies and more

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionService.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionService.fs
@@ -25,7 +25,8 @@ type internal FSharpCompletionService
         ImmutableArray.Create<CompletionProvider>(
             FSharpCompletionProvider(workspace, serviceProvider, checkerProvider, projectInfoManager),
             ReferenceDirectiveCompletionProvider(),
-            LoadDirectiveCompletionProvider()
+            LoadDirectiveCompletionProvider(),
+            IncludeDirectiveCompletionProvider()
             // we've turned off keyword completion because it does not filter suggestion depending on context.
             // FSharpKeywordCompletionProvider(workspace, projectInfoManager)
             )

--- a/vsintegration/src/FSharp.Editor/Completion/FileSystemCompletion.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/FileSystemCompletion.fs
@@ -93,7 +93,7 @@ module internal FileSystemCompletion =
         else
             None
 
-    let private includeDirectiveCleanRegex = Regex("""\s*#I\s+(@?"*(?<literal>[^"]*)"?)""", RegexOptions.Compiled ||| RegexOptions.ExplicitCapture)
+    let private includeDirectiveCleanRegex = Regex("""#I\s+(@?"*(?<literal>[^"]*)"?)""", RegexOptions.Compiled ||| RegexOptions.ExplicitCapture)
 
     let getIncludeDirectives (document: Document, position: int) =
         async {
@@ -105,9 +105,9 @@ module internal FileSystemCompletion =
                 lines
                 |> Seq.filter (fun x -> x.LineNumber <= caretLine)
                 |> Seq.choose (fun line ->
-                    let lineStr = line.ToString()
+                    let lineStr = line.ToString().Trim()
                     // optimization: fail fast if the line does not start with "(optional spaces) #I"
-                    if not (lineStr.TrimStart().StartsWith "#I") then None
+                    if not (lineStr.StartsWith "#I") then None
                     else
                         match includeDirectiveCleanRegex.Match lineStr with
                         | m when m.Success -> Some (m.Groups.["literal"].Value)

--- a/vsintegration/src/FSharp.Editor/Completion/FileSystemCompletion.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/FileSystemCompletion.fs
@@ -41,6 +41,7 @@ module internal FileSystemCompletion =
 
     let getItems(provider: CompletionProvider, document: Document, position: int, allowableExtensions: string[], directiveRegex: Regex) =
         asyncMaybe {
+            do! Option.guard (Path.GetExtension document.FilePath = ".fsx")
             let! ct = liftAsync Async.CancellationToken
             let! text = document.GetTextAsync ct
             let line = text.Lines.GetLineFromPosition(position)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/873919/23352207/ec2a1716-fcd6-11e6-88df-98bbd60a84b7.png)

It also restricts file types where `#r` and `#load` completion works to `*.fsx` only.