### PR TITLE
Debugger Proxy

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -4643,7 +4643,7 @@ and GenBindAfterSequencePoint cenv cgbuf eenv sp (TBind(vspec,rhsExpr,_)) =
     // Workaround for .NET and Visual Studio restriction w.r.t debugger type proxys
     // Mark internal constructors in internal classes as public. 
     let access = 
-        if access = ILMemberAccess.Assembly && vspec.IsConstructor && IsHiddenTycon eenv.sigToImplRemapInfo vspec.MemberApparentParent.Deref then 
+        if access = ILMemberAccess.Assembly && (vspec.IsConstructor || vspec.IsPropertyGetterMethod) && IsHiddenTycon eenv.sigToImplRemapInfo vspec.MemberApparentParent.Deref then 
             ILMemberAccess.Public
         else
             access

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -2321,6 +2321,12 @@ and [<StructuredFormatDisplay("{LogicalName}")>]
     /// Indicates if this is a member
     member x.IsMember                   = x.MemberInfo.IsSome
 
+    /// Indicates whether this value represents a property getter.
+    member x.IsPropertyGetterMethod = 
+        match x.MemberInfo with
+        | None -> false
+        | Some (memInfo:ValMemberInfo) -> memInfo.MemberFlags.MemberKind = MemberKind.PropertyGet || memInfo.MemberFlags.MemberKind = MemberKind.PropertyGetSet
+
     /// Indicates if this is a member, excluding extension members
     member x.IsIntrinsicMember          = x.IsMember && not x.IsExtensionMember
 


### PR DESCRIPTION
Extend the Ahem 'hack' that makes internal constructors public for  Debugger Proxies to also make Property Getters public for them too.

