### PR TITLE
Fix quick info for active pattern definition

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -101,7 +101,7 @@ type internal FSharpAddOpenCodeFixProvider
             
             let! symbol = 
                 asyncMaybe {
-                    let! lexerSymbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, context.Span.End, document.FilePath, defines, SymbolLookupKind.Greedy)
+                    let! lexerSymbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, context.Span.End, document.FilePath, defines, SymbolLookupKind.Greedy, false)
                     return! checkResults.GetSymbolUseAtLocation(Line.fromZ linePos.Line, lexerSymbol.Ident.idRange.EndColumn, line.ToString(), lexerSymbol.FullIsland)
                 } |> liftAsync
 

--- a/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
@@ -169,7 +169,7 @@ type internal FSharpImplementInterfaceCodeFixProvider
                 | _ -> 
                     Some context.Span.End
             let! interfaceState = queryInterfaceState appendBracketAt interfacePos tokens parsedInput                        
-            let! symbol = Tokenizer.getSymbolAtPosition(context.Document.Id, sourceText, fixupPosition, context.Document.FilePath, defines, SymbolLookupKind.Greedy)
+            let! symbol = Tokenizer.getSymbolAtPosition(context.Document.Id, sourceText, fixupPosition, context.Document.FilePath, defines, SymbolLookupKind.Greedy, false)
             let fcsTextLineNumber = textLine.LineNumber + 1
             let lineContents = textLine.ToString()                            
             let! options = context.Document.GetOptionsAsync(cancellationToken)

--- a/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
@@ -56,7 +56,7 @@ type internal FSharpDocumentHighlightsService [<ImportingConstructor>] (checkerP
             let textLine = sourceText.Lines.GetLineFromPosition(position)
             let textLinePos = sourceText.Lines.GetLinePosition(position)
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
-            let! symbol = Tokenizer.getSymbolAtPosition(documentKey, sourceText, position, filePath, defines, SymbolLookupKind.Greedy)
+            let! symbol = Tokenizer.getSymbolAtPosition(documentKey, sourceText, position, filePath, defines, SymbolLookupKind.Greedy, false)
             let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults = true)
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland)
             let! symbolUses = checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol) |> liftAsync

--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -150,7 +150,7 @@ type internal InlineRenameService
             let textLine = sourceText.Lines.GetLineFromPosition(position)
             let textLinePos = sourceText.Lines.GetLinePosition(position)
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
-            let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy)
+            let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy, false)
             let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, options, allowStaleResults = true)
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.Text.ToString(), symbol.FullIsland)
             let! declLoc = symbolUse.GetDeclarationLocation(document)

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -65,7 +65,7 @@ module internal SymbolHelpers =
             do! Option.guard (originalText.Length > 0)
             let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject document
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.Name, options.OtherOptions |> Seq.toList)
-            let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, symbolSpan.Start, document.FilePath, defines, SymbolLookupKind.Greedy)
+            let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, symbolSpan.Start, document.FilePath, defines, SymbolLookupKind.Greedy, false)
             let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, options, allowStaleResults = true)
             let textLine = sourceText.Lines.GetLineFromPosition(symbolSpan.Start)
             let textLinePos = sourceText.Lines.GetLinePosition(symbolSpan.Start)

--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -23,6 +23,7 @@ type internal LexerSymbolKind =
     | Punctuation
     | GenericTypeParameter
     | StaticallyResolvedTypeParameter
+    | ActivePattern
     | Other
 
 type internal LexerSymbol =
@@ -393,7 +394,7 @@ module internal Tokenizer =
         let isOperator t = t.ColorClass = FSharpTokenColorKind.Operator
         let isPunctuation t = t.ColorClass = FSharpTokenColorKind.Punctuation
     
-        let inline (|GenericTypeParameterPrefix|StaticallyResolvedTypeParameterPrefix|Other|) (token: FSharpTokenInfo) =
+        let inline (|GenericTypeParameterPrefix|StaticallyResolvedTypeParameterPrefix|ActivePattern|Other|) (token: FSharpTokenInfo) =
             if token.Tag = FSharpTokenTag.QUOTE then GenericTypeParameterPrefix
             elif token.Tag = FSharpTokenTag.INFIX_AT_HAT_OP then
                     // The lexer return INFIX_AT_HAT_OP token for both "^" and "@" symbols.
@@ -401,6 +402,10 @@ module internal Tokenizer =
                     if token.FullMatchedLength = 1 && lineStr.[token.LeftColumn] = '^' then 
                         StaticallyResolvedTypeParameterPrefix
                     else Other
+            elif token.Tag = FSharpTokenTag.LPAREN then
+                if token.FullMatchedLength = 1 && lineStr.[token.LeftColumn+1] = '|' then
+                    ActivePattern
+                else Other
             else Other
        
         // Operators: Filter out overlapped operators (>>= operator is tokenized as three distinct tokens: GREATER, GREATER, EQUALS. 
