### PR TITLE
expose more properties via the Fsc build task

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.targets
@@ -259,7 +259,10 @@ this file.
               HighEntropyVA="$(HighEntropyVA)"
               TargetProfile="$(TargetProfile)"
               DotnetFscCompilerPath="$(DotnetFscCompilerPath)"
-        />
+              SkipCompilerExecution="$(SkipCompilerExecution)"
+              ProvideCommandLineArgs="$(ProvideCommandLineArgs)">
+            <Output TaskParameter="CommandLineArgs" ItemName="FscCommandLineArgs" />
+        </Fsc>
 
         <ItemGroup>
             <_CoreCompileResourceInputs Remove="@(_CoreCompileResourceInputs)" />


### PR DESCRIPTION
Make the build properties exposed via #2523 available to the framework compiler.  This is inline with dotnet/netcorecli-fsc#88.

FYI @KevinRansom @Srivatsn @enricosada