### PR TITLE
small optimization: avoid unecessary call to List.map

### DIFF
--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -686,11 +686,12 @@ let queryableTypeGetMethodBySearch cenv emEnv parentT (mref:ILMethodRef) =
                 argTs,resT 
           
           (* methInfo implied Types *)
-            let haveArgTs = methInfo.GetParameters() |> Array.toList |> List.map (fun param -> param.ParameterType) 
+            let methodParameters = methInfo.GetParameters()
          
             let haveResT  = methInfo.ReturnType
           (* check for match *)
-            if argTs.Length <> haveArgTs.Length then false (* method argument length mismatch *) else
+            if argTs.Length <> methodParameters.Length then false (* method argument length mismatch *) else
+            let haveArgTs = methodParameters |> Array.map (fun param -> param.ParameterType) |> Array.toList
             let res = equalTypes resT haveResT && equalTypeLists argTs haveArgTs
             res
        

--- a/src/fsharp/QuotationTranslator.fs
+++ b/src/fsharp/QuotationTranslator.fs
@@ -66,7 +66,7 @@ type QuotationGenerationScope =
 
     member cenv.Close() = 
         cenv.referencedTypeDefs |> ResizeArray.toList, 
-        cenv.typeSplices |> ResizeArray.toList |> List.map (fun (ty,m) -> mkTyparTy ty, m), 
+        cenv.typeSplices |> ResizeArray.map (fun (ty,m) -> mkTyparTy ty, m) |> ResizeArray.toList, 
         cenv.exprSplices |> ResizeArray.toList
 
     static member ComputeQuotationFormat g = 

--- a/src/ilx/EraseUnions.fs
+++ b/src/ilx/EraseUnions.fs
@@ -908,7 +908,7 @@ let mkClassUnionDef (addMethodGeneratedAttrs, addPropertyGeneratedAttrs, addProp
         [ for alt in cud.cudAlternatives do 
            if repr.RepresentAlternativeAsFreshInstancesOfRootClass (info,alt) then
         // TODO
-            let fields = alt.FieldDefs |> Array.toList |> List.map mkUnionCaseFieldId 
+            let fields = alt.FieldDefs |> Array.map mkUnionCaseFieldId |> Array.toList
             let baseInit = 
                 if isStruct then None else
                 match td.Extends with 


### PR DESCRIPTION
* Replace usages of Array.toList |> List.map (and same for ResizeArray)
* in queryableTypeGetMethodBySearch, do not map parameter types if the expected length is not matching