### PR TITLE
[WIP] Improve solution load performance

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -222,6 +222,10 @@
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Shell.Interop.11.0.11.0.61030\lib\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Shell.Interop.12.0.12.0.30110\lib\Microsoft.VisualStudio.Shell.Interop.12.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
       <Private>True</Private>

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -335,15 +335,18 @@ and
         let cookie = ref 0u
         (runningDocumentTable :?> IVsRunningDocumentTable).AdviseRunningDocTableEvents(this, cookie) |> ignore
             
+        // Setup the project with Roslyn workspaces
         Events.SolutionEvents.OnAfterOpenProject.Add <| fun args ->
             match args.Hierarchy with
             | :? IProvideProjectSite as siteProvider ->
                 this.SetupProjectFile(siteProvider, this.Workspace)
             | _ -> ()
             
+        // Clear any state that we had for projects in the closing solution
         Events.SolutionEvents.OnAfterCloseSolution.Add <| fun _ ->
             singleFileProjects.Keys |> Seq.iter tryRemoveSingleFileProjectById
             projectContexts.Clear()
+            ProjectSitesAndFiles.ClearCache()
 
         let theme = package.ComponentModel.DefaultExportProvider.GetExport<ISetThemeColors>().Value
         theme.SetColors()

--- a/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
+++ b/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
@@ -160,6 +160,9 @@ type internal ProjectSitesAndFiles() =
             projectCache.[cacheKey] <- options
             options
 
+    static member ClearCache() : unit =
+        projectCache.Clear()
+
     /// Construct a project site for a single file. May be a single file project (for scripts) or an orphan project site (for everything else).
     static member ProjectSiteOfSingleFile(filename:string) : IProjectSite = 
         if SourceFile.MustBeSingleFileProject(filename) then 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/AssemblyReferenceNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/AssemblyReferenceNode.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         {
             get
             {
-                return this.myAssemblyPath;
+                return Path.GetFullPath(this.myAssemblyPath);
             }
         }
 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
@@ -697,7 +697,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
         public void SetDebugLogger(Microsoft.Build.Framework.ILogger debugLogger)
         {
-            myDebugLogger = debugLogger;
+            //myDebugLogger = debugLogger;
         }
 
 
@@ -3128,7 +3128,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
+        public abstract void NotifySourcesAndFlags();
         public abstract void ComputeSourcesAndFlags();
+        public abstract IDisposable AcquireExclusiveBuildResource(bool actuallyBuild);
 
         internal abstract int FixupAppConfigOnTargetFXChange(string newTargetFramework, string targetFSharpCoreVersion, bool autoGenerateBindingRedirects);
 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectReferenceNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectReferenceNode.cs
@@ -483,7 +483,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             // build the full path adding the name of the assembly to the output path.
             outputPath = System.IO.Path.Combine(outputPath, assemblyName);
 
-            return outputPath;
+            return System.IO.Path.GetFullPath(outputPath);
 
         }
 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectReferenceNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectReferenceNode.cs
@@ -872,11 +872,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             if (hierarchy == null)
                 return null;
 
