### PR TITLE
load the VS 2017 VsDevCmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -380,6 +380,21 @@ echo INCLUDE_TEST_TAGS=%INCLUDE_TEST_TAGS%
 echo PUBLISH_VSIX=%PUBLISH_VSIX%
 echo MYGET_APIKEY=%MYGET_APIKEY%
 
+REM load Visual Studio 2017 developer command prompt if VS150COMNTOOLS is not set
+
+if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+)
+if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" (
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"
+)
+if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+)
+if "%VS150COMNTOOLS%" EQU "" if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" (
+    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat"
+)
+
 echo .
 echo Environment
 echo 

--- a/netci.groovy
+++ b/netci.groovy
@@ -67,8 +67,6 @@ def static getBuildJobName(def configuration, def os) {
                         batchFile("""
 echo *** Build Visual F# Tools ***
 
-SET VS150COMNTOOLS=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\
-
 .\\build.cmd ${buildFlavor} ${build_args}""")
                     }
                     else {


### PR DESCRIPTION
If VS150COMNTOOLS is not set, this looks for VS 2017 in the [usual spots](https://github.com/fsharp/FAKE/blob/master/src/app/FakeLib/MSBuildHelper.fs#L29-L32). This makes it easier for people to simply clone this repo and build.

/[cc](https://github.com/dotnet/dotnet-ci/blob/master/docs/CI-SETUP.md) @mmitche test ci please