### PR TITLE
update SWIX dependency to shipped version

### DIFF
--- a/setup/packages.config
+++ b/setup/packages.config
@@ -7,7 +7,7 @@
   <package id="FsSrGen" version="2.0.0" targetFramework="net46" />
   <package id="MicroBuild.Core" version="0.2.0" />
   <package id="MicroBuild.Core.Sentinel" version="1.0.0" />
-  <package id="MicroBuild.Plugins.SwixBuild" version="1.1.0-g0701ee829f" />
+  <package id="MicroBuild.Plugins.SwixBuild" version="1.0.115" />
   <package id="WiX.Toolset.2015" version="3.10.0.1503" />
   <package id="Microsoft.VisualFSharp.Core.Redist" version="1.0.0" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net46" />


### PR DESCRIPTION
This PR is mainly to ensure that our CI still works; the official builds have a hard override to 1.0.115 anyways, so those should remain unchanged.

Adding @jaredpar because F# and Roslyn have both run into issues with differing SWIX plugin versions in the past.