### PR TITLE
enable publishing VSIX packages on MyGet

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -76,6 +76,9 @@ set TEST_VS_IDEUNIT_SUITE=0
 set INCLUDE_TEST_SPEC_NUNIT=
 set INCLUDE_TEST_TAGS=
 
+set PUBLISH_VSIX=0
+set MYGET_APIKEY=
+
 
 REM ------------------ Parse all arguments -----------------------
 
@@ -188,6 +191,7 @@ if /i '%ARG%' == 'microbuild' (
     set TEST_PORTABLE_COREUNIT_SUITE=1
     set TEST_VS_IDEUNIT_SUITE=1
     set CI=1
+    set PUBLISH_VSIX=1
 )
 
 REM These divide 'ci' into two chunks which can be done in parallel
@@ -331,6 +335,10 @@ if /i '%ARG%' == 'init' (
     set BUILD_PROTO_WITH_CORECLR_LKG=1
 )
 
+if /i [%ARG:~0,13%] == [MYGET_APIKEY:] (
+    set MYGET_APIKEY=%ARG:~13%
+)
+
 goto :EOF
 :: Note: "goto :EOF" returns from an in-batchfile "call" command
 :: in preference to returning from the entire batch file.
@@ -364,6 +372,8 @@ echo TEST_PORTABLE_COREUNIT_SUITE=%TEST_PORTABLE_COREUNIT_SUITE%
 echo TEST_VS_IDEUNIT_SUITE=%TEST_VS_IDEUNIT_SUITE%
 echo INCLUDE_TEST_SPEC_NUNIT=%INCLUDE_TEST_SPEC_NUNIT%
 echo INCLUDE_TEST_TAGS=%INCLUDE_TEST_TAGS%
+echo PUBLISH_VSIX=%PUBLISH_VSIX%
+echo MYGET_APIKEY=%MYGET_APIKEY%
 
 
 echo .
@@ -866,6 +876,17 @@ if '%TEST_VS_IDEUNIT_SUITE%' == '1' (
         echo Error: Running tests vs-ideunit failed, see logs above, search for "Errors and Failures"  -- FAILED
         echo ----------------------------------------------------------------------------------------------------
         goto :failure
+    )
+)
+
+REM ---------------- publish-vsix -----------------------
+
+if '%PUBLISH_VSIX%' == '1' (
+    if not '%MYGET_APIKEY%' == '' (
+        powershell -noprofile -executionPolicy ByPass -file "%~dp0setup\publish-assets.ps1" -binariesPath "%~dp0%BUILD_CONFIG%" -branchName "%BUILD_SOURCEBRANCH%" -apiKey "%MYGET_APIKEY%"
+        if errorlevel 1 goto :failure
+    ) else (
+        echo No MyGet API key specified, skipping package publish.
     )
 )
 

--- a/setup/publish-assets.ps1
+++ b/setup/publish-assets.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+Publishes the VSIX package on MyGet.
+
+.PARAMETER binariesPath
+The root directory where the build outputs are written.
+
+.PARAMETER branchName
+The name of the branch that is being built.
+
+.PARAMETER apiKey
+The API key used to authenticate with MyGet.
+
+#>
+
+Param(
+    [string]$binariesPath = $null,
+    [string]$branchName = $null,
+    [string]$apiKey = $null
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+try {
+    $branchName = $branchName -Replace "refs/heads/" # get rid of prefix
+
+    switch ($branchName) {
+        "master" { }
+        default {
+            Write-Host "Branch [$branchName] is not supported for publishing."
+            exit 0 # non-fatal
+        }
+    }
+
+    $branchName = $branchName.Replace("/", "_") # can't have slashes in the branch name
+    $requestUrl = "https://dotnet.myget.org/F/fsharp/vsix/upload"
+    $vsix = Join-Path $binariesPath "net40\bin\VisualFSharpFull.vsix"
+
+    Write-Host "  Uploading '$vsix' to '$requestUrl'."
+
+    $response = Invoke-WebRequest -Uri $requestUrl -Headers @{"X-NuGet-ApiKey"=$apiKey} -ContentType "multipart/form-data" -InFile $vsix -Method Post -UseBasicParsing
+    if ($response.StatusCode -ne 201) {
+        Write-Error "Failed to upload VSIX: $vsix.  Upload failed with status cude: $response.StatusCode."
+        exit 1
+    }
+}
+catch [exception] {
+    Write-Host $_.Exception
+    exit -1
+}

--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -7,7 +7,7 @@
     <Description xml:space="preserve">Deploy Visual F# Tools templates to Visual Studio</Description>
     <PackageId>Microsoft.FSharp.VSIX.Full.Core</PackageId>
   </Metadata>
-  <Installation>
+  <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0]" />
   </Installation>
   <Installer>


### PR DESCRIPTION
This is the initial work to enable publishing nightly VSIX packages on MyGet.

Notes:
- The value `%MYGET_APIKEY%` is passed in as a command line value on the official build machine so it's value is never exposed.  Also, I've confirmed that the build logs replace it with `********`.
- `Experimental="true"` is what will allow a nightly VSIX to install into `%APPDATA%` on top of the official VSIX and this is what the Roslyn team has been doing internally for some time.

I'm running a full internal validation build now and I won't merge this until that's doing what's expected.

FYI @KevinRansom 
