### PR TITLE
Fix assembly resolution for FSI

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3454,9 +3454,10 @@ type TcAssemblyResolutions(results : AssemblyResolution list, unresolved : Unres
     let resolvedPathToResolution      = results |> List.map (fun r -> r.resolvedPath,r) |> Map.ofList
 
     /// Add some resolutions to the map of resolution results.                
-    member tcResolutions.AddResolutionResults(newResults) = TcAssemblyResolutions(newResults @ results, unresolved)
+    member tcResolutions.AddResolutionResults(newResults) = TcAssemblyResolutions(results @ newResults, unresolved)
+
     /// Add some unresolved results.
-    member tcResolutions.AddUnresolvedReferences(newUnresolved) = TcAssemblyResolutions(results, newUnresolved @ unresolved)
+    member tcResolutions.AddUnresolvedReferences(newUnresolved) = TcAssemblyResolutions(results, unresolved @ newUnresolved)
 
     /// Get information about referenced DLLs
     member tcResolutions.GetAssemblyResolutions() = results

--- a/tests/fsharp/core/.gitignore
+++ b/tests/fsharp/core/.gitignore
@@ -9,6 +9,9 @@ tmptest1.exe
 
 access/fsc.cmd.args
 
+fsi-reference/ImplementationAssembly/ReferenceAssemblyExample.dll
+fsi-reference/ReferenceAssembly/ReferenceAssemblyExample.dll
+
 forwarders/orig
 forwarders/split
 

--- a/tests/fsharp/core/fsi-reference/ImplementationAssembly.fs
+++ b/tests/fsharp/core/fsi-reference/ImplementationAssembly.fs
@@ -1,0 +1,4 @@
+﻿namespace ReferenceAssembly
+
+type MyClass() = 
+    member this.X = printfn "Implemented MyClass.X in F#"

--- a/tests/fsharp/core/fsi-reference/ReferenceAssembly.fs
+++ b/tests/fsharp/core/fsi-reference/ReferenceAssembly.fs
@@ -1,0 +1,4 @@
+﻿namespace ReferenceAssembly
+
+type MyClass() = 
+    member this.X = raise (new System.NotImplementedException("Not Implemented !!!!!!!!!"))

--- a/tests/fsharp/core/fsi-reference/test.fsx
+++ b/tests/fsharp/core/fsi-reference/test.fsx
@@ -1,0 +1,8 @@
+#r @"ImplementationAssembly\ReferenceAssemblyExample.dll"
+#r @"ReferenceAssembly\ReferenceAssemblyExample.dll"
+let c = new ReferenceAssembly.MyClass()
+let _ = c.X
+
+// If this fails then the jit blows up so this file will not get written.
+let os = System.IO.File.CreateText "test.ok" in os.Close() 
+exit 0

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -26,7 +26,6 @@ let FSI_BASIC = FSI_FILE
 #endif
 
 module CoreTests = 
-
     // These tests are enabled for .NET Framework and .NET Core
     [<Test>]
     let ``access-FSC_BASIC``() = singleTestBuildAndRun "core/access" FSC_BASIC
@@ -226,8 +225,8 @@ module CoreTests =
     [<Test>]
     let csext () = singleTestBuildAndRun "core/csext" FSC_BASIC
 
-
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
+
     [<Test>]
     let events () = 
         let cfg = testConfig "core/events"
@@ -380,7 +379,20 @@ module CoreTests =
         peverify cfg "test.exe"
 
         exec cfg ("." ++ "test.exe") ""
-                
+
+    [<Test>]
+    let ``fsi-reference`` () = 
+
+        let cfg = testConfig "core/fsi-reference"
+
+        begin
+            use testOkFile = fileguard cfg "test.ok"
+            fsc cfg @"--target:library -o:ImplementationAssembly\ReferenceAssemblyExample.dll" ["ImplementationAssembly.fs"]
+            fsc cfg @"--target:library -o:ReferenceAssembly\ReferenceAssemblyExample.dll" ["ReferenceAssembly.fs"]
+            fsiStdin cfg "test.fsx" "" []
+            testOkFile.CheckExists()
+        end
+
     [<Test>]
     let ``fsi-reload`` () = 
         let cfg = testConfig "core/fsi-reload"
@@ -417,7 +429,7 @@ module CoreTests =
         fsiStdin cfg "prepare.fsx" "--maxerrors:1" []
 
         use testOkFile = fileguard cfg "test.ok"
-        
+
         fsiStdin cfg "test.fsx" "--maxerrors:1"  []
 
         testOkFile.CheckExists()


### PR DESCRIPTION
Fixes https://github.com/Microsoft/visualfsharp/issues/2554

AddResolutionResults generated the assembly resolutions in reverse order from which they were presented in a script.  When two assemblies with the same name were added, this would cause refemit to generate types against different dll's for the same assembly name.  Causing the Jit to get confused.

This change generates results in the order they were presented allowing a first come first served resolution strategy, which matches the noremal F# assembly resolution pattern.

