### PR TITLE
Make unittests runnable again

### DIFF
--- a/tests/fsharp/FSharp.Tests.FSharpSuite.fsproj
+++ b/tests/fsharp/FSharp.Tests.FSharpSuite.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="single-test.fs" />
     <Compile Include="TypeProviderTests.fs" />
     <Compile Include="tests.fs" />
+    <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/tests/fsharp/packages.config
+++ b/tests/fsharp/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net45" />
+</packages>

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -181,7 +181,17 @@ let config configurationName envVars =
     let ILDASM = requireFile (CORSDK ++ "ildasm.exe")
     let SN = requireFile (CORSDK ++ "sn.exe") 
     let PEVERIFY = requireFile (CORSDK ++ "peverify.exe")
-    let FSI_FOR_SCRIPTS = requireFile (SCRIPT_ROOT ++ ".." ++ ".." ++ (System.Environment.GetEnvironmentVariable("_fsiexe").Trim([| '\"' |])))
+    let FSI_FOR_SCRIPTS =
+        match envVars |> Map.tryFind "_fsiexe" with
+        | Some fsiexe when (not (String.IsNullOrWhiteSpace fsiexe)) -> requireFile (SCRIPT_ROOT ++ ".." ++ ".." ++ (fsiexe.Trim([| '\"' |])))
+        | _ ->
+            // build.cmd sets that var, if it is not set, we are probably called directly from visual studio or the nunit console runner.
+            let packagesDir = SCRIPT_ROOT ++ ".." ++ ".." ++ @"packages"
+            let fsharpCompilerTools = Directory.GetDirectories(packagesDir, "FSharp.Compiler.Tools.*")
+            match fsharpCompilerTools with
+            | [||] -> failwithf "Could not find any 'FSharp.Compiler.Tools' inside '%s'" packagesDir
+            | [| dir |] -> Path.Combine(dir, "tools", "fsi.exe")
+            | _ -> failwithf "Found more than one 'FSharp.Compiler.Tools' inside '%s', please clean up." packagesDir
     let dotNetExe = SCRIPT_ROOT ++ ".." ++ ".." ++ "Tools" ++ "dotnetcli" ++ "dotnet.exe"
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS


### PR DESCRIPTION
After:
![image](https://cloud.githubusercontent.com/assets/4236651/25093778/106e167a-2394-11e7-804e-8c0df11e5fba.png)

Aint that nice? You can easily run a single test! You can even debug it! Wow!


Before: 
![image](https://cloud.githubusercontent.com/assets/4236651/25093771/07de647e-2394-11e7-8812-02b50928f873.png)

(the env var is set in build.cmd)