@@ -419,11 +424,21 @@ module internal Tokenizer =
             |> List.foldi (fun (acc, lastToken) index (token: FSharpTokenInfo) ->
                 match lastToken with
                 | Some t when token.LeftColumn <= t.RightColumn -> acc, lastToken
+                | Some ({ Kind = LexerSymbolKind.ActivePattern } as lastToken) when 
+                    token.Tag = FSharpTokenTag.BAR || token.Tag = FSharpTokenTag.IDENT || token.Tag = FSharpTokenTag.UNDERSCORE ->
+                    
+                    let mergedToken =
+                        {lastToken.Token with Tag = FSharpTokenTag.IDENT
+                                                    RightColumn = token.RightColumn
+                                                    FullMatchedLength = lastToken.Token.FullMatchedLength + token.FullMatchedLength }
+
+                    acc, Some { lastToken with Token = mergedToken; RightColumn = lastToken.RightColumn + token.FullMatchedLength }
                 | _ ->
                     let isLastToken = index = tokensCount - 1
                     match token with
                     | GenericTypeParameterPrefix when not isLastToken -> acc, Some (DraftToken.Create LexerSymbolKind.GenericTypeParameter token)
                     | StaticallyResolvedTypeParameterPrefix when not isLastToken -> acc, Some (DraftToken.Create LexerSymbolKind.StaticallyResolvedTypeParameter token)
+                    | ActivePattern -> acc, Some (DraftToken.Create LexerSymbolKind.ActivePattern token)
                     | _ ->
                         let draftToken =
                             match lastToken with
@@ -434,6 +449,8 @@ module internal Tokenizer =
                             | Some { Kind = LexerSymbolKind.StaticallyResolvedTypeParameter } ->
                                 DraftToken.Create LexerSymbolKind.Operator { token with LeftColumn = token.LeftColumn - 1
                                                                                         FullMatchedLength = 1 }
+                            | Some ( { Kind = LexerSymbolKind.ActivePattern } as ap) when token.Tag = FSharpTokenTag.RPAREN ->
+                                DraftToken.Create LexerSymbolKind.Ident ap.Token
                             | _ -> 
                                 let kind = 
                                     if isOperator token then LexerSymbolKind.Operator 
@@ -459,7 +476,8 @@ module internal Tokenizer =
         tokensUnderCursor
         |> List.tryFind (fun { DraftToken.Kind = k } -> 
             match k with 
-            | LexerSymbolKind.Ident 
+            | LexerSymbolKind.Ident
+            | LexerSymbolKind.ActivePattern
             | LexerSymbolKind.GenericTypeParameter 
             | LexerSymbolKind.StaticallyResolvedTypeParameter -> true 
             | _ -> false) 
@@ -582,7 +600,7 @@ module internal Tokenizer =
         | LexerSymbolKind.Punctuation, _ -> PrettyNaming.IsPunctuation name
         | LexerSymbolKind.GenericTypeParameter, _ -> isGenericTypeParameter name
         | LexerSymbolKind.StaticallyResolvedTypeParameter, _ -> isStaticallyResolvedTypeParameter name
-        | (LexerSymbolKind.Ident | LexerSymbolKind.Other), _ ->
+        | (LexerSymbolKind.Ident | LexerSymbolKind.ActivePattern | LexerSymbolKind.Other), _ ->
             match symbol with
             | :? FSharpEntity as e when e.IsClass || e.IsFSharpRecord || e.IsFSharpUnion || e.IsValueType || e.IsFSharpModule || e.IsInterface -> isTypeNameIdent name
             | _ -> isFixableIdentifier name

--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -54,7 +54,7 @@ type internal FSharpFindUsagesService
             let lineNumber = sourceText.Lines.GetLinePosition(position).Line + 1
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.FilePath, options.OtherOptions |> Seq.toList)
             
-            let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy)
+            let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy, false)
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(lineNumber, symbol.Ident.idRange.EndColumn, textLine, symbol.FullIsland)
             let! declaration = checkFileResults.GetDeclarationLocationAlternate (lineNumber, symbol.Ident.idRange.EndColumn, textLine, symbol.FullIsland, false) |> liftAsync
             let tags = GlyphTags.GetTags(Tokenizer.GetGlyphForSymbol (symbolUse.Symbol, symbol.Kind))

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
@@ -45,7 +45,7 @@ module internal FSharpGoToDefinition =
             let textLine = sourceText.Lines.GetLineFromPosition position
             let textLinePos = sourceText.Lines.GetLinePosition position
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
-            let! lexerSymbol = Tokenizer.getSymbolAtPosition(documentKey, sourceText, position, filePath, defines, SymbolLookupKind.Greedy)
+            let! lexerSymbol = Tokenizer.getSymbolAtPosition(documentKey, sourceText, position, filePath, defines, SymbolLookupKind.Greedy, false)
             let! _, _, checkFileResults = 
                 checker.ParseAndCheckDocument 
                     (filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults = preferSignature) 
