### PR TITLE
Priority in completion

### DIFF
--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -407,8 +407,10 @@ val internal ResolveExprDotLongIdentAndComputeRange : TcResultsSink -> NameResol
 /// A generator of type instantiations used when no more specific type instantiation is known.
 val FakeInstantiationGenerator : range -> Typar list -> TType list
 
+val ResolveType : NameResolver -> NameResolutionEnv -> range -> string list -> TType option
+
 /// Resolve a (possibly incomplete) long identifier to a set of possible resolutions.
-val ResolvePartialLongIdent : NameResolver -> NameResolutionEnv -> (MethInfo -> TType -> bool) -> range -> AccessorDomain -> string list -> bool -> Item list * TType option
+val ResolvePartialLongIdent : NameResolver -> NameResolutionEnv -> (MethInfo -> TType -> bool) -> range -> AccessorDomain -> string list -> bool -> Item list
 
 [<RequireQualifiedAccess>]
 type ResolveCompletionTargets =

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -408,7 +408,7 @@ val internal ResolveExprDotLongIdentAndComputeRange : TcResultsSink -> NameResol
 val FakeInstantiationGenerator : range -> Typar list -> TType list
 
 /// Resolve a (possibly incomplete) long identifier to a set of possible resolutions.
-val ResolvePartialLongIdent : NameResolver -> NameResolutionEnv -> (MethInfo -> TType -> bool) -> range -> AccessorDomain -> string list -> bool -> Item list
+val ResolvePartialLongIdent : NameResolver -> NameResolutionEnv -> (MethInfo -> TType -> bool) -> range -> AccessorDomain -> string list -> bool -> Item list * TType option
 
 [<RequireQualifiedAccess>]
 type ResolveCompletionTargets =

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -7,14 +7,12 @@ open System
 open System.IO
 open System.Collections.Generic
 open System.Threading
-open System.Threading.Tasks
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.NameResolution
 open Microsoft.FSharp.Compiler.Tastops
 open Microsoft.FSharp.Compiler.Lib
 open Microsoft.FSharp.Compiler.AbstractIL
 open Microsoft.FSharp.Compiler.AbstractIL.IL
-open Microsoft.FSharp.Compiler.AbstractIL.Diagnostics 
 open Microsoft.FSharp.Compiler.AbstractIL.Internal
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library 
 open Microsoft.FSharp.Compiler.CompileOps

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -679,9 +679,9 @@ module internal ItemDescriptionsImpl =
                     suppressNestedTypes=true;
                     maxMembers=Some EnvMisc2.maxMembers }
 
-    let rec FullNameOfItem g d = 
+    let rec FullNameOfItem g item = 
         let denv = DisplayEnv.Empty(g)
-        match d with
+        match item with
         | Item.ImplicitOp(_, { contents = Some(TraitConstraintSln.FSMethSln(_, vref, _)) }) 
         | Item.Value vref | Item.CustomBuilder (_,vref) -> fullDisplayTextOfValRef vref
         | Item.UnionCase (ucinfo,_) -> fullDisplayTextOfUnionCaseRef  ucinfo.UnionCaseRef
@@ -698,9 +698,12 @@ module internal ItemDescriptionsImpl =
         | Item.MethodGroup(_,_,Some minfo) -> bufs (fun os -> NicePrint.outputTyconRef denv os minfo.DeclaringEntityRef; bprintf os ".%s" minfo.DisplayName)        
         | Item.MethodGroup(_,minfo :: _,_) -> bufs (fun os -> NicePrint.outputTyconRef denv os minfo.DeclaringEntityRef; bprintf os ".%s" minfo.DisplayName)        
         | Item.UnqualifiedType (tcref :: _) -> bufs (fun os -> NicePrint.outputTyconRef denv os tcref)
-        | Item.FakeInterfaceCtor typ 
-        | Item.DelegateCtor typ 
-        | Item.Types(_,typ:: _) -> bufs (fun os -> NicePrint.outputTyconRef denv os (tcrefOfAppTy g typ))
+        | Item.FakeInterfaceCtor typ
+        | Item.DelegateCtor typ
+        | Item.Types(_, typ :: _) ->
+            match typ with
+            | TType.TType_app _ -> bufs (fun os -> NicePrint.outputTyconRef denv os (tcrefOfAppTy g typ))
+            | _ -> ""
         | Item.ModuleOrNamespaces((modref :: _) as modrefs) -> 
             let definiteNamespace = modrefs |> List.forall (fun modref -> modref.IsNamespace)
             if definiteNamespace then fullDisplayTextOfModRef modref else modref.DemangledModuleOrNamespaceName

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1439,6 +1439,11 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[]) =
                         | Some ty when tyconRefEq g (tcrefOfAppTy g pinfo.EnclosingType) (tcrefOfAppTy g ty) ->
                             { x with Priority = CompletionItemPriority.High }
                         | _ -> x
+                    | Item.ILField finfo ->
+                        match x.Type with
+                        | Some ty when tyconRefEq g (tcrefOfAppTy g finfo.EnclosingType) (tcrefOfAppTy g ty) ->
+                            { x with Priority = CompletionItemPriority.High }
+                        | _ -> x
                     | _ -> x)
             |> List.sortBy (fun x -> x.Priority)
             |> List.fold (fun (prevPrior, acc) x ->

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1454,7 +1454,7 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[]) =
                 ) (0, 0, [])
 
         // Remove all duplicates. We've put the types first, so this removes the DelegateCtor and DefaultStructCtor's.
-        let items = items |> RemoveDuplicateCompletionItems g
+        let items = items |> List.rev |> RemoveDuplicateCompletionItems g
 
         if verbose then dprintf "service.ml: mkDecls: %d found groups after filtering\n" (List.length items); 
 

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1350,7 +1350,7 @@ module internal ItemDescriptionsImpl =
      
 /// An intellisense declaration
 [<Sealed>]
-type FSharpDeclarationListItem(name: string, nameInCode: string, glyphMajor: GlyphMajor, glyphMinor: GlyphMinor, info, isAttribute: bool, kind: CompletionItemKind, isOwnMember: bool, priority: int) =
+type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: string, glyphMajor: GlyphMajor, glyphMinor: GlyphMinor, info, isAttribute: bool, kind: CompletionItemKind, isOwnMember: bool, priority: int) =
     let mutable descriptionTextHolder:FSharpToolTipText<_> option = None
     let mutable task = null
 
@@ -1403,7 +1403,6 @@ type FSharpDeclarationListItem(name: string, nameInCode: string, glyphMajor: Gly
                 result
 
     member decl.DescriptionText = decl.StructuredDescriptionText |> Tooltips.ToFSharpToolTipText
-
     member decl.Glyph = 6 * int glyphMajor + int glyphMinor
     member decl.GlyphMajor = glyphMajor 
     member decl.GlyphMinor = glyphMinor
@@ -1411,6 +1410,7 @@ type FSharpDeclarationListItem(name: string, nameInCode: string, glyphMajor: Gly
     member decl.Kind = kind
     member decl.IsOwnMember = isOwnMember
     member decl.MinorPriority = priority
+    member decl.FullName = fullName
       
 /// A table of declarations for Intellisense completion 
 [<Sealed>]
@@ -1489,14 +1489,16 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[]) =
                             if IsOperatorName nm then cleanName else "``" + cleanName + "``"
                         else nm, nm
 
+                    let fullName = ItemDescriptionsImpl.FullNameOfItem g items.Head.Item
+
                     new FSharpDeclarationListItem(
-                        name, nameInCode, glyphMajor, glyphMinor, Choice1Of2 (items, infoReader, m, denv, reactor, checkAlive), IsAttribute infoReader items.Head.Item, 
+                        name, nameInCode, fullName, glyphMajor, glyphMinor, Choice1Of2 (items, infoReader, m, denv, reactor, checkAlive), IsAttribute infoReader items.Head.Item, 
                         items.Head.Kind, items.Head.IsOwnMember, items.Head.MinorPriority))
 
         new FSharpDeclarationListInfo(Array.ofList decls)
     
     static member Error msg = 
         new FSharpDeclarationListInfo(
-                [| new FSharpDeclarationListItem("<Note>", "<Note>", GlyphMajor.Error, GlyphMinor.Normal, 
+                [| new FSharpDeclarationListItem("<Note>", "<Note>", "<Note>", GlyphMajor.Error, GlyphMinor.Normal, 
                                                  Choice2Of2 (FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError msg]), false, CompletionItemKind.Other, false, 0) |])
     static member Empty = new FSharpDeclarationListInfo([| |])

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1436,22 +1436,27 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[]) =
                 // Put type ctors after types, sorted by #typars. RemoveDuplicateItems will remove DefaultStructCtors if a type is also reported with this name
                 | Item.CtorGroup (_, (cinfo :: _)) -> { x with MinorPriority = 1000 + 10 * (tcrefOfAppTy g cinfo.EnclosingType).TyparsNoRange.Length }
                 | Item.MethodGroup(_, minfo :: _, _) ->
