### PR TITLE
always generate pdbs in release mode

### DIFF
--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -77,11 +77,10 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <!-- Flags used for Release mode.		-->
-    <DebugType Condition=" '$(DebugType)' == '' and '$(TargetFramework)' != 'coreclr' and '$(UseSourceLink)' != 'true' ">pdbonly</DebugType>
-    <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
+    <DebugType>pdbonly</DebugType>
+
     <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
     <EmbedAllSource>false</EmbedAllSource>
-
     <ErrorReport Condition=" '$(ErrorReport)' == '' ">prompt</ErrorReport>
     <DefineConstants Condition=" '$(ProjectLanguage)' != 'VisualBasic' ">TRACE;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition=" '$(ProjectLanguage)' == 'VisualBasic' ">TRACE=True,$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
The internal symbol servers don't currently support portable or embedded PDBs and until that's fixed, we can't ship any F# binaries.

This change partly undoes work by @KevinRansom to generate regular (indexable) PDBs.

Also including @dsyme for his input, too.

I've verified that doing a full internal build generates the same set of PDBs that we used to and they can be index by our symbol servers.