@@ -84,7 +84,7 @@ module internal FSharpGoToDefinition =
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing (originDocument.FilePath, projectOptions.OtherOptions |> Seq.toList)
             let originTextSpan = RoslynHelpers.FSharpRangeToTextSpan (sourceText, originRange)
             let position = originTextSpan.Start
-            let! lexerSymbol = Tokenizer.getSymbolAtPosition (originDocument.Id, sourceText, position, originDocument.FilePath, defines, SymbolLookupKind.Greedy)
+            let! lexerSymbol = Tokenizer.getSymbolAtPosition (originDocument.Id, sourceText, position, originDocument.FilePath, defines, SymbolLookupKind.Greedy, false)
             
             let textLinePos = sourceText.Lines.GetLinePosition position
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
@@ -245,7 +245,7 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>]
             let textLine = sourceText.Lines.GetLineFromPosition position
             let textLinePos = sourceText.Lines.GetLinePosition position
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
-            let! lexerSymbol = Tokenizer.getSymbolAtPosition(documentKey, sourceText, position, filePath, defines, SymbolLookupKind.Greedy)
+            let! lexerSymbol = Tokenizer.getSymbolAtPosition(documentKey, sourceText, position, filePath, defines, SymbolLookupKind.Greedy, false)
             let! _, _, checkFileResults = 
                 checker.ParseAndCheckDocument 
                     (filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults = true)  |> Async.RunSynchronously
@@ -278,7 +278,7 @@ type internal FSharpGoToDefinitionService [<ImportingConstructor>]
             let! _, _, checkFileResults = 
                 checkerProvider.Checker.ParseAndCheckDocument (originDocument, projectOptions, allowStaleResults=true, sourceText=sourceText)
                 
-            let! lexerSymbol = Tokenizer.getSymbolAtPosition (originDocument.Id, sourceText, position,originDocument.FilePath, defines, SymbolLookupKind.Greedy)
+            let! lexerSymbol = Tokenizer.getSymbolAtPosition (originDocument.Id, sourceText, position,originDocument.FilePath, defines, SymbolLookupKind.Greedy, false)
             let idRange = lexerSymbol.Ident.idRange
 
             let! declarations = 

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -114,7 +114,7 @@ module private FSharpQuickInfo =
             // project options need to be retrieved because the signature file could be in another project 
             let! extProjectOptions = projectInfoManager.TryGetOptionsForProject extDocId.ProjectId
             let extDefines = CompilerEnvironment.GetCompilationDefinesForEditing (extDocument.FilePath, List.ofSeq extProjectOptions.OtherOptions)
-            let! extLexerSymbol = Tokenizer.getSymbolAtPosition(extDocId, extSourceText, extSpan.Start, declRange.FileName, extDefines, SymbolLookupKind.Greedy)
+            let! extLexerSymbol = Tokenizer.getSymbolAtPosition(extDocId, extSourceText, extSpan.Start, declRange.FileName, extDefines, SymbolLookupKind.Greedy, true)
             let! _, _, extCheckFileResults = checker.ParseAndCheckDocument(extDocument,extProjectOptions,allowStaleResults=true,sourceText=extSourceText)
             
             let! extTooltipText = 
@@ -149,7 +149,7 @@ module private FSharpQuickInfo =
             let! sourceText = document.GetTextAsync cancellationToken
             let! projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject document
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing(document.FilePath, projectOptions.OtherOptions |> Seq.toList)
-            let! lexerSymbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy)
+            let! lexerSymbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy, true)
             let idRange = lexerSymbol.Ident.idRange  
             let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, projectOptions, allowStaleResults = true, sourceText=sourceText)
             let textLinePos = sourceText.Lines.GetLinePosition position
@@ -305,7 +305,7 @@ type internal FSharpQuickInfoProvider
             let textLine = sourceText.Lines.GetLineFromPosition position
             let textLineNumber = textLine.LineNumber + 1 // Roslyn line numbers are zero-based
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing (filePath, options.OtherOptions |> Seq.toList)
-            let! symbol = Tokenizer.getSymbolAtPosition (documentId, sourceText, position, filePath, defines, SymbolLookupKind.Precise)
+            let! symbol = Tokenizer.getSymbolAtPosition (documentId, sourceText, position, filePath, defines, SymbolLookupKind.Precise, true)
             let! res = checkFileResults.GetStructuredToolTipTextAlternate (textLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland, FSharpTokenTag.IDENT) |> liftAsync
             match res with
             | FSharpToolTipText [] 


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/2367

![image](https://cloud.githubusercontent.com/assets/873919/24771178/3b0685c0-1b15-11e7-807a-84329c21df55.png)

![image](https://cloud.githubusercontent.com/assets/873919/24771166/32d0e4fe-1b15-11e7-916b-464c6db09a1f.png)

Ported changes from FSAC made since VFTP code was copied there...
