### PR TITLE
Remove dead code for fixup sequence points

### DIFF
--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -3542,8 +3542,9 @@ let writeDirectory os dict =
 
 let writeBytes (os: BinaryWriter) (chunk:byte[]) = os.Write(chunk,0,chunk.Length)  
 
-let writeBinaryAndReportMappings (outfile, ilg: ILGlobals, pdbfile: string option, signer: ILStrongNameSigner option, portablePDB, embeddedPDB, embedAllSource, embedSourceList,
-                                  sourceLink, fixupOverlappingSequencePoints, emitTailcalls, showTimes, dumpDebugInfo) modul =
+let writeBinaryAndReportMappings (outfile, 
+                                  ilg: ILGlobals, pdbfile: string option, signer: ILStrongNameSigner option, portablePDB, embeddedPDB, 
+                                  embedAllSource, embedSourceList, sourceLink, emitTailcalls, showTimes, dumpDebugInfo) modul =
     // Store the public key from the signer into the manifest.  This means it will be written 
     // to the binary and also acts as an indicator to leave space for delay sign 
 
@@ -3696,7 +3697,7 @@ let writeBinaryAndReportMappings (outfile, ilg: ILGlobals, pdbfile: string optio
           let pdbOpt =
             match portablePDB with
             | true  -> 
-                let (uncompressedLength, contentId, stream) as pdbStream = generatePortablePdb fixupOverlappingSequencePoints embedAllSource embedSourceList sourceLink showTimes pdbData 
+                let (uncompressedLength, contentId, stream) as pdbStream = generatePortablePdb embedAllSource embedSourceList sourceLink showTimes pdbData 
                 if embeddedPDB then Some (compressPortablePdbStream uncompressedLength contentId stream)
                 else Some (pdbStream)
             | _ -> None
@@ -4204,7 +4205,7 @@ let writeBinaryAndReportMappings (outfile, ilg: ILGlobals, pdbfile: string optio
 #if FX_NO_PDB_WRITER
                     Array.empty<idd>
 #else
-                    writePdbInfo fixupOverlappingSequencePoints showTimes outfile fpdb pdbData debugDataChunk
+                    writePdbInfo showTimes outfile fpdb pdbData debugDataChunk
 #endif
             reportTime showTimes "Generate PDB Info"
 
@@ -4269,14 +4270,13 @@ type options =
      embedSourceList: string list
      sourceLink: string
      signer: ILStrongNameSigner option
-     fixupOverlappingSequencePoints: bool
      emitTailcalls : bool
      showTimes: bool
      dumpDebugInfo:bool }
 
 let WriteILBinary (outfile, (args: options), modul) =
-    writeBinaryAndReportMappings (outfile, args.ilg, args.pdbfile, args.signer, args.portablePDB, args.embeddedPDB, 
-                                  args.embedAllSource, args.embedSourceList, args.sourceLink, args.fixupOverlappingSequencePoints, 
-                                  args.emitTailcalls, args.showTimes, args.dumpDebugInfo) modul 
+    writeBinaryAndReportMappings (outfile, 
+                                  args.ilg, args.pdbfile, args.signer, args.portablePDB, args.embeddedPDB, args.embedAllSource, 
+                                  args.embedSourceList, args.sourceLink, args.emitTailcalls, args.showTimes, args.dumpDebugInfo) modul 
     |> ignore
 

--- a/src/absil/ilwrite.fsi
+++ b/src/absil/ilwrite.fsi
@@ -24,7 +24,6 @@ type options =
    embedSourceList: string list
    sourceLink: string
    signer : ILStrongNameSigner option
-   fixupOverlappingSequencePoints : bool
    emitTailcalls: bool
    showTimes : bool
    dumpDebugInfo : bool }

--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -217,43 +217,8 @@ let getRowCounts tableRowCounts =
     tableRowCounts |> Seq.iter(fun x -> builder.Add(x))
     builder.MoveToImmutable()
 
