### PR TITLE
Make properties navigable from QuickInfo

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1371,7 +1371,11 @@ module InfoMemberPrinting =
         let rty = pinfo.GetPropertyType(amap,m) 
         let rty = if pinfo.IsIndexer then mkRefTupledTy g (pinfo.GetParamTypes(amap, m)) --> rty else  rty 
         let _, rty, _ = PrettyTypes.PrettifyTypes1 g rty
-        let nameL = DemangleOperatorNameAsLayout tagProperty pinfo.PropertyName
+        let tagProp =
+            match pinfo.ArbitraryValRef with
+            | None -> tagProperty
+            | Some vref -> tagProperty >> mkNav vref.DefinitionRange
+        let nameL = DemangleOperatorNameAsLayout tagProp pinfo.PropertyName
         wordL (tagText (FSComp.SR.typeInfoProperty())) ^^
         layoutTyconRef denv (tcrefOfAppTy g pinfo.EnclosingType) ^^
         SepL.dot ^^

--- a/src/fsharp/layout.fs
+++ b/src/fsharp/layout.fs
@@ -19,7 +19,7 @@ type NavigableTaggedText(taggedText: TaggedText, range: Range.range) =
     interface TaggedText with
         member x.Tag = taggedText.Tag
         member x.Text = taggedText.Text
-let mkNav r t = NavigableTaggedText(t, r)
+let mkNav r t = NavigableTaggedText(t, r) :> TaggedText
 
 let spaces n = new String(' ',n)
 

--- a/src/fsharp/layout.fsi
+++ b/src/fsharp/layout.fsi
@@ -16,7 +16,7 @@ type NavigableTaggedText =
     new : TaggedText * Range.range -> NavigableTaggedText
     member Range: Range.range
     interface TaggedText
-val mkNav : Range.range -> TaggedText -> NavigableTaggedText
+val mkNav : Range.range -> TaggedText -> TaggedText
 
 module TaggedTextOps = Internal.Utilities.StructuredFormat.TaggedTextOps
 


### PR DESCRIPTION
Currently:

![props](https://cloud.githubusercontent.com/assets/1760221/24802849/ae47ecd8-1ba9-11e7-9a12-68239cb6b527.gif)

This PR:

![props2](https://cloud.githubusercontent.com/assets/1760221/24802851/afda3d76-1ba9-11e7-99ba-5a0f16bea50f.gif)
