### PR TITLE
fix binding redirects

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.dll.config
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.dll.config
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <configuration>
-    <runtime>
-        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <dependentAssembly>
-              <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-              <bindingRedirect oldVersion="2.0.0.0-4.4.1.0" newVersion="FSCoreVersion"/>
-            </dependentAssembly>
-        </assemblyBinding>
-    </runtime>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="2.0.0.0-4.4.1.0" newVersion="FSCoreVersion"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/fsharp/Fsc/fsc.exe.config
+++ b/src/fsharp/Fsc/fsc.exe.config
@@ -5,13 +5,12 @@
     <gcServer enabled="true"/>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="FSharp.Core"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"/>
-        <bindingRedirect
-          oldVersion="2.0.0.0-4.4.1.0"
-          newVersion="4.4.1.0"/>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="2.0.0.0-4.4.1.0" newVersion="4.4.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/fsharp/fsi/fsi.exe.config
+++ b/src/fsharp/fsi/fsi.exe.config
@@ -4,13 +4,12 @@
     <legacyUnhandledExceptionPolicy enabled="true" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="FSharp.Core"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"/>
-        <bindingRedirect
-          oldVersion="2.0.0.0-4.4.1.0"
-          newVersion="4.4.1.0"/>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="2.0.0.0-4.4.1.0" newVersion="4.4.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/fsharp/fsi/fsiAnyCpu.exe.config
+++ b/src/fsharp/fsi/fsiAnyCpu.exe.config
@@ -5,13 +5,12 @@
     <legacyUnhandledExceptionPolicy enabled="true" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity
-          name="FSharp.Core"
-          publicKeyToken="b03f5f7f11d50a3a"
-          culture="neutral"/>
-        <bindingRedirect
-          oldVersion="2.0.0.0-4.4.1.0"
-          newVersion="4.4.1.0"/>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="2.0.0.0-4.4.1.0" newVersion="4.4.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION

Unfortunately we don't use AutoGenerateBindingRedirects for these, because that doesn't generate an FSHarp.Core binding redirect, which is required for most type providers to work.

So we have to do this manually for now unless we find someway to automate this