### PR TITLE
redirect %TEMP% and %TMP% to point to the build output

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -190,6 +190,10 @@ if /i "%ARG%" == "microbuild" (
     set TEST_VS_IDEUNIT_SUITE=1
     set CI=1
     set PUBLISH_VSIX=1
+
+    REM redirecting TEMP directories
+    set TEMP=%~dp0%BUILD_CONFIG%\TEMP
+    set TMP=%~dp0%BUILD_CONFIG%\TEMP
 )
 
 REM These divide "ci" into two chunks which can be done in parallel
@@ -378,6 +382,7 @@ echo INCLUDE_TEST_SPEC_NUNIT=%INCLUDE_TEST_SPEC_NUNIT%
 echo INCLUDE_TEST_TAGS=%INCLUDE_TEST_TAGS%
 echo PUBLISH_VSIX=%PUBLISH_VSIX%
 echo MYGET_APIKEY=%MYGET_APIKEY%
+echo TEMP=%TEMP%
 
 REM load Visual Studio 2017 developer command prompt if VS150COMNTOOLS is not set
 


### PR DESCRIPTION
There have been recent signed build issues stemming from the `%TEMP%` directory containing more than 65k items.  I'm working with the build lab to correct this on their end but thought it would be wise to implement something that Roslyn does, too: redirecting `%TEMP%` to the build output directory.  This benefits us in two ways:

1.  We always have a clean `%TEMP%` directory so the 65k limit is never reached.
2.  Official build archives will also contain this potentially making hard-to-diagnose bugs easier to investigate.

FYI @KevinRansom: don't merge this one without me (assuming it's green), I need to run some more extensive testing.
