### PR TITLE
add more properties to Fsc msbuild task

### DIFF
--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -161,6 +161,9 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
     let mutable highEntropyVA : bool = false
     let mutable targetProfile : string = null
     let mutable dotnetFscCompilerPath : string = null
+    let mutable skipCompilerExecution : bool  = false
+    let mutable provideCommandLineArgs : bool = false
+    let mutable commandLineArgs : ITaskItem list = []
 
     let mutable capturedArguments : string list = []  // list of individual args, to pass to HostObject Compile()
     let mutable capturedFilenames : string list = []  // list of individual source filenames, to pass to HostObject Compile()
@@ -500,6 +503,19 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
         with get() = dotnetFscCompilerPath
         and set(p) = dotnetFscCompilerPath <- p
 
+    member fsc.SkipCompilerExecution  
+        with get() = skipCompilerExecution
+        and set(p) = skipCompilerExecution <- p
+
+    member fsc.ProvideCommandLineArgs  
+        with get() = provideCommandLineArgs
+        and set(p) = provideCommandLineArgs <- p
+
+    [<Output>]
+    member fsc.CommandLineArgs
+        with get() = List.toArray commandLineArgs
+        and set(p) = commandLineArgs <- (List.ofArray p)
+
     // ToolTask methods
     override fsc.ToolName = "fsc.exe" 
     override fsc.StandardErrorEncoding = if utf8output then System.Text.Encoding.UTF8 else base.StandardErrorEncoding
@@ -513,32 +529,41 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
 
     /// Intercept the call to ExecuteTool to handle the host compile case.
     override fsc.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands) =
-        let host = box fsc.HostObject
-        match host with
-        | null -> base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
-        | _ ->
-            let sources = sources|>Array.map(fun i->i.ItemSpec)
+        if provideCommandLineArgs then
+            commandLineArgs <- 
+                fsc.GetCapturedArguments()
+                |> Array.map (fun (arg: string) -> TaskItem(arg) :> ITaskItem)
+                |> Array.toList
+
+        if skipCompilerExecution then
+            0
+        else
+            let host = box fsc.HostObject
+            match host with
+            | null -> base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
+            | _ ->
+                let sources = sources|>Array.map(fun i->i.ItemSpec)
 #if FX_NO_CONVERTER
-            let baseCallDelegate = new Func<int>(fun () -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands) )
+                let baseCallDelegate = new Func<int>(fun () -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands) )
 #else
-            let baseCall = fun (dummy : int) -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
-            // We are using a Converter<int,int> rather than a "unit->int" because it is too hard to
-            // figure out how to pass an F# function object via reflection.  
-            let baseCallDelegate = new System.Converter<int,int>(baseCall)
+                let baseCall = fun (dummy : int) -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
+                // We are using a Converter<int,int> rather than a "unit->int" because it is too hard to
+                // figure out how to pass an F# function object via reflection.  
+                let baseCallDelegate = new System.Converter<int,int>(baseCall)
 #endif
-            try 
-                let ret = 
-                    (host.GetType()).InvokeMember("Compile", BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.InvokeMethod ||| BindingFlags.Instance, null, host, 
-                                                [| baseCallDelegate; box (capturedArguments |> List.toArray); box (capturedFilenames |> List.toArray) |],
-                                                System.Globalization.CultureInfo.InvariantCulture)
-                unbox ret
-            with 
-            | :? System.Reflection.TargetInvocationException as tie when (match tie.InnerException with | :? Microsoft.Build.Exceptions.BuildAbortedException -> true | _ -> false) ->
-                fsc.Log.LogError(tie.InnerException.Message, [| |])
-                -1  // ok, this is what happens when VS IDE cancels the build, no need to assert, just log the build-canceled error and return -1 to denote task failed
-            | e ->
-                System.Diagnostics.Debug.Assert(false, "HostObject received by Fsc task did not have a Compile method or the compile method threw an exception. "+(e.ToString()))
-                reraise()
+                try 
+                    let ret = 
+                        (host.GetType()).InvokeMember("Compile", BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.InvokeMethod ||| BindingFlags.Instance, null, host, 
+                                                    [| baseCallDelegate; box (capturedArguments |> List.toArray); box (capturedFilenames |> List.toArray) |],
+                                                    System.Globalization.CultureInfo.InvariantCulture)
+                    unbox ret
+                with 
+                | :? System.Reflection.TargetInvocationException as tie when (match tie.InnerException with | :? Microsoft.Build.Exceptions.BuildAbortedException -> true | _ -> false) ->
+                    fsc.Log.LogError(tie.InnerException.Message, [| |])
+                    -1  // ok, this is what happens when VS IDE cancels the build, no need to assert, just log the build-canceled error and return -1 to denote task failed
+                | e ->
+                    System.Diagnostics.Debug.Assert(false, "HostObject received by Fsc task did not have a Compile method or the compile method threw an exception. "+(e.ToString()))
+                    reraise()
 
     override fsc.GenerateCommandLineCommands() =
         let builder = new FscCommandLineBuilder()

--- a/src/fsharp/FSharp.Build/Fsc.fsi
+++ b/src/fsharp/FSharp.Build/Fsc.fsi
@@ -55,4 +55,7 @@ type Fsc = class
              member HighEntropyVA : bool with get,set
              member TargetProfile : string with get,set
              member DotnetFscCompilerPath : string with get,set
+             member SkipCompilerExecution : bool with get,set
+             member ProvideCommandLineArgs : bool with get,set
+             member CommandLineArgs : Microsoft.Build.Framework.ITaskItem [] with get,set
            end


### PR DESCRIPTION
- `SkipCompilerExecution` to skip compilation (default false)
- `ProvideCommandLineArgs` to populate output CommandLineArgs (default false)
- `CommandLineArgs` (output) the list of fsc arguments (only if ProvideCommandLineArgs is true)

All default to previous behaviour (so are disabled)

That's needed for

- FCS https://github.com/fsharp/FSharp.Compiler.Service/issues/707
- roslyn https://github.com/dotnet/roslyn-project-system/pull/1670

Change to target file is just

```xml
              SkipCompilerExecution="$(SkipCompilerExecution)"
              ProvideCommandLineArgs="$(ProvideCommandLineArgs)">
          <Output TaskParameter="CommandLineArgs" ItemName="FscCommandLineArgs" />
        </Fsc>
```

I didnt added to current in vf# repo, because is only used with new fsproj.
And new target file for fsproj isnt there, but in [https://github.com/dotnet/netcorecli-fsc/src/FSharp.NET.Sdk/build/FSharp.NET.Core.Sdk.targets](https://github.com/dotnet/netcorecli-fsc/blob/cd5af4e132362ca0abcfeb07d015989e4bca1cf7/src/FSharp.NET.Sdk/build/FSharp.NET.Core.Sdk.targets)

/cc @dsyme @KevinRansom 