### PR TITLE
Bug fix to allow RebuildShapeCombination for indexed static property gets

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Quotations/FSharpQuotations.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Quotations/FSharpQuotations.fs
@@ -11,6 +11,9 @@ open Microsoft.FSharp.Quotations
 
 type E = Microsoft.FSharp.Quotations.Expr;;
 
+type StaticIndexedPropertyTest() =
+    static member IdxProp with get (n : int) = n + 1
+
 module Check =
     let argumentException f =
         let mutable ex = false
@@ -66,6 +69,17 @@ type FSharpQuotationsTests() =
         |   ExprShape.ShapeCombination(shape, [value;lambda]) ->
                 let wrongValue = <@ "!" @>
                 Check.argumentException(fun () -> ExprShape.RebuildShapeCombination(shape, [wrongValue;lambda]))
+        |   _ -> Assert.Fail()
+
+    [<Test>]
+    member x.ReShapeStaticIndexedProperties() = 
+        let q0 = <@ StaticIndexedPropertyTest.IdxProp 5 @>
+        match q0 with
+        |   ExprShape.ShapeCombination(shape, args) ->
+                try
+                    ExprShape.RebuildShapeCombination(shape, args) |> ignore
+                with
+                | _ -> Assert.Fail()
         |   _ -> Assert.Fail()
 
     [<Test>]

--- a/src/fsharp/FSharp.Core/quotations.fs
+++ b/src/fsharp/FSharp.Core/quotations.fs
@@ -2171,7 +2171,7 @@ module ExprShape =
             | NewTupleOp(ty),_    -> mkNewTupleWithType(ty, args)
             | TupleGetOp(ty,i),[arg] -> mkTupleGet(ty,i,arg)
             | InstancePropGetOp(pinfo),(obj::args)    -> mkInstancePropGet(obj,pinfo,args)
-            | StaticPropGetOp(pinfo),[] -> mkStaticPropGet(pinfo,args)
+            | StaticPropGetOp(pinfo),_ -> mkStaticPropGet(pinfo,args)
             | InstancePropSetOp(pinfo),obj::(FrontAndBack(args,v)) -> mkInstancePropSet(obj,pinfo,args,v)
             | StaticPropSetOp(pinfo),(FrontAndBack(args,v)) -> mkStaticPropSet(pinfo,args,v)
             | InstanceFieldGetOp(finfo),[obj]   -> mkInstanceFieldGet(obj,finfo)


### PR DESCRIPTION
The current implementation of RebuildShapeCombination fails if there are parameters passed to a StaticPropGetOp. The match pattern requires the arguments to be an empty list, even though the code for that match doesn't require this, and indeed mkStaticPropertyGet explicitly supports indexed properties and non-empty args lists.

All that is required is to replace the [] in the match with _, so that any list (whether empty or not) will match.