### PR TITLE
fix 2926 - FSharp.Core XML docs not showing in scripts and standalone files

### DIFF
--- a/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
+++ b/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
@@ -54,6 +54,7 @@
         <!-- F# compiler -->
         <File Id="FSharp_Core_Sigdata_File" Source="$(var.BinariesDir)\net40\bin\FSharp.Core.sigdata" />
         <File Id="FSharp_Core_Optdata_File" Source="$(var.BinariesDir)\net40\bin\FSharp.Core.optdata" />
+        <File Id="FSharp_Core_Xml_File" Source="$(var.BinariesDir)\net40\bin\FSharp.Core.xml" />
       </Component>
 
       <Component Id="Compiler_Redist_FSharp.Build.dll" Guid="$(fsharp.guid(Compiler_Redist_FSharp.Build.dll, $(var.LocaleCode)))">


### PR DESCRIPTION
Proposed fix for https://github.com/Microsoft/visualfsharp/issues/2926

I validated by manually copying the file across and XML docs started to appear

@brettfo Please check the setup change