### PR TITLE
Install directory probed for assemblies when loading ResourceDictionary

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/AssemblyInfo.fs
+++ b/vsintegration/src/FSharp.Editor/Common/AssemblyInfo.fs
@@ -14,3 +14,8 @@ open Microsoft.VisualStudio.Shell
 
 do()
 
+// This is needed to load XAML resource dictionaries from FSharp.UIResources assembly because ProvideCodeBase attribute does not work for that purpose.
+// This adds $PackageFolder$ to the directories probed for assemblies to load.
+// The attribute is inexplicably class-targeted, hence the dummy class.
+[<ProvideBindingPath>]
+type private BindingPathForUIResources = class end

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
@@ -44,9 +44,7 @@ type internal QuickInfoViewProvider
         glyphService: IGlyphService
     ) =
 
-    do Application.ResourceAssembly <- typeof<Microsoft.VisualStudio.FSharp.UIResources.Strings>.Assembly
-
-    let styles = ResourceDictionary(Source = Uri("HyperlinkStyles.xaml", UriKind.Relative))
+    let styles = ResourceDictionary(Source = Uri(@"/FSharp.UIResources;component/HyperlinkStyles.xaml", UriKind.Relative))
 
     let getStyle() : Style =
         let key =


### PR DESCRIPTION
This hopefully fixes #2966 once and for all.

The previous approach of setting `ResourceAssembly` global property was inherently wrong because it is really global, not isolated per extension. If some other installed extension made the same mistake there was conflict and runtime failure.