### PR TITLE
Update to 4 ci parts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -19,7 +19,7 @@ echo Usage:
 echo.
 echo build.cmd ^<all^|net40^|coreclr^|pcls^|vs^>
 echo           ^<proto^|protofx^>
-echo           ^<ci^|ci_part1^|ci_part2^|ci_part3^|microbuild^>
+echo           ^<ci^|ci_part1^|ci_part2^|ci_part3^|ci_part4^|microbuild^>
 echo           ^<debug^|release^>
 echo           ^<diag^|publicsign^>
 echo           ^<test^|test-net40-coreunit^|test-coreclr-coreunit^|test-compiler-unit^|test-pcl-coreunit^|test-net40-fsharp^|test-coreclr-fsharp^|test-net40-fsharpqa^>
@@ -203,8 +203,6 @@ if /i '%ARG%' == 'ci_part1' (
     set BUILD_PORTABLE=1
     set BUILD_VS=1
     set BUILD_SETUP=%FSC_BUILD_SETUP%
-    set TEST_NET40_COMPILERUNIT_SUITE=1
-    set TEST_NET40_FSHARPQA_SUITE=1
     set TEST_VS_IDEUNIT_SUITE=1
     set CI=1
 )
@@ -213,16 +211,13 @@ if /i '%ARG%' == 'ci_part2' (
     set _autoselect=0
 
     REM what we do
-    set BUILD_PROTO_WITH_CORECLR_LKG=1
     set BUILD_PROTO=1
     set BUILD_NET40=1
-    set BUILD_PORTABLE=1
 
     set TEST_NET40_COREUNIT_SUITE=1
     set TEST_NET40_FSHARP_SUITE=1
     set TEST_PORTABLE_COREUNIT_SUITE=1
     set CI=1
-
 )
 
 if /i '%ARG%' == 'ci_part3' (
@@ -236,7 +231,20 @@ if /i '%ARG%' == 'ci_part3' (
     set TEST_CORECLR_FSHARP_SUITE=1
     set TEST_CORECLR_COREUNIT_SUITE=1
     set CI=1
+)
 
+if /i '%ARG%' == 'ci_part4' (
+    set _autoselect=0
+
+    REM what we do
+    set BUILD_PROTO=1
+    set BUILD_NET40=1
+    set BUILD_PORTABLE=1
+
+    set TEST_NET40_COMPILERUNIT_SUITE=1
+    set TEST_NET40_FSHARPQA_SUITE=1
+    set TEST_PORTABLE_COREUNIT_SUITE=1
+    set CI=1
 )
 
 if /i '%ARG%' == 'proto' (

--- a/netci.groovy
+++ b/netci.groovy
@@ -12,7 +12,7 @@ def static getBuildJobName(def configuration, def os) {
 
 [true, false].each { isPullRequest ->
     osList.each { os ->
-        def configurations = ['Debug', 'Release_ci_part1', 'Release_ci_part2', 'Release_ci_part3', 'Release_net40_no_vs' ];
+        def configurations = ['Debug', 'Release_ci_part1', 'Release_ci_part2', 'Release_ci_part3', 'Release_ci_part4', 'Release_net40_no_vs' ];
         if (os != 'Windows_NT') {
             // Only build one configuration on Linux/... so far
             configurations = ['Release'];
@@ -41,6 +41,9 @@ def static getBuildJobName(def configuration, def os) {
                 }
                 else if (configuration == "Release_ci_part3") {
                     build_args = "ci_part3"
+                }
+                else if (configuration == "Release_ci_part4") {
+                    build_args = "ci_part4"
                 }
                 else if (configuration == "Release_net40_no_vs") {
                     build_args = "net40"


### PR DESCRIPTION
Rework the CI to be finished quicker.  Now there are four ci parts.

ci_part1 ---  Desktop + VS components + VS tests
ci_part2 ---  Desktop + Portable + CoreUnitTests
ci_part3 ---  Coreclr + coreclr tests
ci_part4 ---  Desktop + FSharp (Cambridge) + FSharpQa

I removed the Net40_ No Build --- it has no probative value, since ci_part1, 2 and 4 build build portable and coreclr.  If the build test would fail one of those would fail in a similar amount of time with the same errors.

Kevin