### PR TITLE
Add option to the "IntelliSense" page to disable "Show all symbols"

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -215,7 +215,10 @@ type internal FSharpCompletionProvider
             let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
             let! textVersion = context.Document.GetTextVersionAsync(context.CancellationToken)
             let! _, _, fileCheckResults = checkerProvider.Checker.ParseAndCheckDocument(document, options, true)
-            let getAllSymbols() = assemblyContentProvider.GetAllEntitiesInProjectAndReferencedAssemblies(fileCheckResults)
+            let getAllSymbols() =
+                if Settings.IntelliSense.ShowAllSymbols
+                then assemblyContentProvider.GetAllEntitiesInProjectAndReferencedAssemblies(fileCheckResults)
+                else []
             let! results = 
                 FSharpCompletionProvider.ProvideCompletionsAsyncAux(checkerProvider.Checker, sourceText, context.Position, options, 
                                                                     document.FilePath, textVersion.GetHashCode(), getAllSymbols)

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -34,7 +34,7 @@ type internal Settings [<ImportingConstructor>](store: SettingsStore) =
         
         store.RegisterDefault
             { ShowAfterCharIsTyped = true
-              ShowAfterCharIsDeleted = false
+              ShowAfterCharIsDeleted = true
               ShowAllSymbols = true }
 
         store.RegisterDefault

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -11,7 +11,8 @@ open OptionsUIHelpers
 [<CLIMutable>]
 type IntelliSenseOptions =
   { ShowAfterCharIsTyped: bool
-    ShowAfterCharIsDeleted: bool }
+    ShowAfterCharIsDeleted: bool
+    ShowAllSymbols : bool }
 
 [<RequireQualifiedAccess>]
 type QuickInfoUnderlineStyle = Dot | Dash | Solid
@@ -33,7 +34,8 @@ type internal Settings [<ImportingConstructor>](store: SettingsStore) =
         
         store.RegisterDefault
             { ShowAfterCharIsTyped = true
-              ShowAfterCharIsDeleted = false }
+              ShowAfterCharIsDeleted = false
+              ShowAllSymbols = true }
 
         store.RegisterDefault
             { DisplayLinks = true

--- a/vsintegration/src/FSharp.UIResources/IntelliSenseOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/IntelliSenseOptionControl.xaml
@@ -25,6 +25,8 @@
                             <CheckBox x:Name="charDeleted" IsEnabled="{Binding IsChecked, ElementName=charTyped}" IsChecked="{Binding ShowAfterCharIsDeleted}"
                                       Content="{x:Static local:Strings.Show_completion_list_after_a_character_is_deleted}"/>
                         </StackPanel>
+                        <CheckBox x:Name="showAllSymbols" IsChecked="{Binding ShowAllSymbols}"
+                                  Content="{x:Static local:Strings.Show_all_symbols}"/>
                     </StackPanel>
                 </GroupBox>
             </StackPanel>

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -115,6 +115,15 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show s_ymbols in unopened namespaces.
+        /// </summary>
+        public static string Show_all_symbols {
+            get {
+                return ResourceManager.GetString("Show_all_symbols", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show completion list after a character is _deleted.
         /// </summary>
         public static string Show_completion_list_after_a_character_is_deleted {

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -135,6 +135,9 @@
   <data name="Navigation_links" xml:space="preserve">
     <value>Navigation links</value>
   </data>
+  <data name="Show_all_symbols" xml:space="preserve">
+    <value>Show s_ymbols in unopened namespaces</value>
+  </data>
   <data name="Show_completion_list_after_a_character_is_deleted" xml:space="preserve">
     <value>Show completion list after a character is _deleted</value>
   </data>

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -85,7 +85,7 @@ let VerifyNoCompletionList(fileContents: string, marker: string) =
 
 [<OneTimeSetUp>]
 let usingDefaultSettings() = 
-    SettingsPersistence.setSettings { ShowAfterCharIsTyped = true; ShowAfterCharIsDeleted = false }
+    SettingsPersistence.setSettings { ShowAfterCharIsTyped = true; ShowAfterCharIsDeleted = false; ShowAllSymbols = true }
     
 [<Test>]
 let ShouldTriggerCompletionAtCorrectMarkers() =


### PR DESCRIPTION
This PR adds an option to the _IntelliSense_ page to enable/disable the show all symbols option.

![image](https://cloud.githubusercontent.com/assets/64654/25563865/62b4a13e-2d9d-11e7-9965-26fc21914046.png)

I've found that getting all symbols adds about 300ms of lag to IntelliSense even on a project with no references (nearly 50% of the total time to generate the completion list):

[F#][INFO 12:12:36 PM] GetAllEntitiesInProjectAndReferencedAssemblies: 299 msec