### PR TITLE
Fix module classification (semantic highlighting)

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1580,7 +1580,7 @@ type TypeCheckInfo
                     Some (m, SemanticClassificationType.ValueType)
                 else Some (m, SemanticClassificationType.ReferenceType)
             | CNR(_, Item.ModuleOrNamespaces refs, LegitTypeOccurence, _, _, _, m) when refs |> List.exists (fun x -> x.IsModule) ->
-                Some (m, SemanticClassificationType.ReferenceType)
+                Some (m, SemanticClassificationType.Module)
             | CNR(_, (Item.ActivePatternCase _ | Item.UnionCase _ | Item.ActivePatternResult _), _, _, _, _, m) ->
                 Some (m, SemanticClassificationType.UnionCase)
             | _ -> None)


### PR DESCRIPTION
Modules were highlighted as reference types. This PR fixes this.

cc @vasily-kirichenko for review as I believe he was the last one to touch this.