### PR TITLE
Fix completion performance

### DIFF
--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -919,9 +919,6 @@ module UntypedParseImpl =
         | None -> None
         | Some pt ->
 
-        let ast = sprintf "%+A" pt
-        let _x = ast
-
         match GetEntityKind(pos, pt) with
         | Some EntityKind.Attribute -> Some CompletionContext.AttributeApplication
         | _ ->


### PR DESCRIPTION
Remove wrongly left a costly sprintf "%A" parsed-input which makes completion very slow. It was introduced in https://github.com/Microsoft/visualfsharp/pull/2594

Sorry for that and thanks @forki for bug report!