### PR TITLE
Fix theme manager in RTM

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -55,6 +55,7 @@ module internal FSharpClassificationTypes =
 module internal ClassificationDefinitions =
 
     [<Export>]
+    [<Export(typeof<ISetThemeColors>)>]
     type internal ThemeColors
         [<ImportingConstructor>]
         (
@@ -113,6 +114,9 @@ module internal ClassificationDefinitions =
             | DarkTheme -> Nullable dark
             | UnknownTheme -> Nullable()
 
+        interface ISetThemeColors with member this.SetColors() = setColors()
+
+
     [<Export; Name(FSharpClassificationTypes.Function); BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)>]
     let FSharpFunctionClassificationType : ClassificationTypeDefinition = null
 
@@ -133,11 +137,10 @@ module internal ClassificationDefinitions =
     [<Name(FSharpClassificationTypes.Function)>]
     [<UserVisible(true)>]
     [<Order(After = PredefinedClassificationTypeNames.Keyword)>]
-    type internal FSharpFunctionTypeFormat [<ImportingConstructor>](theme: ThemeColors) as self =
+    type internal FSharpFunctionTypeFormat() as self =
         inherit ClassificationFormatDefinition()
 
         do self.DisplayName <- SR.FSharpFunctionsOrMethodsClassificationType.Value
-           self.ForegroundColor <- theme.GetColor FSharpClassificationTypes.Function
 
     [<Export(typeof<EditorFormatDefinition>)>]
     [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.MutableVar)>]
@@ -166,12 +169,10 @@ module internal ClassificationDefinitions =
     [<Name(FSharpClassificationTypes.Property)>]
     [<UserVisible(true)>]
     [<Order(After = PredefinedClassificationTypeNames.Keyword)>]
-    type internal FSharpPropertyFormat [<ImportingConstructor>](theme: ThemeColors) as self =
+    type internal FSharpPropertyFormat() as self =
         inherit ClassificationFormatDefinition()
 
         do self.DisplayName <- SR.FSharpPropertiesClassificationType.Value
-           self.ForegroundColor <- theme.GetColor FSharpClassificationTypes.Property
-
 
     [<Export(typeof<EditorFormatDefinition>)>]
     [<ClassificationType(ClassificationTypeNames = FSharpClassificationTypes.Disposable)>]

--- a/vsintegration/src/FSharp.Editor/Common/CommonHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CommonHelpers.fs
@@ -18,6 +18,8 @@ open Microsoft.FSharp.Compiler.Ast
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.FSharp.Compiler.SourceCodeServices.ItemDescriptionIcons
 
+type internal ISetThemeColors = abstract member SetColors: unit -> unit
+
 [<RequireQualifiedAccess>]
 type internal LexerSymbolKind =
     | Ident

--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -291,6 +291,9 @@ and
                 do! setupProjectsAfterSolutionOpen() 
             }
         setupProjectsAfterSolutionOpen() |> Async.StartImmediate
+
+        let theme = package.ComponentModel.DefaultExportProvider.GetExport<ISetThemeColors>().Value
+        theme.SetColors()
         
     /// Sync the information for the project 
     member this.SyncProject(project: AbstractProject, projectContext: IWorkspaceProjectContext, site: IProjectSite, forceUpdate) =


### PR DESCRIPTION
This fixes #2555 by setting colors according to selected theme at each startup.

Visual Studio now saves our custom `EditorFormatDefinition`s as defaults at first instantiation and then always uses those saved formats instead of what is set in the constructor of each FormatDefinition. In effect, after switching to dark theme everything looked OK but only until a restart.
 
That means that while we already set colors at theme switch we also must do it at startup to overwrite potentially wrong defaults.

I also removed defaults from "Function" and "Property" to avoid the confusion of black on black default in Fonts and Colors page. It should show inherited light foreground default for dark themes now.

All of this doesn't affect the functionality we had before.