### PR TITLE
Fix 2416

### DIFF
--- a/tests/fsharp/core/syntax/test.fsx
+++ b/tests/fsharp/core/syntax/test.fsx
@@ -54,6 +54,15 @@ module CheckDynamicOperatorsOnTypes =
     let hw  : string = foo ? world
     let hw2  : unit = foo ? world <- "3"
         
+module CheckDynamicOperatorsOnTypesUnconstrained = 
+    type OpDynamic() =
+      static member ( ? ) (x, n) = x
+      member x.Prop = 1
+
+    let f()  = 
+      let op  = OpDynamic ()
+      op?Hello.Prop
+
 
 // Copyright (c) Microsoft Corporation 2005-2006.  .
 


### PR DESCRIPTION
This is a possible fix for https://github.com/Microsoft/visualfsharp/issues/2416 to address the regression

Before the change, for operator applications, 
1. The propagation of types implied by delayed applications is done
2. The application arguments are checked, and name lookups are processed
3. The constraint is applied

After the change, for operator applications, 
1. The propagation of types implied by delayed applications is done
2. The application arguments are checked, but not name lookups
3. The constraint is applied
4. The name lookups are applied



