### PR TITLE
More TaskCanceledException fixes

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -702,7 +702,7 @@ module Cancellable =
     /// Run a cancellable computation using the given cancellation token
     let run (ct: System.Threading.CancellationToken) (Cancellable oper) = 
         if ct.IsCancellationRequested then 
-            ValueOrCancelled.Cancelled (OperationCanceledException()) 
+            ValueOrCancelled.Cancelled (OperationCanceledException ct) 
         else
             oper ct 
 
@@ -762,7 +762,7 @@ module Cancellable =
     let token () = Cancellable (fun ct -> ValueOrCancelled.Value ct)
 
     /// Represents a canceled computation
-    let canceled() = Cancellable (fun ct -> ValueOrCancelled.Cancelled (new OperationCanceledException(ct)))
+    let canceled() = Cancellable (fun ct -> ValueOrCancelled.Cancelled (OperationCanceledException ct))
 
     /// Catch exceptions in a computation
     let private catch (Cancellable e) = 

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1543,13 +1543,13 @@ namespace Microsoft.FSharp.Control
                     if completedTask.IsCanceled then
                         if useCcontForTaskCancellation
                         then args.aux.ccont (new OperationCanceledException(args.aux.token))
-                        else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException(args.aux.token)))
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException(completedTask)))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else
                         args.cont completedTask.Result)) |> unfake
 
-            task.ContinueWith(Action<Task<'T>>(continuation), TaskContinuationOptions.None) |> ignore |> fake
+            task.ContinueWith(Action<Task<'T>>(continuation), TaskContinuationOptions.None, args.aux.token) |> ignore |> fake
 
         let continueWithUnit (task : Task, args, useCcontForTaskCancellation) = 
 
@@ -1558,13 +1558,13 @@ namespace Microsoft.FSharp.Control
                     if completedTask.IsCanceled then
                         if useCcontForTaskCancellation
                         then args.aux.ccont (new OperationCanceledException(args.aux.token))
-                        else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException(args.aux.token)))
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException(completedTask)))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else
                         args.cont ())) |> unfake
 
-            task.ContinueWith(Action<Task>(continuation), TaskContinuationOptions.None) |> ignore |> fake
+            task.ContinueWith(Action<Task>(continuation), TaskContinuationOptions.None, args.aux.token) |> ignore |> fake
 #endif
 
 #if FX_NO_REGISTERED_WAIT_HANDLES

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1536,6 +1536,14 @@ namespace Microsoft.FSharp.Control
     // Contains helpers that will attach continuation to the given task.
     // Should be invoked as a part of protectedPrimitive(withResync) call
     module TaskHelpers = 
+        let private continueWithExtra token =
+#if FSCORE_PORTABLE_OLD || FSCORE_PORTABLE_NEW
+            token |> ignore
+            TaskContinuationOptions.None
+#else
+            token
+#endif
+
         let continueWith (task : Task<'T>, args, useCcontForTaskCancellation) = 
 
             let continuation (completedTask : Task<_>) : unit =
@@ -1549,7 +1557,7 @@ namespace Microsoft.FSharp.Control
                     else
                         args.cont completedTask.Result)) |> unfake
 
-            task.ContinueWith(Action<Task<'T>>(continuation), args.aux.token) |> ignore |> fake
+            task.ContinueWith(Action<Task<'T>>(continuation), continueWithExtra args.aux.token) |> ignore |> fake
 
         let continueWithUnit (task : Task, args, useCcontForTaskCancellation) = 
 
@@ -1564,7 +1572,7 @@ namespace Microsoft.FSharp.Control
                     else
                         args.cont ())) |> unfake
 
