### PR TITLE
Update README/DEVGUIDE for VS 2017

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -105,7 +105,7 @@ Where you should set proper proxy address, user name and password.
 
 # The Visual F# IDE Tools (Windows Only)
 
-To build and test Visual F# IDE Tools, you must use the latest version of [Visual Studio 2017 RC](https://www.visualstudio.com/vs/visual-studio-2017-rc/#downloadvs).  See the section titled "Development tools" in the [readme](README.md).
+To build and test Visual F# IDE Tools, you must use the latest version of [Visual Studio 2017](https://www.visualstudio.com/downloads/).  See the section titled "Development tools" in the [readme](README.md).
 
     build.cmd vs              -- build the Visual F# IDE Tools (see below)
     build.cmd vs test         -- build Visual F# IDE Tools, run all tests (see below)
@@ -118,7 +118,7 @@ Use ``VisualFSharp.sln`` if you're building the Visual F# IDE Tools.
 At time of writing, the Visual F# IDE Tools can only be installed into the latest Visual Studio 2017 RC releases.
 The new builds of the Visual F# IDE Tools can no longer be installed into Visual Studio 2015.
 
-You can install Visual Studio 2017 RC from https://www.visualstudio.com/vs/visual-studio-2017-rc/#downloadvs.
+You can install Visual Studio 2017 from https://www.visualstudio.com/downloads/.
 
 **Note:** This step will install a VSIX extension into Visual Studio "Next" that changes the Visual F# IDE Tools 
 components installed in that VS installation.  You can revert this step by disabling or uninstalling the addin.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For Visual F# IDE Tools 4.1 development (Windows)
     - Select "F# language suport" under the optional components.
   - Under the "Other Toolsets" workloads, select "Visual Studio extension development".
   - Under the "Individual Components" tab select "Windows 10 SDK" as shown below:
-  ![image](https://cloud.githubusercontent.com/assets/1249087/23730172/f2d71bf4-041a-11e7-9d7c-30f32b10ecd5.png)
+  ![image](https://cloud.githubusercontent.com/assets/1249087/23730261/5c78c850-041b-11e7-9d9d-62766351fd0f.png)
 
 
 ####Additional frameworks

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For Visual F# IDE Tools 4.1 development (Windows)
     - Select "F# language suport" under the optional components.
   - Under the "Other Toolsets" workloads, select "Visual Studio extension development".
   - Under the "Individual Components" tab select "Windows 10 SDK" as shown below:
-  ![image](https://cloud.githubusercontent.com/assets/1249087/23730064/4ed6fa2e-041a-11e7-8294-0762f27b7949.png)
+  ![image](https://cloud.githubusercontent.com/assets/1249087/23730172/f2d71bf4-041a-11e7-9d7c-30f32b10ecd5.png)
 
 
 ####Additional frameworks

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ For F# Compiler on OSX and Linux (see .travis.yml for build steps)
 
 For Visual F# IDE Tools 4.1 development (Windows)
 
-- [Visual Studio 2017 RC](https://www.visualstudio.com/vs/visual-studio-2017-rc/#downloadvs)
+- [Visual Studio 2017](https://www.visualstudio.com/downloads/)
   - Under the "Windows" workloads, select ".NET desktop development".
     - Select "F# language suport" under the optional components.
+  - Under the "Windows" workloads, select "Desktop development with C++" (This installs the required Windows 10 SDK)
   - Under the "Other Toolsets" workloads, select "Visual Studio extension development".
 
 ####Additional frameworks

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ For Visual F# IDE Tools 4.1 development (Windows)
 - [Visual Studio 2017](https://www.visualstudio.com/downloads/)
   - Under the "Windows" workloads, select ".NET desktop development".
     - Select "F# language suport" under the optional components.
-  - Under the "Windows" workloads, select "Desktop development with C++" (This installs the required Windows 10 SDK)
   - Under the "Other Toolsets" workloads, select "Visual Studio extension development".
+  - Under the "Individual Components" tab select "Windows 10 SDK" as shown below:
+  ![image](https://cloud.githubusercontent.com/assets/1249087/23730064/4ed6fa2e-041a-11e7-8294-0762f27b7949.png)
+
 
 ####Additional frameworks
 


### PR DESCRIPTION
This addresses #2556 

- Contributors are required to install the Windows 10 SDK in order to build the repository, but this was not documented.
- I have updated the links to point to Visual Studio 2017 instead of the RC.

