### PR TITLE
fix 2871

### DIFF
--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1897,7 +1897,7 @@ let rec getTypeRefsInType (allTypes: AllTypes) typ acc =
     | ILType.FunctionPointer _callsig -> failwith "getTypeRefsInType: fptr"
     | ILType.Modified _   -> failwith "getTypeRefsInType: modified"
 
-let verbose2 = true
+let verbose2 = false
 
 let createTypeRef (visited : Dictionary<_,_>, created : Dictionary<_,_>) emEnv tref = 
 

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1875,7 +1875,7 @@ let getEnclosingTypeRefs (tref:ILTypeRef) =
 [<RequireQualifiedAccess>]
 type AllTypes = Yes | No
 
-// Find all constitunt type references
+// Find all constituent type references
 let rec getTypeRefsInType (allTypes: AllTypes) typ acc = 
     match typ with
     | ILType.Void 

--- a/tests/fsharp/core/fsi-load/test.fsx
+++ b/tests/fsharp/core/fsi-load/test.fsx
@@ -1,4 +1,4 @@
-namespace global
+//namespace global
 
 //See https://github.com/Microsoft/visualfsharp/issues/2871
 module MyModule =

--- a/tests/fsharp/core/fsi-load/test.fsx
+++ b/tests/fsharp/core/fsi-load/test.fsx
@@ -1,0 +1,19 @@
+namespace global
+
+//See https://github.com/Microsoft/visualfsharp/issues/2871
+module MyModule =
+    type MyType = A of string
+
+module OtherModule = 
+  open MyModule
+
+  open System.Collections.Generic
+
+  let foo () = [ for (k: KeyValuePair<string,MyType>) in []    -> () ]
+
+
+  let _ =
+          stdout.WriteLine "Test Passed"
+          System.IO.File.WriteAllText("test.ok","ok")
+          exit 0
+

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1014,6 +1014,16 @@ module CoreTests =
         peverifyWithArgs cfg "/nologo /MD" "test.exe"
                 
     [<Test>]
+    let fsi_load () = 
+        let cfg = testConfig "core/fsi-load"
+
+        use testOkFile = fileguard cfg "test.ok"
+
+        fsi cfg "%s" cfg.fsi_flags ["test.fsx"]
+
+        testOkFile.CheckExists()
+                
+    [<Test>]
     let queriesLeafExpressionConvert () = 
         let cfg = testConfig "core/queriesLeafExpressionConvert"
 


### PR DESCRIPTION
This simplifies the type traversal code prior to calling ``CreateType`` and in the process fixes https://github.com/Microsoft/visualfsharp/issues/2871 by ensuring the enclosing types of a type are created before the type itself.  The ``priority``parameter served no useful purpose since enclosing types always need to be created first and was part of the cause of the problem.

**Please don't pull this until we have also run the Mono tests that are in fsharp/fsharp** as Mono versions are sensitive to order of CreateType calls (they have been fixing issues in this area in Mono 5.0)

