### PR TITLE
escape member which needs backtick in the completion list

### DIFF
--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1366,16 +1366,16 @@ type FSharpAccessibility(a:Accessibility, ?isProtected) =
 /// An intellisense declaration
 [<Sealed>]
 type FSharpDeclarationListItem
-    ( name          : string
-    , nameInCode    : string
-    , fullName      : string
-    , glyph         : FSharpGlyph
-    , info
-    , isAttribute   : bool
-    , accessibility : FSharpAccessibility option
-    , kind          : CompletionItemKind
-    , isOwnMember   : bool
-    , priority      : int
+    ( name          : string,
+      nameInCode    : string,
+      fullName      : string,
+      glyph         : FSharpGlyph,
+      info,
+      isAttribute   : bool,
+      accessibility : FSharpAccessibility option,
+      kind          : CompletionItemKind,
+      isOwnMember   : bool,
+      priority      : int
     ) =
 
     let mutable descriptionTextHolder:FSharpToolTipText<_> option = None
@@ -1519,16 +1519,16 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[]) =
                     let fullName = ItemDescriptionsImpl.FullNameOfItem g item.Item
 
                     FSharpDeclarationListItem(
-                        name
-                        , nameInCode
-                        , fullName
-                        , glyph
-                        , Choice1Of2 (items, infoReader, m, denv, reactor, checkAlive)
-                        , ItemDescriptionsImpl.IsAttribute infoReader item.Item
-                        , getAccessibility item.Item
-                        , item.Kind
-                        , item.IsOwnMember
-                        , item.MinorPriority
+                        name,
+                        nameInCode,
+                        fullName,
+                        glyph,
+                        Choice1Of2 (items, infoReader, m, denv, reactor, checkAlive),
+                        ItemDescriptionsImpl.IsAttribute infoReader item.Item,
+                        getAccessibility item.Item,
+                        item.Kind,
+                        item.IsOwnMember,
+                        item.MinorPriority
                         )
             )
 

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1365,8 +1365,18 @@ type FSharpAccessibility(a:Accessibility, ?isProtected) =
 
 /// An intellisense declaration
 [<Sealed>]
-type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: string, glyph: FSharpGlyph, info, isAttribute: bool, accessibility: FSharpAccessibility option,
-                               kind: CompletionItemKind, isOwnMember: bool, priority: int) =
+type FSharpDeclarationListItem
+    ( name          : string
+    , nameInCode    : string
+    , fullName      : string
+    , glyph         : FSharpGlyph
+    , info
+    , isAttribute   : bool
+    , accessibility : FSharpAccessibility option
+    , kind          : CompletionItemKind
+    , isOwnMember   : bool
+    , priority      : int
+    ) =
 
     let mutable descriptionTextHolder:FSharpToolTipText<_> option = None
     let mutable task = null
@@ -1493,23 +1503,34 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[]) =
             
         let decls = 
             // Filter out duplicate names
-            items |> List.map (fun (nm,itemsWithSameName) -> 
+            items |> List.map (fun (name,itemsWithSameName) -> 
                 match itemsWithSameName with
                 | [] -> failwith "Unexpected empty bag"
                 | item :: _ as items -> 
                     let glyph = ItemDescriptionsImpl.GlyphOfItem(denv, item.Item)
                     let name, nameInCode =
-                        if nm.StartsWith "( " && nm.EndsWith " )" then
-                            let cleanName = nm.[2..nm.Length - 3]
+                        if name.StartsWith "( " && name.EndsWith " )" then
+                            let cleanName = name.[2..name.Length - 3]
                             cleanName, 
-                            if IsOperatorName nm then cleanName else "``" + cleanName + "``"
-                        else nm, nm
+                            if IsOperatorName name then cleanName else "``" + cleanName + "``"
+                        else
+                            name, Lexhelp.Keywords.QuoteIdentifierIfNeeded name
 
                     let fullName = ItemDescriptionsImpl.FullNameOfItem g item.Item
 
                     FSharpDeclarationListItem(
-                        name, nameInCode, fullName, glyph, Choice1Of2 (items, infoReader, m, denv, reactor, checkAlive), 
-                        ItemDescriptionsImpl.IsAttribute infoReader item.Item, getAccessibility item.Item, item.Kind, item.IsOwnMember, item.MinorPriority))
+                        name
+                        , nameInCode
+                        , fullName
+                        , glyph
+                        , Choice1Of2 (items, infoReader, m, denv, reactor, checkAlive)
+                        , ItemDescriptionsImpl.IsAttribute infoReader item.Item
+                        , getAccessibility item.Item
+                        , item.Kind
+                        , item.IsOwnMember
+                        , item.MinorPriority
+                        )
+            )
 
         new FSharpDeclarationListInfo(Array.ofList decls)
     


### PR DESCRIPTION
Fixes one of the issues listed in #2610

before:
![vs2017 backtick completion simplebroken](https://cloud.githubusercontent.com/assets/87944/24068438/0d73a31c-0b8f-11e7-8e44-b13c3111a6a7.gif)

after:
![vs2017 backtick completion simplefix](https://cloud.githubusercontent.com/assets/87944/24068440/12e071f4-0b8f-11e7-81cb-0c94dac23c07.gif)

In our last fallback case, the text in the list is unaffected, but the `nameInCode` is transformed using `Lexhelp.Keywords.QuoteIdentifierIfNeeded`