### PR TITLE
Fix navigation issue #2895

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/CodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CodeAnalysisExtensions.fs
@@ -86,6 +86,7 @@ type Solution with
         //The same file may be present in many projects. We choose one from current or referenced project.
         let rec matchingDoc = function
         | [] -> None
+        | [docId] -> Some docId
         | (docId:DocumentId)::_ when checkProjectId docId -> Some docId
         | docId::tail -> 
             match projectId with 


### PR DESCRIPTION
This is a harmless workaround for #2902.

This partially fixes QuickInfo navigation that stopped working from dependent projects #2895,
#2904 still remains.