### PR TITLE
Show map keys in the Name column in the debugger Locals window

### DIFF
--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -629,12 +629,20 @@ namespace Microsoft.FSharp.Collections
 
 
 #if !FX_NO_DEBUG_PROXIES
-    and 
+    and
         [<Sealed>]
         MapDebugView<'Key,'Value when 'Key : comparison>(v: Map<'Key,'Value>)  =  
 
-         [<DebuggerBrowsable(DebuggerBrowsableState.RootHidden)>]
-         member x.Items = v |> Seq.truncate 10000 |> Seq.toArray
+            [<DebuggerBrowsable(DebuggerBrowsableState.RootHidden)>]
+            member x.Items =
+                v |> Seq.truncate 10000 |> Seq.map KeyValuePairDebugFriendly |> Seq.toArray
+    
+    and
+        [<DebuggerDisplay("{keyValue.Value}", Name = "[{keyValue.Key}]", Type = "")>]
+        KeyValuePairDebugFriendly<'Key,'Value>(keyValue : KeyValuePair<'Key, 'Value>) =
+        
+            [<DebuggerBrowsable(DebuggerBrowsableState.RootHidden)>]
+            member x.KeyValue = keyValue
 #endif
         
 


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/64654/25063071/e3e0fd16-21d1-11e7-99d1-0a68b6d4c7b9.png)

After:
![image](https://cloud.githubusercontent.com/assets/64654/25063061/a7c39b7c-21d1-11e7-8d4a-23f5019cb44b.png)

Note that you won't be able to reproduce this unless you're using my PR that fixes F# debugger proxies or using the legacy EE (see https://github.com/dotnet/roslyn/pull/18648)