### PR TITLE
[WIP] add new sdk fsproj

### DIFF
--- a/NuGet.netcore2.config
+++ b/NuGet.netcore2.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget-org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="fsharpnetsdk-for-netcore2" value="https://www.myget.org/F/netcorecli-fsc-netcore2/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/FSharpSource.Sdk.props
+++ b/src/FSharpSource.Sdk.props
@@ -6,6 +6,7 @@
     <NoWarn>$(NoWarn);69;65;54;61;75</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>3</WarningLevel>
+    <DebugType>pdbonly</DebugType>
 
     <_MyTargetFramework>coreclr</_MyTargetFramework>
 

--- a/src/FSharpSource.Sdk.props
+++ b/src/FSharpSource.Sdk.props
@@ -67,6 +67,7 @@ $(DefineConstants)
 
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(FSharpSourcesRoot)\..\Tools\MSFT.snk</AssemblyOriginatorKeyFile>
+    <!--<AssemblyOriginatorKeyFile>$(FSharpSourcesRoot)\fsharp\msft.pubkey</AssemblyOriginatorKeyFile>-->
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <DelaySign>true</DelaySign>

--- a/src/FSharpSource.Sdk.props
+++ b/src/FSharpSource.Sdk.props
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
@@ -65,10 +64,12 @@ $(DefineConstants)
 
   </PropertyGroup>
 
-  <!--<PropertyGroup>
+  <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(FSharpSourcesRoot)\..\Tools\MSFT.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
-  </PropertyGroup>-->
+    <DelaySign>true</DelaySign>
+    <OtherFlags>$(OtherFlags) --delaysign+</OtherFlags>
+  </PropertyGroup>
 
 </Project>

--- a/src/FSharpSource.Sdk.props
+++ b/src/FSharpSource.Sdk.props
@@ -13,6 +13,9 @@
     <!-- Disable wildcard include of resx .-->
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 
+    <FscToolPath>e:\github\fsharp\src\fsharp\FSharp.Compiler\..\..\..\Proto\net40\bin\</FscToolPath>
+    <FscToolExe>fsc-proto.exe</FscToolExe>
+
     <DefineConstants>
 MSBUILD_AT_LEAST_14;
 STRONG_NAME_AND_DELAY_SIGN_FSHARP_COMPILER_WITH_MSFT_KEY;

--- a/src/FSharpSource.Sdk.targets
+++ b/src/FSharpSource.Sdk.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+</Project>

--- a/src/FSharpSource.Settings.props
+++ b/src/FSharpSource.Settings.props
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <OtherFlags>$(OtherFlags) --times</OtherFlags>
+    <NoWarn>$(NoWarn);69;65;54;61;75</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningLevel>3</WarningLevel>
+
+    <_MyTargetFramework>coreclr</_MyTargetFramework>
+
+    <!-- Disable wildcard include of resx .-->
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+
+    <DefineConstants>
+MSBUILD_AT_LEAST_14;
+STRONG_NAME_AND_DELAY_SIGN_FSHARP_COMPILER_WITH_MSFT_KEY;
+TRACE;
+VS_VERSION_DEV15;
+FX_PORTABLE_OR_NETSTANDARD;
+PREFERRED_UI_LANG;
+FX_NO_APP_DOMAINS;
+FX_NO_ARRAY_LONG_LENGTH;
+FX_NO_BEGINEND_READWRITE;
+FX_NO_BINARY_SERIALIZATION;
+FX_NO_CONVERTER;
+FX_NO_DEFAULT_DEPENDENCY_TYPE;
+FX_NO_CORHOST_SIGNER;
+FX_NO_CRYPTO;
+FX_NO_EVENTWAITHANDLE_IDISPOSABLE;
+FX_NO_EXIT_CONTEXT_FLAGS;
+FX_NO_HEAPTERMINATION;
+FX_NO_LINKEDRESOURCES;
+FX_NO_LOADER_OPTIMIZATION;
+FX_NO_SIMPLIFIED_LOADER;
+FX_NO_PARAMETERIZED_THREAD_START;
+FX_NO_PDB_READER;
+FX_NO_PDB_WRITER;
+FX_NO_REFLECTION_MODULE_HANDLES;
+FX_NO_REFLECTION_ONLY;
+FX_NO_RUNTIMEENVIRONMENT;
+FX_NO_SECURITY_PERMISSIONS;
+FX_NO_SERVERCODEPAGES;
+FX_NO_SYMBOLSTORE;
+FX_NO_SYSTEM_CONFIGURATION;
+FX_NO_THREAD;
+FX_NO_THREADABORT;
+FX_NO_WAITONE_MILLISECONDS;
+FX_NO_WEB_CLIENT;
+FX_NO_WIN_REGISTRY;
+FX_NO_WINFORMS;
+FX_REDUCED_EXCEPTIONS;
+FX_REDUCED_CONSOLE;
+FX_RESHAPED_REFEMIT;
+FX_RESHAPED_CONSOLE;
+FX_RESHAPED_GLOBALIZATION;
+FX_RESHAPED_REFLECTION;
+FX_JITTRACKING_ISSUE;
+FX_RESHAPED_MSBUILD;
+FSI_TODO_NETCORE;
+SIGNED;
+$(DefineConstants)
+    </DefineConstants>
+
+  </PropertyGroup>
+
+  <!--<PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(FSharpSourcesRoot)\..\Tools\MSFT.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
+  </PropertyGroup>-->
+
+</Project>

