### PR TITLE
xplat build cleanup/improvement, part 5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -427,7 +427,13 @@ if [ "$BUILD_PROTO_WITH_CORECLR_LKG" = '1' ]; then
     fi
 fi
 
-# TODO: Check for existence of fsi (either on the system, or from the FSharp.Compiler.Tools package that was restored).
+export _dotnetexe="${_scriptdir}Tools/dotnetcli/dotnet.exe"
+export NUGET_PACKAGES="${_scriptdir}packages/"
+
+export _fsiexe="${NUGET_PACKAGES}FSharp.Compiler.Tools.4.0.1.21/tools/fsi.exe"
+if [ ! -f "$_fsiexe" ]; then
+    failwith "Could not find fsi.exe at $_fsiexe"
+fi
 
 build_status "Done with package restore, starting proto"
 
@@ -436,8 +442,8 @@ if [ ! -f "Proto/net40/bin/fsc-proto.exe" ]; then
   export BUILD_PROTO=1
 fi
 
-_dotnetexe=dotnet
-_architecture=win7-x64
+export _dotnetexe="${_scriptdir}Tools/dotnetcli/dotnet.exe"
+export _architecture="osx-x64"
 
 # Build Proto
 if [ "$BUILD_PROTO" = '1' ]; then
@@ -479,7 +485,7 @@ if [ "$BUILD_NET40" = '1' ]; then
 #    fi
 fi
 
-NUNITPATH="packages/NUnit.Console.3.0.0/tools/"
+NUNITPATH="${NUGET_PACKAGES}NUnit.Console.3.0.0/tools/"
 printf "set NUNITPATH=%s\n" "$NUNITPATH"
 if [ ! -d "$NUNITPATH" ]; then
     failwith "Could not find $NUNITPATH"

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -443,7 +443,8 @@
 
     <NugetRestoreCommand>"$(NuGetToolPath)NuGet.exe install -OutputDirectory "$(PackagesDir)" -Config "$(NuGetToolPath)NuGet.Config"</NugetRestoreCommand>
 
-    <DnuRestoreCommand>"$(NuGetToolPath)NuGet.exe" restore -OutputDirectory "$(PackagesDir)" -Config "$(NuGetToolPath)NuGet.Config"</DnuRestoreCommand>
+    <DnuRestoreCommand Condition="'$(OS)' != 'Unix'">"$(NuGetToolPath)NuGet.exe" restore -OutputDirectory "$(PackagesDir)" -Config "$(NuGetToolPath)NuGet.Config"</DnuRestoreCommand>
+    <DnuRestoreCommand Condition="'$(OS)' == 'Unix'">mono "$(NuGetToolPath)NuGet.exe" restore -OutputDirectory "$(PackagesDir)" -Config "$(NuGetToolPath)NuGet.Config"</DnuRestoreCommand>
 
     <!-- Current version of .NET Core does not support all semantics used in our packages, 
          so we ignore the pre-calculation in the lock file and calculate asset applicability in the build task -->


### PR DESCRIPTION
Additional work towards getting the code in this repository building and running successfully under mono on Linux/Mac.
It's still not possible to run the binaries compiled from this repository (see #2595 and #2605), but these changes help us continue moving towards being able to build/run the test suite on mono (e.g., ``./build.sh net40 test``).