### PR TITLE
Enable JIT tracking for portable PDB debugging

### DIFF
--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -466,9 +466,9 @@ let SetDebugSwitch (tcConfigB : TcConfigBuilder) (dtype : string option) (s : Op
     match dtype with
     | Some(s) ->
        match s with 
-       | "portable" ->  tcConfigB.portablePDB <- true;  tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- false; tcConfigB.ignoreSymbolStoreSequencePoints <- true
+       | "portable" ->  tcConfigB.portablePDB <- true;  tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- true; tcConfigB.ignoreSymbolStoreSequencePoints <- true
        | "pdbonly" ->   tcConfigB.portablePDB <- false; tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- false
-       | "embedded" ->  tcConfigB.portablePDB <- true;  tcConfigB.embeddedPDB <- true;  tcConfigB.jitTracking <- false; tcConfigB.ignoreSymbolStoreSequencePoints <- true
+       | "embedded" ->  tcConfigB.portablePDB <- true;  tcConfigB.embeddedPDB <- true;  tcConfigB.jitTracking <- true; tcConfigB.ignoreSymbolStoreSequencePoints <- true
        | "full" ->      tcConfigB.portablePDB <- false; tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- true
        | _ -> error(Error(FSComp.SR.optsUnrecognizedDebugType(s), rangeCmdArgs))
     | None ->           tcConfigB.portablePDB <- false; tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- s = OptionSwitch.On;


### PR DESCRIPTION
Setting JIT tracking to true adds the `DebuggableAttribute.DebuggingModes.Default`
flag to the generated Debuggable attribute
See https://msdn.microsoft.com/en-us/library/system.diagnostics.debuggableattribute.debuggingmodes(v=vs.110).aspx

Without this flag I see the following message when debugging unless I have "Debug project code only: do not step into framework code" unchecked to allow stepping into framework code.
```
Skipped loading symbols. Module is optimized and the debugger option 'Just My Code' is enabled.
```
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=55092