### PR TITLE
Remove ci_prt3 dependence on build net40

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -104,7 +104,6 @@ if /i '%_autoselect_tests%' == '1' (
     )
 
     if /i '%BUILD_CORECLR%' == '1' (
-        set BUILD_NET40=1
         set TEST_CORECLR_FSHARP_SUITE=1
         set TEST_CORECLR_COREUNIT_SUITE=1
     )
@@ -228,7 +227,6 @@ if /i '%ARG%' == 'ci_part3' (
     REM what we do
     set BUILD_PROTO_WITH_CORECLR_LKG=1
     set BUILD_PROTO=1
-    set BUILD_NET40=1
     set BUILD_CORECLR=1
 
     set TEST_CORECLR_FSHARP_SUITE=1

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -44,7 +44,7 @@ let singleTestBuildAndRunCore  cfg (copyFiles:string) p =
 
         let fsccArgs = sprintf """--OutputDir:%s --CopyDlls:%s %s""" outDir copyFiles fscArgs
 
-        fsi cfg "--exec %s %s %s"
+        fsi_script cfg "--exec %s %s %s"
                cfg.fsi_flags
                (__SOURCE_DIRECTORY__ ++ @"../scripts/fscc.fsx")
                fsccArgs
@@ -68,7 +68,7 @@ let singleTestBuildAndRunCore  cfg (copyFiles:string) p =
 
         use testOkFile = new FileGuard (getfullpath cfg "test.ok")
 
-        fsi cfg "--exec %s %s %s"
+        fsi_script cfg "--exec %s %s %s"
                cfg.fsi_flags
                (__SOURCE_DIRECTORY__ ++ @"../scripts/fsci.fsx")
                fsciArgs

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -54,10 +54,11 @@ module Commands =
         let contents = File.ReadAllText(from)
         File.AppendAllText(dest, contents)
 
-    let fsc workDir exec (fscExe: FilePath) flags srcFiles =
+    let fsc workDir exec (dotNetExe: FilePath) (fscExe: FilePath) flags srcFiles =
         let args = (sprintf "%s %s" flags (srcFiles |> Seq.ofList |> String.concat " "))
-    #if FSC_IN_PROCESS
-    // This is not yet complete
+
+#if FSC_IN_PROCESS
+        // This is not yet complete
         let fscCompiler = FSharp.Compiler.Hosted.FscCompiler()
         let exitCode, _stdin, _stdout = FSharp.Compiler.Hosted.CompilerHelpers.fscCompile workDir (FSharp.Compiler.Hosted.CompilerHelpers.parseCommandLine args)
 
@@ -66,10 +67,15 @@ module Commands =
         | err -> 
             let msg = sprintf "Error running command '%s' with args '%s' in directory '%s'" fscExe args workDir 
             CmdResult.ErrorLevel (msg, err)
-    #else
+#else
         ignore workDir 
+#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+        ignore dotNetExe
         exec fscExe args
-    #endif
+#else
+        exec dotNetExe (fscExe + " " + args)
+#endif
+#endif
 
     let csc exec cscExe flags srcFiles =
         exec cscExe (sprintf "%s %s"  flags (srcFiles |> Seq.ofList |> String.concat " "))
@@ -117,7 +123,6 @@ type TestConfig =
 
 
 module WindowsPlatform = 
-
     let Is64BitOperatingSystem envVars =
         // On Windows PROCESSOR_ARCHITECTURE has the value AMD64 on 64 bit Intel Machines
         let value =
@@ -162,25 +167,26 @@ let config configurationName envVars =
 
     let SCRIPT_ROOT = __SOURCE_DIRECTORY__ 
     let FSCBinPath = SCRIPT_ROOT ++ ".." ++ ".." ++ configurationName ++ "net40" ++ "bin"
-
     let csc_flags = "/nologo" 
     let fsc_flags = "-r:System.Core.dll --nowarn:20 --define:COMPILED" 
     let fsi_flags = "-r:System.Core.dll --nowarn:20  --define:INTERACTIVE --maxerrors:1 --abortonerror" 
-
     let CORDIR, CORSDK = WindowsPlatform.clrPaths envVars
-
     let Is64BitOperatingSystem = WindowsPlatform.Is64BitOperatingSystem envVars
-
-    let fsiroot = if Is64BitOperatingSystem then "fsiAnyCpu" else "fsi"
-
     let CSC = requireFile (CORDIR ++ "csc.exe")
     let NGEN = requireFile (CORDIR ++ "ngen.exe")
     let ILDASM = requireFile (CORSDK ++ "ildasm.exe")
     let SN = requireFile (CORSDK ++ "sn.exe") 
     let PEVERIFY = requireFile (CORSDK ++ "peverify.exe")
+    let FSI = requireFile (SCRIPT_ROOT ++ ".." ++ ".." ++ (System.Environment.GetEnvironmentVariable("_fsiexe").Trim([| '\"' |])))
+    let dotNetExe = SCRIPT_ROOT ++ ".." ++ ".." ++ "Tools" ++ "dotnetcli" ++ "dotnet.exe"
+
+#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
     let FSC = requireFile (FSCBinPath ++ "fsc.exe")
-    let FSI = requireFile (FSCBinPath ++ (fsiroot+".exe"))
     let FSCOREDLLPATH = requireFile (FSCBinPath ++ "FSharp.Core.dll") 
+#else
+    let FSC = SCRIPT_ROOT ++ ".." ++ ".." ++ "tests" ++ "testbin" ++ configurationName ++ "coreclr" ++ "FSC" ++ "fsc.exe"
+    let FSCOREDLLPATH = "" 
+#endif
 
     let defaultPlatform = 
         match Is64BitOperatingSystem with 
@@ -188,9 +194,6 @@ let config configurationName envVars =
 //        | PlatformID.Unix,true -> "ubuntu.14.04-x64"
         | true -> "win7-x64"
         | false -> "win7-x86"
-
-
-    let dotNetExe = SCRIPT_ROOT ++ ".." ++ ".." ++ "Tools" ++ "dotnetcli" ++ "dotnet.exe"
 
     { EnvironmentVariables = envVars
       CORDIR = CORDIR |> Commands.pathAddBackslash
@@ -423,13 +426,12 @@ let execAppendOutIgnoreExitCode cfg workDir outFile p = Command.exec workDir  cf
 let execAppendErrExpectFail cfg errPath p = Command.exec cfg.Directory cfg.EnvironmentVariables { execArgs with Output = Error(Overwrite(errPath)) } p >> checkErrorLevel1
 let execStdin cfg l p = Command.exec cfg.Directory cfg.EnvironmentVariables { Output = Inherit; Input = Some(RedirectInput(l)) } p >> checkResult
 let execStdinAppendBothIgnoreExitCode cfg stdoutPath stderrPath stdinPath p = Command.exec cfg.Directory cfg.EnvironmentVariables { Output = OutputAndError(Append(stdoutPath), Append(stderrPath)); Input = Some(RedirectInput(stdinPath)) } p >> alwaysSuccess
-let fsc cfg arg = Printf.ksprintf (Commands.fsc cfg.Directory (exec cfg) cfg.FSC) arg
-let fscIn cfg workDir arg = Printf.ksprintf (Commands.fsc workDir (execIn cfg workDir) cfg.FSC) arg
-let fscAppend cfg stdoutPath stderrPath arg = Printf.ksprintf (Commands.fsc cfg.Directory (execAppend cfg stdoutPath stderrPath) cfg.FSC) arg
-let fscAppendIgnoreExitCode cfg stdoutPath stderrPath arg = Printf.ksprintf (Commands.fsc cfg.Directory (execAppendIgnoreExitCode cfg stdoutPath stderrPath) cfg.FSC) arg
-let fscBothToOut cfg out arg = Printf.ksprintf (Commands.fsc cfg.Directory (execBothToOut cfg cfg.Directory out) cfg.FSC) arg
-let fscAppendErrExpectFail cfg errPath arg = Printf.ksprintf (Commands.fsc cfg.Directory (execAppendErrExpectFail cfg errPath) cfg.FSC) arg
-
+let fsc cfg arg = Printf.ksprintf (Commands.fsc cfg.Directory (exec cfg) cfg.DotNetExe cfg.FSC) arg
+let fscIn cfg workDir arg = Printf.ksprintf (Commands.fsc workDir (execIn cfg workDir) cfg.DotNetExe  cfg.FSC) arg
+let fscAppend cfg stdoutPath stderrPath arg = Printf.ksprintf (Commands.fsc cfg.Directory (execAppend cfg stdoutPath stderrPath) cfg.DotNetExe  cfg.FSC) arg
+let fscAppendIgnoreExitCode cfg stdoutPath stderrPath arg = Printf.ksprintf (Commands.fsc cfg.Directory (execAppendIgnoreExitCode cfg stdoutPath stderrPath) cfg.DotNetExe  cfg.FSC) arg
+let fscBothToOut cfg out arg = Printf.ksprintf (Commands.fsc cfg.Directory (execBothToOut cfg cfg.Directory out) cfg.DotNetExe  cfg.FSC) arg
+let fscAppendErrExpectFail cfg errPath arg = Printf.ksprintf (Commands.fsc cfg.Directory (execAppendErrExpectFail cfg errPath) cfg.DotNetExe  cfg.FSC) arg
 let csc cfg arg = Printf.ksprintf (Commands.csc (exec cfg) cfg.CSC) arg
 let ildasm cfg arg = Printf.ksprintf (Commands.ildasm (exec cfg) cfg.ILDASM) arg
 let peverify cfg = Commands.peverify (exec cfg) cfg.PEVERIFY "/nologo"

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -112,6 +112,7 @@ type TestConfig =
       FSCBinPath : string
       FSCOREDLLPATH : string
       FSI : string
+      FSI_FOR_SCRIPTS : string
       fsi_flags : string
       ILDASM : string
       SN : string
@@ -177,13 +178,15 @@ let config configurationName envVars =
     let ILDASM = requireFile (CORSDK ++ "ildasm.exe")
     let SN = requireFile (CORSDK ++ "sn.exe") 
     let PEVERIFY = requireFile (CORSDK ++ "peverify.exe")
-    let FSI = requireFile (SCRIPT_ROOT ++ ".." ++ ".." ++ (System.Environment.GetEnvironmentVariable("_fsiexe").Trim([| '\"' |])))
+    let FSI_FOR_SCRIPTS = requireFile (SCRIPT_ROOT ++ ".." ++ ".." ++ (System.Environment.GetEnvironmentVariable("_fsiexe").Trim([| '\"' |])))
     let dotNetExe = SCRIPT_ROOT ++ ".." ++ ".." ++ "Tools" ++ "dotnetcli" ++ "dotnet.exe"
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+    let FSI = requireFile (FSCBinPath ++ "fsi.exe")
     let FSC = requireFile (FSCBinPath ++ "fsc.exe")
     let FSCOREDLLPATH = requireFile (FSCBinPath ++ "FSharp.Core.dll") 
 #else
+    let FSI = SCRIPT_ROOT ++ ".." ++ ".." ++ "tests" ++ "testbin" ++ configurationName ++ "coreclr" ++ "FSC" ++ "fsi.exe"
     let FSC = SCRIPT_ROOT ++ ".." ++ ".." ++ "tests" ++ "testbin" ++ configurationName ++ "coreclr" ++ "FSC" ++ "fsc.exe"
     let FSCOREDLLPATH = "" 
 #endif
@@ -208,6 +211,7 @@ let config configurationName envVars =
       BUILD_CONFIG = configurationName
       FSC = FSC
       FSI = FSI
+      FSI_FOR_SCRIPTS = FSI_FOR_SCRIPTS
       csc_flags = csc_flags
       fsc_flags = fsc_flags 
       fsi_flags = fsi_flags 
@@ -438,6 +442,7 @@ let peverify cfg = Commands.peverify (exec cfg) cfg.PEVERIFY "/nologo"
 let sn cfg outfile arg = execAppendOutIgnoreExitCode cfg cfg.Directory outfile cfg.SN arg
 let peverifyWithArgs cfg args = Commands.peverify (exec cfg) cfg.PEVERIFY args
 let fsi cfg = Printf.ksprintf (Commands.fsi (exec cfg) cfg.FSI)
+let fsi_script cfg = Printf.ksprintf (Commands.fsi (exec cfg) cfg.FSI_FOR_SCRIPTS)
 let fsiExpectFail cfg = Printf.ksprintf (Commands.fsi (execExpectFail cfg) cfg.FSI)
 let fsiAppendIgnoreExitCode cfg stdoutPath stderrPath = Printf.ksprintf (Commands.fsi (execAppendIgnoreExitCode cfg stdoutPath stderrPath) cfg.FSI)
 let fileguard cfg = (Commands.getfullpath cfg.Directory) >> (fun x -> new FileGuard(x))

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1355,8 +1355,10 @@ module CoreTests =
         peverifyWithArgs cfg "/nologo" "xmlverify.exe"
 #endif
 
+#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
 module ToolsTests = 
 
+    // This test is disabled in coreclr builds dependent on fixing : https://github.com/Microsoft/visualfsharp/issues/2600
     [<Test>]
     let bundle () = 
         let cfg = testConfig "tools/bundle"
@@ -1376,6 +1378,7 @@ module ToolsTests =
         fsc cfg "%s -a --standalone -r:test_two_fsharp_modules_module_1.dll -o:test_two_fsharp_modules_module_2_as_dll.dll -g" cfg.fsc_flags ["test_two_fsharp_modules_module_2.fs"]
    
         peverify cfg "test_two_fsharp_modules_module_2_as_dll.dll"
+#endif
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
     [<Test>]
@@ -1397,6 +1400,8 @@ module RegressionTests =
     [<Test >]
     let ``321`` () = singleTestBuildAndRun "regression/321" FSC_BASIC
 
+#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+    // This test is disabled in coreclr builds dependent on fixing : https://github.com/Microsoft/visualfsharp/issues/2600
     [<Test>]
     let ``655`` () = 
         let cfg = testConfig "regression/655"
@@ -1415,6 +1420,7 @@ module RegressionTests =
 
         testOkFile.CheckExists()
                 
+    // This test is disabled in coreclr builds dependent on fixing : https://github.com/Microsoft/visualfsharp/issues/2600
     [<Test >]
     let ``656`` () = 
         let cfg = testConfig "regression/656"
@@ -1422,6 +1428,7 @@ module RegressionTests =
         fsc cfg "%s -o:pack.exe" cfg.fsc_flags ["misc.fs mathhelper.fs filehelper.fs formshelper.fs plot.fs traj.fs playerrecord.fs trackedplayers.fs form.fs"]
 
         peverify cfg  "pack.exe"
+#endif
                 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
     // Requires WinForms
@@ -1445,6 +1452,8 @@ module RegressionTests =
     [<Test >]
     let ``struct-tuple-bug-1-FSI_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI_BASIC
 
+#if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+    // This test is disabled in coreclr builds dependent on fixing : https://github.com/Microsoft/visualfsharp/issues/2600
     [<Test>]
     let ``struct-measure-bug-1`` () = 
         let cfg = testConfig "regression/struct-measure-bug-1"
@@ -1452,7 +1461,7 @@ module RegressionTests =
         fsc cfg "%s --optimize- -o:test.exe -g" cfg.fsc_flags ["test.fs"]
 
         peverify cfg "test.exe"
-
+#endif
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
 module OptimizationTests =
 

--- a/vsintegration/tests/unittests/TestLib.LanguageService.fs
+++ b/vsintegration/tests/unittests/TestLib.LanguageService.fs
@@ -360,13 +360,6 @@ type LanguageServiceBaseTests() =
     [<OneTimeSetUp>]
     member this.Init() =
 #endif
-        match Internal.Utilities.FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(None) with 
-        | Some(folder) -> 
-            let fscPath = Path.Combine(folder,"fsc.exe")
-            System.Diagnostics.Debug.Assert(File.Exists(fscPath), sprintf "Path to fsc.exe (%s) does not exist. Unittests will surely fail. Is Unittest.exe.config stale?" fscPath)
-        | None -> 
-            System.Diagnostics.Debug.Assert(false, "No path to fsc.exe found. Unittests will surely fail.")
-
         let AssertNotAssemblyNameContains(a:System.Reflection.Assembly, text1:string, text2:string) = 
             let fullname = sprintf "%A" a
             if fullname.Contains(text1) && fullname.Contains(text2) then


### PR DESCRIPTION
Whilest looking at something yesterday I noticed that build ci_part3 was depending on the desktop build.  This in fact was masking a bug on the coreclr compiler because inadvertently a test case was using the desktop version of the compiler.

Anyway this PR removes the need to build net40 when running ci_part3.

Kevin