### PR TITLE
CompileOps.qnameOrder uses full file path without extension to compare instead of module name inferred from file name

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -5101,7 +5101,10 @@ type RootSigs =  Zmap<QualifiedNameOfFile, ModuleOrNamespaceType>
 type RootImpls = Zset<QualifiedNameOfFile >
 type TypecheckerSigsAndImpls = RootSigsAndImpls of RootSigs * RootImpls * ModuleOrNamespaceType * ModuleOrNamespaceType
 
-let qnameOrder = Order.orderBy (fun (q:QualifiedNameOfFile) -> Path.ChangeExtension(q.Range.FileName, ""))
+let qnameOrder = 
+    Order.orderBy (fun (q:QualifiedNameOfFile) -> 
+        let res = Path.ChangeExtension(q.Range.FileName, "")
+        if String.IsNullOrWhiteSpace res then q.Text else res)
 
 type TcState = 
     { tcsCcu: CcuThunk

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -5101,7 +5101,7 @@ type RootSigs =  Zmap<QualifiedNameOfFile, ModuleOrNamespaceType>
 type RootImpls = Zset<QualifiedNameOfFile >
 type TypecheckerSigsAndImpls = RootSigsAndImpls of RootSigs * RootImpls * ModuleOrNamespaceType * ModuleOrNamespaceType
 
-let qnameOrder = Order.orderBy (fun (q:QualifiedNameOfFile) -> q.Text)
+let qnameOrder = Order.orderBy (fun (q:QualifiedNameOfFile) -> Path.ChangeExtension(q.Range.FileName, ""))
 
 type TcState = 
     { tcsCcu: CcuThunk


### PR DESCRIPTION
I fixes https://github.com/Microsoft/visualfsharp/issues/2679

@dsyme I'm not sure I've not broken something. It should still work for sig + impl pairs because I compare by full file name without signature.