-            task.ContinueWith(Action<Task>(continuation), args.aux.token) |> ignore |> fake
+            task.ContinueWith(Action<Task>(continuation), continueWithExtra args.aux.token) |> ignore |> fake
 #endif
 
 #if FX_NO_REGISTERED_WAIT_HANDLES

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1542,7 +1542,7 @@ namespace Microsoft.FSharp.Control
                 args.aux.trampolineHolder.Protect((fun () ->
                     if completedTask.IsCanceled then
                         if useCcontForTaskCancellation then args.aux.ccont(new OperationCanceledException(args.aux.token))
-                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException(completedTask)))
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException(task)))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else
@@ -1556,7 +1556,7 @@ namespace Microsoft.FSharp.Control
                 args.aux.trampolineHolder.Protect((fun () ->
                     if completedTask.IsCanceled then
                         if useCcontForTaskCancellation then args.aux.ccont (new OperationCanceledException(args.aux.token))
-                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException(completedTask)))
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException(task)))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1541,8 +1541,9 @@ namespace Microsoft.FSharp.Control
             let continuation (completedTask : Task<_>) : unit =
                 args.aux.trampolineHolder.Protect((fun () ->
                     if completedTask.IsCanceled then
-                        if useCcontForTaskCancellation then args.aux.ccont(new OperationCanceledException(args.aux.token))
-                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException(task)))
+                        if useCcontForTaskCancellation
+                        then args.aux.ccont (new OperationCanceledException(args.aux.token))
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException(args.aux.token)))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else
@@ -1554,9 +1555,9 @@ namespace Microsoft.FSharp.Control
 
             let continuation (completedTask : Task) : unit =
                 args.aux.trampolineHolder.Protect((fun () ->
-                    if completedTask.IsCanceled then
-                        if useCcontForTaskCancellation then args.aux.ccont (new OperationCanceledException(args.aux.token))
-                        else args.aux.econt (ExceptionDispatchInfo.Capture(new TaskCanceledException(task)))
+                        if useCcontForTaskCancellation
+                        then args.aux.ccont (new OperationCanceledException(args.aux.token))
+                        else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException(args.aux.token)))
                     elif completedTask.IsFaulted then
                         args.aux.econt (MayLoseStackTrace(completedTask.Exception))
                     else

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1555,6 +1555,7 @@ namespace Microsoft.FSharp.Control
 
             let continuation (completedTask : Task) : unit =
                 args.aux.trampolineHolder.Protect((fun () ->
+                    if completedTask.IsCanceled then
                         if useCcontForTaskCancellation
                         then args.aux.ccont (new OperationCanceledException(args.aux.token))
                         else args.aux.econt (ExceptionDispatchInfo.Capture(new OperationCanceledException(args.aux.token)))

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1549,7 +1549,7 @@ namespace Microsoft.FSharp.Control
                     else
                         args.cont completedTask.Result)) |> unfake
 
-            task.ContinueWith(Action<Task<'T>>(continuation), TaskContinuationOptions.None, args.aux.token) |> ignore |> fake
+            task.ContinueWith(Action<Task<'T>>(continuation), args.aux.token) |> ignore |> fake
 
         let continueWithUnit (task : Task, args, useCcontForTaskCancellation) = 
 
@@ -1564,7 +1564,7 @@ namespace Microsoft.FSharp.Control
                     else
                         args.cont ())) |> unfake
 
-            task.ContinueWith(Action<Task>(continuation), TaskContinuationOptions.None, args.aux.token) |> ignore |> fake
+            task.ContinueWith(Action<Task>(continuation), args.aux.token) |> ignore |> fake
 #endif
 
 #if FX_NO_REGISTERED_WAIT_HANDLES

--- a/vsintegration/src/FSharp.Editor/Common/Pervasive.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Pervasive.fs
@@ -197,40 +197,7 @@ module Async =
                     replyCh.Reply res 
             }
         async { return! agent.PostAndAsyncReply id }
-
-
-type Async with 
-
-    /// Better implementation of Async.AwaitTask that correctly passes the exception of a failed task to the async mechanism
-    static member AwaitTaskCorrect (task:Task) : Async<unit> =
-        Async.FromContinuations (fun (successCont,exceptionCont,_cancelCont) ->
-            task.ContinueWith (fun (task:Task) ->
-                if task.IsFaulted then
-                    let e = task.Exception
-                    if e.InnerExceptions.Count = 1 then 
-                        exceptionCont e.InnerExceptions.[0]
-                    else exceptionCont e
-                elif task.IsCanceled then
-                    exceptionCont(TaskCanceledException ())
-                else successCont ())
-            |> ignore)
-
-    /// Better implementation of Async.AwaitTask that correctly passes the exception of a failed task to the async mechanism
-    static member AwaitTaskCorrect (task:'T Task) : Async<'T> =
-        Async.FromContinuations( fun (successCont,exceptionCont,_cancelCont) ->
-            task.ContinueWith (fun (task:'T Task) ->
-                if task.IsFaulted then
-                    let e = task.Exception
-                    if e.InnerExceptions.Count = 1 then 
-                        exceptionCont e.InnerExceptions.[0]
-                    else exceptionCont e
-                elif task.IsCanceled then
-                    exceptionCont (TaskCanceledException ())
-                else successCont task.Result)
-            |> ignore)    
-    static member RunTaskSynchronously task  = 
-        task |> Async.AwaitTask |> Async.RunSynchronously 
-
+        
 
 type AsyncBuilder with
     member __.Bind(computation: System.Threading.Tasks.Task<'a>, binder: 'a -> Async<'b>): Async<'b> =


### PR DESCRIPTION
We weren't passing the cancellation token to Task.ContinueWith, so a default cancellation token was being set. That meant that when we raised a TaskCanceledException, we were raising it with an invalid cancellation token.

I really hope this squashes the diagnostic warnings once and for all :) 