### PR TITLE
bring qualified assembly name in error message to disambiguate types

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1072,7 +1072,6 @@ module private PrintTypes =
             nameL
         nameL ^^ wordL (tagPunctuation ":") ^^ tauL
 
-
     let layoutPrettyType denv typ = 
         let _,typ,cxs = PrettyTypes.PrettifyTypes1 denv.g typ
         let env = SimplifyTypes.CollectInfo true [typ] cxs
@@ -1082,6 +1081,9 @@ module private PrintTypes =
     let layoutPrettyTypeNoCx denv typ = 
         let _,typ,_cxs = PrettyTypes.PrettifyTypes1 denv.g typ
         layoutTypeWithInfoAndPrec denv SimplifyTypes.typeSimplificationInfo0 5 typ  
+
+    let layoutAssemblyName _denv (typ: TType) =
+        typ.GetAssemblyName()
 
 /// Printing TAST objects
 module private PrintTastMemberOrVals = 
@@ -1988,14 +1990,26 @@ let minimalStringsOfTwoTypes denv t1 t2=
     match attempt3 with 
     | Some res -> res 
     | None -> 
-    let lastAttempt = 
+    let attempt4 = 
         // try denv + show full paths + static parameters
         let denv = denv.SetOpenPaths []
         let denv = { denv with includeStaticParametersInTypeNames=true }
         let min1 = stringOfTy denv t1
         let min2 = stringOfTy denv t2
-        (min1,min2,stringOfTyparConstraints denv tpcs)  
-    lastAttempt    
+        if min1 <> min2 then Some (min1,min2,stringOfTyparConstraints denv tpcs) else None
+    match attempt4 with
+    | Some res -> res
+    | None ->
+        // https://github.com/Microsoft/visualfsharp/issues/2561
+        // still identical, we better (try to) show assembly qualified name to disambiguate
+        let denv = denv.SetOpenPaths []
+        let denv = { denv with includeStaticParametersInTypeNames=true }
+        let makeName t =
+            let assemblyName = PrintTypes.layoutAssemblyName denv t |> function | null | "" -> "" | name -> sprintf " (%s)" name
+            sprintf "%s%s" (stringOfTy denv t1) assemblyName
+
+        (makeName t1,makeName t2,stringOfTyparConstraints denv tpcs)
+    
 
 // Note: Always show imperative annotations when comparing value signatures 
 let minimalStringsOfTwoValues denv v1 v2= 

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -3480,7 +3480,7 @@ and
 
     /// TType_app(tyconRef, typeInstantiation).
     ///
-    /// Indicates the type is build from a named type and a number of type arguments
+    /// Indicates the type is built from a named type and a number of type arguments
     | TType_app of TyconRef * TypeInst
 
     /// TType_tuple(elementTypes).
@@ -3519,6 +3519,20 @@ and
         | TType_ucase (uc,tinst) -> "union case type " + uc.CaseName + (match tinst with [] -> "" | tys -> "<" + String.concat "," (List.map string tys) + ">")
         | TType_var tp -> tp.DisplayName
         | TType_measure ms -> sprintf "%A" ms