-                    { x with Kind = CompletionItemKind.Method
-                             IsOwnMember = 
+                    { x with IsOwnMember = 
                                 match x.Type with
                                 | Some ty -> tyconRefEq g minfo.DeclaringEntityRef (tcrefOfAppTy g ty)
                                 | _ -> false }
                 | Item.Property(_, pinfo :: _) ->
-                    { x with Kind = CompletionItemKind.Property
-                             IsOwnMember = 
+                    { x with IsOwnMember = 
                                 match x.Type with
                                 | Some ty -> tyconRefEq g (tcrefOfAppTy g pinfo.EnclosingType) (tcrefOfAppTy g ty)
                                 | _ -> false }
                 | Item.ILField finfo ->
-                    { x with Kind = CompletionItemKind.Field
-                             IsOwnMember = 
+                    { x with IsOwnMember = 
                                 match x.Type with
                                 | Some ty -> tyconRefEq g (tcrefOfAppTy g finfo.EnclosingType) (tcrefOfAppTy g ty)
+                                | _ -> false }
+                | Item.Value vinfo ->
+                    { x with IsOwnMember =
+                                match x.Type with
+                                | Some ty -> 
+                                    let _y = ty
+                                    let _x = vinfo.TopValActualParent
+                                    true
                                 | _ -> false }
                 | _ -> x)
             |> List.sortBy (fun x -> x.MinorPriority)

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -701,8 +701,8 @@ module internal ItemDescriptionsImpl =
         | Item.FakeInterfaceCtor typ
         | Item.DelegateCtor typ
         | Item.Types(_, typ :: _) ->
-            match typ with
-            | TType.TType_app _ -> bufs (fun os -> NicePrint.outputTyconRef denv os (tcrefOfAppTy g typ))
+            match tryDestAppTy g typ with
+            | Some tcref -> bufs (fun os -> NicePrint.outputTyconRef denv os tcref)
             | _ -> ""
         | Item.ModuleOrNamespaces((modref :: _) as modrefs) -> 
             let definiteNamespace = modrefs |> List.forall (fun modref -> modref.IsNamespace)

--- a/src/fsharp/vs/ServiceDeclarations.fsi
+++ b/src/fsharp/vs/ServiceDeclarations.fsi
@@ -68,8 +68,8 @@ module internal Tooltips =
 
 [<RequireQualifiedAccess>]
 type internal CompletionItemPriority =
-    | Default = 0
-    | High = 1
+    | Relative of int
+    | High
 
 type internal CompletionItem =
     { Item: Item

--- a/src/fsharp/vs/ServiceDeclarations.fsi
+++ b/src/fsharp/vs/ServiceDeclarations.fsi
@@ -67,13 +67,19 @@ module internal Tooltips =
     val Map: f: ('T1 -> 'T2) -> a: Async<'T1> -> Async<'T2>
 
 [<RequireQualifiedAccess>]
-type internal CompletionItemPriority =
-    | Relative of int
-    | High
+type internal CompletionItemKind =
+    | Field
+    | Property
+    | Method
+    | Event
+    | Argument
+    | Other
 
 type internal CompletionItem =
     { Item: Item
-      Priority: CompletionItemPriority
+      Kind: CompletionItemKind
+      IsOwnMember: bool
+      MinorPriority: int
       Type: TType option }
 
 [<Sealed>]
@@ -101,7 +107,9 @@ type internal FSharpDeclarationListItem =
     member GlyphMajor : ItemDescriptionIcons.GlyphMajor
     member GlyphMinor : ItemDescriptionIcons.GlyphMinor
     member IsAttribute : bool
-    member CompletionPriority : CompletionItemPriority
+    member Kind : CompletionItemKind
+    member IsOwnMember : bool
+    member MinorPriority : int
 
 [<Sealed>]
 /// Represents a set of declarations in F# source code, with information attached ready for display by an editor.

--- a/src/fsharp/vs/ServiceDeclarations.fsi
+++ b/src/fsharp/vs/ServiceDeclarations.fsi
@@ -110,6 +110,7 @@ type internal FSharpDeclarationListItem =
     member Kind : CompletionItemKind
     member IsOwnMember : bool
     member MinorPriority : int
+    member FullName : string
 
 [<Sealed>]
 /// Represents a set of declarations in F# source code, with information attached ready for display by an editor.

--- a/src/fsharp/vs/ServiceDeclarations.fsi
+++ b/src/fsharp/vs/ServiceDeclarations.fsi
@@ -73,7 +73,8 @@ type internal CompletionItemPriority =
 
 type internal CompletionItem =
     { Item: Item
-      Priority: CompletionItemPriority }
+      Priority: CompletionItemPriority
+      Type: TType option }
 
 [<Sealed>]
 /// Represents a declaration in F# source code, with information attached ready for display by an editor.
@@ -136,9 +137,11 @@ module internal ItemDescriptionsImpl =
     val FormatStructuredReturnTypeOfItem  : InfoReader -> range -> DisplayEnv -> Item -> Layout
     val FormatReturnTypeOfItem  : InfoReader -> range -> DisplayEnv -> Item -> string
     val RemoveDuplicateItems : TcGlobals -> Item list -> Item list
+    val RemoveDuplicateItemsWithType : TcGlobals -> (Item * TType option) list -> (Item * TType option) list
     val RemoveExplicitlySuppressed : TcGlobals -> Item list -> Item list
     val RemoveDuplicateCompletionItems : TcGlobals -> CompletionItem list -> CompletionItem list
     val RemoveExplicitlySuppressedCompletionItems : TcGlobals -> CompletionItem list -> CompletionItem list
+    val RemoveExplicitlySuppressedItemsWithType : TcGlobals -> (Item * TType option) list -> (Item * TType option) list
     val GetF1Keyword : Item -> string option
     val rangeOfItem : TcGlobals -> bool option -> Item -> range option
     val fileNameOfItem : TcGlobals -> string option -> range -> Item -> string

--- a/src/fsharp/vs/ServiceDeclarations.fsi
+++ b/src/fsharp/vs/ServiceDeclarations.fsi
@@ -66,6 +66,15 @@ module internal Tooltips =
     val ToFSharpToolTipText: FSharpStructuredToolTipText -> FSharpToolTipText
     val Map: f: ('T1 -> 'T2) -> a: Async<'T1> -> Async<'T2>
 
+[<RequireQualifiedAccess>]
+type internal CompletionItemPriority =
+    | Default = 0
+    | High = 1
+
+type internal CompletionItem =
+    { Item: Item
+      Priority: CompletionItemPriority }
+
 [<Sealed>]
 /// Represents a declaration in F# source code, with information attached ready for display by an editor.
 /// Returned by GetDeclarations.
@@ -91,6 +100,7 @@ type internal FSharpDeclarationListItem =
     member GlyphMajor : ItemDescriptionIcons.GlyphMajor
     member GlyphMinor : ItemDescriptionIcons.GlyphMinor
     member IsAttribute : bool
+    member CompletionPriority : CompletionItemPriority
 
 [<Sealed>]
 /// Represents a set of declarations in F# source code, with information attached ready for display by an editor.
@@ -101,7 +111,7 @@ type internal FSharpDeclarationListInfo =
     member Items : FSharpDeclarationListItem[]
 
     // Implementation details used by other code in the compiler    
-    static member internal Create : infoReader:InfoReader * m:range * denv:DisplayEnv * items:Item list * reactor:IReactorOperations * checkAlive:(unit -> bool) -> FSharpDeclarationListInfo
+    static member internal Create : infoReader:InfoReader * m:range * denv:DisplayEnv * items:CompletionItem list * reactor:IReactorOperations * checkAlive:(unit -> bool) -> FSharpDeclarationListInfo
     static member internal Error : message:string -> FSharpDeclarationListInfo
     static member Empty : FSharpDeclarationListInfo
 
@@ -127,6 +137,8 @@ module internal ItemDescriptionsImpl =
     val FormatReturnTypeOfItem  : InfoReader -> range -> DisplayEnv -> Item -> string
     val RemoveDuplicateItems : TcGlobals -> Item list -> Item list
     val RemoveExplicitlySuppressed : TcGlobals -> Item list -> Item list
+    val RemoveDuplicateCompletionItems : TcGlobals -> CompletionItem list -> CompletionItem list
+    val RemoveExplicitlySuppressedCompletionItems : TcGlobals -> CompletionItem list -> CompletionItem list
     val GetF1Keyword : Item -> string option
     val rangeOfItem : TcGlobals -> bool option -> Item -> range option
     val fileNameOfItem : TcGlobals -> string option -> range -> Item -> string

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -1135,6 +1135,10 @@ module UntypedParseImpl =
                                 Some (CompletionContext.ParameterList args)
                             | _ -> 
                                 defaultTraverse expr
+                        
+                        | NewObjectOrMethodCall args ->
+                            Some (CompletionContext.ParameterList args)
+
                         | _ -> defaultTraverse expr
 
                     member this.VisitRecordField(path, copyOpt, field) = 

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -1136,9 +1136,6 @@ module UntypedParseImpl =
                             | _ -> 
                                 defaultTraverse expr
                         
-                        | NewObjectOrMethodCall args ->
-                            Some (CompletionContext.ParameterList args)
-
                         | _ -> defaultTraverse expr
 
                     member this.VisitRecordField(path, copyOpt, field) = 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -445,7 +445,7 @@ type FSharpFindDeclResult =
 [<RequireQualifiedAccess>]
 [<NoEquality; NoComparison>]
 type internal NameResResult = 
-    | Members of (Item list * DisplayEnv * range)
+    | Members of (Item list * Item list * DisplayEnv * range)
     | Cancel of DisplayEnv * range
     | Empty
     | TypecheckStaleAndTextChanged
@@ -461,7 +461,7 @@ type GetPreciseCompletionListFromExprTypingsResult =
     | NoneBecauseTypecheckIsStaleAndTextChanged
     | NoneBecauseThereWereTypeErrors
     | None
-    | Some of (Item list * DisplayEnv * range)
+    | Some of (Item list * Item list * DisplayEnv * range)
 
 type Names = string list 
 
@@ -504,6 +504,10 @@ type SemanticClassificationType =
     | TypeArgument
     | Operator
     | Disposable
+
+type CompletionItemPriority =
+    | Normal = 0
+    | High = 1
 
 // A scope represents everything we get back from the typecheck of a file.
 // It acts like an in-memory database about the file.
@@ -621,7 +625,7 @@ type TypeCheckInfo
             if hasTextChangedSinceLastTypecheck(textSnapshotInfo, m) then
                 NameResResult.TypecheckStaleAndTextChanged // typecheck is stale, wait for second-chance IntelliSense to bring up right result
             else
-                f(items, denv, m) 
+                f([], items, denv, m) 
         else NameResResult.Empty
 
     let GetCapturedNameResolutions endOfNamesPos resolveOverloads =
@@ -812,7 +816,7 @@ type TypeCheckInfo
                 let items = items |> RemoveDuplicateItems g
                 let items = items |> RemoveExplicitlySuppressed g
                 let items = items |> FilterItemsForCtors filterCtors 
-                GetPreciseCompletionListFromExprTypingsResult.Some(items,denv,m)
+                GetPreciseCompletionListFromExprTypingsResult.Some([],items,denv,m)
             | None -> 
                 if textChanged then GetPreciseCompletionListFromExprTypingsResult.NoneBecauseTypecheckIsStaleAndTextChanged
                 else GetPreciseCompletionListFromExprTypingsResult.None
@@ -825,7 +829,7 @@ type TypeCheckInfo
         let items = items |> RemoveExplicitlySuppressed g
         let items = items |> FilterItemsForCtors filterCtors 
          
-        items, nenv.DisplayEnv, m 
+        [], items, nenv.DisplayEnv, m
 
     /// Find record fields in the best naming environment.
     let GetClassOrRecordFieldsEnvironmentLookupResolutions(cursorPos, plid, (_residue : string option)) = 
@@ -865,25 +869,26 @@ type TypeCheckInfo
     /// This also checks that there are some remaining results 
     /// exactMatchResidueOpt = Some _ -- means that we are looking for exact matches
     let FilterRelevantItemsBy (exactMatchResidueOpt : _ option) check (items, denv, m) =
-            
         // can throw if type is in located in non-resolved CCU: i.e. bigint if reference to System.Numerics is absent
         let safeCheck item = try check item with _ -> false
                                                 
         // Are we looking for items with precisely the given name?
         if not (isNil items) && exactMatchResidueOpt.IsSome then
-            let items = items |> FilterDeclItemsByResidue exactMatchResidueOpt.Value |> List.filter safeCheck 
-            if not (isNil items) then Some(items, denv, m) else None        
+            items |> FilterDeclItemsByResidue exactMatchResidueOpt.Value |> List.filter safeCheck 
         else 
             // When (items = []) we must returns Some([],..) and not None
             // because this value is used if we want to stop further processing (e.g. let x.$ = ...)
-            let items = items |> List.filter safeCheck
-            Some(items, denv, m) 
+            items |> List.filter safeCheck
 
     /// Post-filter items to make sure they have precisely the right name
     /// This also checks that there are some remaining results 
     let (|FilterRelevantItems|_|) exactMatchResidueOpt orig =
-        FilterRelevantItemsBy exactMatchResidueOpt (fun _ -> true) orig
-
+        let pItems, items, denv, m = orig
+        let pItems = FilterRelevantItemsBy exactMatchResidueOpt (fun _ -> true) (pItems, denv, m)
+        let items = FilterRelevantItemsBy exactMatchResidueOpt (fun _ -> true) (items, denv, m)
+        match pItems, items with
+        | [], [] -> None
+        | _ -> Some (pItems, items, denv, m)
     
     /// Find the first non-whitespace postion in a line prior to the given character
     let FindFirstNonWhitespacePosition (lineStr: string) i = 
@@ -944,7 +949,7 @@ type TypeCheckInfo
                 
             match nameResItems with            
             | NameResResult.TypecheckStaleAndTextChanged -> None // second-chance intellisense will try again
-            | NameResResult.Cancel(denv,m) -> Some([], denv, m)
+            | NameResResult.Cancel(denv,m) -> Some([], [], denv, m)
             | NameResResult.Members(FilterRelevantItems exactMatchResidueOpt items) -> 
                 // lookup based on name resolution results successful
                 Some items
@@ -1003,15 +1008,15 @@ type TypeCheckInfo
                 match nameResItems, envItems, qualItems with            
             
                 // First, use unfiltered name resolution items, if they're not empty
-                | NameResResult.Members(items, denv, m), _, _ when not (isNil items) -> 
+                | NameResResult.Members(pItems, items, denv, m), _, _ when not (isNil pItems) || not (isNil items) -> 
                     // lookup based on name resolution results successful
-                    Some(items, denv, m)                
+                    Some(pItems, items, denv, m)
             
                 // If we have nonempty items from environment that were resolved from a type, then use them... 
                 // (that's better than the next case - here we'd return 'int' as a type)
-                | _, FilterRelevantItems exactMatchResidueOpt (items, denv, m), _ when not (isNil items) ->
+                | _, FilterRelevantItems exactMatchResidueOpt (pItems, items, denv, m), _ when not (isNil pItems) || not (isNil items) ->
                     // lookup based on name and environment successful
-                    Some(items, denv, m)
+                    Some(pItems, items, denv, m)
 
                 // Try again with the qualItems
                 | _, _, GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt items) ->
@@ -1030,6 +1035,9 @@ type TypeCheckInfo
             | atDot when lineStr.[atDot] = '.' -> atDot + 1
             | atStart when atStart = 0 -> 0
             | otherwise -> otherwise - 1
+
+        let ast = parseResultsOpt |> Option.map (fun x -> x.ParseTree) |> sprintf "%+A"
+        let _x = ast
 
         // Look for a "special" completion context
         match UntypedParseImpl.TryGetCompletionContext(mkPos line colAtEndOfNamesAndResidue, parseResultsOpt, lineStr) with
@@ -1083,7 +1091,7 @@ type TypeCheckInfo
                     |> List.filter (fun m -> not (fields.Contains m.DisplayName))
                 match declaredItems with
                 | None -> Some (items, denv, m)
-                | Some (declItems, declaredDisplayEnv, declaredRange) -> Some (filtered @ declItems, declaredDisplayEnv, declaredRange)
+                | Some (declItems, declaredDisplayEnv, declaredRange) -> Some (filtered, declItems, declaredDisplayEnv, declaredRange)
             | _ -> declaredItems
 
         | Some(CompletionContext.AttributeApplication) ->

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -505,10 +505,6 @@ type SemanticClassificationType =
     | Operator
     | Disposable
 
-type CompletionItemPriority =
-    | Normal = 0
-    | High = 1
-
 // A scope represents everything we get back from the typecheck of a file.
 // It acts like an in-memory database about the file.
 // It is effectively immutable and not updated: when we re-typecheck we just drop the previous
@@ -822,17 +818,16 @@ type TypeCheckInfo
                 else GetPreciseCompletionListFromExprTypingsResult.None
 
     /// Find items in the best naming environment.
-    let GetEnvironmentLookupResolutions(cursorPos, plid, filterCtors, showObsolete) = 
+    let GetEnvironmentLookupResolutions(cursorPos, plid, filterCtors, showObsolete) : Item list * DisplayEnv * range = 
         let (nenv,ad),m = GetBestEnvForPos cursorPos
         let items = NameResolution.ResolvePartialLongIdent ncenv nenv (ConstraintSolver.IsApplicableMethApprox g amap m) m ad plid showObsolete
         let items = items |> RemoveDuplicateItems g 
         let items = items |> RemoveExplicitlySuppressed g
         let items = items |> FilterItemsForCtors filterCtors 
-         
         items, nenv.DisplayEnv, m 
 
     /// Find record fields in the best naming environment.
-    let GetClassOrRecordFieldsEnvironmentLookupResolutions(cursorPos, plid, (_residue : string option)) = 
+    let GetClassOrRecordFieldsEnvironmentLookupResolutions(cursorPos, plid, (_residue : string option)) : Item list * DisplayEnv * range = 
         let (nenv, ad),m = GetBestEnvForPos cursorPos
         let items = NameResolution.ResolvePartialLongIdentToClassOrRecdFields ncenv nenv m ad plid false
         let items = items |> RemoveDuplicateItems g 
@@ -887,7 +882,6 @@ type TypeCheckInfo
     /// This also checks that there are some remaining results 
     let (|FilterRelevantItems|_|) exactMatchResidueOpt orig =
         FilterRelevantItemsBy exactMatchResidueOpt (fun _ -> true) orig
-
     
     /// Find the first non-whitespace postion in a line prior to the given character
     let FindFirstNonWhitespacePosition (lineStr: string) i = 
@@ -897,7 +891,14 @@ type TypeCheckInfo
         while p >= 0 && System.Char.IsWhiteSpace(lineStr.[p]) do
             p <- p - 1
         if p >= 0 then Some p else None
-        
+    
+    let DefaultCompletionItem (item: Item) =
+        { Item = item
+          Priority = CompletionItemPriority.Default }
+    
+    let HighPriorityCompletionItem (item: Item) =
+        { Item = item
+          Priority = CompletionItemPriority.High }
 
     let GetDeclaredItems (parseResultsOpt: FSharpParseFileResults option, lineStr: string, origLongIdentOpt, colAtEndOfNamesAndResidue, residueOpt, line, loc, filterCtors,resolveOverloads, hasTextChangedSinceLastTypecheck, isInRangeOperator) =
  
@@ -949,9 +950,9 @@ type TypeCheckInfo
             match nameResItems with            
             | NameResResult.TypecheckStaleAndTextChanged -> None // second-chance intellisense will try again
             | NameResResult.Cancel(denv,m) -> Some([], denv, m)
-            | NameResResult.Members(FilterRelevantItems exactMatchResidueOpt items) -> 
+            | NameResResult.Members(FilterRelevantItems exactMatchResidueOpt (items, denv, m)) -> 
                 // lookup based on name resolution results successful
-                Some items
+                Some (items |> List.map DefaultCompletionItem, denv, m)
             | _ ->
         
             match origLongIdentOpt with
@@ -980,14 +981,14 @@ type TypeCheckInfo
                         GetPreciseCompletionListFromExprTypingsResult.None, false
 
                 match qualItems,thereIsADotInvolved with            
-                | GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt items), _
+                | GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt (items, denv, m)), _
                         // Initially we only use the expression typings when looking up, e.g. (expr).Nam or (expr).Name1.Nam
                         // These come through as an empty plid and residue "". Otherwise we try an environment lookup
                         // and then return to the qualItems. This is because the expression typings are a little inaccurate, primarily because
                         // it appears we're getting some typings recorded for non-atomic expressions like "f x"
                         when (match plid with [] -> true | _ -> false)  -> 
                     // lookup based on expression typings successful
