### PR TITLE
Add non-regression test for backtick member completion

### DIFF
--- a/vsintegration/src/FSharp.LanguageService.Base/LanguageService.cs
+++ b/vsintegration/src/FSharp.LanguageService.Base/LanguageService.cs
@@ -1395,6 +1395,8 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
 
         internal abstract String GetName(string filterText, int index);
 
+        internal abstract string GetNameInCode(string filterText, int index);
+
         internal abstract String GetDescription(string filterText, int index);
 
         internal abstract int GetGlyph(string filterText, int index);

--- a/vsintegration/src/FSharp.LanguageService/Intellisense.fs
+++ b/vsintegration/src/FSharp.LanguageService/Intellisense.fs
@@ -163,6 +163,16 @@ type internal FSharpDeclarations(documentationBuilder, declarations: FSharpDecla
             else 
                 item.Name
         else String.Empty
+    
+    override decl.GetNameInCode(filterText, index) =
+        let decls = trimmedDeclarations filterText
+        if (index >= 0 && index < decls.Length) then
+            let item = decls.[index]
+            if (item.Glyph = FSharpGlyph.Error) then
+                ""
+            else 
+                item.NameInCode
+        else String.Empty
 
     override decl.GetDescription(filterText, index) =
         let decls = trimmedDeclarations filterText

--- a/vsintegration/tests/Salsa/SalsaUtils.fs
+++ b/vsintegration/tests/Salsa/SalsaUtils.fs
@@ -206,21 +206,21 @@ module internal VsOpsUtils =
     /// Verify the completion list is empty, typically for negative tests
     let AssertCompListIsEmpty (completions : CompletionItem[]) = 
       if not (Array.isEmpty completions) then
-          printfn "Expected empty completion list but got: %A" (completions |> Array.map (fun (nm, _, _, _) -> nm))
+          printfn "Expected empty completion list but got: %A" (completions |> Array.map (fun (CompletionItem(nm, _, _, _, _)) -> nm))
       Assert.IsTrue(Array.isEmpty completions, "Expected empty completion list but got some items")
 
     /// Verify that the given completion list contains a member with the given name
     let AssertCompListContains(completions : CompletionItem[], membername) =
-        let found = completions |> Array.filter(fun (name,_,_,_) -> name = membername) |> Array.length
+        let found = completions |> Array.filter(fun (CompletionItem(name,_,_,_,_)) -> name = membername) |> Array.length
         if found = 0 then
             printfn "Failed to find expected value %s in " membername
             let MAX = 25
             printfn "Completion list = %s" (if completions.Length > MAX then sprintf "%A ... and more" completions.[0..MAX] else sprintf "%A" completions)
-            Assert.Fail(sprintf "Couldn't find '%s' in completion list: %+A" membername (completions |> Array.map (fun (name,_,_,_) -> name)))
+            Assert.Fail(sprintf "Couldn't find '%s' in completion list: %+A" membername (completions |> Array.map (fun (CompletionItem(name,_,_,_,_)) -> name)))
 
     /// Verify the completion list does not contain a member with the given name
     let AssertCompListDoesNotContain(completions : CompletionItem[], membername) =
-        let found = completions |> Array.filter(fun (name,_,_,_) -> name = membername) |> Array.length
+        let found = completions |> Array.filter(fun (CompletionItem(name,_,_,_,_)) -> name = membername) |> Array.length
         if found <> 0 then
             printfn "Value %s should have been absent from " membername
             printfn "Completion list = %A" completions

--- a/vsintegration/tests/Salsa/salsa.fs
+++ b/vsintegration/tests/Salsa/salsa.fs
@@ -457,7 +457,7 @@ module internal Salsa =
     
 
     // Result of querying the completion list
-    and CompletionItem = string * string * (unit -> string) * DeclarationType
+    and CompletionItem = CompletionItem of name: string * displayText: string * nameInCode: string * (unit -> string) * DeclarationType
 
     /// Representes the information that is displayed in the navigation bar
     and NavigationBarResult = 
@@ -1327,7 +1327,7 @@ module internal Salsa =
                     let result = Array.zeroCreate count
                     for i in 0..count-1 do 
                         let glyph = enum<DeclarationType> (declarations.GetGlyph(filterText,i))
-                        result.[i] <- (declarations.GetDisplayText(filterText,i), declarations.GetName(filterText,i), (fun () -> declarations.GetDescription(filterText,i)), glyph)
+                        result.[i] <- CompletionItem (declarations.GetDisplayText(filterText,i), declarations.GetName(filterText,i), declarations.GetNameInCode(filterText,i), (fun () -> declarations.GetDescription(filterText,i)), glyph)
                     result
 
             member file.AutoCompleteAtCursor(?filterText) = file.AutoCompleteAtCursorImpl(BackgroundRequestReason.MemberSelect, ?filterText=filterText)

--- a/vsintegration/tests/unittests/TestLib.LanguageService.fs
+++ b/vsintegration/tests/unittests/TestLib.LanguageService.fs
@@ -75,8 +75,8 @@ type internal Helper =
         TakeCoffeeBreak(file.VS) (* why needed? *)       
         MoveCursorToEndOfMarker(file,marker)
         let completions = AutoCompleteAtCursor file
-        match completions |> Array.tryFind (fun (name, _, _, _) -> name = completionName) with
-        | Some(_, _, descrFunc, _) ->
+        match completions |> Array.tryFind (fun (CompletionItem(name, _, _, _, _)) -> name = completionName) with
+        | Some(CompletionItem(_, _, _, descrFunc, _)) ->
             let descr = descrFunc()
             AssertContainsInOrder(descr,rhsContainsOrder)
         | None -> 

--- a/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
@@ -196,14 +196,25 @@ type UsingMSBuild() as this  =
 
     //**Help Function for checking Ctrl-Space Completion Contains the expected value *************
     member private this.AssertCtrlSpaceCompletionContains(fileContents : list<string>, marker, expected, ?addtlRefAssy: list<string>)  = 
+        this.AssertCtrlSpaceCompletion(
+            fileContents,
+            marker,
+            (fun completions -> 
+                Assert.AreNotEqual(0,completions.Length)
+                let found = completions |> Array.exists(fun (CompletionItem(s,_,_,_,_)) -> s = expected)
+                if not(found) then 
+                    printfn "Expected: %A to contain %s" completions expected  
+                    Assert.Fail()                
+            ),
+            ?addtlRefAssy = addtlRefAssy
+        )
+
+   //**Help Function for checking Ctrl-Space Completion Contains the expected value *************
+    member private this.AssertCtrlSpaceCompletion(fileContents : list<string>, marker, checkCompletion: (CompletionItem array -> unit), ?addtlRefAssy: list<string>)  = 
         let (_, _, file) = this.CreateSingleFileProject(fileContents, ?references = addtlRefAssy)
         MoveCursorToEndOfMarker(file,marker)
         let completions = CtrlSpaceCompleteAtCursor file
-        Assert.AreNotEqual(0,completions.Length)
-        let found = completions |> Array.exists(fun (s,_,_,_) -> s = expected)
-        if not(found) then 
-            printfn "Expected: %A to contain %s" completions expected  
-            Assert.Fail() 
+        checkCompletion completions
 
     member private this.AutoCompletionListNotEmpty (fileContents : list<string>) marker  = 
         let (_, _, file) = this.CreateSingleFileProject(fileContents)
@@ -293,7 +304,31 @@ type UsingMSBuild() as this  =
         test "DU_3." "DU_3." ["ExtensionPropObj"; "ExtensionMethodObj"; "Equals"] ["GetHashCode"] // no gethashcode, has equals defined in DU3 type
         test "DU_4." "DU_4." ["ExtensionPropObj"; "ExtensionMethodObj"; "GetHashCode"] ["Equals"] // no equals, has gethashcode defined in DU4 type
 
-    
+    [<Test>]
+    member this.``AutoCompletion.escaped with backticks`` () =
+        let code = """
+type MyRec = {
+  ``field.field``  : string
+}
+
+let a = {``field.field`` = ""}
+a.
+        """
+        this.AssertCtrlSpaceCompletion(
+          [code]
+          , "a."
+          , (fun completions ->
+              completions 
+              |> Seq.tryFind (fun (CompletionItem(_,name,nameInCode,_,_)) ->
+                name = "field.field" 
+                && nameInCode = "``field.field``"
+              )
+              |> function
+                  | Some _ -> ()
+                  | None -> Assert.Fail "expected ``field.field`` to be present"
+
+          ))
+        
     [<Test>]
     member this.``AutoCompletion.BeforeThis``() = 
         let code = 
@@ -1759,7 +1794,7 @@ let x = new MyClass2(0)
         let completions = AutoCompleteAtCursor file
         
         // Get description for Expr.Var
-        let (_, _, descrFunc, _) = completions |> Array.find (fun (name, _, _, _) -> name = "WhileLoop")
+        let (CompletionItem(_, _, _, descrFunc, _)) = completions |> Array.find (fun (CompletionItem(name, _, _, _, _)) -> name = "WhileLoop")
         let descr = descrFunc()
         // Check whether the description contains the name only once        
         let occurrences = ("  " + descr + "  ").Split([| "WhileLoop" |], System.StringSplitOptions.None).Length - 1
@@ -2112,8 +2147,8 @@ let x = new MyClass2(0)
         Assert.IsTrue(completions.Length > 0)
         for completion in completions do
             match completion with 
-              | _,_,_,DeclarationType.Method -> ()
-              | name,_,_,x -> failwith (sprintf "Unexpected item %s seen with declaration type %A" name x)
+              | CompletionItem(_,_,_,_,DeclarationType.Method) -> ()
+              | CompletionItem(name,_,_,_,x) -> failwith (sprintf "Unexpected item %s seen with declaration type %A" name x)
                          
     // FEATURE: Pressing ctrl+space or ctrl+j will give a list of valid completions.
     
@@ -3997,9 +4032,9 @@ let x = query { for bbbb in abbbbc(*D0*) do
         let completions = time1 AutoCompleteAtCursor file "Time of first autocomplete."
         for completion in completions do
             match completion with 
-              | ("Obsolete" as s,_,_,_) 
+              | CompletionItem("Obsolete" as s,_,_,_,_) 
               //| ("Private" as s,_,_,_)  this isn't supported yet
-              | ("CompilerMessageTest" as s,_,_,_)-> failwith (sprintf "Unexpected item %s at top level."  s)
+              | CompletionItem("CompilerMessageTest" as s,_,_,_,_)-> failwith (sprintf "Unexpected item %s at top level."  s)
               | _ -> ()              
     
     // Test various configurations of nested obsolete modules & types
@@ -4113,7 +4148,7 @@ let x = query { for bbbb in abbbbc(*D0*) do
         let (_, _, file) = this.CreateSingleFileProject(code)
         MoveCursorToEndOfMarker(file, marker)
         let completions = AutoCompleteAtCursor file
-        let (_, _, descrFunc, _) = completions |> Array.find (fun (name, _, _, _) -> name = shortName)
+        let (CompletionItem(_, _, _, descrFunc, _)) = completions |> Array.find (fun (CompletionItem(name, _, _, _, _)) -> name = shortName)
         let descr = descrFunc()
         // Check whether the description contains the name only once        
         let occurrences = ("  " + descr + "  ").Split([| fullName |], System.StringSplitOptions.None).Length - 1
@@ -4150,7 +4185,7 @@ let x = query { for bbbb in abbbbc(*D0*) do
         let completions = AutoCompleteAtCursor file
         
         // Get description for Expr.Var
-        let (_, _, descrFunc, _) = completions |> Array.find (fun (name, _, _, _) -> name = "Open")
+        let (CompletionItem(_, _, _, descrFunc, _)) = completions |> Array.find (fun (CompletionItem(name, _, _, _, _)) -> name = "Open")
         let occurrences = this.CountMethodOccurrences(descrFunc(), "File.Open")
         AssertEqualWithMessage(3, occurrences, "Found wrong number of overloads for 'File.Open'.")
 
@@ -4165,7 +4200,7 @@ let x = query { for bbbb in abbbbc(*D0*) do
         let completions = AutoCompleteAtCursor file
           
         // Get description for Expr.Var
-        let (_, _, descrFunc, _) = completions |> Array.find (fun (name, _, _, _) -> name = "Start")
+        let (CompletionItem(_, _, _, descrFunc, _)) = completions |> Array.find (fun (CompletionItem(name, _, _, _, _)) -> name = "Start")
         let occurrences = this.CountMethodOccurrences(descrFunc(), "Start")        
         AssertEqualWithMessage(1, occurrences, "Found wrong number of overloads for 'MailboxProcessor.Start'.")
        
@@ -4185,7 +4220,7 @@ let x = query { for bbbb in abbbbc(*D0*) do
         let completions = AutoCompleteAtCursor file
         // Should contain something
         Assert.AreNotEqual(0,completions.Length)      
-        Assert.IsTrue(completions |> Array.exists (fun (name,_,_,_) -> name.Contains("AddMilliseconds")))  
+        Assert.IsTrue(completions |> Array.exists (fun (CompletionItem(name,_,_,_,_)) -> name.Contains("AddMilliseconds")))  
         
     // FEATURE: Saving file N does not cause files 1 to N-1 to re-typecheck (but does cause files N to <end> to 
     [<Test>]
@@ -4366,9 +4401,9 @@ let x = query { for bbbb in abbbbc(*D0*) do
         let (_, _, file) = this.CreateSingleFileProject(code)
         MoveCursorToEndOfMarker(file,"= Set")
         let completions = CtrlSpaceCompleteAtCursor(file)
-        let found = completions |> Array.tryFind (fun (n, _, _, _) -> n = "Set")
+        let found = completions |> Array.tryFind (fun (CompletionItem(n, _, _, _, _)) -> n = "Set")
         match found with 
-        | Some(_, _, f, _) ->
+        | Some(CompletionItem(_, _, _, f, _)) ->
             let tip = f()
             AssertContains(tip, "module Set")        
             AssertContains(tip, "type Set")        
@@ -4430,29 +4465,29 @@ let x = query { for bbbb in abbbbc(*D0*) do
         Assert.IsTrue(completions.Length>0)
         for completion in completions do
             match completion with 
-              | "A",_,_,DeclarationType.EnumMember -> ()
-              | "B",_,_,DeclarationType.EnumMember -> ()
-              | "C",_,_,DeclarationType.EnumMember -> ()
-              | "Function",_,_,_ -> ()
-              | "Enum",_,_,DeclarationType.Enum -> ()
-              | "Constant",_,_,_ -> ()
-              | "FunctionValue",_,_,DeclarationType.Method -> ()
-              | "OutOfRange",_,_,DeclarationType.Exception -> ()
-              | "OutOfRangeException",_,_,DeclarationType.Class -> ()
-              | "Interface",_,_,DeclarationType.Interface -> ()
-              | "Struct",_,_,DeclarationType.ValueType -> ()
-              | "Tuple",_,_,_ -> ()
-              | "Submodule",_,_,DeclarationType.Module -> ()
-              | "Record",_,_,DeclarationType.Class -> ()
-              | "DiscriminatedUnion",_,_,DeclarationType.DiscriminatedUnion -> ()
-              | "AsmType",_,_,DeclarationType.Class -> ()
-              | "FunctionType",_,_,DeclarationType.Class -> ()
-              | "TupleType",_,_,DeclarationType.Class -> ()
-              | "ValueType",_,_,DeclarationType.ValueType -> ()
-              | "Class",_,_,DeclarationType.Class -> ()
-              | "Int32",_,_,DeclarationType.Method -> ()
-              | "TupleTypeAbbreviation",_,_,_ -> ()
-              | name,_,_,x -> failwith (sprintf "Unexpected module member %s seen with declaration type %A" name x)
+              | CompletionItem("A",_,_,_,DeclarationType.EnumMember)                          -> ()
+              | CompletionItem("B",_,_,_,DeclarationType.EnumMember)                          -> ()
+              | CompletionItem("C",_,_,_,DeclarationType.EnumMember)                          -> ()
+              | CompletionItem("Function",_,_,_,_)                                            -> ()
+              | CompletionItem("Enum",_,_,_,DeclarationType.Enum)                             -> ()
+              | CompletionItem("Constant",_,_,_,_)                                            -> ()
+              | CompletionItem("FunctionValue",_,_,_,DeclarationType.Method)                  -> ()
+              | CompletionItem("OutOfRange",_,_,_,DeclarationType.Exception)                  -> ()
+              | CompletionItem("OutOfRangeException",_,_,_,DeclarationType.Class)             -> ()
+              | CompletionItem("Interface",_,_,_,DeclarationType.Interface)                   -> ()
+              | CompletionItem("Struct",_,_,_,DeclarationType.ValueType)                      -> ()
+              | CompletionItem("Tuple",_,_,_,_)                                               -> ()
+              | CompletionItem("Submodule",_,_,_,DeclarationType.Module)                      -> ()
+              | CompletionItem("Record",_,_,_,DeclarationType.Class)                          -> ()
+              | CompletionItem("DiscriminatedUnion",_,_,_,DeclarationType.DiscriminatedUnion) -> ()
+              | CompletionItem("AsmType",_,_,_,DeclarationType.Class)                         -> ()
+              | CompletionItem("FunctionType",_,_,_,DeclarationType.Class)                    -> ()
+              | CompletionItem("TupleType",_,_,_,DeclarationType.Class)                       -> ()
+              | CompletionItem("ValueType",_,_,_,DeclarationType.ValueType)                   -> ()
+              | CompletionItem("Class",_,_,_,DeclarationType.Class)                           -> ()
+              | CompletionItem("Int32",_,_,_,DeclarationType.Method)                          -> ()
+              | CompletionItem("TupleTypeAbbreviation",_,_,_,_)                               -> ()
+              | CompletionItem(name,_,_,_,x) -> failwith (sprintf "Unexpected module member %s seen with declaration type %A" name x)
 
         MoveCursorToEndOfMarker(file,"AbbreviationModule.")
         let completions = time1 AutoCompleteAtCursor file "Time of second autocomplete."
@@ -4460,20 +4495,24 @@ let x = query { for bbbb in abbbbc(*D0*) do
         Assert.IsTrue(completions.Length>0)
         for completion in completions do
             match completion with 
-              | "Int32",_,_,_ | "Function",_,_,_
-              | "Enum",_,_,_ | "Constant",_,_,_
-              | "Function",_,_,_ | "Interface",_,_,_ 
-              | "Struct",_,_,_ | "Tuple",_,_,_ 
-              | "Record",_,_,_ -> ()
-              | "EnumAbbreviation",_,_,DeclarationType.Enum -> ()
-              | "InterfaceAbbreviation",_,_,DeclarationType.Interface -> ()
-              | "StructAbbreviation",_,_,DeclarationType.ValueType -> ()
-              | "DiscriminatedUnion",_,_,_ -> ()
-              | "RecordAbbreviation",_,_,DeclarationType.Class -> ()
-              | "DiscriminatedUnionAbbreviation",_,_,DeclarationType.DiscriminatedUnion -> ()
-              | "AsmTypeAbbreviation",_,_,DeclarationType.Class -> ()
-              | "TupleTypeAbbreviation",_,_,_ -> ()
-              | name,_,_,x -> failwith (sprintf "Unexpected union member %s seen with declaration type %A" name x)
+              | CompletionItem("Int32",_,_,_,_) 
+              | CompletionItem("Function",_,_,_,_)
+              | CompletionItem("Enum",_,_,_,_)
+              | CompletionItem("Constant",_,_,_,_)
+              | CompletionItem("Function",_,_,_,_)
+              | CompletionItem("Interface",_,_,_,_)
+              | CompletionItem("Struct",_,_,_,_)
+              | CompletionItem("Tuple",_,_,_,_)
+              | CompletionItem("Record",_,_,_,_) -> ()
+              | CompletionItem("EnumAbbreviation",_,_,_,DeclarationType.Enum) -> ()
+              | CompletionItem("InterfaceAbbreviation",_,_,_,DeclarationType.Interface) -> ()
+              | CompletionItem("StructAbbreviation",_,_,_,DeclarationType.ValueType) -> ()
+              | CompletionItem("DiscriminatedUnion",_,_,_,_) -> ()
+              | CompletionItem("RecordAbbreviation",_,_,_,DeclarationType.Class) -> ()
+              | CompletionItem("DiscriminatedUnionAbbreviation",_,_,_,DeclarationType.DiscriminatedUnion) -> ()
+              | CompletionItem("AsmTypeAbbreviation",_,_,_,DeclarationType.Class) -> ()
+              | CompletionItem("TupleTypeAbbreviation",_,_,_,_) -> ()
+              | CompletionItem(name,_,_,_,x) -> failwith (sprintf "Unexpected union member %s seen with declaration type %A" name x)
         
     [<Test>]
     member public this.ListFunctions() = 
@@ -4489,12 +4528,12 @@ let x = query { for bbbb in abbbbc(*D0*) do
         Assert.IsTrue(completions.Length>0)
         for completion in completions do
             match completion with 
-              | "Cons",_,_,DeclarationType.Method -> ()
-              | "Equals",_,_,DeclarationType.Method -> ()
-              | "Empty",_,_,DeclarationType.Property -> () 
-              | "empty",_,_,_ -> () 
-              | _,_,_,DeclarationType.Method -> ()
-              | name,_,_,x -> failwith (sprintf "Unexpected item %s seen with declaration type %A" name x)
+              | CompletionItem("Cons",_,_,_,DeclarationType.Method) -> ()
+              | CompletionItem("Equals",_,_,_,DeclarationType.Method) -> ()
+              | CompletionItem("Empty",_,_,_,DeclarationType.Property) -> () 
+              | CompletionItem("empty",_,_,_,_) -> () 
+              | CompletionItem(_,_,_,_,DeclarationType.Method) -> ()
+              | CompletionItem(name,_,_,_,x) -> failwith (sprintf "Unexpected item %s seen with declaration type %A" name x)
 
     [<Test>]
     member public this.``SystemNamespace``() =
@@ -4513,8 +4552,8 @@ let x = query { for bbbb in abbbbc(*D0*) do
         
         for completion in completions do
             match completion with 
-              | "Action" as name,_,_,decl -> AssertIsDecl(name,decl,DeclarationType.Class)
-              | "CodeDom" as name,_,_,decl -> AssertIsDecl(name,decl,DeclarationType.Namespace)
+              | CompletionItem("Action" as name,_,_,_,decl) -> AssertIsDecl(name,decl,DeclarationType.Class)
+              | CompletionItem("CodeDom" as name,_,_,_,decl) -> AssertIsDecl(name,decl,DeclarationType.Namespace)
               | _ -> ()
       
     // If there is a compile error that prevents a data tip from resolving then show that data tip.
@@ -4534,7 +4573,7 @@ let x = query { for bbbb in abbbbc(*D0*) do
         let completions = time1 CtrlSpaceCompleteAtCursor file "Time of first autocomplete."
         Assert.IsTrue(completions.Length>0)      
         for completion in completions do 
-            let _,_,descfunc,_ = completion
+            let (CompletionItem(_,_,_,descfunc,_)) = completion
             let desc = descfunc()
             printfn "MemberInfoCompileErrorsShowInDataTip: desc = <<<%s>>>" desc
             AssertContains(desc,"Simulated compiler error")
@@ -4549,8 +4588,8 @@ let x = query { for bbbb in abbbbc(*D0*) do
         let completions = time1 CtrlSpaceCompleteAtCursor file "Time of first autocomplete."
         for completion in completions do
             match completion with 
-              | ("IChapteredRowset" as s,_,_,_) 
-              | ("ICorRuntimeHost" as s,_,_,_)-> failwith (sprintf "Unexpected item %s at top level."  s)
+              | CompletionItem("IChapteredRowset" as s,_,_,_,_) 
+              | CompletionItem("ICorRuntimeHost" as s,_,_,_,_) -> failwith (sprintf "Unexpected item %s at top level."  s)
               | _ -> ()
               
     [<Test>]
@@ -4660,13 +4699,13 @@ let x = query { for bbbb in abbbbc(*D0*) do
                     
         for completion in completions do
             match completion with 
-              | "Head" as name,_,_,decl -> 
+              | CompletionItem("Head" as name,_,_,_,decl) -> 
                 count<-count + 1
                 AssertIsDecl(name,decl,DeclarationType.Property) 
-              | "Tail" as name,_,_,decl -> 
+              | CompletionItem("Tail" as name,_,_,_,decl) -> 
                 count<-count + 1
                 AssertIsDecl(name,decl,DeclarationType.Property) 
-              | name,_,_,x -> ()        
+              | CompletionItem(name,_,_,_,x) -> ()        
         
         Assert.AreEqual(2,count)
         
@@ -4688,9 +4727,9 @@ let x = query { for bbbb in abbbbc(*D0*) do
                     
         for completion in completions do
             match completion with 
-              | "BackgroundColor" as name,_,_,decl -> AssertIsDecl(name,decl,DeclarationType.Property) 
-              | "CancelKeyEvent" as name,_,_,decl -> AssertIsDecl(name,decl,DeclarationType.Event) 
-              | name,_,_,x -> ()
+              | CompletionItem("BackgroundColor" as name,_,_,_,decl) -> AssertIsDecl(name,decl,DeclarationType.Property) 
+              | CompletionItem("CancelKeyEvent" as name,_,_,_,decl) -> AssertIsDecl(name,decl,DeclarationType.Event) 
+              | CompletionItem(name,_,_,_,x) -> ()
 
     // Test completions in an incomplete computation expression (case 1: for "let")
     [<Test>]
@@ -4778,7 +4817,7 @@ let x = query { for bbbb in abbbbc(*D0*) do
         MoveCursorToEndOfMarker(file, "File1.")
         let completionItems = 
             AutoCompleteAtCursor(file)
-            |> Array.map (fun (name, _, _, _) -> name)
+            |> Array.map (fun (CompletionItem(name, _, _, _, _)) -> name)
         Assert.AreEqual(1, completionItems.Length, "Expected 1 item in the list")
         Assert.AreEqual("x", completionItems.[0], "Expected 'x' in the list")
  

--- a/vsintegration/tests/unittests/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.QuickInfo.fs
@@ -1700,8 +1700,8 @@ let f (tp:ITypeProvider(*$$$*)) = tp.Invalidate
         TakeCoffeeBreak(this.VS) (* why needed? *)       
         MoveCursorToEndOfMarker(file,marker)
         let completions = CtrlSpaceCompleteAtCursor file
-        match completions |> Array.tryFind (fun (name, _, _, _) -> name = completionName) with
-        | Some(_, _, descrFunc, _) ->
+        match completions |> Array.tryFind (fun (CompletionItem(name, _, _, _, _)) -> name = completionName) with
+        | Some(CompletionItem(_, _, _, descrFunc, _)) ->
             let descr = descrFunc()
             AssertContainsInOrder(descr,rhsContainsOrder)
         | None -> 

--- a/vsintegration/tests/unittests/Tests.LanguageService.Script.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.Script.fs
@@ -328,7 +328,7 @@ type UsingMSBuild() as this =
 
         MoveCursorToEndOfMarker(fsx, "InDifferentFS.")
         let completion = AutoCompleteAtCursor fsx
-        let completion = completion |> Array.map (fun (name, _, _, _) -> name) |> set
+        let completion = completion |> Array.map (fun (CompletionItem(name, _, _, _, _)) -> name) |> set
         Assert.AreEqual(Set.count completion, 2, "Expected 2 elements in the completion list")
         Assert.IsTrue(completion.Contains "x", "Completion list should contain x because INTERACTIVE is defined")
         Assert.IsTrue(completion.Contains "B", "Completion list should contain B because DEBUG is not defined")


### PR DESCRIPTION
This tests #2649/#2610

As I had to chase down where `and CompletionItem = string * string * (unit -> string) * DeclarationType` was originating from, I had to make it a single case DU to find places which would break and eventually find the source (Salsa.Privates.SimpleOpenFile.AutoCompleteAtCursorImpl); I think having it as a DU is better, and we should avoid type alias over mere tuples as finding their source is difficult.

I had to surface "nameInCode" into CompletionItem to add my test.

I added AssertCtrlSpaceCompletion taking higher order function to enable arbitrary checks on the completion lists.