--- a/src/fsharp/FSharp.Compiler/FSharp.Compiler.netcore.fsproj
+++ b/src/fsharp/FSharp.Compiler/FSharp.Compiler.netcore.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
   </PropertyGroup>
-  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.props" />
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Sdk.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -497,5 +497,7 @@
       <Link>LegacyHostedCompilerForTesting.fs</Link>
     </Compile>
   </ItemGroup>
+
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Sdk.targets" />
 
 </Project>

--- a/src/fsharp/FSharp.Compiler/FSharp.Compiler.netcore.fsproj
+++ b/src/fsharp/FSharp.Compiler/FSharp.Compiler.netcore.fsproj
@@ -18,6 +18,9 @@
     <DefineConstants>INCLUDE_METADATA_READER;$(DefineConstants)</DefineConstants>
     <DefineConstants>INCLUDE_METADATA_WRITER;$(DefineConstants)</DefineConstants>
     <DefineConstants>FX_RESHAPED_REFLECTION_CORECLR;$(DefineConstants)</DefineConstants>
+
+    <OtherFlags>$(OtherFlags) --keyfile:e:\github\fsharp\src\fsharp\Fsc\..\..\fsharp\msft.pubkey</OtherFlags>
+    <OtherFlags>$(OtherFlags) -g</OtherFlags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsharp/FSharp.Compiler/FSharp.Compiler.netcore.fsproj
+++ b/src/fsharp/FSharp.Compiler/FSharp.Compiler.netcore.fsproj
@@ -49,6 +49,9 @@
     <FsSrGen Include="..\FSComp.txt">
       <Link>FSComp.txt</Link>
     </FsSrGen>
+    <EmbeddedResource Include="obj\coreclr\FSComp.resources">
+      <Link>FSComp.resources</Link>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\FSStrings.resx">
       <Link>FSStrings.resx</Link>
     </EmbeddedResource>