-                    Some items
+                    Some (items |> List.map DefaultCompletionItem, denv, m)
                 | GetPreciseCompletionListFromExprTypingsResult.NoneBecauseThereWereTypeErrors, _ ->
                     // There was an error, e.g. we have "<expr>." and there is an error determining the type of <expr>  
                     // In this case, we don't want any of the fallback logic, rather, we want to produce zero results.
@@ -1009,23 +1010,27 @@ type TypeCheckInfo
                 // First, use unfiltered name resolution items, if they're not empty
                 | NameResResult.Members(items, denv, m), _, _ when not (isNil items) -> 
                     // lookup based on name resolution results successful
-                    Some(items, denv, m)                
+                    Some(items |> List.map DefaultCompletionItem, denv, m)                
             
                 // If we have nonempty items from environment that were resolved from a type, then use them... 
                 // (that's better than the next case - here we'd return 'int' as a type)
                 | _, FilterRelevantItems exactMatchResidueOpt (items, denv, m), _ when not (isNil items) ->
                     // lookup based on name and environment successful
-                    Some(items, denv, m)
+                    Some(items |> List.map DefaultCompletionItem, denv, m)
 
                 // Try again with the qualItems
-                | _, _, GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt items) ->
-                    Some(items)
+                | _, _, GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt (items, denv, m)) ->
+                    Some(items |> List.map DefaultCompletionItem, denv, m)
                 
                 | _ -> None
 
