### PR TITLE
Fix completion in comp expressions and inside record construction { F = ... }

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -584,15 +584,17 @@ type TypeCheckInfo
                     | _ -> bestAlmostIncludedSoFar := Some (possm,env,ad))
         
         let resEnv = 
-            match !bestAlmostIncludedSoFar with 
-            | Some (_m,env,ad) -> 
-                env,ad
-            | None -> 
+            match !bestAlmostIncludedSoFar, mostDeeplyNestedEnclosingScope with 
+            | Some (_,env,ad), None -> env, ad
+            | Some (_,almostIncludedEnv,ad), Some (_,mostDeeplyNestedEnv,_) 
+                when almostIncludedEnv.eFieldLabels.Count >= mostDeeplyNestedEnv.eFieldLabels.Count -> 
+                almostIncludedEnv,ad
+            | _ -> 
                 match mostDeeplyNestedEnclosingScope with 
-                | Some (_m,env,ad) -> 
+                | Some (_,env,ad) -> 
                     env,ad
                 | None -> 
-                    (sFallback,AccessibleFromSomeFSharpCode)
+                    sFallback,AccessibleFromSomeFSharpCode
         let pm = mkRange mainInputFileName cursorPos cursorPos 
 
         resEnv,pm
@@ -1079,8 +1081,12 @@ type TypeCheckInfo
 
         // Completion at ' { XXX = ... } "
         | Some(CompletionContext.RecordField(RecordContext.New(plid, residue))) ->
-            Some(GetClassOrRecordFieldsEnvironmentLookupResolutions(mkPos line loc, plid, residue))
-            |> Option.map toCompletionItems
+            // { x. } can be either record construction or computation expression. Try to get all visible record fields first
+            match GetClassOrRecordFieldsEnvironmentLookupResolutions(mkPos line loc, plid, residue) |> toCompletionItems with
+            | [],_,_ -> 
+                // no record fields found, return completion list as if we were outside any computation expression
+                GetDeclaredItems (parseResultsOpt, lineStr, origLongIdentOpt, colAtEndOfNamesAndResidue, residueOpt, line, loc, filterCtors,resolveOverloads, hasTextChangedSinceLastTypecheck, false)
+            | result -> Some(result)
 
         // Completion at ' { XXX = ... with ... } "
         | Some(CompletionContext.RecordField(RecordContext.CopyOnUpdate(r, (plid, residue)))) -> 


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/2573 and the absence of record field names in record construction.

Before (no completion at all)

![image](https://cloud.githubusercontent.com/assets/873919/23834960/0774a9a2-0770-11e7-99ba-8bc777e0ad6d.png)

after

![image](https://cloud.githubusercontent.com/assets/873919/23834963/12daa4e0-0770-11e7-95fa-8555a24be2e3.png)

before (no `R` field in completion)

![image](https://cloud.githubusercontent.com/assets/873919/23834972/2b2ef622-0770-11e7-9ba2-ad5b08426970.png)

after

![image](https://cloud.githubusercontent.com/assets/873919/23834976/3a41ac0e-0770-11e7-8ed0-f17f43ec5b38.png)