-let fixupOverlappingSequencePoints fixupSPs showTimes methods =
-    // This next bit is a workaround.  The sequence points we get 
-    // from F# (which has nothing to do with this module) are actually expression 
-    // marks, i.e. the source ranges they denote are typically 
-    // nested, and each point indicates where the  
-    // code for an expression with a particular range begins.  
-    // This is in many ways a much more convenient form to emit. 
-    // However, it is not the form that debug tools accept nicely. 
-    // However, sequence points are really a non-overlapping, non-nested 
-    // partition of the source code of a method.  So here we shorten the 
-    // length of all sequence point marks so they do not go further than 
-    // the next sequence point in the source. 
-    let spCounts =  methods |> Array.map (fun x -> x.SequencePoints.Length)
-    let allSps = methods |> Array.collect (fun x -> x.SequencePoints)
-                         |> Array.mapi (fun i sp -> i, sp)
-    if fixupSPs then 
-        // sort the sequence points into source order 
-        Array.sortInPlaceWith (fun (_,sp1) (_,sp2) -> SequencePoint.orderBySource sp1 sp2) allSps
-        // shorten the ranges of any that overlap with following sequence points 
-        // sort the sequence points back into offset order 
-        for i = 0 to Array.length allSps - 2 do
-            let n,sp1 = allSps.[i]
-            let _,sp2 = allSps.[i+1]
-            if (sp1.Document = sp2.Document) && 
-               (sp1.EndLine > sp2.Line || 
-                (sp1.EndLine = sp2.Line &&
-                 sp1.EndColumn >= sp2.Column)) then
-              let adjustToPrevLine = (sp1.Line < sp2.Line)
-              allSps.[i] <-  n,{sp1 with EndLine = (if adjustToPrevLine then sp2.Line-1 else sp2.Line)
-                                         EndColumn = (if adjustToPrevLine then 80 else sp2.Column) }
-        reportTime showTimes (sprintf "PDB: fixupOverlappingSequencePoints %d" (allSps |> Array.length) )
-        Array.sortInPlaceBy fst allSps
-    spCounts, allSps
-
-let generatePortablePdb fixupSPs (embedAllSource:bool) (embedSourceList:string list) (sourceLink:string) showTimes (info:PdbData) = 
+let generatePortablePdb (embedAllSource:bool) (embedSourceList:string list) (sourceLink:string) showTimes (info:PdbData) = 
     sortMethods showTimes info
-    let _spCounts, _allSps = fixupOverlappingSequencePoints fixupSPs showTimes info.Methods
     let externalRowCounts = getRowCounts info.TableRowCounts
     let docs = 
         match info.Documents with
