### PR TITLE
Make projectContext changes on foreground thread

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -314,7 +314,6 @@ and
         if updated then
             projectInfoManager.UpdateProjectInfo(project.Id, site, project.Workspace)
 
-
     member this.SetupProjectFile(siteProvider: IProvideProjectSite, workspace: VisualStudioWorkspaceImpl) =
         let  rec setup (site: IProjectSite) =
             let projectGuid = Guid(site.ProjectGuid)

--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -314,7 +314,7 @@ and
         // update the cached options
         if updated then
             projectInfoManager.UpdateProjectInfo(project.Id, site, project.Workspace)
-      } |> Async.Start
+      } |> Async.StartImmediate
 
     member this.SetupProjectFile(siteProvider: IProvideProjectSite, workspace: VisualStudioWorkspaceImpl) =
         let  rec setup (site: IProjectSite) =

--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -294,7 +294,6 @@ and
         
     /// Sync the information for the project 
     member this.SyncProject(project: AbstractProject, projectContext: IWorkspaceProjectContext, site: IProjectSite, forceUpdate) =
-      async {
         let hashSetIgnoreCase x = new HashSet<string>(x, StringComparer.OrdinalIgnoreCase)
         let updatedFiles = site.SourceFilesOnDisk() |> hashSetIgnoreCase
         let workspaceFiles = project.GetCurrentDocuments() |> Seq.map(fun file -> file.FilePath) |> hashSetIgnoreCase
@@ -314,7 +313,7 @@ and
         // update the cached options
         if updated then
             projectInfoManager.UpdateProjectInfo(project.Id, site, project.Workspace)
-      } |> Async.StartImmediate
+
 
     member this.SetupProjectFile(siteProvider: IProvideProjectSite, workspace: VisualStudioWorkspaceImpl) =
         let  rec setup (site: IProjectSite) =


### PR DESCRIPTION
This is a workaround for [https://github.com/dotnet/roslyn/issues/17527](https://github.com/dotnet/roslyn/issues/17527)

It turns out changing ProjectContext from background thread doesn't always work.
Sorry @vasily-kirichenko :)