### PR TITLE
make f# debuggable again

### DIFF
--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -46,7 +46,7 @@
 
   <PropertyGroup Condition="'$(MonoPackaging)' != 'true' AND '$(OS)' != 'Unix'">
     <UseMicroBuild>true</UseMicroBuild> 
-    <UseSourceLink Condition = " '$(UseSourceLink)' == '' ">true</UseSourceLink>
+    <UseSourceLink Condition = " '$(UseSourceLink)' == '' ">false</UseSourceLink>
     <UseGatherBinaries>true</UseGatherBinaries>
     <AddVsSdkAttributesToSomeCoreComponents>true</AddVsSdkAttributesToSomeCoreComponents>
     <VsSDKInstall Condition=" '$(VsSDKInstall)' == '' ">$(MSBuildThisFileDirectory)..\packages\$(VSSDK_BUILDTOOLS_VERSION)\tools\vssdk</VsSDKInstall>
@@ -64,13 +64,12 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <!-- Settings for Debug mode        -->
-    <DebugType Condition=" '$(DebugType)' == '' and '$(TargetFramework)' != 'coreclr' and '$(UseSourceLink)' != 'true' ">full</DebugType>
-    <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
+    <DebugType>full</DebugType>
 
     <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
     <ErrorReport Condition=" '$(ErrorReport)' == '' ">prompt</ErrorReport>
     <OtherFlags>$(OtherFlags) --no-jit-optimize</OtherFlags>
-    <EmbedAllSource Condition=" '$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded' ">true</EmbedAllSource>
+    <EmbedAllSource Condition=" '$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded' ">portable</EmbedAllSource>
     <DefineConstants Condition=" '$(ProjectLanguage)' != 'VisualBasic' ">DEBUG;TRACE;CODE_ANALYSIS;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition=" '$(ProjectLanguage)' == 'VisualBasic' ">DEBUG=True,TRACE=True,CODE_ANALYSIS=True,$(DefineConstants)</DefineConstants>
     <SIGN_WITH_MSFT_KEY Condition=" '$(SIGN_WITH_MSFT_KEY)' == '' ">false</SIGN_WITH_MSFT_KEY>
@@ -78,9 +77,8 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <!-- Flags used for Release mode.		-->
-    <DebugType Condition=" '$(DebugType)' == '' and '$(TargetFramework)' != 'coreclr' and '$(UseSourceLink)' != 'true' ">pdbonly</DebugType>
-    <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
-    <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
+    <DebugType>full</DebugType>
+    <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
     <EmbedAllSource>false</EmbedAllSource>
 
     <ErrorReport Condition=" '$(ErrorReport)' == '' ">prompt</ErrorReport>
@@ -91,8 +89,8 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Proto'">
     <!-- Flags used when running the Proto compiler.		-->
-    <DebugType Condition=" '$(DebugType)' == '' ">embedded</DebugType>
-    <Optimize>true</Optimize>
+    <DebugType Condition=" '$(DebugType)' == '' ">full</DebugType>
+    <Optimize>false</Optimize>
     <DefineConstants>DEBUG;NO_STRONG_NAMES;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -77,7 +77,8 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <!-- Flags used for Release mode.		-->
-    <DebugType>portable</DebugType>
+    <DebugType Condition=" '$(DebugType)' == '' and '$(TargetFramework)' != 'coreclr' and '$(UseSourceLink)' != 'true' ">pdbonly</DebugType>
+    <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
     <EmbedAllSource>false</EmbedAllSource>
 

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -46,7 +46,7 @@
 
   <PropertyGroup Condition="'$(MonoPackaging)' != 'true' AND '$(OS)' != 'Unix'">
     <UseMicroBuild>true</UseMicroBuild> 
-    <UseSourceLink Condition = " '$(UseSourceLink)' == '' ">false</UseSourceLink>
+    <UseSourceLink Condition = " '$(UseSourceLink)' == '' AND '$(Configuration)'=='Release' ">true</UseSourceLink>
     <UseGatherBinaries>true</UseGatherBinaries>
     <AddVsSdkAttributesToSomeCoreComponents>true</AddVsSdkAttributesToSomeCoreComponents>
     <VsSDKInstall Condition=" '$(VsSDKInstall)' == '' ">$(MSBuildThisFileDirectory)..\packages\$(VSSDK_BUILDTOOLS_VERSION)\tools\vssdk</VsSDKInstall>
@@ -77,8 +77,8 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <!-- Flags used for Release mode.		-->
-    <DebugType>full</DebugType>
-    <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
+    <DebugType>portable</DebugType>
+    <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
     <EmbedAllSource>false</EmbedAllSource>
 
     <ErrorReport Condition=" '$(ErrorReport)' == '' ">prompt</ErrorReport>
@@ -90,7 +90,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Proto'">
     <!-- Flags used when running the Proto compiler.		-->
     <DebugType Condition=" '$(DebugType)' == '' ">full</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <DefineConstants>DEBUG;NO_STRONG_NAMES;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -69,7 +69,7 @@
     <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
     <ErrorReport Condition=" '$(ErrorReport)' == '' ">prompt</ErrorReport>
     <OtherFlags>$(OtherFlags) --no-jit-optimize</OtherFlags>
-    <EmbedAllSource Condition=" '$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded' ">portable</EmbedAllSource>
+    <EmbedAllSource Condition=" '$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded' ">true</EmbedAllSource>
     <DefineConstants Condition=" '$(ProjectLanguage)' != 'VisualBasic' ">DEBUG;TRACE;CODE_ANALYSIS;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition=" '$(ProjectLanguage)' == 'VisualBasic' ">DEBUG=True,TRACE=True,CODE_ANALYSIS=True,$(DefineConstants)</DefineConstants>
     <SIGN_WITH_MSFT_KEY Condition=" '$(SIGN_WITH_MSFT_KEY)' == '' ">false</SIGN_WITH_MSFT_KEY>


### PR DESCRIPTION
The following diff mostly fixes the debugging issue for me, see https://github.com/Microsoft/visualfsharp/issues/2771#issuecomment-291001951.

Sourcelink was not the issue, but I had to disable it, because it only works with portable pdb.

I don't think it makes sense to pull this as-is, especially because it globally disables optimizations.

Is there a way to differentiate between a local build (where optimizations could be disabled) and a nightly build, where they should stay enabled?

-----

Edit: this should now change only Debug configuration, so should be safe to pull.
Fixing the root-cause would obviously still be better.