### PR TITLE
Reliability ---  Additional diagnostics for fsharpqa build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -216,7 +216,6 @@ if /i '%ARG%' == 'ci_part2' (
 
     set TEST_NET40_COREUNIT_SUITE=1
     set TEST_NET40_FSHARP_SUITE=1
-    set TEST_PORTABLE_COREUNIT_SUITE=1
     set CI=1
 )
 

--- a/tests/fsharpqa/Source/run.pl
+++ b/tests/fsharpqa/Source/run.pl
@@ -420,10 +420,17 @@ sub RunCompilerCommand {
         # remainder of response is output of compiler
         @CommandOutput = <$remote>;
 
+        print "--------------------------------------------------------\n";
+        print "Error from hosted compiler\n";
+        print "Exit code: $ExitCode\n";
+        print "Error:     $Type\n";
+        print @CommandOutput;
+        print "--------------------------------------------------------\n";
+
         # still some issues with reliability of hosted compiler.
         # if compilation unexpectedly fails, try again with standard compiler
         if ($ExitCode && ($Type < TEST_SEEK_ERROR)) {
-          return RunCommand($msg, $cmd);
+                return RunCommand($msg, $cmd); 
         }
 
         return $ExitCode;


### PR DESCRIPTION
The fsharpqa build has occasionally failed to build tests cases.  The failures succeeded on retry.

This PR adds some minor additional output to see if we can diagnose why, when next it happens.