--- a/src/fsharp/FSharp.Compiler/FSharp.Compiler.netcore.fsproj
+++ b/src/fsharp/FSharp.Compiler/FSharp.Compiler.netcore.fsproj
@@ -1,0 +1,501 @@
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
+  </PropertyGroup>
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+
+    <AssemblyName>FSharp.Compiler</AssemblyName>
+    <NoWarn>$(NoWarn);62;9</NoWarn>
+    <BaseAddress>0x06800000</BaseAddress>
+    <OtherFlags>$(OtherFlags) /warnon:1182</OtherFlags>
+
+    <DefineConstants>EXTENSIONTYPING;$(DefineConstants)</DefineConstants>
+    <DefineConstants>COMPILER;$(DefineConstants)</DefineConstants>
+    <DefineConstants>INCLUDE_METADATA_READER;$(DefineConstants)</DefineConstants>
+    <DefineConstants>INCLUDE_METADATA_WRITER;$(DefineConstants)</DefineConstants>
+    <DefineConstants>FX_RESHAPED_REFLECTION_CORECLR;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+
+    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="1.1.0" />
+    <PackageReference Include="Microsoft.DiaSymReader" Version="1.1.0" />
+
+    <ProjectReference Include="..\FSharp.Core\FSharp.Core.netcore.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- TODO prebuild step to fscomp it -->
+    <Compile Include="obj\coreclr\FSComp.fs" />
+    <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Compiler.dll.fs">
+      <Link>assemblyinfo.FSharp.Compiler.dll.fs</Link>
+    </Compile>
+    <FsSrGen Include="..\FSComp.txt">
+      <Link>FSComp.txt</Link>
+    </FsSrGen>
+    <EmbeddedResource Include="..\FSStrings.resx">
+      <Link>FSStrings.resx</Link>
+    </EmbeddedResource>
+    <Compile Include="..\..\utils\reshapedreflection.fs">
+      <Link>Reflection\reshapedreflection.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\reshapedmsbuild.fs">
+      <Link>Reflection\reshapedmsbuild.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\sformat.fsi">
+      <Link>ErrorText\sformat.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\utils\sformat.fs">
+      <Link>ErrorText\sformat.fs</Link>
+    </Compile>
+    <Compile Include="..\sr.fsi">
+      <Link>ErrorText\sr.fsi</Link>
+    </Compile>
+    <Compile Include="..\sr.fs">
+      <Link>ErrorText\sr.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\prim-lexing.fsi">
+      <Link>LexYaccRuntime\prim-lexing.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\utils\prim-lexing.fs">
+      <Link>LexYaccRuntime\prim-lexing.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\prim-parsing.fsi">
+      <Link>LexYaccRuntime\prim-parsing.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\utils\prim-parsing.fs">
+      <Link>LexYaccRuntime\prim-parsing.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\ResizeArray.fsi">
+      <Link>Utilities\ResizeArray.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\utils\ResizeArray.fs">
+      <Link>Utilities\ResizeArray.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\HashMultiMap.fsi">
+      <Link>Utilities\HashMultiMap.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\utils\HashMultiMap.fs">
+      <Link>Utilities\HashMultiMap.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\EditDistance.fs">
+      <Link>Utilities\EditDistance.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\TaggedCollections.fsi">
+      <Link>Utilities\TaggedCollections.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\utils\TaggedCollections.fs">
+      <Link>Utilities\TaggedCollections.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ildiag.fsi">
+      <Link>Utilities\ildiag.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ildiag.fs">
+      <Link>Utilities\ildiag.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\illib.fs">
+      <Link>Utilities\illib.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\filename.fsi">
+      <Link>Utilities\filename.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\utils\filename.fs">
+      <Link>Utilities\filename.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\zmap.fsi">
+      <Link>Utilities\zmap.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\zmap.fs">
+      <Link>Utilities\zmap.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\zset.fsi">
+      <Link>Utilities\zset.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\zset.fs">
+      <Link>Utilities\zset.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\bytes.fsi">
+      <Link>Utilities\bytes.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\bytes.fs">
+      <Link>Utilities\bytes.fs</Link>
+    </Compile>
+    <Compile Include="..\InternalCollections.fsi">
+      <Link>Utilities\InternalCollections.fsi</Link>
+    </Compile>
+    <Compile Include="..\InternalCollections.fs">
+      <Link>Utilities\InternalCollections.fs</Link>
+    </Compile>
+    <Compile Include="..\QueueList.fs">
+      <Link>Utilities\QueueList.fs</Link>
+    </Compile>
+    <Compile Include="..\lib.fs">
+      <Link>Utilities\lib.fs</Link>
+    </Compile>
+    <Compile Include="..\rational.fsi">
+      <Link>Utilities\rational.fsi</Link>
+    </Compile>
+    <Compile Include="..\rational.fs">
+      <Link>Utilities\rational.fs</Link>
+    </Compile>
+    <Compile Include="..\range.fsi">
+      <Link>ErrorLogging\range.fsi</Link>
+    </Compile>
+    <Compile Include="..\range.fs">
+      <Link>ErrorLogging\range.fs</Link>
+    </Compile>
+    <Compile Include="..\ErrorLogger.fs">
+      <Link>ErrorLogging\ErrorLogger.fs</Link>
+    </Compile>
+    <Compile Include="..\ErrorResolutionHints.fs">
+      <Link>ErrorLogging\ErrorResolutionHints.fs</Link>
+    </Compile>
+    <Compile Include="..\ReferenceResolver.fs">
+      <Link>ReferenceResolution\ReferenceResolver.fs</Link>
+    </Compile>
+    <FsLex Include="..\..\absil\illex.fsl">
+      <OtherFlags>--unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <Link>AbsIL\illex.fsl</Link>
+    </FsLex>
+    <FsYacc Include="..\..\absil\ilpars.fsy">
+      <OtherFlags>--module Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiParser --open Microsoft.FSharp.Compiler.AbstractIL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
+      <Link>AbsIL\ilpars.fsy</Link>
+    </FsYacc>
+    <Compile Include="..\..\absil\il.fsi">
+      <Link>AbsIL\il.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\il.fs">
+      <Link>AbsIL\il.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilx.fsi">
+      <Link>AbsIL\ilx.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilx.fs">
+      <Link>AbsIL\ilx.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilascii.fsi">
+      <Link>AbsIL\ilascii.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilascii.fs">
+      <Link>AbsIL\ilascii.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilprint.fsi">
+      <Link>AbsIL\ilprint.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilprint.fs">
+      <Link>AbsIL\ilprint.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilmorph.fsi">
+      <Link>AbsIL\ilmorph.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilmorph.fs">
+      <Link>AbsIL\ilmorph.fs</Link>
+    </Compile>
+     <Compile Include="..\..\absil\ilsign.fs" Condition=" '$(_MyTargetFramework)' == 'coreclr' "> 
+      <Link>AbsIL\ilsign.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilsupp.fsi">
+      <Link>AbsIL\ilsupp.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilsupp.fs">
+      <Link>AbsIL\ilsupp.fs</Link>
+    </Compile>
+    <Compile Include="ilpars.fs">
+      <Link>AbsIL\ilpars.fs</Link>
+    </Compile>
+    <Compile Include="illex.fs">
+      <Link>AbsIL\illex.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilbinary.fsi">
+      <Link>AbsIL\ilbinary.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilbinary.fs">
+      <Link>AbsIL\ilbinary.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilread.fsi">
+      <Link>AbsIL\ilread.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilread.fs">
+      <Link>AbsIL\ilread.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilwrite.fsi">
+      <Link>AbsIL\ilwrite.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilwritepdb.fsi">
+      <Link>AbsIL\ilwritepdb.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilwritepdb.fs">
+      <Link>AbsIL\ilwritepdb.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilwrite.fs">
+      <Link>AbsIL\ilwrite.fs</Link>
+    </Compile>
+    <Compile Include="..\..\absil\ilreflect.fs">
+      <Link>AbsIL\ilreflect.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\CompilerLocationUtils.fs">
+      <Link>CompilerLocation\CompilerLocationUtils.fs</Link>
+    </Compile>
+    <Compile Include="..\PrettyNaming.fs">
+      <Link>PrettyNaming\PrettyNaming.fs</Link>
+    </Compile>
+    <Compile Include="..\..\ilx\ilxsettings.fs">
+      <Link>ILXErase\ilxsettings.fs</Link>
+    </Compile>
+    <Compile Include="..\..\ilx\EraseClosures.fsi">
+      <Link>ILXErase\EraseClosures.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\ilx\EraseClosures.fs">
+      <Link>ILXErase\EraseClosures.fs</Link>
+    </Compile>
+    <Compile Include="..\..\ilx\EraseUnions.fsi">
+      <Link>ILXErase\EraseUnions.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\ilx\EraseUnions.fs">
+      <Link>ILXErase\EraseUnions.fs</Link>
+    </Compile>
+    <FsLex Include="..\pplex.fsl">
+      <OtherFlags>--unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <Link>ParserAndUntypedAST\pplex.fsl</Link>
+    </FsLex>
+    <FsYacc Include="..\pppars.fsy">
+      <OtherFlags>--module Microsoft.FSharp.Compiler.PPParser --open Microsoft.FSharp.Compiler --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
+      <Link>ParserAndUntypedAST\pppars.fsy</Link>
+    </FsYacc>
+    <FsLex Include="..\lex.fsl">
+      <OtherFlags>--unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
+      <Link>ParserAndUntypedAST\lex.fsl</Link>
+    </FsLex>
+    <FsYacc Include="..\pars.fsy">
+      <OtherFlags>--module Microsoft.FSharp.Compiler.Parser --open Microsoft.FSharp.Compiler --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
+      <Link>ParserAndUntypedAST\pars.fsy</Link>
+    </FsYacc>
+    <Compile Include="..\UnicodeLexing.fsi">
+      <Link>ParserAndUntypedAST\UnicodeLexing.fsi</Link>
+    </Compile>
+    <Compile Include="..\UnicodeLexing.fs">
+      <Link>ParserAndUntypedAST\UnicodeLexing.fs</Link>
+    </Compile>
+    <Compile Include="..\layout.fsi">
+      <Link>ParserAndUntypedAST\layout.fsi</Link>
+    </Compile>
+    <Compile Include="..\layout.fs">
+      <Link>ParserAndUntypedAST\layout.fs</Link>
+    </Compile>
+    <Compile Include="..\ast.fs">
+      <Link>ParserAndUntypedAST\ast.fs</Link>
+    </Compile>
+    <Compile Include="pppars.fs">
+      <Link>ParserAndUntypedAST\pppars.fs</Link>
+    </Compile>
+    <Compile Include="pars.fs">
+      <Link>ParserAndUntypedAST\pars.fs</Link>
+    </Compile>
+    <Compile Include="..\lexhelp.fsi">
+      <Link>ParserAndUntypedAST\lexhelp.fsi</Link>
+    </Compile>
+    <Compile Include="..\lexhelp.fs">
+      <Link>ParserAndUntypedAST\lexhelp.fs</Link>
+    </Compile>
+    <Compile Include="pplex.fs">
+      <Link>ParserAndUntypedAST\pplex.fs</Link>
+    </Compile>
+    <Compile Include="lex.fs">
+      <Link>ParserAndUntypedAST\lex.fs</Link>
+    </Compile>
+    <Compile Include="..\LexFilter.fs">
+      <Link>ParserAndUntypedAST\lexfilter.fs</Link>
+    </Compile>
+    <Compile Include="..\tainted.fsi">
+      <Link>TypedAST\tainted.fsi</Link>
+    </Compile>
+    <Compile Include="..\tainted.fs">
+      <Link>TypedAST\tainted.fs</Link>
+    </Compile>
+    <Compile Include="..\ExtensionTyping.fsi">
+      <Link>TypedAST\ExtensionTyping.fsi</Link>
+    </Compile>
+    <Compile Include="..\ExtensionTyping.fs">
+      <Link>TypedAST\ExtensionTyping.fs</Link>
+    </Compile>
+    <Compile Include="..\QuotationPickler.fsi">
+      <Link>TypedAST\QuotationPickler.fsi</Link>
+    </Compile>
+    <Compile Include="..\QuotationPickler.fs">
+      <Link>TypedAST\QuotationPickler.fs</Link>
+    </Compile>
+    <Compile Include="..\tast.fs">
+      <Link>TypedAST\tast.fs</Link>
+    </Compile>
+    <Compile Include="..\TcGlobals.fs">
+      <Link>TypedAST\TcGlobals.fs</Link>
+    </Compile>
+    <Compile Include="..\TastOps.fsi">
+      <Link>TypedAST\TastOps.fsi</Link>
+    </Compile>
+    <Compile Include="..\TastOps.fs">
+      <Link>TypedAST\TastOps.fs</Link>
+    </Compile>
+    <Compile Include="..\TastPickle.fsi">
+      <Link>TypedAST\TastPickle.fsi</Link>
+    </Compile>
+    <Compile Include="..\TastPickle.fs">
+      <Link>TypedAST\TastPickle.fs</Link>
+    </Compile>
+    <Compile Include="..\import.fsi">
+      <Link>Logic\import.fsi</Link>
+    </Compile>
+    <Compile Include="..\import.fs">
+      <Link>Logic\import.fs</Link>
+    </Compile>
+    <Compile Include="..\infos.fs">
+      <Link>Logic\infos.fs</Link>
+    </Compile>
+    <Compile Include="..\AccessibilityLogic.fs">
+      <Link>Logic\AccessibilityLogic.fs</Link>
+    </Compile>
+    <Compile Include="..\AttributeChecking.fs">
+      <Link>Logic\AttributeChecking.fs</Link>
+    </Compile>
+    <Compile Include="..\InfoReader.fs">
+      <Link>Logic\InfoReader.fs</Link>
+    </Compile>
+    <Compile Include="..\NicePrint.fs">
+      <Link>Logic\NicePrint.fs</Link>
+    </Compile>
+    <Compile Include="..\AugmentWithHashCompare.fsi">
+      <Link>Logic\AugmentWithHashCompare.fsi</Link>
+    </Compile>
+    <Compile Include="..\AugmentWithHashCompare.fs">
+      <Link>Logic\AugmentWithHashCompare.fs</Link>
+    </Compile>
+    <Compile Include="..\NameResolution.fsi">
+      <Link>Logic\NameResolution.fsi</Link>
+    </Compile>
+    <Compile Include="..\NameResolution.fs">
+      <Link>Logic\NameResolution.fs</Link>
+    </Compile>
+    <Compile Include="..\TypeRelations.fs">
+      <Link>Logic\TypeRelations.fs</Link>
+    </Compile>
+    <Compile Include="..\SignatureConformance.fs">
+      <Link>Logic\SignatureConformance.fs</Link>
+    </Compile>
+    <Compile Include="..\MethodOverrides.fs">
+      <Link>Logic\MethodOverrides.fs</Link>
+    </Compile>
+    <Compile Include="..\MethodCalls.fs">
+      <Link>Logic\MethodCalls.fs</Link>
+    </Compile>
+    <Compile Include="..\PatternMatchCompilation.fsi">
+      <Link>Logic\PatternMatchCompilation.fsi</Link>
+    </Compile>
+    <Compile Include="..\PatternMatchCompilation.fs">
+      <Link>Logic\PatternMatchCompilation.fs</Link>
+    </Compile>
+    <Compile Include="..\ConstraintSolver.fsi">
+      <Link>Logic\ConstraintSolver.fsi</Link>
+    </Compile>
+    <Compile Include="..\ConstraintSolver.fs">
+      <Link>Logic\ConstraintSolver.fs</Link>
+    </Compile>
+    <Compile Include="..\CheckFormatStrings.fsi">
+      <Link>Logic\CheckFormatStrings.fsi</Link>
+    </Compile>
+    <Compile Include="..\CheckFormatStrings.fs">
+      <Link>Logic\CheckFormatStrings.fs</Link>
+    </Compile>
+    <Compile Include="..\FindUnsolved.fs">
+      <Link>Logic\FindUnsolved.fs</Link>
+    </Compile>
+    <Compile Include="..\QuotationTranslator.fsi">
+      <Link>Logic\QuotationTranslator.fsi</Link>
+    </Compile>
+    <Compile Include="..\QuotationTranslator.fs">
+      <Link>Logic\QuotationTranslator.fs</Link>
+    </Compile>
+    <Compile Include="..\PostInferenceChecks.fsi">
+      <Link>Logic\PostInferenceChecks.fsi</Link>
+    </Compile>
+    <Compile Include="..\PostInferenceChecks.fs">
+      <Link>Logic\PostInferenceChecks.fs</Link>
+    </Compile>
+    <Compile Include="..\TypeChecker.fsi">
+      <Link>Logic\TypeChecker.fsi</Link>
+    </Compile>
+    <Compile Include="..\TypeChecker.fs">
+      <Link>Logic\TypeChecker.fs</Link>
+    </Compile>
+    <Compile Include="..\Optimizer.fsi">
+      <Link>Optimize\Optimizer.fsi</Link>
+    </Compile>
+    <Compile Include="..\Optimizer.fs">
+      <Link>Optimize\Optimizer.fs</Link>
+    </Compile>
+    <Compile Include="..\DetupleArgs.fsi">
+      <Link>Optimize\DetupleArgs.fsi</Link>
+    </Compile>
+    <Compile Include="..\DetupleArgs.fs">
+      <Link>Optimize\DetupleArgs.fs</Link>
+    </Compile>
+    <Compile Include="..\InnerLambdasToTopLevelFuncs.fsi">
+      <Link>Optimize\InnerLambdasToTopLevelFuncs.fsi</Link>
+    </Compile>
+    <Compile Include="..\InnerLambdasToTopLevelFuncs.fs">
+      <Link>Optimize\InnerLambdasToTopLevelFuncs.fs</Link>
+    </Compile>
+    <Compile Include="..\LowerCallsAndSeqs.fs">
+      <Link>Optimize\LowerCallsAndSeqs.fs</Link>
+    </Compile>
+    <Compile Include="..\autobox.fs">
+      <Link>Optimize\autobox.fs</Link>
+    </Compile>
+    <Compile Include="..\IlxGen.fsi">
+      <Link>CodeGen\IlxGen.fsi</Link>
+    </Compile>
+    <Compile Include="..\IlxGen.fs">
+      <Link>CodeGen\IlxGen.fs</Link>
+    </Compile>
+    <Compile Include="..\CompileOps.fsi">
+      <Link>Driver\CompileOps.fsi</Link>
+    </Compile>
+    <Compile Include="..\CompileOps.fs">
+      <Link>Driver\CompileOps.fs</Link>
+    </Compile>
+    <Compile Include="..\CompileOptions.fsi">
+      <Link>Driver\CompileOptions.fsi</Link>
+    </Compile>
+    <Compile Include="..\CompileOptions.fs">
+      <Link>Driver\CompileOptions.fs</Link>
+    </Compile>
+    <Compile Include="..\fsc.fsi">
+      <Link>Driver\fsc.fsi</Link>
+    </Compile>
+    <Compile Include="..\fsc.fs">
+      <Link>Driver\fsc.fs</Link>
+    </Compile>
+    <Compile Include="..\MSBuildReferenceResolver.fs">
+      <Link>MSBuildReferenceResolver.fs</Link>
+    </Compile>
+    <Compile Include="InternalsVisibleTo.fs" Condition=" '$(_MyTargetFramework)' != 'coreclr' ">
+      <Link>InternalsVisibleTo.fs</Link>
+    </Compile>
+    <Compile Include="..\LegacyHostedCompilerForTesting.fs">
+      <Link>LegacyHostedCompilerForTesting.fs</Link>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/src/fsharp/FSharp.Core/FSharp.Core.netcore.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.netcore.fsproj
@@ -17,6 +17,8 @@
 
     <OtherFlags>$(OtherFlags) --warnon:1182 --compiling-fslib --maxerrors:20   --extraoptimizationloops:1 </OtherFlags>
     <OtherFlags Condition=" '$(_MyTargetFramework)' == 'coreclr' ">$(OtherFlags)     --compiling-fslib-40</OtherFlags>
