### PR TITLE
Use Primary GUID when opening items from SolutionExplorer

### DIFF
--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -15,6 +15,11 @@
 "Culture"="neutral"
 "codeBase"="$PackageFolder$\FSharp.Core.dll"
 
+[$RootKey$\Editors\{8a5aa6cf-46e3-4520-a70a-7393d15233e9}\LogicalViews]
+"{7651a700-06e5-11d1-8ebd-00a0c90f26ea}"=""
+"{7651a701-06e5-11d1-8ebd-00a0c90f26ea}"=""
+"{7651a703-06e5-11d1-8ebd-00a0c90f26ea}"=""
+
 [$RootKey$\Projects\{A1591282-1198-4647-A2B1-27E5FF5F6F3B}\LanguageTemplates]
 "{F2A71F9B-5D33-465A-A702-920D77279786}"="{76B279E8-36ED-494E-B145-5344F8DEFCB6}"
 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/FSharpEditorFactory.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/FSharpEditorFactory.cs
@@ -118,7 +118,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             pbstrPhysicalView = null; 
 
-            if(rguidLogicalView.Equals(VSConstants.LOGVIEWID.Designer_guid) || rguidLogicalView.Equals(VSConstants.LOGVIEWID.Primary_guid))
+            if(rguidLogicalView == VSConstants.LOGVIEWID.Primary_guid ||
+                rguidLogicalView == VSConstants.LOGVIEWID.Debugging_guid ||
+                rguidLogicalView == VSConstants.LOGVIEWID.Code_guid ||
+                rguidLogicalView == VSConstants.LOGVIEWID.TextView_guid)
             {
                 return VSConstants.S_OK;
             }

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -2170,7 +2170,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                 let manager = (x.GetDocumentManager() :?> FileDocumentManager)
                 Debug.Assert(manager <> null, "Could not get the FileDocumentManager")
 
-                let viewGuid = (if x.IsFormSubType then VSConstants.LOGVIEWID_Designer else VSConstants.LOGVIEWID_TextView)
+                let viewGuid = (if x.IsFormSubType then VSConstants.LOGVIEWID_Designer else VSConstants.LOGVIEWID_Primary)
                 let mutable frame : IVsWindowFrame = null
                 manager.Open(false, false, viewGuid, &frame, WindowFrameShowAction.Show) |> ignore
 


### PR DESCRIPTION
Fixes #2490 

Our editor factory is listening for designer GUIDs and Primary GUIDs: https://github.com/Microsoft/visualfsharp/blob/f68c6dd66499f7f08b00516ab4024c95e2448fe9/vsintegration/src/FSharp.ProjectSystem.Base/Project/FSharpEditorFactory.cs#L121-L124

We need to ensure that we request our documents are opened with these GUIDs or the FSharpEditorFactory won't create the editor and the regular text factory will. This causes us to lose our Alt+Enter keybindings.

This was introduced in #2417 while adding support for the preview window. I have done a once over to ensure I haven't broken preview:

![image](https://i.gyazo.com/83a5be7c79dcf3c1623100850c236f5c.gif)

@vasily-kirichenko is there anything more I should do to validate I haven't regressed preview? I'm not very familiar with the feature.

