### PR TITLE
Fixed typo in FSComp.txt 

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1091,7 +1091,7 @@ lexIndentOffForML,"Consider using a file with extension '.ml' or '.mli' instead"
 1246,tcCallerInfoWrongType,"'%s' must be applied to an argument of type '%s', but has been applied to an argument of type '%s'"
 1247,tcCallerInfoNotOptional,"'%s' can only be applied to optional arguments"
 # reshapedmsbuild.fs
-1300,toolLocationHelperUnsupportedFrameworkVersion,"The specified .NET Framework version "%s" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion."
+1300,toolLocationHelperUnsupportedFrameworkVersion,"The specified .NET Framework version '%s' is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion."
 # -----------------------------------------------------------------------------
 # ilsign errors
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I see somebody already submitted one of the typos fixed in [FCS PR 688](https://github.com/fsharp/FSharp.Compiler.Service/pull/688/files#diff-0e57ebf050db850b5efdd7e2cb13e725), so here is the other one.