### PR TITLE
Fix "Add New" dialog suggesting file names that already exist

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
@@ -5211,6 +5211,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             bool found = false;
             bool fFolderCase = false;
             HierarchyNode parent = this.NodeFromItemId(itemIdLoc);
+            
+            if (parent is FileNode)
+                parent = parent.Parent;
 
             extToUse = ext.Trim();
             if (String.Compare(extToUse, ".config", StringComparison.OrdinalIgnoreCase) == 0 ||

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectSystem.Base.csproj
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectSystem.Base.csproj
@@ -310,7 +310,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
-  <Import Project="$(VsSDKTargets)"/>
+  <Import Project="$(VsSDKTargets)" />
   <Target Name="GatherBinariesToBeSigned" AfterTargets="Localize" Condition="'$(UseGatherBinaries)' == 'true'">
     <ItemGroup>
       <BinariesToBeSigned Include="$(OutDir)$(AssemblyName).dll" />

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -1995,7 +1995,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     (cmd = (uint32)VSProjectConstants.MoveUpCmd.ID) then
 
                     result <- result ||| QueryStatusResult.SUPPORTED
-                    if FSharpFileNode.CanMoveUp(x) then
+                    if noBuildInProgress && root.GetSelectedNodes().Count < 2 && FSharpFileNode.CanMoveUp(x) then
                         result <- result ||| QueryStatusResult.ENABLED
                     VSConstants.S_OK
 
@@ -2003,7 +2003,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     (cmd = (uint32)VSProjectConstants.MoveDownCmd.ID) then
 
                     result <- result ||| QueryStatusResult.SUPPORTED
-                    if FSharpFileNode.CanMoveDown(x) then
+                    if noBuildInProgress && root.GetSelectedNodes().Count < 2 && FSharpFileNode.CanMoveDown(x) then
                         result <- result ||| QueryStatusResult.ENABLED
                     VSConstants.S_OK
 


### PR DESCRIPTION
…when adding above/below a file in the project tree.

Also fix being able to move folders up/down when a build is in progress.

Fixes #2892