@@ -512,7 +477,7 @@ let embedPortablePdbInfo (uncompressedLength:int64)  (contentId:BlobContentId) (
 // PDB Writer.  The function [WritePdbInfo] abstracts the 
 // imperative calls to the Symbol Writer API.
 //---------------------------------------------------------------------
-let writePdbInfo fixupOverlappingSequencePoints showTimes f fpdb info cvChunk =
+let writePdbInfo showTimes f fpdb info cvChunk =
 
     try FileSystem.FileDelete fpdb with _ -> ()
 
@@ -534,35 +499,8 @@ let writePdbInfo fixupOverlappingSequencePoints showTimes f fpdb info cvChunk =
     Array.sortInPlaceBy (fun x -> x.MethToken) info.Methods
     reportTime showTimes (sprintf "PDB: Sorted %d methods" info.Methods.Length)
 
-    // This next bit is a workaround.  The sequence points we get 
-    // from F# (which has nothing to do with this module) are actually expression 
-    // marks, i.e. the source ranges they denote are typically 
-    // nested, and each point indicates where the  
-    // code for an expression with a particular range begins.  
-    // This is in many ways a much more convenient form to emit. 
-    // However, it is not the form that debug tools accept nicely. 
-    // However, sequence points are really a non-overlapping, non-nested 
-    // partition of the source code of a method.  So here we shorten the 
-    // length of all sequence point marks so they do not go further than 
-    // the next sequence point in the source. 
     let spCounts = info.Methods |> Array.map (fun x -> x.SequencePoints.Length)
     let allSps = Array.collect (fun x -> x.SequencePoints) info.Methods |> Array.indexed
-    if fixupOverlappingSequencePoints then
-        // sort the sequence points into source order 
-        Array.sortInPlaceWith (fun (_,sp1) (_,sp2) -> SequencePoint.orderBySource sp1 sp2) allSps
-        // shorten the ranges of any that overlap with following sequence points 
-        // sort the sequence points back into offset order 
-        for i = 0 to Array.length allSps - 2 do
-            let n,sp1 = allSps.[i]
-            let _,sp2 = allSps.[i+1]
-            if (sp1.Document = sp2.Document) && 
-               (sp1.EndLine > sp2.Line || 
-                (sp1.EndLine = sp2.Line &&
-                 sp1.EndColumn >= sp2.Column)) then
-              let adjustToPrevLine = (sp1.Line < sp2.Line)
-              allSps.[i] <-  n,{sp1 with EndLine = (if adjustToPrevLine then sp2.Line-1 else sp2.Line)
-                                         EndColumn = (if adjustToPrevLine then 80 else sp2.Column) }
-        Array.sortInPlaceBy fst allSps
 
     let spOffset = ref 0
     info.Methods |> Array.iteri (fun i minfo ->

--- a/src/absil/ilwritepdb.fsi
+++ b/src/absil/ilwritepdb.fsi
@@ -82,11 +82,11 @@ type idd =
       iddData: byte[];
       iddChunk: BinaryChunk }
 
-val generatePortablePdb : fixupSPs:bool -> embedAllSource:bool -> embedSourceList:string list -> sourceLink: string -> showTimes:bool -> info:PdbData -> (int64 * BlobContentId * MemoryStream) 
+val generatePortablePdb : embedAllSource:bool -> embedSourceList:string list -> sourceLink: string -> showTimes:bool -> info:PdbData -> (int64 * BlobContentId * MemoryStream) 
 val compressPortablePdbStream : uncompressedLength:int64 -> contentId:BlobContentId -> stream:MemoryStream -> (int64 * BlobContentId * MemoryStream)
 val embedPortablePdbInfo : uncompressedLength:int64 -> contentId:BlobContentId -> stream:MemoryStream -> showTimes:bool -> fpdb:string -> cvChunk:BinaryChunk -> pdbChunk:BinaryChunk -> idd[]
 val writePortablePdbInfo : contentId:BlobContentId -> stream:MemoryStream -> showTimes:bool -> fpdb:string -> cvChunk:BinaryChunk -> idd[]
 
 #if !FX_NO_PDB_WRITER
-val writePdbInfo : fixupOverlappingSequencePoints:bool -> showTimes:bool -> f:string -> fpdb:string -> info:PdbData -> cvChunk:BinaryChunk -> idd[]
+val writePdbInfo : showTimes:bool -> f:string -> fpdb:string -> info:PdbData -> cvChunk:BinaryChunk -> idd[]
 #endif

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1962,7 +1962,6 @@ let main4 (Args (ctok, tcConfig, errorLogger: ErrorLogger, ilGlobals, ilxMainMod
                     embedSourceList = tcConfig.embedSourceList
                     sourceLink = tcConfig.sourceLink
                     signer = GetStrongNameSigner signingInfo
-                    fixupOverlappingSequencePoints = false
                     dumpDebugInfo = tcConfig.dumpDebugInfo }, 
                   ilxMainModule)
             with Failure msg -> 


### PR DESCRIPTION
Whilst looking at a portable PDB issue I noticed that, fixupOverlappingSequencePoints  was only ever set to _false_.  So that allows me to remove some code, arguments, fields et.c.

Anyway here it is:


