### PR TITLE
Fixes resource generation when using msbuild under mono.

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.targets
@@ -66,7 +66,7 @@ this file.
 
     <PropertyGroup>
         <UsingXBuild>false</UsingXBuild>
-        <UsingXBuild Condition="$(MSBuildExtensionsPath32.Contains('xbuild'))">true</UsingXBuild>
+        <UsingXBuild Condition="'$(MSBuildAssemblyVersion)' == ''">true</UsingXBuild>
     </PropertyGroup>
 
     <Target


### PR DESCRIPTION
 See https://bugzilla.xamarin.com/show_bug.cgi?id=53195