+
+    /// For now, used only as a discriminant in error message.
+    /// See https://github.com/Microsoft/visualfsharp/issues/2561
+    member x.GetAssemblyName() =
+        match x with
+        | TType_forall (_tps, ty)        -> ty.GetAssemblyName()
+        | TType_app (tcref, _tinst)      -> tcref.CompilationPath.ILScopeRef.AssemblyRef.QualifiedName
+        | TType_tuple (_tupInfo, _tinst) -> ""
+        | TType_fun (_d,_r)              -> ""
+        | TType_measure _ms              -> ""
+        | TType_var tp                   -> tp.Solution |> function Some sln -> sln.GetAssemblyName() | None -> ""
+        | TType_ucase (_uc,_tinst)       ->
+            let scope,_nesting,_definition = _uc.Tycon.ILTyconInfo
+            scope.AssemblyRef.QualifiedName
 
 and TypeInst = TType list 
 and TTypes = TType list 

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
@@ -1,5 +1,5 @@
-//<Expects id="FS0001" status="error">This expression was expected to have type 'A \(liba, Version=0\.0\.0\.0,</Expects>
-//<Expects id="FS0001" status="error">This expression was expected to have type 'B<Microsoft.FSharp.Core.int> \(liba, Version=0\ .0\.0\.0,</Expects>
+//<Expects id="FS0001" status="error">This expression was expected to have type     'A \(liba, Version=0\.0\.0\.0,</Expects>
+//<Expects id="FS0001" status="error">This expression was expected to have type     'B<Microsoft.FSharp.Core.int> \(liba, Version=0\ .0\.0\.0,</Expects>
 
 
 let a = AMaker.makeA()

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
@@ -1,0 +1,6 @@
+//<Expects id="FS0001" status="error">This expression was expected to have type 'A (liba, Version=0.0.0.0,</Expects>
+
+let a = AMaker.makeA()
+let otherA = OtherAMaker.makeOtherA()
+printfn "%A %A" (a.GetType().AssemblyQualifiedName) (otherA.GetType().AssemblyQualifiedName)
+printfn "%A" (a = otherA)

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
@@ -1,5 +1,5 @@
-//<Expects id="FS0001" status="error">This expression was expected to have type 'A (liba, Version=0.0.0.0,</Expects>
-//<Expects id="FS0001" status="error">This expression was expected to have type 'B<Microsoft.FSharp.Core.int> (liba, Version=0.0.0.0,</Expects>
+//<Expects id="FS0001" status="error">This expression was expected to have type 'A \(liba, Version=0\.0\.0\.0,</Expects>
+//<Expects id="FS0001" status="error">This expression was expected to have type 'B<Microsoft.FSharp.Core.int> \(liba, Version=0\ .0\.0\.0,</Expects>
 
 
 let a = AMaker.makeA()

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
@@ -1,5 +1,5 @@
-//<Expects id="FS0001" status="error">'A \(liba, Version=0\.0\.0\.0,</Expects>
-//<Expects id="FS0001" status="error">'B<Microsoft.FSharp.Core.int> \(liba, Version=0\ .0\.0\.0,</Expects>
+//<Expects id="FS0001" status="error">'A \(liba, Version</Expects>
+//<Expects id="FS0001" status="error">'B<Microsoft.FSharp.Core.int> \(liba, Version</Expects>
 
 
 let a = AMaker.makeA()

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
@@ -1,5 +1,5 @@
-//<Expects id="FS0001" status="error">This expression was expected to have type     'A \(liba, Version=0\.0\.0\.0,</Expects>
-//<Expects id="FS0001" status="error">This expression was expected to have type     'B<Microsoft.FSharp.Core.int> \(liba, Version=0\ .0\.0\.0,</Expects>
+//<Expects id="FS0001" status="error">'A \(liba, Version=0\.0\.0\.0,</Expects>
+//<Expects id="FS0001" status="error">'B<Microsoft.FSharp.Core.int> \(liba, Version=0\ .0\.0\.0,</Expects>
 
 
 let a = AMaker.makeA()

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
@@ -1,6 +1,13 @@
 //<Expects id="FS0001" status="error">This expression was expected to have type 'A (liba, Version=0.0.0.0,</Expects>
+//<Expects id="FS0001" status="error">This expression was expected to have type 'B<Microsoft.FSharp.Core.int> (liba, Version=0.0.0.0,</Expects>
+
 
 let a = AMaker.makeA()
 let otherA = OtherAMaker.makeOtherA()
 printfn "%A %A" (a.GetType().AssemblyQualifiedName) (otherA.GetType().AssemblyQualifiedName)
 printfn "%A" (a = otherA)
+
+let b = AMaker.makeB<int>()
+let otherB = OtherAMaker.makeOtherB<int>()
+printfn "%A %A" (b.GetType().AssemblyQualifiedName) (otherB.GetType().AssemblyQualifiedName)
+printfn "%A" (b = otherB)

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/app.fs
@@ -1,5 +1,13 @@
-//<Expects id="FS0001" status="error">'A \(liba, Version</Expects>
-//<Expects id="FS0001" status="error">'B<Microsoft.FSharp.Core.int> \(liba, Version</Expects>
+//<Expects id="FS0001" status="error" span="(16,19)">This expression was expected to have type</Expects>
+//<Expects>'A (liba, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null)'</Expects>
+//<Expects>but here has type</Expects>
+//<Expects>'A (libb, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null)'</Expects>
+
+
+//<Expects id="FS0001" status="error" span="(21,19)">This expression was expected to have type</Expects>
+//<Expects>'B<Microsoft.FSharp.Core.int> (liba, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null)'</Expects>
+//<Expects>but here has type</Expects>
+//<Expects>'B<Microsoft.FSharp.Core.int> (libb, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null)'</Expects>
 
 
 let a = AMaker.makeA()
@@ -11,3 +19,4 @@ let b = AMaker.makeB<int>()
 let otherB = OtherAMaker.makeOtherB<int>()
 printfn "%A %A" (b.GetType().AssemblyQualifiedName) (otherB.GetType().AssemblyQualifiedName)
 printfn "%A" (b = otherB)
+ 

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/compile.bat
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/compile.bat
@@ -1,0 +1,6 @@
+rem if you want to try it out without running the whole suite
+csc liba-and-b.cs -t:library -out:liba.dll
+csc liba-and-b.cs -t:library -out:libb.dll
+fsc libc.fs --target:library -r:liba.dll --out:libc.dll
+fsc libd.fs --target:library -r:libb.dll --out:libd.dll
+fsc app.fs -r:liba.dll -r:libb.dll -r:libc.dll -r:libd.dll

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/compile.bat
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/compile.bat
@@ -1,6 +1,6 @@
 rem if you want to try it out without running the whole suite