+
+    <OtherFlags>$(OtherFlags) --keyfile:e:\github\fsharp\src\fsharp\Fsc\..\..\fsharp\msft.pubkey</OtherFlags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsharp/FSharp.Core/FSharp.Core.netcore.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.netcore.fsproj
@@ -21,7 +21,7 @@
     <OtherFlags>$(OtherFlags) --keyfile:e:\github\fsharp\src\fsharp\Fsc\..\..\fsharp\msft.pubkey</OtherFlags>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' " >
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
@@ -29,6 +29,10 @@
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' " >
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.5-rc1-*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/fsharp/FSharp.Core/FSharp.Core.netcore.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.netcore.fsproj
@@ -1,0 +1,234 @@
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
+  </PropertyGroup>
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+
+    <AssemblyName>FSharp.Core</AssemblyName>
+    <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
+    <BaseAddress>0x05000000</BaseAddress>
+    <CompilingFsLib>true</CompilingFsLib>
+
+    <DefineConstants>RUNTIME;$(DefineConstants)</DefineConstants>
+
+    <OtherFlags>$(OtherFlags) --warnon:1182 --compiling-fslib --maxerrors:20   --extraoptimizationloops:1 </OtherFlags>
+    <OtherFlags Condition=" '$(_MyTargetFramework)' == 'coreclr' ">$(OtherFlags)     --compiling-fslib-40</OtherFlags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--<CustomAdditionalCompileInputs Include="$(FSharpSourcesRoot)\..\Proto\$(ProtoFlavour)\bin\fsc-proto.exe">
+      <Visible>false</Visible>
+    </CustomAdditionalCompileInputs>-->
+    <EmbeddedResource Include="FSCore.resx">
+      <Link>FSCore.resx</Link>
+    </EmbeddedResource>
+    <Compile Include="prim-types-prelude.fsi">
+      <Link>Primitives/prim-types-prelude.fsi</Link>
+    </Compile>
+    <Compile Include="prim-types-prelude.fs">
+      <Link>Primitives/prim-types-prelude.fs</Link>
+    </Compile>
+    <Compile Include="SR.fs">
+      <Link>Primitives/SR.fs</Link>
+    </Compile>
+    <Compile Include="prim-types.fsi">
+      <Link>Primitives/prim-types.fsi</Link>
+    </Compile>
+    <Compile Include="prim-types.fs">
+      <Link>Primitives/prim-types.fs</Link>
+    </Compile>
+    <Compile Include="local.fsi">
+      <Link>Collections/local.fsi</Link>
+    </Compile>
+    <Compile Include="local.fs">
+      <Link>Collections/local.fs</Link>
+    </Compile>
+    <Compile Include="array2.fsi">
+      <Link>Collections/array2.fsi</Link>
+    </Compile>
+    <Compile Include="array2.fs">
+      <Link>Collections/array2.fs</Link>
+    </Compile>
+    <Compile Include="option.fsi">
+      <Link>Collections/option.fsi</Link>
+    </Compile>
+    <Compile Include="option.fs">
+      <Link>Collections/option.fs</Link>
+    </Compile>
+    <Compile Include="result.fsi">
+      <Link>Collections/result.fsi</Link>
+    </Compile>
+    <Compile Include="result.fs">
+      <Link>Collections/result.fs</Link>
+    </Compile>
+    <Compile Include="collections.fsi">
+      <Link>Collections/collections.fsi</Link>
+    </Compile>
+    <Compile Include="collections.fs">
+      <Link>Collections/collections.fs</Link>
+    </Compile>
+    <Compile Include="seqcore.fsi">
+      <Link>Collections/seqcore.fsi</Link>
+    </Compile>
+    <Compile Include="seqcore.fs">
+      <Link>Collections/seqcore.fs</Link>
+    </Compile>
+    <Compile Include="seq.fsi">
+      <Link>Collections/seq.fsi</Link>
+    </Compile>
+    <Compile Include="seq.fs">
+      <Link>Collections/seq.fs</Link>
+    </Compile>
+    <Compile Include="string.fsi">
+      <Link>Collections/string.fsi</Link>
+    </Compile>
+    <Compile Include="string.fs">
+      <Link>Collections/string.fs</Link>
+    </Compile>
+    <Compile Include="list.fsi">
+      <Link>Collections/list.fsi</Link>
+    </Compile>
+    <Compile Include="list.fs">
+      <Link>Collections/list.fs</Link>
+    </Compile>
+    <Compile Include="array.fsi">
+      <Link>Collections/array.fsi</Link>
+    </Compile>
+    <Compile Include="array.fs">
+      <Link>Collections/array.fs</Link>
+    </Compile>
+    <Compile Include="array3.fsi">
+      <Link>Collections/array3.fsi</Link>
+    </Compile>
+    <Compile Include="array3.fs">
+      <Link>Collections/array3.fs</Link>
+    </Compile>
+    <Compile Include="map.fsi">
+      <Link>Collections/map.fsi</Link>
+    </Compile>
+    <Compile Include="map.fs">
+      <Link>Collections/map.fs</Link>
+    </Compile>
+    <Compile Include="set.fsi">
+      <Link>Collections/set.fsi</Link>
+    </Compile>
+    <Compile Include="set.fs">
+      <Link>Collections/set.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\reshapedreflection.fs">
+      <Link>Reflection/reshapedreflection.fs</Link>
+    </Compile>
+    <Compile Include="reflect.fsi">
+      <Link>Reflection/reflect.fsi</Link>
+    </Compile>
+    <Compile Include="reflect.fs">
+      <Link>Reflection/reflect.fs</Link>
+    </Compile>
+    <Compile Include="event.fsi">
+      <Link>Event/event.fsi</Link>
+    </Compile>
+    <Compile Include="event.fs">
+      <Link>Event/event.fs</Link>
+    </Compile>
+    <Compile Include="math\n.fsi">
+      <Link>Numerics/n.fsi</Link>
+    </Compile>
+    <Compile Include="math\n.fs">
+      <Link>Numerics/n.fs</Link>
+    </Compile>
+    <Compile Include="math\z.fsi">
+      <Link>Numerics/z.fsi</Link>
+    </Compile>
+    <Compile Include="math\z.fs">
+      <Link>Numerics/z.fs</Link>
+    </Compile>
+    <Compile Include="..\..\utils\sformat.fsi">
+      <Link>Printf/sformat.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\utils\sformat.fs">
+      <Link>Printf/sformat.fs</Link>
+    </Compile>
+    <Compile Include="printf.fsi">
+      <Link>Printf/printf.fsi</Link>
+    </Compile>
+    <Compile Include="printf.fs">
+      <Link>Printf/printf.fs</Link>
+    </Compile>
+    <Compile Include="quotations.fsi">
+      <Link>Quotations/quotations.fsi</Link>
+    </Compile>
+    <Compile Include="quotations.fs">
+      <Link>Quotations/quotations.fs</Link>
+    </Compile>
+    <Compile Include="nativeptr.fsi">
+      <Link>NativeInterop/nativeptr.fsi</Link>
+    </Compile>
+    <Compile Include="nativeptr.fs">
+      <Link>NativeInterop/nativeptr.fs</Link>
+    </Compile>
+    <Compile Include="control.fsi">
+      <Link>Async/control.fsi</Link>
+    </Compile>
+    <Compile Include="control.fs">
+      <Link>Async/control.fs</Link>
+    </Compile>
+    <Compile Include="Linq.fsi">
+      <Link>Queries/Linq.fsi</Link>
+    </Compile>
+    <Compile Include="Linq.fs">
+      <Link>Queries/Linq.fs</Link>
+    </Compile>
+    <Compile Include="MutableTuple.fs">
+      <Link>Queries/MutableTuple.fs</Link>
+    </Compile>
+    <Compile Include="QueryExtensions.fs">
+      <Link>Queries/QueryExtensions.fs</Link>
+    </Compile>
+    <Compile Include="Query.fsi">
+      <Link>Queries/Query.fsi</Link>
+    </Compile>
+    <Compile Include="Query.fs">
+      <Link>Queries/Query.fs</Link>
+    </Compile>
+    <Compile Include="SI.fs">
+      <Link>Units/SI.fs</Link>
+    </Compile>
+    <Compile Include="fslib-extra-pervasives.fsi">
+      <Link>Extras/fslib-extra-pervasives.fsi</Link>
+    </Compile>
+    <Compile Include="fslib-extra-pervasives.fs">
+      <Link>Extras/fslib-extra-pervasives.fs</Link>
+    </Compile>
+    <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Core.dll.fs">
+      <Link>assemblyinfo.FSharp.Core.dll.fs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <!-- Hook compilation phase to do custom work -->
+  <!-- NOTE: The optdata and sigdata files are no longer needed by the F# compiler (the information is -->
+  <!-- integrated as resources into more recent FSharp.Core.dll's. However they are still produced to -->
+  <!-- allow older versions of the F# compiler to reference more recent FSharp.Core packages -->
+  <Target Name="CopyToBuiltBin" BeforeTargets="AfterCompile" AfterTargets="CoreCompile" >
+    <ItemGroup>
+      <BuiltProjectOutputGroupKeyOutput Include="$(IntermediateOutputPath)\FSharp.Core.sigdata" />
+      <BuiltProjectOutputGroupKeyOutput Include="$(IntermediateOutputPath)\FSharp.Core.optdata" />
+    </ItemGroup>
+    <Copy SourceFiles="$(IntermediateOutputPath)\FSharp.Core.sigdata" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(IntermediateOutputPath)\FSharp.Core.optdata" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/src/fsharp/FSharp.Core/FSharp.Core.netcore.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.netcore.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
   </PropertyGroup>
