### PR TITLE
disable flaky high entropy and subsystem version tests

### DIFF
--- a/tests/fsharpqa/Source/CompilerOptions/fsc/highentropyva/env.lst
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/highentropyva/env.lst
@@ -3,11 +3,11 @@
 	SOURCE=dummy.fs SCFLAGS="--platform:x86"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe no"	# CheckHighEntropyALSR - x86
 
 # --highentropyva+ and --highentropyva
-	SOURCE=dummy.fs SCFLAGS="--platform:x64 --highentropyva+"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"		# CheckHighEntropyALSR - x64 highentropyva+
-	SOURCE=dummy.fs SCFLAGS="--platform:x86 --highentropyva+"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"		# CheckHighEntropyALSR - x86 highentropyva+
-	SOURCE=dummy.fs SCFLAGS="--platform:x64 --highentropyva"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"		# CheckHighEntropyALSR - x64 highentropyva
-	SOURCE=dummy.fs SCFLAGS="--platform:x86 --highentropyva"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"		# CheckHighEntropyALSR - x86 highentropyva
-	SOURCE=dummy.fs SCFLAGS="--platform:Itanium --highentropyva"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"	# CheckHighEntropyALSR - IA64 highentropyva
+#	SOURCE=dummy.fs SCFLAGS="--platform:x64 --highentropyva+"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"		# CheckHighEntropyALSR - x64 highentropyva+
+#	SOURCE=dummy.fs SCFLAGS="--platform:x86 --highentropyva+"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"		# CheckHighEntropyALSR - x86 highentropyva+
+#	SOURCE=dummy.fs SCFLAGS="--platform:x64 --highentropyva"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"		# CheckHighEntropyALSR - x64 highentropyva
+#	SOURCE=dummy.fs SCFLAGS="--platform:x86 --highentropyva"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"		# CheckHighEntropyALSR - x86 highentropyva
+#	SOURCE=dummy.fs SCFLAGS="--platform:Itanium --highentropyva"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe yes"	# CheckHighEntropyALSR - IA64 highentropyva
 
 # --highentropyva-
 	SOURCE=dummy.fs SCFLAGS="--platform:x64 --highentropyva-"    COMPILE_ONLY=1  POSTCMD="CheckHighEntropyASLR.bat dummy.exe no"		# CheckHighEntropyALSR - x64 highentropyva-

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/subsystemversion/env.lst
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/subsystemversion/env.lst
@@ -1,22 +1,22 @@
 # Default behavior
-	SOURCE=dummy.fs                         COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 4.00"	# default is 4.00
+#	SOURCE=dummy.fs                         COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 4.00"	# default is 4.00
 
-	SOURCE=dummy.fs  SCFLAGS="--subsystemversion:4.00" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 4.00"	# explicit 4.00
-	SOURCE=dummy.fs  SCFLAGS="--subsystemversion:5.01" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 5.01"	# explicit 5.01
-	SOURCE=dummy.fs  SCFLAGS="--subsystemversion:6.00" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.00"	# explicit 6.00 - Vista
-	SOURCE=dummy.fs  SCFLAGS="--subsystemversion:6.02" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.02"	# explicit 6.02 - Win8
+#	SOURCE=dummy.fs  SCFLAGS="--subsystemversion:4.00" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 4.00"	# explicit 4.00
+#	SOURCE=dummy.fs  SCFLAGS="--subsystemversion:5.01" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 5.01"	# explicit 5.01
+#	SOURCE=dummy.fs  SCFLAGS="--subsystemversion:6.00" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.00"	# explicit 6.00 - Vista
+#	SOURCE=dummy.fs  SCFLAGS="--subsystemversion:6.02" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.02"	# explicit 6.02 - Win8
 
 # Different targets...
-	SOURCE=dummy.fs  SCFLAGS="--target:winexe  --subsystemversion:6.01"                POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.01"	# explicit 6.01 - Win7 - winexe
-	SOURCE=dummy.fs  SCFLAGS="--target:exe     --subsystemversion:6.01"                POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.01"	# explicit 6.01 - Win7 - exe
-	SOURCE=dummy.fs  SCFLAGS="--target:library --subsystemversion:6.01" COMPILE_ONLY=1 POSTCMD="CheckSubsystemVersion.bat dummy.dll 6.01"	# explicit 6.01 - Win7 - library
-	SOURCE=dummy.fs  SCFLAGS="--target:module  --subsystemversion:6.01" COMPILE_ONLY=1 POSTCMD="CheckSubsystemVersion.bat dummy.netmodule 6.01"	# explicit 6.01 - Win7 - module
+#	SOURCE=dummy.fs  SCFLAGS="--target:winexe  --subsystemversion:6.01"                POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.01"	# explicit 6.01 - Win7 - winexe
+#	SOURCE=dummy.fs  SCFLAGS="--target:exe     --subsystemversion:6.01"                POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.01"	# explicit 6.01 - Win7 - exe
+#	SOURCE=dummy.fs  SCFLAGS="--target:library --subsystemversion:6.01" COMPILE_ONLY=1 POSTCMD="CheckSubsystemVersion.bat dummy.dll 6.01"	# explicit 6.01 - Win7 - library
+#	SOURCE=dummy.fs  SCFLAGS="--target:module  --subsystemversion:6.01" COMPILE_ONLY=1 POSTCMD="CheckSubsystemVersion.bat dummy.netmodule 6.01"	# explicit 6.01 - Win7 - module
 
 
 # Misc formats...
-	SOURCE=dummy.fs    SCFLAGS="--subsystemversion:6.2"         COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.02"		# 6.2
-	SOURCE=dummy.fs    SCFLAGS="--subsystemversion:06.002"      COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.02"		# 06.002
-	SOURCE=dummy.fs    SCFLAGS="--subsystemversion:65535.65535" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 65535.65535"	# 65535.65535
+#	SOURCE=dummy.fs    SCFLAGS="--subsystemversion:6.2"         COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.02"		# 6.2
+#	SOURCE=dummy.fs    SCFLAGS="--subsystemversion:06.002"      COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 6.02"		# 06.002
+#	SOURCE=dummy.fs    SCFLAGS="--subsystemversion:65535.65535" COMPILE_ONLY=1  POSTCMD="CheckSubsystemVersion.bat dummy.exe 65535.65535"	# 65535.65535
 
 # Bad arguments...
 	SOURCE=E_Error01.fs  SCFLAGS="--subsystemversion:3.99"        COMPILE_ONLY=1	# 3.99


### PR DESCRIPTION
These tests have been failing in our nightly run and are being temporarily disabled.

FYI @KevinRansom 

Edit: #2858 has been created to track re-enabling of these tests.