-            object otherTargetFrameworkMonikerObj;
-
-            hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID4.VSHPROPID_TargetFrameworkMoniker, out otherTargetFrameworkMonikerObj);
-
-            string targetFrameworkMoniker = (string)otherTargetFrameworkMonikerObj;
+            object otargetFrameworkMoniker = null;
+            int hr = hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID4.VSHPROPID_TargetFrameworkMoniker, out otargetFrameworkMoniker);
+            if (!ErrorHandler.Succeeded(hr))
+                return null;
+            
+            string targetFrameworkMoniker = (string)otargetFrameworkMoniker;
             return new System.Runtime.Versioning.FrameworkName(targetFrameworkMoniker);
         }
 

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectFlagsService.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectFlagsService.fs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.ProjectSystem
+
+open System
+open System.ComponentModel.Composition
+open System.Collections.Generic
+open Microsoft.VisualStudio.FSharp.LanguageService
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.Shell
+open Microsoft.VisualStudio.Shell.Interop
+open Microsoft.Build.Execution
+
+(*
+[<Export(typeof<ProjectFlagsService>)>]
+type internal ProjectFlagsService 
+    [<ImportingConstructor>]
+    (
+        [<Import(typeof<SVsBuildManagerAccessor>)>] accessor : IVsBuildManagerAccessor
+    ) =
+*)
+type internal ProjectFlagsService 
+    (
+        accessor : IVsBuildManagerAccessor
+    ) =
+
+    let queueLock = obj()
+    let projectQueue = Stack<ProjectNode>()
+    let dirtyProjects = Dictionary<ProjectNode,bool>()
+
+    /// Insert a project into the front of the queue to be processed.
+    member __.QueueProject(project : ProjectNode) =
+        lock queueLock <| fun () ->
+            dirtyProjects.[project] <- true
+            projectQueue.Push project
+    
+    /// Moves a project to the front of the queue if it is already in the queue.
+    member __.PrioritiseProject(project : ProjectNode) =
+        lock queueLock <| fun () ->
+            match dirtyProjects.TryGetValue project with
+            | true, true ->
+                projectQueue.Push project
+            | _ -> ()
+    
+    member __.Clear() =
+        lock queueLock <| fun () ->
+            dirtyProjects.Clear()
+            projectQueue.Clear()
+    
+    member __.TryPop() =
+        lock queueLock <| fun () ->
+            if projectQueue.Count > 0 then 
+                let project = projectQueue.Pop()
+
+                // Only process the project if it is dirty.
+                // A project can be in the queue and clean if it was in the queue multiple times
+                // and it's already been processed.
+                if dirtyProjects.[project] then
+                    dirtyProjects.[project] <- false
+                    Some project
+                else
+                    None
+            else
+                None
+    
+    member this.StartProcessing() =
+        let processProject (project : ProjectNode) = async {
+            let completeEvent = Event<unit>()
+            
+            // Keep trying to grab the exclusive lock for a design time build
+            while accessor.BeginDesignTimeBuild() |> ErrorHandler.Failed do
+                do! Async.Sleep 2000
+
+            // Notify the project to not invoke compilation when a call comes from Fsc. We're
+            // only interested in the source files and flags that are passed from MSBuild.
+            let buildResource = project.AcquireExclusiveBuildResource(actuallyBuild = false)
+
+            // Build completion callback - called from the UI thread
+            let onComplete (_result : MSBuildResult) (_instance : ProjectInstance) =
+                buildResource.Dispose()
+                project.NotifySourcesAndFlags()
+                accessor.EndDesignTimeBuild() |> ignore
+                completeEvent.Trigger()
+
+            // Notes regarding the _ResolveReferenceDependencies property
+            // TODO: check whether this can be achieved in a less painful way 
+            // (names that start with '_' are treated as implementation details and not recommended
+            // for usage).
+            // Setting this property enforces MSBuild to resolve second order dependencies, so if
+            // desktop applications references .NET Core based portable assemblies then MSBuild
+            // will detect that one of references requires System.Runtime and expand list of
+            // references with framework facades for portables.
+            // Usually facades are located at: %programfiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\Facades\
+            // If the property is not set then MSBuild will resolve only primary dependencies, and
+            // the compiler will be very unhappy as all fundamental types should be taken from
+            // System.Runtime that is not supplied.
+            
+            let projectInstance = ref null
+            UIThread.Run(fun () ->
+                project.DoMSBuildSubmission(BuildKind.ASYNC, "Compile", projectInstance, MSBuildCoda onComplete, [KeyValuePair("_ResolveReferenceDependencies", "true")]) |> ignore
+                )
+            
+            // Wait until the build is complete before we continue servicing the queue
+            do! Async.AwaitEvent completeEvent.Publish
+        }
+
+        async {
+            while true do
+                match this.TryPop() with
+                | None -> ()
+                | Some project ->
+                    do! processProject project
+
+                // Having an exclusive lock on design-time builds means the user can't initiate
+                // any builds themselves. Wait a few seconds before trying to grab one again.
+                do! Async.Sleep 2000
+        }
+    
+    member this.Initialize() =
+        this.StartProcessing() |> Async.StartImmediate
+
+        // Clear the queue when the solution is closed
+        Events.SolutionEvents.OnAfterCloseSolution.Add (ignore >> this.Clear)

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
@@ -88,11 +88,13 @@
     <Compile Include="WaitDialog.fs" />
     <Compile Include="MSBuildUtilities.fs" />
     <Compile Include="AppConfigHelper.fs" />
+    <Compile Include="ProjectFlagsService.fs" />
     <Compile Include="Project.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
@@ -210,6 +212,10 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.$(RoslynVSBinariesVersion), Version=$(RoslynVSBinariesVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Shell.$(RoslynVSBinariesVersion).$(RoslynVSPackagesVersion)\lib\Microsoft.VisualStudio.Shell.$(RoslynVSBinariesVersion).dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.AttributedModel">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.LanguageService.Compiler\FSharp.LanguageService.Compiler.fsproj">
       <Project>{a437a6ec-5323-47c2-8f86-e2cac54ff152}</Project>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
@@ -186,6 +186,9 @@
     <Reference Include="Microsoft.VisualStudio.Threading">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Threading.15.0.240\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=$(RoslynVSBinariesVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.ComponentModelHost.15.0.26201-alpha\lib\net46\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Framework.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Fixes #2793, fixes #2916, fixes #1944.

This is a very WIP pull request that improves solution load performance by moving ComputeSourcesAndFlags from being a UI thread operation to a background thread operation.

The design consists of a new ProjectFlagsService which processes a queue of projects that are dirty and need their sources/flags recalculating. It takes an exclusive lock on VS's design-time build and then runs an asynchronous build of the project (stopping just before invoking the compiler).

This PR also contains changes to ProjectsSitesAndFiles options caching. These changes mean that the Dense solution loads in 20 seconds instead of hanging VS forever. The ProjectsSitesAndFiles changes brought the load time down to 2:50mins, and the off-loading of ComputeSourcesAndFlags brings it down further to 20 seconds.

### Remaining work

- [x] Investigate whether Roslyn workspace setup can now be made synchronous
- [ ] Revert changes conflicting with #3002 
- [ ] Use MEF for ProjectFlagsService
- [ ] Prioritise the currently viewed project when the active document is changed
- [ ] Be resilient to Path.GetFullPath failing in reference node properties
- [ ] Fix sources and flags results not being passed down to the background compiler