-  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.props" />
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Sdk.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -230,5 +230,7 @@
     <Copy SourceFiles="$(IntermediateOutputPath)\FSharp.Core.sigdata" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(IntermediateOutputPath)\FSharp.Core.optdata" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
   </Target>
+
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Sdk.targets" />
 
 </Project>

--- a/src/fsharp/Fsc/Fsc.netcore.fsproj
+++ b/src/fsharp/Fsc/Fsc.netcore.fsproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
+  </PropertyGroup>
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+
+    <AssemblyName>fsc</AssemblyName>
+    <NoWarn>$(NoWarn);62</NoWarn>
+    <AssemblyName>fsc</AssemblyName>
+
+    <DefineConstants>EXTENSIONTYPING;COMPILER;$(DefineConstants)</DefineConstants>
+
+    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+
+    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+
+    <ProjectReference Include="..\FSharp.Core\FSharp.Core.netcore.fsproj" />
+    <ProjectReference Include="..\FSharp.Compiler\FSharp.Compiler.netcore.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="InternalsVisibleTo.fs" />
+    <Compile Include="..\..\assemblyinfo\assemblyinfo.fsc.exe.fs">
+      <Link>Resources/assemblyinfo.fsc.exe.fs</Link>
+    </Compile>
+    <Compile Include="..\fscmain.fs">
+      <Link>fscmain.fs</Link>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/src/fsharp/Fsc/Fsc.netcore.fsproj
+++ b/src/fsharp/Fsc/Fsc.netcore.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
   </PropertyGroup>
