### PR TITLE
Tidy up Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 
 language: csharp
 
+sudo: required
+
+dist: trusty
+
+os:
+  - linux
+  - osx
+
+mono:
+  - latest
+  - '4.4.2'
+  - '4.0.5'
+
 matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-      mono:
-        - latest
-        - 4.4.2
-        - 4.0.5
-    - os: osx
-      mono:
-        - latest
-        - 4.4.2
-        - 4.0.5
   # Allow builds which fail only on OSX (macOS) to succeed for now
   # while we're working on getting macOS CI builds working.
   allow_failures:


### PR DESCRIPTION
Individual jobs in `matrix.include` cannot specify a sequence of `mono` values. Matrix expansion keys must appear on the top level.