+    let toCompletionItems (items: Item list, denv: DisplayEnv, m: range) : CompletionItem list * DisplayEnv * range =
+        items |> List.map DefaultCompletionItem, denv, m
 
     /// Get the auto-complete items at a particular location.
-    let GetDeclItemsForNamesAtPosition(ctok: CompilationThreadToken, parseResultsOpt: FSharpParseFileResults option, origLongIdentOpt: string list option, residueOpt:string option, line:int, lineStr:string, colAtEndOfNamesAndResidue, filterCtors, resolveOverloads, hasTextChangedSinceLastTypecheck: (obj * range -> bool)) = 
+    let GetDeclItemsForNamesAtPosition(ctok: CompilationThreadToken, parseResultsOpt: FSharpParseFileResults option, origLongIdentOpt: string list option, 
+                                       residueOpt:string option, line:int, lineStr:string, colAtEndOfNamesAndResidue, filterCtors, resolveOverloads, 
+                                       hasTextChangedSinceLastTypecheck: (obj * range -> bool)) : (CompletionItem list * DisplayEnv * range) option = 
         RequireCompilationThread ctok // the operations in this method need the reactor thread
 
         let loc = 
@@ -1043,34 +1048,39 @@ type TypeCheckInfo
 
         // Completion at 'inherit C(...)"
         | Some (CompletionContext.Inherit(InheritanceContext.Class, (plid, _))) ->
-            GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, false) 
+            GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, false)
             |> FilterRelevantItemsBy None GetBaseClassCandidates
+            |> Option.map toCompletionItems
 
         // Completion at 'interface ..."
         | Some (CompletionContext.Inherit(InheritanceContext.Interface, (plid, _))) ->
             GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, false) 
             |> FilterRelevantItemsBy None GetInterfaceCandidates
+            |> Option.map toCompletionItems
 
         // Completion at 'implement ..."
         | Some (CompletionContext.Inherit(InheritanceContext.Unknown, (plid, _))) ->
             GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, false) 
             |> FilterRelevantItemsBy None (fun t -> GetBaseClassCandidates t || GetInterfaceCandidates t)
+            |> Option.map toCompletionItems
 
         // Completion at ' { XXX = ... } "
         | Some(CompletionContext.RecordField(RecordContext.New(plid, residue))) ->
             Some(GetClassOrRecordFieldsEnvironmentLookupResolutions(mkPos line loc, plid, residue))
+            |> Option.map toCompletionItems
 
         // Completion at ' { XXX = ... with ... } "
         | Some(CompletionContext.RecordField(RecordContext.CopyOnUpdate(r, (plid, residue)))) -> 
             match GetRecdFieldsForExpr(r) with
             | None -> 
-                GetClassOrRecordFieldsEnvironmentLookupResolutions(mkPos line loc, plid, residue)
-                |> Some
-            | x -> x
+                Some (GetClassOrRecordFieldsEnvironmentLookupResolutions(mkPos line loc, plid, residue))
+                |> Option.map toCompletionItems
+            | x -> x |> Option.map toCompletionItems
 
         // Completion at ' { XXX = ... with ... } "
         | Some(CompletionContext.RecordField(RecordContext.Constructor(typeName))) ->
             Some(GetClassOrRecordFieldsEnvironmentLookupResolutions(mkPos line loc, [typeName], None))
+            |> Option.map toCompletionItems
 
         // Completion at ' SomeMethod( ... ) ' with named arguments 
         | Some(CompletionContext.ParameterList (endPos, fields)) ->
@@ -1085,19 +1095,21 @@ type TypeCheckInfo
                     |> RemoveDuplicateItems g
                     |> RemoveExplicitlySuppressed g
                     |> List.filter (fun m -> not (fields.Contains m.DisplayName))
+                    |> List.map HighPriorityCompletionItem
                 match declaredItems with
-                | None -> Some (items, denv, m)
+                | None -> Some (toCompletionItems (items, denv, m))
                 | Some (declItems, declaredDisplayEnv, declaredRange) -> Some (filtered @ declItems, declaredDisplayEnv, declaredRange)
             | _ -> declaredItems
 
         | Some(CompletionContext.AttributeApplication) ->
             GetDeclaredItems (parseResultsOpt, lineStr, origLongIdentOpt, colAtEndOfNamesAndResidue, residueOpt, line, loc, filterCtors, resolveOverloads, hasTextChangedSinceLastTypecheck, false)
-            |> Option.map (fun (items, denv, r) -> 
-                items 
-                |> List.filter (function
-                    | Item.Types _
-                    | Item.ModuleOrNamespaces _ -> true
-                    | _ -> false), denv, r)
+            |> Option.map (fun (items, denv, m) -> 
+                 items 
+                 |> List.filter (fun cItem ->
+                     match cItem.Item with
+                     | Item.Types _
+                     | Item.ModuleOrNamespaces _ -> true
+                     | _ -> false), denv, m)
 
         // Other completions
         | cc ->
@@ -1136,12 +1148,12 @@ type TypeCheckInfo
 
     /// If an AST is available, then determine if we are at a "special" position in the AST such as an "open".  If so restrict 
     /// or augment the autocompletes available at that point.
-    let FilterAutoCompletesBasedOnParseContext (parseResultsOpt: FSharpParseFileResults option) (pos:pos) items = 
+    let FilterAutoCompletesBasedOnParseContext (parseResultsOpt: FSharpParseFileResults option) (pos: pos) (items: CompletionItem list) = 
         match parseResultsOpt |> Option.bind (fun parseResults -> parseResults.ParseTree) with
         | None -> items
         | Some parseTree -> 
             if IsAtOpenDeclaration (parseTree, pos) then 
-                items |> List.filter (function Item.ModuleOrNamespaces _ -> true | _ -> false)
+                items |> List.filter (fun item -> match item.Item with Item.ModuleOrNamespaces _ -> true | _ -> false)
             else 
                 items
 
@@ -1168,7 +1180,7 @@ type TypeCheckInfo
                 | None -> FSharpDeclarationListInfo.Empty  
                 | Some (items, denv, m) -> 
                     let items = items |> FilterAutoCompletesBasedOnParseContext parseResultsOpt (mkPos line colAtEndOfNamesAndResidue)
-                    let items = if isInterfaceFile then items |> List.filter IsValidSignatureFileItem else items
+                    let items = if isInterfaceFile then items |> List.filter (fun x -> IsValidSignatureFileItem x.Item) else items
                     FSharpDeclarationListInfo.Create(infoReader,m,denv,items,reactorOps,checkAlive))
             (fun msg -> FSharpDeclarationListInfo.Error msg)
 
@@ -1181,10 +1193,10 @@ type TypeCheckInfo
                 | None -> List.Empty  
                 | Some (items, _denv, _m) -> 
                     let items = items |> FilterAutoCompletesBasedOnParseContext parseResultsOpt (mkPos line colAtEndOfNamesAndResidue)
-                    let items = if isInterfaceFile then items |> List.filter IsValidSignatureFileItem else items
+                    let items = if isInterfaceFile then items |> List.filter (fun x -> IsValidSignatureFileItem x.Item) else items
 
                     //do filtering like Declarationset
-                    let items = items |> RemoveExplicitlySuppressed g
+                    let items = items |> RemoveExplicitlySuppressedCompletionItems g
                     
                     // Sort by name. For things with the same name, 
                     //     - show types with fewer generic parameters first
@@ -1192,7 +1204,7 @@ type TypeCheckInfo
                     let items = 
                         items |> List.sortBy (fun d -> 
                             let n = 
-                                match d with  
+                                match d.Item with  
                                 | Item.Types (_,(TType_app(tcref,_) :: _)) -> 1 + tcref.TyparsNoRange.Length
                                 // Put delegate ctors after types, sorted by #typars. RemoveDuplicateItems will remove FakeInterfaceCtor and DelegateCtor if an earlier type is also reported with this name
                                 | Item.FakeInterfaceCtor (TType_app(tcref,_)) 
@@ -1200,21 +1212,21 @@ type TypeCheckInfo
                                 // Put type ctors after types, sorted by #typars. RemoveDuplicateItems will remove DefaultStructCtors if a type is also reported with this name
                                 | Item.CtorGroup (_, (cinfo :: _)) -> 1000 + 10 * (tcrefOfAppTy g cinfo.EnclosingType).TyparsNoRange.Length 
                                 | _ -> 0
-                            (d.DisplayName,n))
+                            (d.Item.DisplayName,n))
 
                     // Remove all duplicates. We've put the types first, so this removes the DelegateCtor and DefaultStructCtor's.
-                    let items = items |> RemoveDuplicateItems g
+                    let items = items |> RemoveDuplicateCompletionItems g
 
                     if verbose then dprintf "service.ml: mkDecls: %d found groups after filtering\n" (List.length items); 
 
                     // Group by display name
-                    let items = items |> List.groupBy (fun d -> d.DisplayName) 
+                    let items = items |> List.groupBy (fun d -> d.Item.DisplayName) 
 
                     // Filter out operators (and list)
                     let items = 
                         // Check whether this item looks like an operator.
                         let isOpItem(nm,item) = 
-                            match item with 
+                            match item |> List.map (fun x -> x.Item) with 
                             | [Item.Value _]
                             | [Item.MethodGroup(_,[_],_)] -> IsOperatorName nm
                             | [Item.UnionCase _] -> IsOperatorName nm
@@ -1232,7 +1244,7 @@ type TypeCheckInfo
                             | [] -> failwith "Unexpected empty bag"
                             | items ->
                                 items 
-                                |> List.map (fun item -> let symbol = FSharpSymbol.Create(g, thisCcu, tcImports, item)
+                                |> List.map (fun item -> let symbol = FSharpSymbol.Create(g, thisCcu, tcImports, item.Item)
                                                          FSharpSymbolUse(g, _denv, symbol, ItemOccurence.Use, _m)))
 
                     //end filtering
@@ -1281,7 +1293,7 @@ type TypeCheckInfo
                     match GetDeclItemsForNamesAtPosition(ctok, None,Some(names),None,line,lineStr,colAtEndOfNames,ResolveTypeNamesToCtors,ResolveOverloads.Yes,fun _ -> false) with
                     | None -> FSharpToolTipText []
                     | Some(items, denv, m) ->
-                         FSharpToolTipText(items |> List.map (FormatStructuredDescriptionOfItem false infoReader m denv )))
+                         FSharpToolTipText(items |> List.map (fun x -> FormatStructuredDescriptionOfItem false infoReader m denv x.Item)))
                 (fun err -> FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError err])
                
         // See devdiv bug 646520 for rationale behind truncating and caching these quick infos (they can be big!)
@@ -1307,16 +1319,16 @@ type TypeCheckInfo
                     match items with
                     | [] -> None
                     | [item] ->
-                        GetF1Keyword item                        
+                        GetF1Keyword item.Item                       
                     | _ ->
                         // handle new Type()
                         let allTypes, constr, typ =
                             List.fold 
                                 (fun (allTypes,constr,typ) item ->
-                                    match item, constr, typ with
+                                    match item.Item, constr, typ with
                                     |   (Item.Types _) as t, _, None  -> allTypes, constr, Some t
                                     |   (Item.Types _), _, _ -> allTypes, constr, typ
-                                    |   (Item.CtorGroup _), None, _ -> allTypes, Some item, typ
+                                    |   (Item.CtorGroup _), None, _ -> allTypes, Some item.Item, typ
                                     |   _ -> false, None, None) 
                                 (true,None,None) items
                         match allTypes, constr, typ with
@@ -1333,7 +1345,7 @@ type TypeCheckInfo
             (fun () -> 
                 match GetDeclItemsForNamesAtPosition(ctok, None,namesOpt,None,line,lineStr,colAtEndOfNames,ResolveTypeNamesToCtors,ResolveOverloads.No, fun _ -> false) with
                 | None -> FSharpMethodGroup("",[| |])
-                | Some (items, denv, m) -> FSharpMethodGroup.Create(infoReader,m,denv,items))
+                | Some (items, denv, m) -> FSharpMethodGroup.Create(infoReader,m,denv,items |> List.map (fun x -> x.Item)))
             (fun msg -> 
                 FSharpMethodGroup(msg,[| |]))
 
