### PR TITLE
Fix wrong FSX colorization when #r directives change

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
@@ -35,7 +35,7 @@ type internal FSharpColorizationService
 
         member this.AddSemanticClassificationsAsync(document: Document, textSpan: TextSpan, result: List<ClassifiedSpan>, cancellationToken: CancellationToken) =
             asyncMaybe {
-                let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
+                let! options = projectInfoManager.TryGetOptionsForDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! _, _, checkResults = checkerProvider.Checker.ParseAndCheckDocument(document, options, sourceText = sourceText, allowStaleResults = false) 
                 // it's crucial to not return duplicated or overlapping `ClassifiedSpan`s because Find Usages service crashes.

--- a/vsintegration/src/FSharp.Editor/Common/CommonHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CommonHelpers.fs
@@ -443,22 +443,12 @@ module internal Extensions =
             let parseAndCheckFile =
                 async {
                     let! parseResults, checkFileAnswer = this.ParseAndCheckFileInProject(filePath, textVersionHash, sourceText, options)
-                    let res =
+                    return
                         match checkFileAnswer with
                         | FSharpCheckFileAnswer.Aborted -> 
                             None
                         | FSharpCheckFileAnswer.Succeeded(checkFileResults) ->
                             Some (parseResults, checkFileResults)
-                    
-                    Logging.Logging.logInfof 
-                                      "ParseAndCheckDocument (\nfile = %s,\ntextVersionHash = %d,\nsourceText = %s,\nallowStaleResults = %b,\nerrors = %+A)"
-                                      (Path.GetFileName filePath) 
-                                      textVersionHash 
-                                      sourceText 
-                                      allowStaleResults 
-                                      (res |> Option.map (fun (_, r) -> r.Errors))
-                    
-                    return res
                 }
 
             let tryGetFreshResultsWithTimeout() : Async<CheckResults> =

--- a/vsintegration/src/FSharp.Editor/Common/CommonHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CommonHelpers.fs
@@ -443,12 +443,22 @@ module internal Extensions =
             let parseAndCheckFile =
                 async {
                     let! parseResults, checkFileAnswer = this.ParseAndCheckFileInProject(filePath, textVersionHash, sourceText, options)
-                    return
+                    let res =
                         match checkFileAnswer with
                         | FSharpCheckFileAnswer.Aborted -> 
                             None
                         | FSharpCheckFileAnswer.Succeeded(checkFileResults) ->
                             Some (parseResults, checkFileResults)
+                    
+                    Logging.Logging.logInfof 
+                                      "ParseAndCheckDocument (\nfile = %s,\ntextVersionHash = %d,\nsourceText = %s,\nallowStaleResults = %b,\nerrors = %+A)"
+                                      (Path.GetFileName filePath) 
+                                      textVersionHash 
+                                      sourceText 
+                                      allowStaleResults 
+                                      (res |> Option.map (fun (_, r) -> r.Errors))
+                    
+                    return res
                 }
 
             let tryGetFreshResultsWithTimeout() : Async<CheckResults> =


### PR DESCRIPTION
It forces recaclulation `FSharpOptions` each time a file changed (FCS caches option by source text, so no optimization is needed).