### PR TITLE
Fix absence of Quick Info in case of malformed XML Doc

### DIFF
--- a/vsintegration/src/FSharp.LanguageService/XmlDocumentation.fs
+++ b/vsintegration/src/FSharp.LanguageService/XmlDocumentation.fs
@@ -153,14 +153,17 @@ module internal XmlDocumentation =
             collector.Add(Literals.dot)
         collector.Add(tagClass parts.[parts.Length - 1])
 
-    type XmlDocReader(s: string) = 
-        let doc = XElement.Parse(ProcessXml(s))
+    type XmlDocReader private (doc: XElement) = 
+
         let tryFindParameter name = 
             doc.Descendants (XName.op_Implicit "param")
             |> Seq.tryFind (fun el -> 
                 match el.Attribute(XName.op_Implicit "name") with
                 | null -> false
                 | attr -> attr.Value = name)
+
+        static member TryCreate (xml: string) =
+            try Some (XmlDocReader(XElement.Parse(ProcessXml xml))) with _ -> None
 
         member __.CollectSummary(collector: ITaggedTextCollector) = 
             match Seq.tryHead (doc.Descendants(XName.op_Implicit "summary")) with
@@ -279,12 +282,13 @@ module internal XmlDocumentation =
 
         interface IDocumentationBuilder with 
             /// Append the given processed XML formatted into the string builder
-            override this.AppendDocumentationFromProcessedXML(appendTo, processedXml, showExceptions, showParameters, paramName) = 
-                let xmlDocReader = XmlDocReader(processedXml)
-                if paramName.IsSome then
-                    xmlDocReader.CollectParameter(appendTo, paramName.Value)
-                else
-                    AppendMemberData(appendTo, xmlDocReader, showExceptions,showParameters)
+            override this.AppendDocumentationFromProcessedXML(appendTo, processedXml, showExceptions, showParameters, paramName) =
+                match XmlDocReader.TryCreate processedXml with
+                | Some xmlDocReader ->
+                    match paramName with
+                    | Some paramName -> xmlDocReader.CollectParameter(appendTo, paramName)
+                    | None -> AppendMemberData(appendTo, xmlDocReader, showExceptions,showParameters)
+                | None -> ()
 
             /// Append Xml documentation contents into the StringBuilder
             override this.AppendDocumentation


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/2506