@@ -1344,25 +1356,25 @@ type TypeCheckInfo
             let allItems =
                 items
                 |> List.collect (fun item ->
-                    match item with 
+                    match item.Item with 
                     | Item.MethodGroup(nm,minfos,orig) -> minfos |> List.map (fun minfo -> Item.MethodGroup(nm,[minfo],orig))  
                     | Item.CtorGroup(nm,cinfos) -> cinfos |> List.map (fun minfo -> Item.CtorGroup(nm,[minfo])) 
                     | Item.FakeInterfaceCtor _
-                    | Item.DelegateCtor _ -> [item]
+                    | Item.DelegateCtor _ -> [item.Item]
                     | Item.NewDef _ 
                     | Item.ILField _ -> []
                     | Item.Event _ -> []
-                    | Item.RecdField(rfinfo) -> if isFunction g rfinfo.FieldType then [item] else []
-                    | Item.Value v -> if isFunction g v.Type then [item] else []
-                    | Item.UnionCase(ucr,_) -> if not ucr.UnionCase.IsNullary then [item] else []
-                    | Item.ExnCase(ecr) -> if isNil (recdFieldsOfExnDefRef ecr) then [] else [item]
+                    | Item.RecdField(rfinfo) -> if isFunction g rfinfo.FieldType then [item.Item] else []
+                    | Item.Value v -> if isFunction g v.Type then [item.Item] else []
+                    | Item.UnionCase(ucr,_) -> if not ucr.UnionCase.IsNullary then [item.Item] else []
+                    | Item.ExnCase(ecr) -> if isNil (recdFieldsOfExnDefRef ecr) then [] else [item.Item]
                     | Item.Property(_,pinfos) -> 
                         let pinfo = List.head pinfos 
-                        if pinfo.IsIndexer then [item] else []
+                        if pinfo.IsIndexer then [item.Item] else []
 #if EXTENSIONTYPING
-                    | Params.ItemIsWithStaticArguments m g _ -> [item] // we pretend that provided-types-with-static-args are method-like in order to get ParamInfo for them
+                    | Params.ItemIsWithStaticArguments m g _ -> [item.Item] // we pretend that provided-types-with-static-args are method-like in order to get ParamInfo for them
 #endif
-                    | Item.CustomOperation(_name, _helpText, _minfo) -> [item]
+                    | Item.CustomOperation(_name, _helpText, _minfo) -> [item.Item]
                     | Item.TypeVar _ -> []
                     | Item.CustomBuilder _ -> []
                     | _ -> [] )
@@ -1382,12 +1394,12 @@ type TypeCheckInfo
               // Later comment: to be honest, they aren't going to work on these new items either.
               // This is probably old code from when we supported 'go to definition' generating IL metadata.
               let item =
-                  match item with
+                  match item.Item with
                   | Item.MethodGroup (_, (ILMeth (_,ilinfo,_)) :: _, _) 
                   | Item.CtorGroup (_, (ILMeth (_,ilinfo,_)) :: _) -> Item.Types ("", [ ilinfo.ApparentEnclosingType ])
                   | Item.ILField (ILFieldInfo (typeInfo, _)) -> Item.Types ("", [ typeInfo.ToType ])
                   | Item.ImplicitOp(_, {contents = Some(TraitConstraintSln.FSMethSln(_, vref, _))}) -> Item.Value(vref)
-                  | _                                         -> item
+                  | _                                         -> item.Item
 
               let fail defaultReason = 
                   match item with            
@@ -1416,7 +1428,7 @@ type TypeCheckInfo
         match GetDeclItemsForNamesAtPosition (ctok, None,Some(names), None, line, lineStr, colAtEndOfNames, ResolveTypeNamesToCtors, ResolveOverloads.Yes, fun _ -> false) with
         | None | Some ([], _, _) -> None
         | Some (item :: _ , denv, m) -> 
-            let symbol = FSharpSymbol.Create(g, thisCcu, tcImports, item)
+            let symbol = FSharpSymbol.Create(g, thisCcu, tcImports, item.Item)
             Some (symbol, denv, m)
 
     member scope.PartialAssemblySignature() = FSharpAssemblySignature(g, thisCcu, tcImports, None, ccuSig)

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -461,7 +461,7 @@ type GetPreciseCompletionListFromExprTypingsResult =
     | NoneBecauseTypecheckIsStaleAndTextChanged
     | NoneBecauseThereWereTypeErrors
     | None
-    | Some of (Item list * DisplayEnv * range)
+    | Some of (Item list * DisplayEnv * range) * TType
 
 type Names = string list 
 
@@ -604,11 +604,10 @@ type TypeCheckInfo
     /// noisy. Filter a few things out.
     ///
     /// e.g. prefer types to constructors for FSharpToolTipText 
-    let FilterItemsForCtors filterCtors items = 
+    let FilterItemsForCtors filterCtors items =
         let items = items |> List.filter (function (Item.CtorGroup _) when filterCtors = ResolveTypeNamesToTypeRefs -> false | _ -> true) 
         items
         
-    
     // Filter items to show only valid & return Some if there are any
     let ReturnItemsOfType items g denv (m:range) filterCtors hasTextChangedSinceLastTypecheck f =
         let items = 
@@ -812,19 +811,19 @@ type TypeCheckInfo
                 let items = items |> RemoveDuplicateItems g
                 let items = items |> RemoveExplicitlySuppressed g
                 let items = items |> FilterItemsForCtors filterCtors 
-                GetPreciseCompletionListFromExprTypingsResult.Some(items,denv,m)
+                GetPreciseCompletionListFromExprTypingsResult.Some((items,denv,m), typ)
             | None -> 
                 if textChanged then GetPreciseCompletionListFromExprTypingsResult.NoneBecauseTypecheckIsStaleAndTextChanged
                 else GetPreciseCompletionListFromExprTypingsResult.None
 
     /// Find items in the best naming environment.
-    let GetEnvironmentLookupResolutions(cursorPos, plid, filterCtors, showObsolete) : Item list * DisplayEnv * range = 
+    let GetEnvironmentLookupResolutions(cursorPos, plid, filterCtors, showObsolete) : (Item list * DisplayEnv * range) * TType option = 
         let (nenv,ad),m = GetBestEnvForPos cursorPos
-        let items = NameResolution.ResolvePartialLongIdent ncenv nenv (ConstraintSolver.IsApplicableMethApprox g amap m) m ad plid showObsolete
+        let items, ty = NameResolution.ResolvePartialLongIdent ncenv nenv (ConstraintSolver.IsApplicableMethApprox g amap m) m ad plid showObsolete
         let items = items |> RemoveDuplicateItems g 
         let items = items |> RemoveExplicitlySuppressed g
         let items = items |> FilterItemsForCtors filterCtors 
-        items, nenv.DisplayEnv, m 
+        (items, nenv.DisplayEnv, m), ty
 
     /// Find record fields in the best naming environment.
     let GetClassOrRecordFieldsEnvironmentLookupResolutions(cursorPos, plid, (_residue : string option)) : Item list * DisplayEnv * range = 
@@ -892,11 +891,15 @@ type TypeCheckInfo
             p <- p - 1
         if p >= 0 then Some p else None
     
-    let DefaultCompletionItem (item: Item) =
+    let CompletionItem (ty: TType option) (item: Item) =
         { Item = item
-          Priority = CompletionItemPriority.Relative 0 }
+          Priority = CompletionItemPriority.Relative 0
+          Type = ty }
+
+    let DefaultCompletionItem = CompletionItem None
     
-    let GetDeclaredItems (parseResultsOpt: FSharpParseFileResults option, lineStr: string, origLongIdentOpt, colAtEndOfNamesAndResidue, residueOpt, line, loc, filterCtors,resolveOverloads, hasTextChangedSinceLastTypecheck, isInRangeOperator) =
+    let GetDeclaredItems (parseResultsOpt: FSharpParseFileResults option, lineStr: string, origLongIdentOpt, colAtEndOfNamesAndResidue, residueOpt, line, loc, 
+                          filterCtors, resolveOverloads, hasTextChangedSinceLastTypecheck, isInRangeOperator) =
  
             // Are the last two chars (except whitespaces) = ".."
             let isLikeRangeOp = 
@@ -943,82 +946,82 @@ type TypeCheckInfo
                     let plid, residue = List.frontAndBack origLongIdent
                     plid, Some residue
                 
+            let envItems, ty = GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, residueOpt.IsSome)
+
             match nameResItems with            
             | NameResResult.TypecheckStaleAndTextChanged -> None // second-chance intellisense will try again
             | NameResResult.Cancel(denv,m) -> Some([], denv, m)
             | NameResResult.Members(FilterRelevantItems exactMatchResidueOpt (items, denv, m)) -> 
                 // lookup based on name resolution results successful
-                Some (items |> List.map DefaultCompletionItem, denv, m)
+                Some (items |> List.map (CompletionItem ty), denv, m)
             | _ ->