-csc liba-and-b.cs -t:library -out:liba.dll
-csc liba-and-b.cs -t:library -out:libb.dll
-fsc libc.fs --target:library -r:liba.dll --out:libc.dll
-fsc libd.fs --target:library -r:libb.dll --out:libd.dll
-fsc app.fs -r:liba.dll -r:libb.dll -r:libc.dll -r:libd.dll
+csc -t:library -out:liba.dll liba-and-b.cs
+csc -t:library -out:libb.dll liba-and-b.cs
+fsc --target:library -r:liba.dll --out:libc.dll libc.fs
+fsc --target:library -r:libb.dll --out:libd.dll libd.fs
+fsc -r:liba.dll -r:libb.dll -r:libc.dll -r:libd.dll app.fs

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/env.lst
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/env.lst
@@ -1,3 +1,3 @@
 # see compile.bat for clearer steps, aim is to get message highlighting fix for https://github.com/Microsoft/visualfsharp/issues/2561
-    SOURCE="app.fs" PRECMD="csc -t:library -out:liba.dll liba-and-b.cs && csc -t:library -out:libb.dll liba-and-b.cs && fsc --target:library -r:liba.dll --out:libc.dll libc.fs && fsc --target:library -r:libb.dll --out:libd.dll libd.fs"
+    SOURCE="app.fs" SCFLAGS="-r:liba.dll -r:libb.dll -r:libc.dll -r:libd.dll" PRECMD="csc -t:library -out:liba.dll liba-and-b.cs && csc -t:library -out:libb.dll liba-and-b.cs && fsc --target:library -r:liba.dll --out:libc.dll libc.fs && fsc --target:library -r:libb.dll --out:libd.dll libd.fs"
     

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/env.lst
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/env.lst
@@ -1,3 +1,3 @@
 # see compile.bat for clearer steps, aim is to get message highlighting fix for https://github.com/Microsoft/visualfsharp/issues/2561
-    SOURCE="app.fs" PRECMD="csc liba-and-b.cs -t:library -out:liba.dll && csc liba-and-b.cs -t:library -out:libb.dll && fsc libc.fs --target:library -r:liba.dll --out:libc.dll && fsc libd.fs --target:library -r:libb.dll --out:libd.dll"
+    SOURCE="app.fs" PRECMD="csc -t:library -out:liba.dll liba-and-b.cs && csc -t:library -out:libb.dll liba-and-b.cs && fsc --target:library -r:liba.dll --out:libc.dll libc.fs && fsc --target:library -r:libb.dll --out:libd.dll libd.fs"
     

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/env.lst
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/env.lst
@@ -1,0 +1,3 @@
+# see compile.bat for clearer steps, aim is to get message highlighting fix for https://github.com/Microsoft/visualfsharp/issues/2561
+    SOURCE="app.fs" PRECMD="csc liba-and-b.cs -t:library -out:liba.dll && csc liba-and-b.cs -t:library -out:libb.dll && fsc libc.fs --target:library -r:liba.dll --out:libc.dll && fsc libd.fs --target:library -r:libb.dll --out:libd.dll"
+    

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/liba-and-b.cs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/liba-and-b.cs
@@ -1,0 +1,1 @@
+public class A { }

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/liba-and-b.cs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/liba-and-b.cs
@@ -1,1 +1,2 @@
 public class A { }
+public class B<T> { }

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/libc.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/libc.fs
@@ -1,4 +1,3 @@
 module AMaker
 let makeA () : A = A()
-
-//printfn "%A"( makeA())
+let makeB () = B<_>()

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/libc.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/libc.fs
@@ -1,0 +1,4 @@
+module AMaker
+let makeA () : A = A()
+
+//printfn "%A"( makeA())

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/libd.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/libd.fs
@@ -1,4 +1,3 @@
 module OtherAMaker
 let makeOtherA () : A = A()
-
-//printfn "%A"( makeA())
+let makeOtherB () = B<_>()

--- a/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/libd.fs
+++ b/tests/fsharpqa/Source/ErrorMessages/ConfusingTypeName/libd.fs
@@ -1,0 +1,4 @@
+module OtherAMaker
+let makeOtherA () : A = A()
+
+//printfn "%A"( makeA())

--- a/tests/fsharpqa/Source/test.lst
+++ b/tests/fsharpqa/Source/test.lst
@@ -262,7 +262,7 @@ Misc01			Libraries\Core\Unchecked
 Misc01			Warnings
 Misc01			ErrorMessages\NameResolution
 Misc01			ErrorMessages\UnitGenericAbstractType
-Misc01                  ErrorMessages\ConfusingTypeName
+Misc01			ErrorMessages\ConfusingTypeName
 
 Misc02			Libraries\Portable
 Misc02			Misc

--- a/tests/fsharpqa/Source/test.lst
+++ b/tests/fsharpqa/Source/test.lst
@@ -262,6 +262,7 @@ Misc01			Libraries\Core\Unchecked
 Misc01			Warnings
 Misc01			ErrorMessages\NameResolution
 Misc01			ErrorMessages\UnitGenericAbstractType
+Misc01                  ErrorMessages\ConfusingTypeName
 
 Misc02			Libraries\Portable
 Misc02			Misc


### PR DESCRIPTION
This is proposed fix for #2561, I need to figure out if the test is correct.

Please let me know if anything needs to be taken care of.