-  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.props" />
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Sdk.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -37,5 +37,7 @@
       <Link>fscmain.fs</Link>
     </Compile>
   </ItemGroup>
+
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Sdk.targets" />
 
 </Project>

--- a/src/fsharp/Fsc/Fsc.netcore.fsproj
+++ b/src/fsharp/Fsc/Fsc.netcore.fsproj
@@ -14,8 +14,11 @@
     <AssemblyName>fsc</AssemblyName>
 
     <DefineConstants>EXTENSIONTYPING;COMPILER;$(DefineConstants)</DefineConstants>
+    <DefineConstants>FX_RESHAPED_REFLECTION_CORECLR;$(DefineConstants)</DefineConstants>
 
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
+    <OtherFlags>$(OtherFlags) --platform:anycpu</OtherFlags>
+    <OtherFlags>$(OtherFlags) --keyfile:e:\github\fsharp\src\fsharp\Fsc\..\..\fsharp\msft.pubkey</OtherFlags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsharp/Fsc/README.md
+++ b/src/fsharp/Fsc/README.md
@@ -1,0 +1,9 @@
+## How to build fsc
+
+How to build and run the F# compiler
+
+```
+dotnet restore Fsc.netcore.fsproj
+dotnet build Fsc.netcore.fsproj -c Release
+dotnet bin\Release\netcoreapp1.1\fsc.dll
+``` 


