### PR TITLE
Improve the reliability of the tests

### DIFF
--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -114,13 +114,14 @@ let singleTestBuildAndRunCore  cfg (copyFiles:string) p =
 
         log "Generated signature file..."
         fsc cfg "%s --sig:tmptest.fsi --define:TESTS_AS_APP" cfg.fsc_flags ["tmptest.fs"]
+        (if File.Exists("FSharp.Core.dll") then log "found fsharp.core.dll after build" else log "found fsharp.core.dll after build") |> ignore
 
         log "Compiling against generated signature file..."
         fsc cfg "%s -o:tmptest1.exe  --define:TESTS_AS_APP" cfg.fsc_flags ["tmptest.fsi";"tmptest.fs"]
+        (if File.Exists("FSharp.Core.dll") then log "found fsharp.core.dll after build" else log "found fsharp.core.dll after build") |> ignore
 
         log "Verifying built .exe..."
         peverify cfg "tmptest1.exe"
-
 
     | FSC_OPT_MINUS_DEBUG -> 
         use cleanup = (cleanUpFSharpCore cfg)

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -33,9 +33,8 @@ module Commands =
         Directory.CreateDirectory ( Path.Combine(workDir, dir) ) |> ignore
 
     let rm dir path =
-        log "rm %s" path
         let p = path |> getfullpath dir
-        if File.Exists(p) then File.Delete(p)
+        if File.Exists(p) then (log "rm %s" p) |> ignore; File.Delete(p); else (log "not found: %s p") |> ignore
 
     let pathAddBackslash (p: FilePath) = 
         if String.IsNullOrWhiteSpace (p) then p

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -34,7 +34,11 @@ module Commands =
 
     let rm dir path =
         let p = path |> getfullpath dir
-        if File.Exists(p) then (log "rm %s" p) |> ignore; File.Delete(p); else (log "not found: %s p") |> ignore
+        if File.Exists(p) then 
+            (log "rm %s" p) |> ignore
+            File.Delete(p)
+        else
+            (log "not found: %s p") |> ignore
 
     let pathAddBackslash (p: FilePath) = 
         if String.IsNullOrWhiteSpace (p) then p


### PR DESCRIPTION
The test failure occurs when calling peverify on the built assembly.  The usual readon for that is a missing or incorrect version of fsharp.core.dll.  An incorrect version of fharp.core.dll can occur because of one left hanging about in the directory at test build time.

This change ensures that we : 
1.     Delete an fsharp.core.dll if it exists prior to the test being run.
2.     At the end of the test deleting it, so it isn't left hanging about.
3.     Slight reformat of some of the test code paths to ensure a consistent cleanup approach.


Kevin