### PR TITLE
update package links to use http

### DIFF
--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <DisplayName>Visual F# Tools</DisplayName>
     <Description xml:space="preserve">Deploy Visual F# Tools templates to Visual Studio</Description>
     <PackageId>Microsoft.FSharp.VSIX.Full.Core</PackageId>
-    <MoreInfo>https://docs.microsoft.com/en-us/dotnet/articles/fsharp/</MoreInfo>
+    <MoreInfo>http://docs.microsoft.com/en-us/dotnet/articles/fsharp/</MoreInfo>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0]" />

--- a/vsintegration/Vsix/VisualFSharpOpenSource/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpOpenSource/Source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <DisplayName>Visual F# Tools</DisplayName>
     <Description xml:space="preserve">Deploy Visual F# Tools templates to Visual Studio</Description>
     <PackageId>Microsoft.FSharp.VSIX.OpenSource.Core</PackageId>
-    <MoreInfo>https://docs.microsoft.com/en-us/dotnet/articles/fsharp/</MoreInfo>
+    <MoreInfo>http://docs.microsoft.com/en-us/dotnet/articles/fsharp/</MoreInfo>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0]" />


### PR DESCRIPTION
The "More Information" link still doesn't work and after reading more in [the official spec](https://msdn.microsoft.com/en-us/library/hh696828.aspx), only HTTP is allowed, so this in another attempt to fix #2832.

