### PR TITLE
automate nightly installs

### DIFF
--- a/scripts/Install-VisualFSharpNightly.ps1
+++ b/scripts/Install-VisualFSharpNightly.ps1
@@ -1,0 +1,43 @@
+# installs a nightly VisualFSharp build
+# the latest version is installed if not specified
+
+# https://blogs.msdn.microsoft.com/dotnet/2017/03/14/announcing-nightly-releases-for-the-visual-f-tools/
+# https://dotnet.myget.org/feed/fsharp/package/vsix/VisualFSharp
+
+# requies Visual Studio Setup PowerShell Module
+# https://github.com/Microsoft/vssetup.powershell
+# Install-Module VSSetup -Scope CurrentUser
+
+[CmdletBinding()]
+param (
+    [Parameter()] [string] $InstanceId,
+    [Parameter()] [string] $Version,
+    [switch] $Quiet
+)
+
+$feed = 'https://dotnet.myget.org/F/fsharp/vsix'
+$wc = New-Object Net.Webclient
+if(-not $Version){
+    $Version = ($wc.DownloadString($feed) -as [xml]).feed.entry.Vsix.Version
+}
+$file = 'VisualFSharp-' + $Version + '.vsix'
+$tempfile = [IO.Path]::Combine([IO.Path]::GetTempPath(), $file)
+$logFile = [IO.Path]::ChangeExtension($tempfile, '.txt')
+$wc.DownloadFile($feed + '/' + $file, $tempfile)
+$vs = Get-VSSetupInstance
+[array]$argumentList = "/logFile:`"$logFile`""
+$argumentList += "/appidinstallpath:`"$($vs.InstallationPath)\Common7\IDE\devenv.exe`""
+$skuName = $vs.Product.Id.Replace("Microsoft.VisualStudio.Product.","")
+$argumentList += "/skuName:$skuName"
+$argumentList += "/skuVersion:`"$($vs.Product.Version)`""
+$argumentList += "/appidname:`"Microsoft $($vs.DisplayName)`""
+if(-not $InstanceId){
+    $InstanceId = $vs.InstanceId
+}
+$argumentList += "/instanceIds:$InstanceId"
+if($Quiet.IsPresent){
+    $argumentList += "/quiet"
+}
+$argumentList += $tempfile
+Start-Process (Join-Path $vs.InstallationPath 'Common7\IDE\VSIXInstaller.exe') -Wait -ArgumentList $argumentList
+Remove-Item $tempfile

--- a/scripts/Uninstall-VisualFSharpNightly.ps1
+++ b/scripts/Uninstall-VisualFSharpNightly.ps1
@@ -1,0 +1,17 @@
+[CmdletBinding()]
+param (
+    [Parameter()] [string] $InstanceId,
+    [Parameter()] [string] $Version,
+    [switch] $Quiet
+)
+
+$vs = Get-VSSetupInstance
+[array]$argumentList = '/u:VisualFSharp'
+if(-not $InstanceId){
+    $InstanceId = $vs.InstanceId
+}
+$argumentList += "/instanceIds:$InstanceId"
+if($Quiet.IsPresent){
+    $argumentList += "/quiet"
+}
+Start-Process (Join-Path $vs.InstallationPath 'Common7\IDE\VSIXInstaller.exe') -ArgumentList $argumentList -Wait


### PR DESCRIPTION
This automates installing the nightly vsix files. It works fine without `-Quiet` when a UI pops open.

### VSIXInstaller.App.InstallSilently bug
I was hoping to use this on AppVeyor, but there is a bug that needs to be hunted down when run with `-Quiet`. When run that way, `vsixinstaller` tries to uninstall and we get an error like #2549:

```
4/9/2017 7:50:01 PM - The extension will be upgraded from version 15.4.1.17022502.
4/9/2017 7:50:03 PM - Uninstalling 'Visual F# Tools', version 15.4.1.17022502.
4/9/2017 7:50:05 PM - Install Error : System.InvalidOperationException: The VSIX's catalog does not include a 'Component' which is required for install/uninstall.
   at Microsoft.VisualStudio.ExtensionManager.ExtensionEngineImpl.PerformSetupEngineUnInstall(IInstalledExtension extension)
   at Microsoft.VisualStudio.ExtensionManager.ExtensionEngineImpl.UninstallInternal(IInstalledExtension extension, Boolean forceDelete, Version targetedVSVersion)
   at Microsoft.VisualStudio.ExtensionManager.ExtensionEngineImpl.Uninstall(IInstalledExtension extension, Version targetedVSVersion)
   at VSIXInstaller.App.InstallSilently(IInstallableExtension extension, IReadOnlyList`1 installSKUs)
```

Would appreciate some help finding a fix for this one. It would allow us to use nightly builds on AppVeyor and other build environments.