### PR TITLE
Use symbol's assembly name and Roslyn's Project.AssemblyName to filter our wrong symbols in Find Usages and Go to Declaration

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -437,7 +437,7 @@ type FSharpFindDeclResult =
     /// declaration not found + reason
     | DeclNotFound of FSharpFindDeclFailureReason
     /// found declaration
-    | DeclFound of range
+    | DeclFound of range * assemblyName : string
 
 
 /// This type is used to describe what was found during the name resolution.
@@ -1404,7 +1404,8 @@ type TypeCheckInfo
                   let projectDir = Filename.directoryName (if projectFileName = "" then mainInputFileName else projectFileName)
                   let filename = fileNameOfItem g (Some projectDir) itemRange item
                   if FileSystem.SafeExists filename then 
-                      FSharpFindDeclResult.DeclFound (mkRange filename itemRange.Start itemRange.End)
+                      let ccu = ItemDescriptionsImpl.ccuOfItem g item |> Option.defaultValue thisCcu
+                      FSharpFindDeclResult.DeclFound (mkRange filename itemRange.Start itemRange.End, ccu.AssemblyName)
                   else 
                       fail FSharpFindDeclFailureReason.NoSourceCode // provided items may have TypeProviderDefinitionLocationAttribute that binds them to some location
 

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -100,7 +100,7 @@ type internal FSharpFindDeclResult =
     /// Indicates a declaration location was not found, with an additional reason
     | DeclNotFound of FSharpFindDeclFailureReason
     /// Indicates a declaration location was found
-    | DeclFound      of range
+    | DeclFound of range * assemblyName : string
      
 /// Represents the checking context implied by the ProjectOptions 
 [<Sealed>]

--- a/vsintegration/src/FSharp.Editor/Common/CommonRoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CommonRoslynHelpers.fs
@@ -257,3 +257,4 @@ module internal RoslynExtensions =
         member this.GetDependentProjects() =
             this.Solution.GetProjectDependencyGraph().GetProjectsThatDirectlyDependOnThisProject(this.Id)
             |> Seq.map this.Solution.GetProject
+            |> Seq.toList

--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -23,8 +23,8 @@ type internal FSharpFindUsagesService
         projectInfoManager: ProjectInfoManager
     ) =
     
-    // File can be included in more than one project, hence single `range` may results with multiple `Document`s.
-    let rangeToDocumentSpans (solution: Solution, range: range, assembly: string, cancellationToken: CancellationToken) =
+    // File can be included into more than one project.
+    let rangeToDocumentSpan (solution: Solution, range: range, cancellationToken: CancellationToken) =
         async {
             if range.Start = range.End then return []
             else 
@@ -33,7 +33,6 @@ type internal FSharpFindUsagesService
                     |> Seq.map (fun documentId ->
                         asyncMaybe {
                             let doc = solution.GetDocument(documentId)
-                            do! Option.guard (doc.Project.AssemblyName = assembly)
                             let! sourceText = doc.GetTextAsync(cancellationToken)
                             match CommonRoslynHelpers.TryFSharpRangeToTextSpan(sourceText, range) with
                             | Some span ->
@@ -66,45 +65,47 @@ type internal FSharpFindUsagesService
                 | FSharpFindDeclResult.DeclFound (range, assemblyName) -> Some (range, assemblyName)
                 | _ -> None
             
-            let! definitionItems =
+            let! declarationSpan =
                 async {
-                    let! declarationSpans =
-                        match declaration with
-                        | Some (range, assembly) -> rangeToDocumentSpans(document.Project.Solution, range, assembly, context.CancellationToken)
-                        | None -> async.Return []
-                    
-                    return 
-                        match declarationSpans with 
-                        | [] -> 
-                            [ DefinitionItem.CreateNonNavigableItem(
-                                tags,
-                                ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Ident.idText)),
-                                ImmutableArray.Create(TaggedText(TextTags.Assembly, symbolUse.Symbol.Assembly.SimpleName))) ]
-                        | _ ->
-                            declarationSpans
-                            |> List.map (fun span ->
-                                DefinitionItem.Create(tags, ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Ident.idText)), span))
+                    match declaration with
+                    | Some (range, assembly) -> 
+                        let! spans = rangeToDocumentSpan(document.Project.Solution, range, context.CancellationToken)
+                        // A file may be part of multiple projects. We are interested in the one own declaration symbol is from.
+                        return spans |> List.tryFind (fun span -> span.Document.Project.AssemblyName = assembly)
+                    | None -> return None
                 } |> liftAsync