### PR DESCRIPTION
Added `.netcore.fsproj` for .net core sdk 1.0

this is going to be a 1-1 conversion of `build coreclr`, to just replace project.json with new sdk.
So build output will go in usual directories `bin\release\coreclr` etc

- `FSharp.Core`
- `FSharp.Compiler`
- `fsc`

this semplify build a lot in the future for new dev

```
cd src\fsharp\Fsc
dotnet restore Fsc.netcore.fsproj
dotnet build Fsc.netcore.fsproj -c Release
dotnet bin\Release\netcoreapp1.1\fsc.dll
```

msbuild can be used too, just `msbuild /t:Restore` and `msbuild /t:Build` instead of `dotnet build/restore`. Same on mono

Same fsprojs can be used to build `netstandard2,0` and fsc `netcoreapp2.0` later.

## TODO

- [x] fix internal visible error signing assemblies, otherwise fsc doesnt work
- [ ] install .net core sdk 1.0.1 in build script
- [ ] replace `build coreclr` completly
- [x] use proto-compiler (it's really needed @dsyme? atm just use `FSharp.Compiler.Tools`)
- [ ] check `dotnet`/msbuild vs/mono
- [ ] replace `FsSrGen`
- [ ] just one `--keyfile`
- [ ] copy `default.win32manifest` to out dir
- [ ] create AssemblyFileVersion file, until https://github.com/dotnet/netcorecli-fsc/issues/93 is fixed

/cc @KevinRansom @cartermp @dsyme @brettfo 
