### PR TITLE
Highlight record functions as functions in semantic colourisation

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1571,9 +1571,12 @@ type TypeCheckInfo
                     Some (m, SemanticClassificationType.Property)
                 elif IsOperatorName vref.DisplayName then
                     Some (m, SemanticClassificationType.Operator)
-                else Some (m, SemanticClassificationType.Function)
+                else
+                    Some (m, SemanticClassificationType.Function)
             | CNR(_, Item.RecdField rfinfo, _, _, _, _, m) when rfinfo.RecdField.IsMutable && rfinfo.LiteralValue.IsNone -> 
                 Some (m, SemanticClassificationType.MutableVar)
+            | CNR(_, Item.RecdField rfinfo, _, _, _, _, m) when isFunction g rfinfo.FieldType ->
+                Some (m, SemanticClassificationType.Function)
             | CNR(_, Item.MethodGroup(_, _, _), _, _, _, _, m) ->
                 Some (m, SemanticClassificationType.Function)
             // custom builders, custom operations get colored as keywords

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1543,6 +1543,11 @@ type TypeCheckInfo
                // || valRefEq g g.nameof_vref vref
             then Some()
             else None
+        
+        let (|EnumCaseFieldInfo|_|) (rfinfo : RecdFieldInfo) =
+            match rfinfo.TyconRef.FSharpObjectModelTypeInfo.fsobjmodel_kind with
+            | TTyconEnum -> Some ()
+            | _ -> None
 
         let resolutions =
             match range with
@@ -1576,7 +1581,9 @@ type TypeCheckInfo
             | CNR(_, Item.RecdField rfinfo, _, _, _, _, m) when rfinfo.RecdField.IsMutable && rfinfo.LiteralValue.IsNone -> 
                 Some (m, SemanticClassificationType.MutableVar)
             | CNR(_, Item.RecdField rfinfo, _, _, _, _, m) when isFunction g rfinfo.FieldType ->
-                Some (m, SemanticClassificationType.Function)
+               Some (m, SemanticClassificationType.Function)
+            | CNR(_, Item.RecdField EnumCaseFieldInfo, _, _, _, _, m) ->
+                Some (m, SemanticClassificationType.Enumeration)
             | CNR(_, Item.MethodGroup(_, _, _), _, _, _, _, m) ->
                 Some (m, SemanticClassificationType.Function)
             // custom builders, custom operations get colored as keywords


### PR DESCRIPTION
Fixes #2718 

Note the bold functions in records below:

![image](https://cloud.githubusercontent.com/assets/64654/24429109/8fcc39e2-1408-11e7-8aee-d0eaa294bcc8.png)

Also enum cases are now highlighted as enum cases:

![image](https://cloud.githubusercontent.com/assets/64654/24429906/fc37fffa-140b-11e7-8e17-97ac656210d0.png)

See also https://github.com/Microsoft/visualfsharp/issues/2410