+                    
+            let definitionItem =
+                match declarationSpan with 
+                | None -> 
+                    DefinitionItem.CreateNonNavigableItem(
+                        tags,
+                        ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Ident.idText)),
+                        ImmutableArray.Create(TaggedText(TextTags.Assembly, symbolUse.Symbol.Assembly.SimpleName)))
+                | Some span ->
+                    DefinitionItem.Create(tags, ImmutableArray.Create(TaggedText(TextTags.Text, symbol.Ident.idText)), span)
             
-            for definitionItem in definitionItems do
-                do! context.OnDefinitionFoundAsync(definitionItem) |> Async.AwaitTask |> liftAsync
+            do! context.OnDefinitionFoundAsync(definitionItem) |> Async.AwaitTask |> liftAsync
             
             let! symbolUses =
-                match symbolUse.GetDeclarationLocation document with
-                | Some SymbolDeclarationLocation.CurrentDocument ->
-                    checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol) |> liftAsync
-                | scope ->
+                match declarationSpan with
+                | Some _ when symbolUse.IsPrivateToFile ->
+                    asyncMaybe {
+                        let! symbolUses = checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol) |> liftAsync
+                        return symbolUses |> Array.map (fun x -> document.Project, x)
+                    }
+                | _ ->
                     let projectsToCheck =
-                        match scope with
-                        | Some (SymbolDeclarationLocation.Projects (declProjects, false)) ->
-                            [ for declProject in declProjects do
-                                yield declProject
-                                yield! declProject.GetDependentProjects() ]
-                            |> List.distinct
-                        | Some (SymbolDeclarationLocation.Projects (declProjects, true)) -> declProjects
-                        // The symbol is declared in .NET framework, an external assembly or in a C# project within the solution.
-                        // In order to find all its usages we have to check all F# projects.
-                        | _ -> Seq.toList document.Project.Solution.Projects
+                        match declarationSpan with
+                        | Some declSpan when symbolUse.Symbol.IsInternalToProject ->
+                            [declSpan.Document.Project]
+                        | Some declSpan ->
+                            [ yield declSpan.Document.Project
+                              yield! declSpan.Document.Project.GetDependentProjects() ]
+                        | None ->
+                            // The symbol is declared in .NET framework, an external assembly or in a C# project within the solution.
+                            // In order to find all its usages we have to check all F# projects.
+                            Seq.toList document.Project.Solution.Projects
                 
                     asyncMaybe {
                         let! symbolUses =
@@ -113,32 +114,32 @@ type internal FSharpFindUsagesService
                                 asyncMaybe {
                                     let! options = projectInfoManager.TryGetOptionsForProject(project.Id)
                                     let! projectCheckResults = checker.ParseAndCheckProject(options) |> liftAsync
-                                    return! projectCheckResults.GetUsesOfSymbol(symbolUse.Symbol) |> liftAsync
+                                    let! symbolUses = projectCheckResults.GetUsesOfSymbol(symbolUse.Symbol) |> liftAsync
+                                    // FCS may return several `FSharpSymbolUse`s for same range, which have different `ItemOccurrence`s (Use, UseInAttribute, UseInType, etc.)
+                                    // We don't care about the occurrence type here, so we distinct by range.
+                                    return symbolUses |> Array.map (fun x -> project, x)
                                 } |> Async.map (Option.defaultValue [||]))
                             |> Async.Parallel
                             |> liftAsync
 
-                        // FCS may return several `FSharpSymbolUse`s for same range, which have different `ItemOccurrence`s (Use, UseInAttribute, UseInType, etc.)
-                        // We don't care about the occurrence type here, so we distinct by range.
-                        return symbolUses |> Array.concat |> Array.distinctBy (fun x -> x.RangeAlternate)
+                        return symbolUses |> Array.concat |> Array.distinctBy (fun (_, x) -> x.RangeAlternate)
                     }
 