-        
-            match origLongIdentOpt with
-            | None -> None
-            | Some _ -> 
-
-                // Try to use the type of the expression on the left to help generate a completion list
-                let qualItems, thereIsADotInvolved = 
-                    match parseResultsOpt with
-                    | None -> 
-                        // Note, you will get here if the 'reason' is not CompleteWord/MemberSelect/DisplayMemberList, as those are currently the 
-                        // only reasons we do a sync parse to have the most precise and likely-to-be-correct-and-up-to-date info.  So for example,
-                        // if you do QuickInfo hovering over A in "f(x).A()", you will only get a tip if typechecking has a name-resolution recorded
-                        // for A, not if merely we know the capturedExpressionTyping of f(x) and you very recently typed ".A()" - in that case, 
-                        // you won't won't get a tip until the typechecking catches back up.
-                        GetPreciseCompletionListFromExprTypingsResult.None, false
-                    | Some parseResults -> 
-
-                    match UntypedParseImpl.TryFindExpressionASTLeftOfDotLeftOfCursor(mkPos line colAtEndOfNamesAndResidue,parseResults.ParseTree) with
-                    | Some(pos,_) ->
-                        GetPreciseCompletionListFromExprTypings(parseResults, pos, filterCtors, hasTextChangedSinceLastTypecheck), true
-                    | None -> 
-                        // Can get here in a case like: if "f xxx yyy" is legal, and we do "f xxx y"
-                        // We have no interest in expression typings, those are only useful for dot-completion.  We want to fallback
-                        // to "Use an environment lookup as the last resort" below
-                        GetPreciseCompletionListFromExprTypingsResult.None, false
-
-                match qualItems,thereIsADotInvolved with            
-                | GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt (items, denv, m)), _
-                        // Initially we only use the expression typings when looking up, e.g. (expr).Nam or (expr).Name1.Nam
-                        // These come through as an empty plid and residue "". Otherwise we try an environment lookup
-                        // and then return to the qualItems. This is because the expression typings are a little inaccurate, primarily because
-                        // it appears we're getting some typings recorded for non-atomic expressions like "f x"
-                        when (match plid with [] -> true | _ -> false)  -> 
-                    // lookup based on expression typings successful
-                    Some (items |> List.map DefaultCompletionItem, denv, m)
-                | GetPreciseCompletionListFromExprTypingsResult.NoneBecauseThereWereTypeErrors, _ ->
-                    // There was an error, e.g. we have "<expr>." and there is an error determining the type of <expr>  
-                    // In this case, we don't want any of the fallback logic, rather, we want to produce zero results.
-                    None
-                | GetPreciseCompletionListFromExprTypingsResult.NoneBecauseTypecheckIsStaleAndTextChanged, _ ->         
-                    // we want to report no result and let second-chance intellisense kick in
-                    None
-                | _, true when (match plid with [] -> true | _ -> false)  -> 
-                    // If the user just pressed '.' after an _expression_ (not a plid), it is never right to show environment-lookup top-level completions.
-                    // The user might by typing quickly, and the LS didn't have an expression type right before the dot yet.
-                    // Second-chance intellisense will bring up the correct list in a moment.
-                    None
-                | _ ->         
-
-                // Use an environment lookup as the last resort
-                let envItems =  GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, residueOpt.IsSome)
-                match nameResItems, envItems, qualItems with            
-            
-                // First, use unfiltered name resolution items, if they're not empty
-                | NameResResult.Members(items, denv, m), _, _ when not (isNil items) -> 
-                    // lookup based on name resolution results successful
-                    Some(items |> List.map DefaultCompletionItem, denv, m)                
-            
-                // If we have nonempty items from environment that were resolved from a type, then use them... 
-                // (that's better than the next case - here we'd return 'int' as a type)
-                | _, FilterRelevantItems exactMatchResidueOpt (items, denv, m), _ when not (isNil items) ->
-                    // lookup based on name and environment successful
-                    Some(items |> List.map DefaultCompletionItem, denv, m)
-
-                // Try again with the qualItems
-                | _, _, GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt (items, denv, m)) ->
-                    Some(items |> List.map DefaultCompletionItem, denv, m)
+                match origLongIdentOpt with
+                | None -> None
+                | Some _ -> 
                 
-                | _ -> None
+                    // Try to use the type of the expression on the left to help generate a completion list
+                    let qualItems, thereIsADotInvolved = 
+                        match parseResultsOpt with
+                        | None -> 
+                            // Note, you will get here if the 'reason' is not CompleteWord/MemberSelect/DisplayMemberList, as those are currently the 
+                            // only reasons we do a sync parse to have the most precise and likely-to-be-correct-and-up-to-date info.  So for example,
+                            // if you do QuickInfo hovering over A in "f(x).A()", you will only get a tip if typechecking has a name-resolution recorded
+                            // for A, not if merely we know the capturedExpressionTyping of f(x) and you very recently typed ".A()" - in that case, 
+                            // you won't won't get a tip until the typechecking catches back up.
+                            GetPreciseCompletionListFromExprTypingsResult.None, false
+                        | Some parseResults -> 
+                
+                        match UntypedParseImpl.TryFindExpressionASTLeftOfDotLeftOfCursor(mkPos line colAtEndOfNamesAndResidue,parseResults.ParseTree) with
+                        | Some(pos,_) ->
+                            GetPreciseCompletionListFromExprTypings(parseResults, pos, filterCtors, hasTextChangedSinceLastTypecheck), true
+                        | None -> 
+                            // Can get here in a case like: if "f xxx yyy" is legal, and we do "f xxx y"
+                            // We have no interest in expression typings, those are only useful for dot-completion.  We want to fallback
+                            // to "Use an environment lookup as the last resort" below
+                            GetPreciseCompletionListFromExprTypingsResult.None, false
+                
+                    match qualItems,thereIsADotInvolved with            
+                    | GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt (items, denv, m), ty), _
+                            // Initially we only use the expression typings when looking up, e.g. (expr).Nam or (expr).Name1.Nam
+                            // These come through as an empty plid and residue "". Otherwise we try an environment lookup
+                            // and then return to the qualItems. This is because the expression typings are a little inaccurate, primarily because
+                            // it appears we're getting some typings recorded for non-atomic expressions like "f x"
+                            when (match plid with [] -> true | _ -> false)  -> 
+                        // lookup based on expression typings successful
+                        Some (items |> List.map (CompletionItem (Some ty)), denv, m)
+                    | GetPreciseCompletionListFromExprTypingsResult.NoneBecauseThereWereTypeErrors, _ ->
+                        // There was an error, e.g. we have "<expr>." and there is an error determining the type of <expr>  
+                        // In this case, we don't want any of the fallback logic, rather, we want to produce zero results.
+                        None
+                    | GetPreciseCompletionListFromExprTypingsResult.NoneBecauseTypecheckIsStaleAndTextChanged, _ ->         
+                        // we want to report no result and let second-chance intellisense kick in
+                        None
+                    | _, true when (match plid with [] -> true | _ -> false)  -> 
+                        // If the user just pressed '.' after an _expression_ (not a plid), it is never right to show environment-lookup top-level completions.
+                        // The user might by typing quickly, and the LS didn't have an expression type right before the dot yet.
+                        // Second-chance intellisense will bring up the correct list in a moment.
+                        None
+                    | _ ->         
+                       
+                       // Use an environment lookup as the last resort
+                       match nameResItems, envItems, qualItems with            
+                       
+                       // First, use unfiltered name resolution items, if they're not empty
+                       | NameResResult.Members(items, denv, m), _, _ when not (isNil items) -> 
+                           // lookup based on name resolution results successful
+                           Some(items |> List.map (CompletionItem ty), denv, m)                
+                       
+                       // If we have nonempty items from environment that were resolved from a type, then use them... 
+                       // (that's better than the next case - here we'd return 'int' as a type)
+                       | _, FilterRelevantItems exactMatchResidueOpt (items, denv, m), _ when not (isNil items) ->
+                           // lookup based on name and environment successful
+                           Some(items |> List.map (CompletionItem ty), denv, m)
+                       
+                       // Try again with the qualItems
+                       | _, _, GetPreciseCompletionListFromExprTypingsResult.Some(FilterRelevantItems exactMatchResidueOpt (items, denv, m), ty) ->
+                           Some(items |> List.map (CompletionItem (Some ty)), denv, m)
+                       
+                       | _ -> None
 
     let toCompletionItems (items: Item list, denv: DisplayEnv, m: range) : CompletionItem list * DisplayEnv * range =
         items |> List.map DefaultCompletionItem, denv, m
@@ -1045,18 +1048,21 @@ type TypeCheckInfo
         // Completion at 'inherit C(...)"
         | Some (CompletionContext.Inherit(InheritanceContext.Class, (plid, _))) ->
             GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, false)
+            |> fst
             |> FilterRelevantItemsBy None GetBaseClassCandidates
             |> Option.map toCompletionItems
 
         // Completion at 'interface ..."
         | Some (CompletionContext.Inherit(InheritanceContext.Interface, (plid, _))) ->
-            GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, false) 
+            GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, false)
+            |> fst
             |> FilterRelevantItemsBy None GetInterfaceCandidates
             |> Option.map toCompletionItems
 
         // Completion at 'implement ..."
         | Some (CompletionContext.Inherit(InheritanceContext.Unknown, (plid, _))) ->
             GetEnvironmentLookupResolutions(mkPos line loc, plid, filterCtors, false) 
+            |> fst
             |> FilterRelevantItemsBy None (fun t -> GetBaseClassCandidates t || GetInterfaceCandidates t)
             |> Option.map toCompletionItems
 
@@ -1091,7 +1097,7 @@ type TypeCheckInfo
                     |> RemoveDuplicateItems g
                     |> RemoveExplicitlySuppressed g
                     |> List.filter (fun m -> not (fields.Contains m.DisplayName))
