### PR TITLE
Pass cancellation tokens and tasks to OperationCanceledException and TaskCanceledException

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -762,7 +762,7 @@ module Cancellable =
     let token () = Cancellable (fun ct -> ValueOrCancelled.Value ct)
 
     /// Represents a canceled computation
-    let canceled() = Cancellable (fun _ -> ValueOrCancelled.Cancelled (new OperationCanceledException()))
+    let canceled() = Cancellable (fun ct -> ValueOrCancelled.Cancelled (new OperationCanceledException(ct)))
 
     /// Catch exceptions in a computation
     let private catch (Cancellable e) = 

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -152,7 +152,7 @@ type Reactor() =
                         with e -> e |> AsyncUtil.AsyncException
 
                     resultCell.RegisterResult(result)),
-                    ccont=(fun () -> resultCell.RegisterResult (AsyncUtil.AsyncCanceled(OperationCanceledException(ctok))) )
+                    ccont=(fun () -> resultCell.RegisterResult (AsyncUtil.AsyncCanceled(OperationCanceledException(ct))) )
 
             )
             return! resultCell.AsyncResult 

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -152,7 +152,7 @@ type Reactor() =
                         with e -> e |> AsyncUtil.AsyncException
 
                     resultCell.RegisterResult(result)),
-                    ccont=(fun () -> resultCell.RegisterResult (AsyncUtil.AsyncCanceled(OperationCanceledException())) )
+                    ccont=(fun () -> resultCell.RegisterResult (AsyncUtil.AsyncCanceled(OperationCanceledException(ctok))) )
 
             )
             return! resultCell.AsyncResult 


### PR DESCRIPTION
This is exhibiting itself in #2100. Roslyn has a try/catch in [ComputeProjectDiagnosticAnalyzerDiagnosticsAsync](http://source.roslyn.io/#Microsoft.CodeAnalysis.Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs,71ad559976c39f3c) to see whether the cancellation came from the same cancellation token as the one that was passed into the analyzer.

The problem is Async isn't passing in the Task or CancelationToken to the exceptions, which C# does.

Fixes #2100 