-            for symbolUse in symbolUses do
+            for symbolUseProject, symbolUse in symbolUses do
                 match declaration with
                 | Some (declRange, _) when declRange = symbolUse.RangeAlternate -> ()
                 | _ ->
                     // report a reference if we're interested in all _or_ if we're looking at an implementation
                     if allReferences || symbolUse.IsFromDispatchSlotImplementation then
                         let! referenceDocSpans = 
-                            rangeToDocumentSpans(document.Project.Solution, symbolUse.RangeAlternate, symbolUse.Symbol.Assembly.SimpleName, context.CancellationToken) |> liftAsync
+                            rangeToDocumentSpan(document.Project.Solution, symbolUse.RangeAlternate, context.CancellationToken) |> liftAsync
                         
-                        match referenceDocSpans with
+                        match referenceDocSpans |> List.filter (fun x -> x.Document.Project = symbolUseProject) with
                         | [] -> ()
                         | _ ->
                             for referenceDocSpan in referenceDocSpans do
-                                for definitionItem in definitionItems do
-                                    let referenceItem = SourceReferenceItem(definitionItem, referenceDocSpan)
-                                    do! context.OnReferenceFoundAsync(referenceItem) |> Async.AwaitTask |> liftAsync
+                                let referenceItem = SourceReferenceItem(definitionItem, referenceDocSpan)
+                                do! context.OnReferenceFoundAsync(referenceItem) |> Async.AwaitTask |> liftAsync
             
             ()
         } |> Async.Ignore

--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -23,7 +23,7 @@ type internal FSharpFindUsagesService
         projectInfoManager: ProjectInfoManager
     ) =
     
-    // File can be included into more than one project.
+    // File can be included in more than one project.
     let rangeToDocumentSpan (solution: Solution, range: range, cancellationToken: CancellationToken) =
         async {
             if range.Start = range.End then return []

--- a/vsintegration/src/FSharp.LanguageService/GotoDefinition.fs
+++ b/vsintegration/src/FSharp.LanguageService/GotoDefinition.fs
@@ -64,7 +64,7 @@ module internal GotoDefinition =
                         |> GotoDefinitionResult.MakeError
                     else
                       match typedResults.GetDeclarationLocationAlternate (line+1, colIdent, lineStr, qualId, false) |> Async.RunSynchronously with
-                      | FSharpFindDeclResult.DeclFound m -> 
+                      | FSharpFindDeclResult.DeclFound (m, _) -> 
                           let span = TextSpan (iStartLine = m.StartLine-1, iEndLine = m.StartLine-1, iStartIndex = m.StartColumn, iEndIndex = m.StartColumn) 
                           GotoDefinitionResult.MakeSuccess(m.FileName, span)
                       | FSharpFindDeclResult.DeclNotFound(reason) ->

--- a/vsintegration/tests/unittests/GoToDefinitionServiceTests.fs
+++ b/vsintegration/tests/unittests/GoToDefinitionServiceTests.fs
@@ -102,7 +102,7 @@ let _ = Module1.foo 1
         let actual = 
            FSharpGoToDefinitionService.FindDefinition(FSharpChecker.Instance, documentId, SourceText.From(fileContents), filePath, caretPosition, [], options, 0) 
            |> Async.RunSynchronously
-           |> Option.map (fun range -> (range.StartLine, range.EndLine, range.StartColumn, range.EndColumn))
+           |> Option.map (fun (range, _) -> (range.StartLine, range.EndLine, range.StartColumn, range.EndColumn))
 
         if actual <> expected then 
             Assert.Fail(sprintf "Incorrect information returned for fileContents=<<<%s>>>, caretMarker=<<<%s>>>, expected =<<<%A>>>, actual = <<<%A>>>" fileContents caretMarker expected actual)


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/2494

However, no matter from where we open the following linked document - from FCS or compiler projects - `Document.Project` is always the compiler one:

![1](https://cloud.githubusercontent.com/assets/873919/23711603/5fc627e4-0431-11e7-8a8b-e6ff0989023d.gif)

It seems there is a bug in the code where we notify Roslyn about opening document, but it's unrelated to the bug this PR is fixing.