### PR TITLE
batch files do not support `and`

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -626,7 +626,7 @@ echo SNEXE64:           %SNEXE64%
 echo ILDASM:            %ILDASM%
 echo
 
-if "%TEST_NET40_COMPILERUNIT_SUITE%" == "0" and "%TEST_PORTABLE_COREUNIT_SUITE" == "0" and "%TEST_CORECLR_COREUNIT_SUITE%" == "0" and "%TEST_VS_IDEUNIT_SUITE%" == "0" and "%TEST_NET40_FSHARP_SUITE%" == "0" and "%TEST_NET40_FSHARPQA_SUITE%" == "0" goto :success
+if "%TEST_NET40_COMPILERUNIT_SUITE%" == "0" (if "%TEST_PORTABLE_COREUNIT_SUITE%" == "0" (if "%TEST_CORECLR_COREUNIT_SUITE%" == "0" (if "%TEST_VS_IDEUNIT_SUITE%" == "0" (if "%TEST_NET40_FSHARP_SUITE%" == "0" (if "%TEST_NET40_FSHARPQA_SUITE%" == "0" goto :success)))))
 
 echo ---------------- Done with update, starting tests -----------------------
 


### PR DESCRIPTION
This is fixed when `'and' is not recognized as an internal or external command` and the build actually skips the tests when appropriate. #2697 was only part of the problem.

https://ci2.dot.net/job/Microsoft_visualfsharp/job/master/job/release_ci_part2_windows_nt_prtest/2258/consoleFull
```
09:45:19 'and' is not recognized as an internal or external command,
09:45:19 operable program or batch file.
```