-                    |> List.map (fun x -> { Item = x; Priority = CompletionItemPriority.High })
+                    |> List.map (fun x -> { Item = x; Priority = CompletionItemPriority.High; Type = None })
                 match declaredItems with
                 | None -> Some (toCompletionItems (items, denv, m))
                 | Some (declItems, declaredDisplayEnv, declaredRange) -> Some (filtered @ declItems, declaredDisplayEnv, declaredRange)

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -890,7 +890,9 @@ type TypeCheckInfo
     
     let CompletionItem (ty: TType option) (item: Item) =
         { Item = item
-          Priority = CompletionItemPriority.Relative 0
+          MinorPriority = 0
+          Kind = CompletionItemKind.Other
+          IsOwnMember = false
           Type = ty }
 
     let DefaultCompletionItem = CompletionItem None
@@ -1093,7 +1095,12 @@ type TypeCheckInfo
                     |> RemoveDuplicateItems g
                     |> RemoveExplicitlySuppressed g
                     |> List.filter (fun m -> not (fields.Contains m.DisplayName))
-                    |> List.map (fun x -> { Item = x; Priority = CompletionItemPriority.High; Type = None })
+                    |> List.map (fun x -> 
+                        { Item = x
+                          Kind = CompletionItemKind.Argument
+                          MinorPriority = 0
+                          IsOwnMember = false
+                          Type = None })
                 match declaredItems with
                 | None -> Some (toCompletionItems (items, denv, m))
                 | Some (declItems, declaredDisplayEnv, declaredRange) -> Some (filtered @ declItems, declaredDisplayEnv, declaredRange)

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -894,12 +894,8 @@ type TypeCheckInfo
     
     let DefaultCompletionItem (item: Item) =
         { Item = item
-          Priority = CompletionItemPriority.Default }
+          Priority = CompletionItemPriority.Relative 0 }
     
-    let HighPriorityCompletionItem (item: Item) =
-        { Item = item
-          Priority = CompletionItemPriority.High }
-
     let GetDeclaredItems (parseResultsOpt: FSharpParseFileResults option, lineStr: string, origLongIdentOpt, colAtEndOfNamesAndResidue, residueOpt, line, loc, filterCtors,resolveOverloads, hasTextChangedSinceLastTypecheck, isInRangeOperator) =
  
             // Are the last two chars (except whitespaces) = ".."
@@ -1095,7 +1091,7 @@ type TypeCheckInfo
                     |> RemoveDuplicateItems g
                     |> RemoveExplicitlySuppressed g
                     |> List.filter (fun m -> not (fields.Contains m.DisplayName))
-                    |> List.map HighPriorityCompletionItem
+                    |> List.map (fun x -> { Item = x; Priority = CompletionItemPriority.High })
                 match declaredItems with
                 | None -> Some (toCompletionItems (items, denv, m))
                 | Some (declItems, declaredDisplayEnv, declaredRange) -> Some (filtered @ declItems, declaredDisplayEnv, declaredRange)

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -889,9 +889,19 @@ type TypeCheckInfo
         if p >= 0 then Some p else None
     
     let CompletionItem (ty: TType option) (item: Item) =
+        let kind = 
+            match item with
+            | Item.MethodGroup _ -> CompletionItemKind.Method 
+            | Item.RecdField _
+            | Item.Property _ -> CompletionItemKind.Property
+            | Item.Event _ -> CompletionItemKind.Event
+            | Item.ILField _ 
+            | Item.Value _ -> CompletionItemKind.Field
+            | _ -> CompletionItemKind.Other
+
         { Item = item
           MinorPriority = 0
-          Kind = CompletionItemKind.Other
+          Kind = kind
           IsOwnMember = false
           Type = ty }
 

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -69,13 +69,14 @@ let ``Intro test`` () =
     let tip = typeCheckResults.GetToolTipTextAlternate(4, 7, inputLines.[1], ["foo"], identToken) |> Async.RunSynchronously
     // Get declarations (autocomplete) for a location
     let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 7, 23, inputLines.[6], [], "msg", fun _ -> false)|> Async.RunSynchronously
-    [ for item in decls.Items -> item.Name ] |> shouldEqual
+    CollectionAssert.AreEquivalent(
           ["Chars"; "Clone"; "CompareTo"; "Contains"; "CopyTo"; "EndsWith"; "Equals";
            "GetEnumerator"; "GetHashCode"; "GetType"; "GetTypeCode"; "IndexOf";
            "IndexOfAny"; "Insert"; "IsNormalized"; "LastIndexOf"; "LastIndexOfAny";
            "Length"; "Normalize"; "PadLeft"; "PadRight"; "Remove"; "Replace"; "Split";
            "StartsWith"; "Substring"; "ToCharArray"; "ToLower"; "ToLowerInvariant";
-           "ToString"; "ToUpper"; "ToUpperInvariant"; "Trim"; "TrimEnd"; "TrimStart"]
+           "ToString"; "ToUpper"; "ToUpperInvariant"; "Trim"; "TrimEnd"; "TrimStart"],
+          [ for item in decls.Items -> item.Name ])
     // Get overloads of the String.Concat method
     let methods = typeCheckResults.GetMethodsAlternate(5, 27, inputLines.[4], Some ["String"; "Concat"]) |> Async.RunSynchronously
 

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -112,8 +112,9 @@ type internal FSharpCompletionProvider
 
                 let completionItem =
                     match declarationItem.CompletionPriority with
-                    | CompletionItemPriority.High -> completionItem.WithSortText("aaaaa" + name)
-                    | _ -> completionItem
+                    | CompletionItemPriority.High -> completionItem.WithSortText("aaaaaaaaaa" + name)
+                    | CompletionItemPriority.Relative 0 -> completionItem
+                    | CompletionItemPriority.Relative priority -> completionItem.WithSortText(name + sprintf "%d" priority)
 
                 declarationItemsCache.Remove(completionItem.DisplayText) |> ignore // clear out stale entries if they exist
                 declarationItemsCache.Add(completionItem.DisplayText, declarationItem)

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -110,11 +110,22 @@ type internal FSharpCompletionProvider
                         completionItem.AddProperty(NameInCodePropName, declarationItem.NameInCode)
                     else completionItem
 
-                let completionItem =
-                    match declarationItem.CompletionPriority with
-                    | CompletionItemPriority.High -> completionItem.WithSortText("aaaaaaaaaa" + name)
-                    | CompletionItemPriority.Relative 0 -> completionItem
-                    | CompletionItemPriority.Relative priority -> completionItem.WithSortText(name + sprintf "%d" priority)
+                let sortText =
+                    let prefixLength =
+                        match declarationItem.Kind with
+                        | CompletionItemKind.Field -> 10
+                        | CompletionItemKind.Property -> 8
+                        | CompletionItemKind.Method -> 6
+                        | CompletionItemKind.Event -> 4
+                        | CompletionItemKind.Argument -> 2
+                        | CompletionItemKind.Other -> 0
+                    
+                    let prefixLength =
+                        if declarationItem.IsOwnMember then prefixLength + 1 else prefixLength
+
+                    String.replicate prefixLength "a" + name + string declarationItem.MinorPriority
+                
+                let completionItem = completionItem.WithSortText(sortText)
 
                 declarationItemsCache.Remove(completionItem.DisplayText) |> ignore // clear out stale entries if they exist
                 declarationItemsCache.Add(completionItem.DisplayText, declarationItem)

--- a/vsintegration/src/FSharp.Editor/Completion/KeywordCompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/KeywordCompletionProvider.fs
@@ -83,5 +83,5 @@ type internal FSharpKeywordCompletionProvider
         context.AddItems(completionItems)
         Task.CompletedTask
 
-    override this.GetDescriptionAsync(_: Document, completionItem: CompletionItem, _: CancellationToken): Task<CompletionDescription> =
+    override this.GetDescriptionAsync(_: Document, completionItem: Completion.CompletionItem, _: CancellationToken): Task<CompletionDescription> =
         Task.FromResult(CompletionDescription.FromText(completionItem.Properties.["description"]))

--- a/vsintegration/tests/unittests/TestLib.Salsa.fs
+++ b/vsintegration/tests/unittests/TestLib.Salsa.fs
@@ -29,7 +29,7 @@ let AssertContainsInOrder(s:string,cs:string list) =
         | expect :: expects ->
             let index = s.IndexOf((expect:string),(fromIndex:int))           
             if index = -1 then
-              Assert.Fail(sprintf "Expected:\n%s\n\nto contain:\n%s\n\nafter index: %d." s expect fromIndex)
+               Assert.Fail(sprintf "Expected:\n%s\n\nto contain:\n%s\n\nafter index: %d." s expect fromIndex)
             else
                printfn "At index %d seen '%s'." index expect
             containsInOrderFrom index expects


### PR DESCRIPTION
It turns out FCS returns completion items in interesting order in some cases, but Roslyn ignore it and sort everything alphabetically. However, it provides a way to sort as you wish. This PR pass `CompletionPriority` property for each item, which is used to sort items. 

Currently it shows arguments and writable properties names at the top of completion list:

![image](https://cloud.githubusercontent.com/assets/873919/23566661/05824464-0064-11e7-8efe-f5deda7af047.png)

Thought whether it's a good behavior or not?