### PR TITLE
fix broken builds on master

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -626,7 +626,7 @@ echo SNEXE64:           %SNEXE64%
 echo ILDASM:            %ILDASM%
 echo
 
-if "%TEST_NET40_COMPILERUNIT_SUITE%" == "0" and "%TEST_PORTABLE_COREUNIT_SUITE" == "0" and "%TEST_CORECLR_COREUNIT_SUITE%" == "0" and "%TEST_VS_IDEUNIT_SUITE%" == "0" and "%TEST_NET40_FSHARP_SUITE%" == "0" and "%TEST_NET40_FSHARPQA_SUITE%" == "0" goto :success
+if "%TEST_NET40_COMPILERUNIT_SUITE%" == "0" and "%TEST_PORTABLE_COREUNIT_SUITE%" == "0" and "%TEST_CORECLR_COREUNIT_SUITE%" == "0" and "%TEST_VS_IDEUNIT_SUITE%" == "0" and "%TEST_NET40_FSHARP_SUITE%" == "0" and "%TEST_NET40_FSHARPQA_SUITE%" == "0" goto :success
 
 echo ---------------- Done with update, starting tests -----------------------
 


### PR DESCRIPTION
A `%` was missed in the [rework build to work with bare command window](https://github.com/Microsoft/visualfsharp/commit/f0c689dda06fa0b1fd64f2e6645db59e9c12d031#diff-02389dfac0a172ab80211625efc34318R614) commit. This breaks the master branch builds with errors like:

```
21:05:40  SDK environment vars
21:05:40  =======================
21:05:40 WINSDKNETFXTOOLS:  C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\
21:05:40 SNEXE32:           C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\sn.exe
21:05:40 SNEXE64:           C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\x64\sn.exe
21:05:40 ILDASM:            C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\ildasm.exe
21:05:40 ECHO is off.
21:05:40 'and' is not recognized as an internal or external command,
21:05:40 operable program or batch file.
21:05:40 ---------------- Done with update, starting tests -----------------------
21:05:40 WHERE_ARG_NUNIT=
21:05:40 Files was unexpected at this time.
21:05:40 Build step 'Execute Windows batch command' marked build as failure
21:05:41 [Current build status] check if current [FAILURE] is worse or equals then [FAILURE] and better or equals then [SUCCESS]
21:05:41 Run condition [Current build status] enabling perform for step [[Archive the artifacts]]
21:05:41 Archiving artifacts
21:05:41 [Current build status] check if current [FAILURE] is worse or equals then [SUCCESS] and better or equals then [SUCCESS]
21:05:41 Run condition [Current build status] preventing perform for step [[Archive the artifacts]]
21:05:41 [BFA] Scanning build for known causes...
21:05:42 ......[BFA] No failure causes found
21:05:47 [BFA] Done. 6s
21:06:17 Notifying endpoint with id 'HTTP:helix-int-notification-url'
21:06:17 Notifying endpoint with id 'HTTP:helix-prod-notification-url'
21:06:17 Notifying endpoint with id 'HTTP:legacy-notification-url'
21:06:18 Setting status of 2a29f78657271985749180141138860c917b6e05 to FAILURE with url https://ci2.dot.net/job/Microsoft_visualfsharp/job/master/job/debug_windows_nt_prtest/2252/ and message: 'Build finished. '
21:06:18 Using context: Windows_NT Debug Build
21:06:18 [WS-CLEANUP] Deleting project workspace...[WS-CLEANUP] done
21:06:18 Finished: FAILURE
```

