### PR TITLE
move `else` clause to the ending line of the `if` block

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -907,8 +907,7 @@ if "%PUBLISH_VSIX%" == "1" (
     if not "%MYGET_APIKEY%" == "" (
         powershell -noprofile -executionPolicy ByPass -file "%~dp0setup\publish-assets.ps1" -binariesPath "%~dp0%BUILD_CONFIG%" -branchName "%BUILD_SOURCEBRANCH%" -apiKey "%MYGET_APIKEY%"
         if errorlevel 1 goto :failure
-    )
-    else (
+    ) else (
         echo No MyGet API key specified, skipping package publish.
     )
 )


### PR DESCRIPTION
According to the `if /?` documentation, the `else` keyword needs to be on the same line as the closing paren of the `if` block.