### PR TITLE
[CompilerPerf] Remove unbox.any when coercing to subsumed interfaces

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2201,9 +2201,9 @@ and GenCoerce cenv cgbuf eenv (e,tgty,m,srcty) sequel =
        if (isInterfaceTy cenv.g tgty) then (
            GenExpr cenv cgbuf eenv SPSuppress e Continue
            let ilToTy = GenType cenv.amap m eenv.tyenv tgty
-           // I believe section "III.1.8.1.3 Merging stack states" of ECMA-335 implies that no unboxing
+           // Section "III.1.8.1.3 Merging stack states" of ECMA-335 implies that no unboxing
            // is required, but we still push the coerce'd type on to the code gen buffer.
-           CG.EmitInstrs cgbuf (pop 1) (Push [ilToTy]) [ (*I_unbox_any ilToTy*)  ]
+           CG.EmitInstrs cgbuf (pop 1) (Push [ilToTy]) []
            GenSequel cenv eenv.cloc cgbuf sequel
        ) else (
            GenExpr cenv cgbuf eenv SPSuppress e sequel

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2198,12 +2198,12 @@ and GenCoerce cenv cgbuf eenv (e,tgty,m,srcty) sequel =
      // Do an extra check - should not be needed 
      TypeRelations.TypeFeasiblySubsumesType 0 cenv.g cenv.amap m tgty TypeRelations.NoCoerce srcty then
      begin 
-       // The .NET IL doesn't always support implict subsumption for interface types, e.g. at stack merge points 
-       // Hence be conservative here and always cast explicitly. 
        if (isInterfaceTy cenv.g tgty) then (
            GenExpr cenv cgbuf eenv SPSuppress e Continue
            let ilToTy = GenType cenv.amap m eenv.tyenv tgty
-           CG.EmitInstrs cgbuf (pop 1) (Push [ilToTy]) [ I_unbox_any ilToTy  ]
+           // I believe section "III.1.8.1.3 Merging stack states" of ECMA-335 implies that no unboxing
+           // is required, but we still push the coerce'd type on to the code gen buffer.
+           CG.EmitInstrs cgbuf (pop 1) (Push [ilToTy]) [ (*I_unbox_any ilToTy*)  ]
            GenSequel cenv eenv.cloc cgbuf sequel
        ) else (
            GenExpr cenv cgbuf eenv SPSuppress e sequel

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/AsyncExpressionStepping/AsyncExpressionSteppingTest5.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/AsyncExpressionStepping/AsyncExpressionSteppingTest5.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -22,27 +22,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.AsyncExpressionSteppingTest5
 {
-  // Offset: 0x00000000 Length: 0x000002B0
+  // Offset: 0x00000000 Length: 0x000002B4
 }
 .mresource public FSharpOptimizationData.AsyncExpressionSteppingTest5
 {
   // Offset: 0x000002B8 Length: 0x000000BE
 }
 .module AsyncExpressionSteppingTest5.dll
-// MVID: {5775B149-6394-30E8-A745-038349B17557}
+// MVID: {590846DB-6394-30E8-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00D30000
+// Image base: 0x012D0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -81,16 +81,16 @@
         .maxstack  5
         .locals init ([0] int32 x)
         .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-        .line 6,6 : 17,31 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\AsyncExpressionStepping\\AsyncExpressionSteppingTest5.fs'
+        .line 6,6 : 17,31 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\AsyncExpressionStepping\\AsyncExpressionSteppingTest5.fs'
         IL_0000:  nop
         IL_0001:  ldarg.1
         IL_0002:  stloc.0
-        .line 7,7 : 20,35
+        .line 7,7 : 20,35 ''
         IL_0003:  ldstr      "hello"
         IL_0008:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
         IL_000d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
         IL_0012:  pop
-        .line 8,8 : 20,37
+        .line 8,8 : 20,37 ''
         IL_0013:  ldstr      "hello 2"
         IL_0018:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
         IL_001d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
@@ -129,16 +129,16 @@
         // Code size       49 (0x31)
         .maxstack  5
         .locals init ([0] int32 x)
-        .line 9,9 : 17,31
+        .line 9,9 : 17,31 ''
         IL_0000:  nop
         IL_0001:  ldarg.1
         IL_0002:  stloc.0
-        .line 10,10 : 20,37
+        .line 10,10 : 20,37 ''
         IL_0003:  ldstr      "goodbye"
         IL_0008:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
         IL_000d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
         IL_0012:  pop
-        .line 11,11 : 20,39
+        .line 11,11 : 20,39 ''
         IL_0013:  ldstr      "goodbye 2"
         IL_0018:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
         IL_001d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
@@ -174,21 +174,20 @@
       .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> 
               Invoke(class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
       {
-        // Code size       36 (0x24)
+        // Code size       31 (0x1f)
         .maxstack  8
-        .line 9,9 : 17,31
+        .line 9,9 : 17,31 ''
         IL_0000:  nop
         IL_0001:  ldarg.0
         IL_0002:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@9-2'::builder@
         IL_0007:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5::get_es()
-        IL_000c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-        IL_0011:  ldarg.0
-        IL_0012:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@9-2'::builder@
-        IL_0017:  newobj     instance void AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@9-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder)
-        IL_001c:  tail.
-        IL_001e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder::For<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+        IL_000c:  ldarg.0
+        IL_000d:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@9-2'::builder@
+        IL_0012:  newobj     instance void AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@9-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder)
+        IL_0017:  tail.
+        IL_0019:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder::For<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>>)
-        IL_0023:  ret
+        IL_001e:  ret
       } // end of method 'f7@9-2'::Invoke
 
     } // end of class 'f7@9-2'
@@ -215,31 +214,30 @@
       .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> 
               Invoke(class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
       {
-        // Code size       69 (0x45)
+        // Code size       64 (0x40)
         .maxstack  8
-        .line 6,6 : 17,31
+        .line 6,6 : 17,31 ''
         IL_0000:  nop
         IL_0001:  ldarg.0
         IL_0002:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/f7@6::builder@
         IL_0007:  ldarg.0
         IL_0008:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/f7@6::builder@
         IL_000d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5::get_es()
-        IL_0012:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-        IL_0017:  ldarg.0
-        IL_0018:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/f7@6::builder@
-        IL_001d:  newobj     instance void AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@6-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder)
-        IL_0022:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder::For<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+        IL_0012:  ldarg.0
+        IL_0013:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/f7@6::builder@
+        IL_0018:  newobj     instance void AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@6-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder)
+        IL_001d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder::For<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>>)
-        IL_0027:  ldarg.0
-        IL_0028:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/f7@6::builder@
-        IL_002d:  ldarg.0
-        IL_002e:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/f7@6::builder@
-        IL_0033:  newobj     instance void AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@9-2'::.ctor(class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder)
-        IL_0038:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<!!0> [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder::Delay<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<!!0>>)
-        IL_003d:  tail.
-        IL_003f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<!!0> [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder::Combine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>,
+        IL_0022:  ldarg.0
+        IL_0023:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/f7@6::builder@
+        IL_0028:  ldarg.0
+        IL_0029:  ldfld      class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/f7@6::builder@
+        IL_002e:  newobj     instance void AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5/'f7@9-2'::.ctor(class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder)
+        IL_0033:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<!!0> [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder::Delay<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<!!0>>)
+        IL_0038:  tail.
+        IL_003a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<!!0> [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder::Combine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>,
                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<!!0>)
-        IL_0044:  ret
+        IL_003f:  ret
       } // end of method f7@6::Invoke
 
     } // end of class f7@6
@@ -259,7 +257,7 @@
       // Code size       22 (0x16)
       .maxstack  4
       .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder builder@)
-      .line 6,6 : 9,14
+      .line 6,6 : 9,14 ''
       IL_0000:  nop
       IL_0001:  call       class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsyncBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_DefaultAsyncBuilder()
       IL_0006:  stloc.0
@@ -298,7 +296,7 @@
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> es,
              [1] class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> V_1,
              [2] class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> V_2)
-    .line 4,4 : 5,21
+    .line 4,4 : 5,21 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.3
     IL_0002:  ldc.i4.4
@@ -313,7 +311,7 @@
     IL_0018:  dup
     IL_0019:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$AsyncExpressionSteppingTest5>'.$AsyncExpressionSteppingTest5::es@4
     IL_001e:  stloc.0
-    .line 13,13 : 13,43
+    .line 13,13 : 13,43 ''
     IL_001f:  call       class [FSharp.Core]Microsoft.FSharp.Control.FSharpAsync`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> AsyncExpressionSteppingTest5/AsyncExpressionSteppingTest5::f7()
     IL_0024:  stloc.1
     IL_0025:  ldloc.1

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/ComputationExpressions/ComputationExpr07.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/ComputationExpressions/ComputationExpr07.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -26,27 +26,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.ComputationExpr07
 {
-  // Offset: 0x00000000 Length: 0x00000212
+  // Offset: 0x00000000 Length: 0x00000216
 }
 .mresource public FSharpOptimizationData.ComputationExpr07
 {
-  // Offset: 0x00000218 Length: 0x0000007D
+  // Offset: 0x00000220 Length: 0x0000007D
 }
 .module ComputationExpr07.exe
-// MVID: {5775B6D2-35BD-E566-A745-0383D2B67557}
+// MVID: {590846DC-35BD-E566-A745-0383DC460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00B60000
+// Image base: 0x01600000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -86,11 +86,11 @@
       .maxstack  7
       .locals init ([0] int32 v)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 9,9 : 9,29 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\ComputationExpressions\\ComputationExpr07.fs'
+      .line 9,9 : 9,29 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\ComputationExpressions\\ComputationExpr07.fs'
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 10,10 : 13,24
+      .line 10,10 : 13,24 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> ComputationExpr07/'res7@9-1'::x
       IL_0009:  ldarg.0
@@ -139,7 +139,7 @@
     {
       // Code size       26 (0x1a)
       .maxstack  8
-      .line 11,11 : 9,18
+      .line 11,11 : 9,18 ''
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldfld      class [ComputationExprLibrary]Library.EventuallyBuilder ComputationExpr07/'res7@11-2'::builder@
@@ -175,15 +175,15 @@
     .method public strict virtual instance class [ComputationExprLibrary]Library.Eventually`1<int32> 
             Invoke(class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
     {
-      // Code size       91 (0x5b)
+      // Code size       86 (0x56)
       .maxstack  9
       .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32> x)
-      .line 8,8 : 9,22
+      .line 8,8 : 9,22 ''
       IL_0000:  nop
       IL_0001:  ldc.i4.1
       IL_0002:  call       class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<!!0> [FSharp.Core]Microsoft.FSharp.Core.Operators::Ref<int32>(!!0)
       IL_0007:  stloc.0
-      .line 9,9 : 9,29
+      .line 9,9 : 9,29 ''
       IL_0008:  ldarg.0
       IL_0009:  ldfld      class [ComputationExprLibrary]Library.EventuallyBuilder ComputationExpr07/res7@8::builder@
       IL_000e:  ldarg.0
@@ -196,26 +196,25 @@
                                                                                                                                                                        int32)
       IL_001c:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [FSharp.Core]Microsoft.FSharp.Core.Operators::CreateSequence<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
       IL_0021:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0026:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_002b:  ldarg.0
-      IL_002c:  ldfld      class [ComputationExprLibrary]Library.EventuallyBuilder ComputationExpr07/res7@8::builder@
-      IL_0031:  ldloc.0
-      IL_0032:  newobj     instance void ComputationExpr07/'res7@9-1'::.ctor(class [ComputationExprLibrary]Library.EventuallyBuilder,
+      IL_0026:  ldarg.0
+      IL_0027:  ldfld      class [ComputationExprLibrary]Library.EventuallyBuilder ComputationExpr07/res7@8::builder@
+      IL_002c:  ldloc.0
+      IL_002d:  newobj     instance void ComputationExpr07/'res7@9-1'::.ctor(class [ComputationExprLibrary]Library.EventuallyBuilder,
                                                                              class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32>)
-      IL_0037:  callvirt   instance class [ComputationExprLibrary]Library.Eventually`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> [ComputationExprLibrary]Library.EventuallyBuilder::For<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+      IL_0032:  callvirt   instance class [ComputationExprLibrary]Library.Eventually`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> [ComputationExprLibrary]Library.EventuallyBuilder::For<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [ComputationExprLibrary]Library.Eventually`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>>)
-      IL_003c:  ldarg.0
-      IL_003d:  ldfld      class [ComputationExprLibrary]Library.EventuallyBuilder ComputationExpr07/res7@8::builder@
-      IL_0042:  ldarg.0
-      IL_0043:  ldfld      class [ComputationExprLibrary]Library.EventuallyBuilder ComputationExpr07/res7@8::builder@
-      IL_0048:  ldloc.0
-      IL_0049:  newobj     instance void ComputationExpr07/'res7@11-2'::.ctor(class [ComputationExprLibrary]Library.EventuallyBuilder,
+      IL_0037:  ldarg.0
+      IL_0038:  ldfld      class [ComputationExprLibrary]Library.EventuallyBuilder ComputationExpr07/res7@8::builder@
+      IL_003d:  ldarg.0
+      IL_003e:  ldfld      class [ComputationExprLibrary]Library.EventuallyBuilder ComputationExpr07/res7@8::builder@
+      IL_0043:  ldloc.0
+      IL_0044:  newobj     instance void ComputationExpr07/'res7@11-2'::.ctor(class [ComputationExprLibrary]Library.EventuallyBuilder,
                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpRef`1<int32>)
-      IL_004e:  callvirt   instance class [ComputationExprLibrary]Library.Eventually`1<!!0> [ComputationExprLibrary]Library.EventuallyBuilder::Delay<int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [ComputationExprLibrary]Library.Eventually`1<!!0>>)
-      IL_0053:  tail.
-      IL_0055:  callvirt   instance class [ComputationExprLibrary]Library.Eventually`1<!!0> [ComputationExprLibrary]Library.EventuallyBuilder::Combine<int32>(class [ComputationExprLibrary]Library.Eventually`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>,
+      IL_0049:  callvirt   instance class [ComputationExprLibrary]Library.Eventually`1<!!0> [ComputationExprLibrary]Library.EventuallyBuilder::Delay<int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [ComputationExprLibrary]Library.Eventually`1<!!0>>)
+      IL_004e:  tail.
+      IL_0050:  callvirt   instance class [ComputationExprLibrary]Library.Eventually`1<!!0> [ComputationExprLibrary]Library.EventuallyBuilder::Combine<int32>(class [ComputationExprLibrary]Library.Eventually`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>,
                                                                                                                                                               class [ComputationExprLibrary]Library.Eventually`1<!!0>)
-      IL_005a:  ret
+      IL_0055:  ret
     } // end of method res7@8::Invoke
 
   } // end of class res7@8
@@ -253,7 +252,7 @@
     .maxstack  4
     .locals init ([0] class [ComputationExprLibrary]Library.Eventually`1<int32> res7,
              [1] class [ComputationExprLibrary]Library.EventuallyBuilder builder@)
-    .line 13,13 : 1,25
+    .line 13,13 : 1,25 ''
     IL_0000:  call       class [ComputationExprLibrary]Library.EventuallyBuilder [ComputationExprLibrary]Library.TheEventuallyBuilder::get_eventually()
     IL_0005:  stloc.1
     IL_0006:  ldloc.1

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/ListExpressionStepping/ListExpressionSteppingTest6.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/ListExpressionStepping/ListExpressionSteppingTest6.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.16774
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly ListExpressionSteppingTest6
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.ListExpressionSteppingTest6
 {
-  // Offset: 0x00000000 Length: 0x000002BA
+  // Offset: 0x00000000 Length: 0x00000299
 }
 .mresource public FSharpOptimizationData.ListExpressionSteppingTest6
 {
-  // Offset: 0x000002C0 Length: 0x000000BC
+  // Offset: 0x000002A0 Length: 0x000000BC
 }
 .module ListExpressionSteppingTest6.exe
-// MVID: {4DAC0CD3-98A2-AB14-A745-0383D30CAC4D}
+// MVID: {590846DA-98A2-AB14-A745-0383DA460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000000000580000
+// Image base: 0x011D0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -113,10 +113,10 @@
       .method public strict virtual instance int32 
               GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
       {
-        // Code size       351 (0x15f)
+        // Code size       341 (0x155)
         .maxstack  6
         .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\ListExpressionStepping\\ListExpressionSteppingTest6.fs'
         IL_0000:  ldarg.0
         IL_0001:  ldfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
         IL_0006:  ldc.i4.1
@@ -139,152 +139,150 @@
 
         IL_002b:  br.s       IL_0042
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_002d:  nop
-        IL_002e:  br         IL_00b2
+        IL_002e:  br         IL_00ad
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0033:  nop
-        IL_0034:  br.s       IL_00a8
+        IL_0034:  br.s       IL_00a3
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0036:  nop
-        IL_0037:  br         IL_0135
+        IL_0037:  br         IL_012b
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_003c:  nop
-        IL_003d:  br         IL_012b
+        IL_003d:  br         IL_0121
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0042:  nop
-        IL_0043:  br         IL_0156
+        IL_0043:  br         IL_014c
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0048:  nop
-        .line 7,9 : 11,21 
+        .line 7,9 : 11,21 ''
         IL_0049:  ldarg.0
         IL_004a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6::get_es()
-        IL_004f:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-        IL_0054:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-        IL_0059:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
-        IL_005e:  ldarg.0
-        IL_005f:  ldc.i4.1
-        IL_0060:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
-        .line 7,9 : 11,21 
-        IL_0065:  ldarg.0
-        IL_0066:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
-        IL_006b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-        IL_0070:  brfalse.s  IL_00b2
+        IL_004f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+        IL_0054:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
+        IL_0059:  ldarg.0
+        IL_005a:  ldc.i4.1
+        IL_005b:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
+        .line 7,9 : 11,21 ''
+        IL_0060:  ldarg.0
+        IL_0061:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
+        IL_0066:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+        IL_006b:  brfalse.s  IL_00ad
 
-        IL_0072:  ldarg.0
-        IL_0073:  ldarg.0
-        IL_0074:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
-        IL_0079:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-        IL_007e:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x
-        .line 8,8 : 14,29 
-        IL_0083:  ldstr      "hello"
-        IL_0088:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-        IL_008d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-        IL_0092:  pop
-        IL_0093:  ldarg.0
-        IL_0094:  ldc.i4.2
-        IL_0095:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
-        .line 9,9 : 14,21 
-        IL_009a:  ldarg.0
-        IL_009b:  ldarg.0
-        IL_009c:  ldfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x
-        IL_00a1:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::current
-        IL_00a6:  ldc.i4.1
-        IL_00a7:  ret
+        IL_006d:  ldarg.0
+        IL_006e:  ldarg.0
+        IL_006f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
+        IL_0074:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+        IL_0079:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x
+        .line 8,8 : 14,29 ''
+        IL_007e:  ldstr      "hello"
+        IL_0083:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+        IL_0088:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+        IL_008d:  pop
+        IL_008e:  ldarg.0
+        IL_008f:  ldc.i4.2
+        IL_0090:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
+        .line 9,9 : 14,21 ''
+        IL_0095:  ldarg.0
+        IL_0096:  ldarg.0
+        IL_0097:  ldfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x
+        IL_009c:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::current
+        IL_00a1:  ldc.i4.1
+        IL_00a2:  ret
 
-        .line 7,9 : 11,21 
-        IL_00a8:  ldarg.0
-        IL_00a9:  ldc.i4.0
-        IL_00aa:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x
-        .line 100001,100001 : 0,0 
-        IL_00af:  nop
-        IL_00b0:  br.s       IL_0065
+        .line 7,9 : 11,21 ''
+        IL_00a3:  ldarg.0
+        IL_00a4:  ldc.i4.0
+        IL_00a5:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x
+        .line 100001,100001 : 0,0 ''
+        IL_00aa:  nop
+        IL_00ab:  br.s       IL_0060
 
-        IL_00b2:  ldarg.0
-        IL_00b3:  ldc.i4.5
-        IL_00b4:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
-        .line 7,9 : 11,21 
-        IL_00b9:  ldarg.0
-        IL_00ba:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
-        IL_00bf:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-        IL_00c4:  nop
-        IL_00c5:  ldarg.0
-        IL_00c6:  ldnull
-        IL_00c7:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
-        .line 10,12 : 11,21 
-        IL_00cc:  ldarg.0
-        IL_00cd:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6::get_es()
-        IL_00d2:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-        IL_00d7:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-        IL_00dc:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
-        IL_00e1:  ldarg.0
-        IL_00e2:  ldc.i4.3
-        IL_00e3:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
-        .line 10,12 : 11,21 
-        IL_00e8:  ldarg.0
-        IL_00e9:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
-        IL_00ee:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-        IL_00f3:  brfalse.s  IL_0135
+        IL_00ad:  ldarg.0
+        IL_00ae:  ldc.i4.5
+        IL_00af:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
+        .line 7,9 : 11,21 ''
+        IL_00b4:  ldarg.0
+        IL_00b5:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
+        IL_00ba:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+        IL_00bf:  nop
+        IL_00c0:  ldarg.0
+        IL_00c1:  ldnull
+        IL_00c2:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
+        .line 10,12 : 11,21 ''
+        IL_00c7:  ldarg.0
+        IL_00c8:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6::get_es()
+        IL_00cd:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+        IL_00d2:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
+        IL_00d7:  ldarg.0
+        IL_00d8:  ldc.i4.3
+        IL_00d9:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
+        .line 10,12 : 11,21 ''
+        IL_00de:  ldarg.0
+        IL_00df:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
+        IL_00e4:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+        IL_00e9:  brfalse.s  IL_012b
 
-        IL_00f5:  ldarg.0
-        IL_00f6:  ldarg.0
-        IL_00f7:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
-        IL_00fc:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-        IL_0101:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x0
-        .line 11,11 : 14,31 
-        IL_0106:  ldstr      "goodbye"
-        IL_010b:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-        IL_0110:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-        IL_0115:  pop
-        IL_0116:  ldarg.0
-        IL_0117:  ldc.i4.4
-        IL_0118:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
-        .line 12,12 : 14,21 
-        IL_011d:  ldarg.0
-        IL_011e:  ldarg.0
-        IL_011f:  ldfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x0
-        IL_0124:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::current
-        IL_0129:  ldc.i4.1
-        IL_012a:  ret
+        IL_00eb:  ldarg.0
+        IL_00ec:  ldarg.0
+        IL_00ed:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
+        IL_00f2:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+        IL_00f7:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x0
+        .line 11,11 : 14,31 ''
+        IL_00fc:  ldstr      "goodbye"
+        IL_0101:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+        IL_0106:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+        IL_010b:  pop
+        IL_010c:  ldarg.0
+        IL_010d:  ldc.i4.4
+        IL_010e:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
+        .line 12,12 : 14,21 ''
+        IL_0113:  ldarg.0
+        IL_0114:  ldarg.0
+        IL_0115:  ldfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x0
+        IL_011a:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::current
+        IL_011f:  ldc.i4.1
+        IL_0120:  ret
 
-        .line 10,12 : 11,21 
+        .line 10,12 : 11,21 ''
+        IL_0121:  ldarg.0
+        IL_0122:  ldc.i4.0
+        IL_0123:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x0
+        .line 100001,100001 : 0,0 ''
+        IL_0128:  nop
+        IL_0129:  br.s       IL_00de
+
         IL_012b:  ldarg.0
-        IL_012c:  ldc.i4.0
-        IL_012d:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::x0
-        .line 100001,100001 : 0,0 
-        IL_0132:  nop
-        IL_0133:  br.s       IL_00e8
-
-        IL_0135:  ldarg.0
-        IL_0136:  ldc.i4.5
-        IL_0137:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
-        .line 10,12 : 11,21 
-        IL_013c:  ldarg.0
-        IL_013d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
-        IL_0142:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-        IL_0147:  nop
-        IL_0148:  ldarg.0
-        IL_0149:  ldnull
-        IL_014a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
-        IL_014f:  ldarg.0
-        IL_0150:  ldc.i4.5
-        IL_0151:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
-        IL_0156:  ldarg.0
-        IL_0157:  ldc.i4.0
-        IL_0158:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::current
-        IL_015d:  ldc.i4.0
-        IL_015e:  ret
+        IL_012c:  ldc.i4.5
+        IL_012d:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
+        .line 10,12 : 11,21 ''
+        IL_0132:  ldarg.0
+        IL_0133:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
+        IL_0138:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+        IL_013d:  nop
+        IL_013e:  ldarg.0
+        IL_013f:  ldnull
+        IL_0140:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
+        IL_0145:  ldarg.0
+        IL_0146:  ldc.i4.5
+        IL_0147:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::pc
+        IL_014c:  ldarg.0
+        IL_014d:  ldc.i4.0
+        IL_014e:  stfld      int32 ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::current
+        IL_0153:  ldc.i4.0
+        IL_0154:  ret
       } // end of method f7@7::GenerateNext
 
       .method public strict virtual instance void 
@@ -295,7 +293,7 @@
         .locals init ([0] class [mscorlib]System.Exception V_0,
                  [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                  [2] class [mscorlib]System.Exception e)
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
         IL_0000:  ldnull
         IL_0001:  stloc.0
         IL_0002:  ldarg.0
@@ -306,13 +304,13 @@
                               IL_0015)
         IL_0013:  br.s       IL_001b
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0015:  nop
         IL_0016:  br         IL_00b2
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_001b:  nop
         .try
         {
@@ -339,40 +337,40 @@
 
           IL_004b:  br.s       IL_005c
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_004d:  nop
           IL_004e:  br.s       IL_008c
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_0050:  nop
           IL_0051:  br.s       IL_0078
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_0053:  nop
           IL_0054:  br.s       IL_0077
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_0056:  nop
           IL_0057:  br.s       IL_0061
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_0059:  nop
           IL_005a:  br.s       IL_0060
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_005c:  nop
           IL_005d:  br.s       IL_008c
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_005f:  nop
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
           IL_0060:  nop
           IL_0061:  ldarg.0
           IL_0062:  ldc.i4.5
@@ -381,11 +379,11 @@
           IL_0069:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::enum0
           IL_006e:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
           IL_0073:  nop
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
           IL_0074:  nop
           IL_0075:  br.s       IL_008c
 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
           IL_0077:  nop
           IL_0078:  ldarg.0
           IL_0079:  ldc.i4.5
@@ -394,7 +392,7 @@
           IL_0080:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6/f7@7::'enum'
           IL_0085:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
           IL_008a:  nop
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
           IL_008b:  nop
           IL_008c:  ldarg.0
           IL_008d:  ldc.i4.5
@@ -411,18 +409,18 @@
         {
           IL_009e:  castclass  [mscorlib]System.Exception
           IL_00a3:  stloc.2
-          .line 7,9 : 11,21 
+          .line 7,9 : 11,21 ''
           IL_00a4:  ldloc.2
           IL_00a5:  stloc.0
           IL_00a6:  ldnull
           IL_00a7:  stloc.1
           IL_00a8:  leave.s    IL_00aa
 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
         }  // end handler
         IL_00aa:  ldloc.1
         IL_00ab:  pop
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
         IL_00ac:  nop
         IL_00ad:  br         IL_0002
 
@@ -435,11 +433,11 @@
 
         IL_00ba:  br.s       IL_00be
 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
         IL_00bc:  ldloc.0
         IL_00bd:  throw
 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
         IL_00be:  ret
       } // end of method f7@7::Close
 
@@ -559,7 +557,7 @@
     {
       // Code size       20 (0x14)
       .maxstack  8
-      .line 7,12 : 9,23 
+      .line 7,12 : 9,23 ''
       IL_0000:  nop
       IL_0001:  ldc.i4.0
       IL_0002:  ldc.i4.0
@@ -603,7 +601,7 @@
     // Code size       38 (0x26)
     .maxstack  6
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> es)
-    .line 5,5 : 5,21 
+    .line 5,5 : 5,21 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.1
     IL_0002:  ldc.i4.2
@@ -618,7 +616,7 @@
     IL_0018:  dup
     IL_0019:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$ListExpressionSteppingTest6>'.$ListExpressionSteppingTest6::es@5
     IL_001e:  stloc.0
-    .line 14,14 : 13,17 
+    .line 14,14 : 13,17 ''
     IL_001f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> ListExpressionSteppingTest6/ListExpressionSteppingTest6::f7()
     IL_0024:  pop
     IL_0025:  ret

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Misc/Seq_for_all01.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Misc/Seq_for_all01.il.bsl
@@ -134,13 +134,12 @@
     IL_0007:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
     IL_000c:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0011:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-    IL_0016:  call       bool [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ForAll<int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>,
+    IL_0011:  call       bool [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ForAll<int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>,
                                                                                                  class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_001b:  dup
-    IL_001c:  stsfld     bool '<StartupCode$Seq_for_all01>'.$Seq_for_all01::q@4
-    IL_0021:  stloc.0
-    IL_0022:  ret
+    IL_0016:  dup
+    IL_0017:  stsfld     bool '<StartupCode$Seq_for_all01>'.$Seq_for_all01::q@4
+    IL_001c:  stloc.0
+    IL_001d:  ret
   } // end of method $Seq_for_all01::main@
 
 } // end of class '<StartupCode$Seq_for_all01>'.$Seq_for_all01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Aggregates01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Aggregates01.il.netfx4.bsl
@@ -38,20 +38,20 @@
 }
 .mresource public FSharpSignatureData.Linq101Aggregates01
 {
-  // Offset: 0x00000000 Length: 0x00000606
+  // Offset: 0x00000000 Length: 0x00000610
 }
 .mresource public FSharpOptimizationData.Linq101Aggregates01
 {
-  // Offset: 0x00000610 Length: 0x00000211
+  // Offset: 0x00000618 Length: 0x00000211
 }
 .module Linq101Aggregates01.exe
-// MVID: {58EED771-D281-4783-A745-038371D7EE58}
+// MVID: {590846DB-D281-4783-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x01660000
+// Image base: 0x01180000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -113,10 +113,10 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'c:\\microsoft\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Aggregates01.fs'
+      .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Aggregates01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
       IL_0006:  ldc.i4.1
@@ -136,17 +136,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -154,69 +154,68 @@
       .line 12,12 : 9,33 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Aggregates01::get_factorsOf300()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
       .line 12,12 : 9,33 ''
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::_arg1
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::_arg1
       .line 12,12 : 9,33 ''
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Aggregates01/uniqueFactors@12::_arg1
-      IL_006f:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Aggregates01/uniqueFactors@12::_arg1
+      IL_006a:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
       .line 13,13 : 9,17 ''
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Aggregates01/uniqueFactors@12::n
-      IL_0082:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Aggregates01/uniqueFactors@12::n
+      IL_007d:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::n
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::n
       .line 12,12 : 9,33 ''
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::_arg1
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
       .line 12,12 : 9,33 ''
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/uniqueFactors@12::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Aggregates01/uniqueFactors@12::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method uniqueFactors@12::GenerateNext
 
     .method public strict virtual instance void 
@@ -481,7 +480,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -503,17 +502,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -521,69 +520,68 @@
       .line 21,21 : 9,28 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Aggregates01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Aggregates01/numSum@21::pc
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Aggregates01/numSum@21::pc
       .line 21,21 : 9,28 ''
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Aggregates01/numSum@21::_arg1
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Aggregates01/numSum@21::_arg1
       .line 21,21 : 9,28 ''
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Aggregates01/numSum@21::_arg1
-      IL_006f:  stfld      int32 Linq101Aggregates01/numSum@21::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Aggregates01/numSum@21::pc
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Aggregates01/numSum@21::_arg1
+      IL_006a:  stfld      int32 Linq101Aggregates01/numSum@21::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Aggregates01/numSum@21::pc
       .line 22,22 : 9,16 ''
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Aggregates01/numSum@21::n
-      IL_0082:  stfld      int32 Linq101Aggregates01/numSum@21::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Aggregates01/numSum@21::n
+      IL_007d:  stfld      int32 Linq101Aggregates01/numSum@21::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Aggregates01/numSum@21::n
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Aggregates01/numSum@21::n
       .line 21,21 : 9,28 ''
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Aggregates01/numSum@21::_arg1
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Aggregates01/numSum@21::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Aggregates01/numSum@21::pc
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Aggregates01/numSum@21::pc
       .line 21,21 : 9,28 ''
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Aggregates01/numSum@21::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Aggregates01/numSum@21::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/numSum@21::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Aggregates01/numSum@21::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Aggregates01/numSum@21::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method numSum@21::GenerateNext
 
     .method public strict virtual instance void 
@@ -876,7 +874,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -898,17 +896,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -916,69 +914,68 @@
       .line 30,30 : 9,26 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Aggregates01::get_words()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Aggregates01/totalChars@30::pc
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Aggregates01/totalChars@30::pc
       .line 30,30 : 9,26 ''
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0063:  stfld      string Linq101Aggregates01/totalChars@30::_arg1
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_005e:  stfld      string Linq101Aggregates01/totalChars@30::_arg1
       .line 30,30 : 9,26 ''
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      string Linq101Aggregates01/totalChars@30::_arg1
-      IL_006f:  stfld      string Linq101Aggregates01/totalChars@30::w
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Aggregates01/totalChars@30::pc
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      string Linq101Aggregates01/totalChars@30::_arg1
+      IL_006a:  stfld      string Linq101Aggregates01/totalChars@30::w
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Aggregates01/totalChars@30::pc
       .line 31,31 : 9,25 ''
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      string Linq101Aggregates01/totalChars@30::w
-      IL_0082:  stfld      string Linq101Aggregates01/totalChars@30::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      string Linq101Aggregates01/totalChars@30::w
+      IL_007d:  stfld      string Linq101Aggregates01/totalChars@30::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      string Linq101Aggregates01/totalChars@30::w
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      string Linq101Aggregates01/totalChars@30::w
       .line 30,30 : 9,26 ''
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      string Linq101Aggregates01/totalChars@30::_arg1
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      string Linq101Aggregates01/totalChars@30::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Aggregates01/totalChars@30::pc
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Aggregates01/totalChars@30::pc
       .line 30,30 : 9,26 ''
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Aggregates01/totalChars@30::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      string Linq101Aggregates01/totalChars@30::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/totalChars@30::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Aggregates01/totalChars@30::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      string Linq101Aggregates01/totalChars@30::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method totalChars@30::GenerateNext
 
     .method public strict virtual instance void 
@@ -1375,7 +1372,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       200 (0xc8)
+      // Code size       192 (0xc0)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -1386,99 +1383,98 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009e
+      IL_0022:  br.s       IL_0096
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_0085
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_008d
+      IL_0028:  br         IL_00b7
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00bf
+      IL_002d:  nop
+      .line 42,42 : 13,26 ''
+      IL_002e:  ldarg.0
+      IL_002f:  ldarg.0
+      IL_0030:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/sum@42::g
+      IL_0035:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_003a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
+      IL_003f:  ldarg.0
+      IL_0040:  ldc.i4.1
+      IL_0041:  stfld      int32 Linq101Aggregates01/sum@42::pc
+      .line 42,42 : 13,26 ''
+      IL_0046:  ldarg.0
+      IL_0047:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
+      IL_004c:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0051:  brfalse.s  IL_0096
 
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_0053:  ldarg.0
+      IL_0054:  ldarg.0
+      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
+      IL_005a:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::_arg3
       .line 42,42 : 13,26 ''
-      IL_0031:  ldarg.0
-      IL_0032:  ldarg.0
-      IL_0033:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/sum@42::g
-      IL_0038:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0042:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
-      IL_0047:  ldarg.0
-      IL_0048:  ldc.i4.1
-      IL_0049:  stfld      int32 Linq101Aggregates01/sum@42::pc
-      .line 42,42 : 13,26 ''
-      IL_004e:  ldarg.0
-      IL_004f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
-      IL_0054:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0059:  brfalse.s  IL_009e
-
-      IL_005b:  ldarg.0
-      IL_005c:  ldarg.0
-      IL_005d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
-      IL_0062:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0067:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::_arg3
-      .line 42,42 : 13,26 ''
-      IL_006c:  ldarg.0
-      IL_006d:  ldarg.0
-      IL_006e:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::_arg3
-      IL_0073:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::x
-      IL_0078:  ldarg.0
-      IL_0079:  ldc.i4.2
-      IL_007a:  stfld      int32 Linq101Aggregates01/sum@42::pc
+      IL_0064:  ldarg.0
+      IL_0065:  ldarg.0
+      IL_0066:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::_arg3
+      IL_006b:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::x
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Aggregates01/sum@42::pc
       .line 43,43 : 13,33 ''
-      IL_007f:  ldarg.0
-      IL_0080:  ldarg.0
-      IL_0081:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::x
-      IL_0086:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::current
-      IL_008b:  ldc.i4.1
-      IL_008c:  ret
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::x
+      IL_007e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::current
+      IL_0083:  ldc.i4.1
+      IL_0084:  ret
 
-      IL_008d:  ldarg.0
-      IL_008e:  ldnull
-      IL_008f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::x
+      IL_0085:  ldarg.0
+      IL_0086:  ldnull
+      IL_0087:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::x
       .line 42,42 : 13,26 ''
-      IL_0094:  ldarg.0
-      IL_0095:  ldnull
-      IL_0096:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::_arg3
+      IL_008c:  ldarg.0
+      IL_008d:  ldnull
+      IL_008e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::_arg3
       .line 100001,100001 : 0,0 ''
-      IL_009b:  nop
-      IL_009c:  br.s       IL_004e
+      IL_0093:  nop
+      IL_0094:  br.s       IL_0046
 
-      IL_009e:  ldarg.0
-      IL_009f:  ldc.i4.3
-      IL_00a0:  stfld      int32 Linq101Aggregates01/sum@42::pc
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.i4.3
+      IL_0098:  stfld      int32 Linq101Aggregates01/sum@42::pc
       .line 42,42 : 13,26 ''
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
-      IL_00ab:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00b0:  nop
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldnull
-      IL_00b3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldc.i4.3
-      IL_00ba:  stfld      int32 Linq101Aggregates01/sum@42::pc
-      IL_00bf:  ldarg.0
-      IL_00c0:  ldnull
-      IL_00c1:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::current
-      IL_00c6:  ldc.i4.0
-      IL_00c7:  ret
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
+      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a8:  nop
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldnull
+      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/sum@42::'enum'
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldc.i4.3
+      IL_00b2:  stfld      int32 Linq101Aggregates01/sum@42::pc
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      class [Utils]Utils/Product Linq101Aggregates01/sum@42::current
+      IL_00be:  ldc.i4.0
+      IL_00bf:  ret
     } // end of method sum@42::GenerateNext
 
     .method public strict virtual instance void 
@@ -1946,7 +1942,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -1968,17 +1964,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -1986,69 +1982,68 @@
       .line 49,49 : 22,41 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Aggregates01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Aggregates01/minNum@49::pc
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Aggregates01/minNum@49::pc
       .line 49,49 : 22,41 ''
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Aggregates01/minNum@49::_arg1
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Aggregates01/minNum@49::_arg1
       .line 49,49 : 22,41 ''
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Aggregates01/minNum@49::_arg1
-      IL_006f:  stfld      int32 Linq101Aggregates01/minNum@49::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Aggregates01/minNum@49::pc
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Aggregates01/minNum@49::_arg1
+      IL_006a:  stfld      int32 Linq101Aggregates01/minNum@49::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Aggregates01/minNum@49::pc
       .line 49,49 : 42,49 ''
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Aggregates01/minNum@49::n
-      IL_0082:  stfld      int32 Linq101Aggregates01/minNum@49::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Aggregates01/minNum@49::n
+      IL_007d:  stfld      int32 Linq101Aggregates01/minNum@49::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Aggregates01/minNum@49::n
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Aggregates01/minNum@49::n
       .line 49,49 : 22,41 ''
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Aggregates01/minNum@49::_arg1
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Aggregates01/minNum@49::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Aggregates01/minNum@49::pc
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Aggregates01/minNum@49::pc
       .line 49,49 : 22,41 ''
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Aggregates01/minNum@49::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Aggregates01/minNum@49::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/minNum@49::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Aggregates01/minNum@49::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Aggregates01/minNum@49::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method minNum@49::GenerateNext
 
     .method public strict virtual instance void 
@@ -2341,7 +2336,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -2363,17 +2358,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -2381,69 +2376,68 @@
       .line 52,52 : 28,45 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Aggregates01::get_words()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Aggregates01/shortestWord@52::pc
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Aggregates01/shortestWord@52::pc
       .line 52,52 : 28,45 ''
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0063:  stfld      string Linq101Aggregates01/shortestWord@52::_arg1
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_005e:  stfld      string Linq101Aggregates01/shortestWord@52::_arg1
       .line 52,52 : 28,45 ''
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      string Linq101Aggregates01/shortestWord@52::_arg1
-      IL_006f:  stfld      string Linq101Aggregates01/shortestWord@52::w
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Aggregates01/shortestWord@52::pc
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      string Linq101Aggregates01/shortestWord@52::_arg1
+      IL_006a:  stfld      string Linq101Aggregates01/shortestWord@52::w
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Aggregates01/shortestWord@52::pc
       .line 52,52 : 46,60 ''
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      string Linq101Aggregates01/shortestWord@52::w
-      IL_0082:  stfld      string Linq101Aggregates01/shortestWord@52::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      string Linq101Aggregates01/shortestWord@52::w
+      IL_007d:  stfld      string Linq101Aggregates01/shortestWord@52::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      string Linq101Aggregates01/shortestWord@52::w
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      string Linq101Aggregates01/shortestWord@52::w
       .line 52,52 : 28,45 ''
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      string Linq101Aggregates01/shortestWord@52::_arg1
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      string Linq101Aggregates01/shortestWord@52::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Aggregates01/shortestWord@52::pc
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Aggregates01/shortestWord@52::pc
       .line 52,52 : 28,45 ''
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Aggregates01/shortestWord@52::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      string Linq101Aggregates01/shortestWord@52::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/shortestWord@52::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Aggregates01/shortestWord@52::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      string Linq101Aggregates01/shortestWord@52::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method shortestWord@52::GenerateNext
 
     .method public strict virtual instance void 
@@ -2840,7 +2834,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       200 (0xc8)
+      // Code size       192 (0xc0)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -2851,99 +2845,98 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009e
+      IL_0022:  br.s       IL_0096
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_0085
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_008d
+      IL_0028:  br         IL_00b7
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00bf
+      IL_002d:  nop
+      .line 59,59 : 27,40 ''
+      IL_002e:  ldarg.0
+      IL_002f:  ldarg.0
+      IL_0030:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/min@59::g
+      IL_0035:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_003a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
+      IL_003f:  ldarg.0
+      IL_0040:  ldc.i4.1
+      IL_0041:  stfld      int32 Linq101Aggregates01/min@59::pc
+      .line 59,59 : 27,40 ''
+      IL_0046:  ldarg.0
+      IL_0047:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
+      IL_004c:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0051:  brfalse.s  IL_0096
 
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_0053:  ldarg.0
+      IL_0054:  ldarg.0
+      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
+      IL_005a:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::_arg3
       .line 59,59 : 27,40 ''
-      IL_0031:  ldarg.0
-      IL_0032:  ldarg.0
-      IL_0033:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/min@59::g
-      IL_0038:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0042:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
-      IL_0047:  ldarg.0
-      IL_0048:  ldc.i4.1
-      IL_0049:  stfld      int32 Linq101Aggregates01/min@59::pc
-      .line 59,59 : 27,40 ''
-      IL_004e:  ldarg.0
-      IL_004f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
-      IL_0054:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0059:  brfalse.s  IL_009e
-
-      IL_005b:  ldarg.0
-      IL_005c:  ldarg.0
-      IL_005d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
-      IL_0062:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0067:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::_arg3
-      .line 59,59 : 27,40 ''
-      IL_006c:  ldarg.0
-      IL_006d:  ldarg.0
-      IL_006e:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::_arg3
-      IL_0073:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::x
-      IL_0078:  ldarg.0
-      IL_0079:  ldc.i4.2
-      IL_007a:  stfld      int32 Linq101Aggregates01/min@59::pc
+      IL_0064:  ldarg.0
+      IL_0065:  ldarg.0
+      IL_0066:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::_arg3
+      IL_006b:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::x
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Aggregates01/min@59::pc
       .line 59,59 : 41,58 ''
-      IL_007f:  ldarg.0
-      IL_0080:  ldarg.0
-      IL_0081:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::x
-      IL_0086:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::current
-      IL_008b:  ldc.i4.1
-      IL_008c:  ret
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::x
+      IL_007e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::current
+      IL_0083:  ldc.i4.1
+      IL_0084:  ret
 
-      IL_008d:  ldarg.0
-      IL_008e:  ldnull
-      IL_008f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::x
+      IL_0085:  ldarg.0
+      IL_0086:  ldnull
+      IL_0087:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::x
       .line 59,59 : 27,40 ''
-      IL_0094:  ldarg.0
-      IL_0095:  ldnull
-      IL_0096:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::_arg3
+      IL_008c:  ldarg.0
+      IL_008d:  ldnull
+      IL_008e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::_arg3
       .line 100001,100001 : 0,0 ''
-      IL_009b:  nop
-      IL_009c:  br.s       IL_004e
+      IL_0093:  nop
+      IL_0094:  br.s       IL_0046
 
-      IL_009e:  ldarg.0
-      IL_009f:  ldc.i4.3
-      IL_00a0:  stfld      int32 Linq101Aggregates01/min@59::pc
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.i4.3
+      IL_0098:  stfld      int32 Linq101Aggregates01/min@59::pc
       .line 59,59 : 27,40 ''
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
-      IL_00ab:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00b0:  nop
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldnull
-      IL_00b3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldc.i4.3
-      IL_00ba:  stfld      int32 Linq101Aggregates01/min@59::pc
-      IL_00bf:  ldarg.0
-      IL_00c0:  ldnull
-      IL_00c1:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::current
-      IL_00c6:  ldc.i4.0
-      IL_00c7:  ret
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
+      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a8:  nop
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldnull
+      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/min@59::'enum'
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldc.i4.3
+      IL_00b2:  stfld      int32 Linq101Aggregates01/min@59::pc
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      class [Utils]Utils/Product Linq101Aggregates01/min@59::current
+      IL_00be:  ldc.i4.0
+      IL_00bf:  ret
     } // end of method min@59::GenerateNext
 
     .method public strict virtual instance void 
@@ -3478,7 +3471,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       200 (0xc8)
+      // Code size       192 (0xc0)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -3489,99 +3482,98 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009e
+      IL_0022:  br.s       IL_0096
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_0085
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_008d
+      IL_0028:  br         IL_00b7
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00bf
+      IL_002d:  nop
+      .line 69,69 : 40,53 ''
+      IL_002e:  ldarg.0
+      IL_002f:  ldarg.0
+      IL_0030:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::g
+      IL_0035:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_003a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
+      IL_003f:  ldarg.0
+      IL_0040:  ldc.i4.1
+      IL_0041:  stfld      int32 Linq101Aggregates01/cheapestProducts@69::pc
+      .line 69,69 : 40,53 ''
+      IL_0046:  ldarg.0
+      IL_0047:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
+      IL_004c:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0051:  brfalse.s  IL_0096
 
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_0053:  ldarg.0
+      IL_0054:  ldarg.0
+      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
+      IL_005a:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::_arg3
       .line 69,69 : 40,53 ''
-      IL_0031:  ldarg.0
-      IL_0032:  ldarg.0
-      IL_0033:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::g
-      IL_0038:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0042:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
-      IL_0047:  ldarg.0
-      IL_0048:  ldc.i4.1
-      IL_0049:  stfld      int32 Linq101Aggregates01/cheapestProducts@69::pc
-      .line 69,69 : 40,53 ''
-      IL_004e:  ldarg.0
-      IL_004f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
-      IL_0054:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0059:  brfalse.s  IL_009e
-
-      IL_005b:  ldarg.0
-      IL_005c:  ldarg.0
-      IL_005d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
-      IL_0062:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0067:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::_arg3
-      .line 69,69 : 40,53 ''
-      IL_006c:  ldarg.0
-      IL_006d:  ldarg.0
-      IL_006e:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::_arg3
-      IL_0073:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::x
-      IL_0078:  ldarg.0
-      IL_0079:  ldc.i4.2
-      IL_007a:  stfld      int32 Linq101Aggregates01/cheapestProducts@69::pc
+      IL_0064:  ldarg.0
+      IL_0065:  ldarg.0
+      IL_0066:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::_arg3
+      IL_006b:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::x
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Aggregates01/cheapestProducts@69::pc
       .line 69,69 : 54,79 ''
-      IL_007f:  ldarg.0
-      IL_0080:  ldarg.0
-      IL_0081:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::x
-      IL_0086:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::current
-      IL_008b:  ldc.i4.1
-      IL_008c:  ret
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::x
+      IL_007e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::current
+      IL_0083:  ldc.i4.1
+      IL_0084:  ret
 
-      IL_008d:  ldarg.0
-      IL_008e:  ldnull
-      IL_008f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::x
+      IL_0085:  ldarg.0
+      IL_0086:  ldnull
+      IL_0087:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::x
       .line 69,69 : 40,53 ''
-      IL_0094:  ldarg.0
-      IL_0095:  ldnull
-      IL_0096:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::_arg3
+      IL_008c:  ldarg.0
+      IL_008d:  ldnull
+      IL_008e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::_arg3
       .line 100001,100001 : 0,0 ''
-      IL_009b:  nop
-      IL_009c:  br.s       IL_004e
+      IL_0093:  nop
+      IL_0094:  br.s       IL_0046
 
-      IL_009e:  ldarg.0
-      IL_009f:  ldc.i4.3
-      IL_00a0:  stfld      int32 Linq101Aggregates01/cheapestProducts@69::pc
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.i4.3
+      IL_0098:  stfld      int32 Linq101Aggregates01/cheapestProducts@69::pc
       .line 69,69 : 40,53 ''
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
-      IL_00ab:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00b0:  nop
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldnull
-      IL_00b3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldc.i4.3
-      IL_00ba:  stfld      int32 Linq101Aggregates01/cheapestProducts@69::pc
-      IL_00bf:  ldarg.0
-      IL_00c0:  ldnull
-      IL_00c1:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::current
-      IL_00c6:  ldc.i4.0
-      IL_00c7:  ret
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
+      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a8:  nop
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldnull
+      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/cheapestProducts@69::'enum'
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldc.i4.3
+      IL_00b2:  stfld      int32 Linq101Aggregates01/cheapestProducts@69::pc
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      class [Utils]Utils/Product Linq101Aggregates01/cheapestProducts@69::current
+      IL_00be:  ldc.i4.0
+      IL_00bf:  ret
     } // end of method cheapestProducts@69::GenerateNext
 
     .method public strict virtual instance void 
@@ -4010,7 +4002,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -4032,17 +4024,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -4050,69 +4042,68 @@
       .line 74,74 : 22,41 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Aggregates01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Aggregates01/maxNum@74::pc
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Aggregates01/maxNum@74::pc
       .line 74,74 : 22,41 ''
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Aggregates01/maxNum@74::_arg1
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Aggregates01/maxNum@74::_arg1
       .line 74,74 : 22,41 ''
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Aggregates01/maxNum@74::_arg1
-      IL_006f:  stfld      int32 Linq101Aggregates01/maxNum@74::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Aggregates01/maxNum@74::pc
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Aggregates01/maxNum@74::_arg1
+      IL_006a:  stfld      int32 Linq101Aggregates01/maxNum@74::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Aggregates01/maxNum@74::pc
       .line 74,74 : 42,49 ''
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Aggregates01/maxNum@74::n
-      IL_0082:  stfld      int32 Linq101Aggregates01/maxNum@74::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Aggregates01/maxNum@74::n
+      IL_007d:  stfld      int32 Linq101Aggregates01/maxNum@74::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Aggregates01/maxNum@74::n
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Aggregates01/maxNum@74::n
       .line 74,74 : 22,41 ''
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Aggregates01/maxNum@74::_arg1
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Aggregates01/maxNum@74::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Aggregates01/maxNum@74::pc
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Aggregates01/maxNum@74::pc
       .line 74,74 : 22,41 ''
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Aggregates01/maxNum@74::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Aggregates01/maxNum@74::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Aggregates01/maxNum@74::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Aggregates01/maxNum@74::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Aggregates01/maxNum@74::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method maxNum@74::GenerateNext
 
     .method public strict virtual instance void 
@@ -4405,7 +4396,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -4427,17 +4418,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -4445,69 +4436,68 @@
       .line 77,77 : 29,46 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Aggregates01::get_words()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Aggregates01/longestLength@77::pc
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Aggregates01/longestLength@77::pc
       .line 77,77 : 29,46 ''
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0063:  stfld      string Linq101Aggregates01/longestLength@77::_arg1
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_005e:  stfld      string Linq101Aggregates01/longestLength@77::_arg1
       .line 77,77 : 29,46 ''
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      string Linq101Aggregates01/longestLength@77::_arg1
-      IL_006f:  stfld      string Linq101Aggregates01/longestLength@77::w
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Aggregates01/longestLength@77::pc
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      string Linq101Aggregates01/longestLength@77::_arg1
+      IL_006a:  stfld      string Linq101Aggregates01/longestLength@77::w
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Aggregates01/longestLength@77::pc
       .line 77,77 : 47,61 ''
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      string Linq101Aggregates01/longestLength@77::w
-      IL_0082:  stfld      string Linq101Aggregates01/longestLength@77::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      string Linq101Aggregates01/longestLength@77::w
+      IL_007d:  stfld      string Linq101Aggregates01/longestLength@77::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      string Linq101Aggregates01/longestLength@77::w
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      string Linq101Aggregates01/longestLength@77::w
       .line 77,77 : 29,46 ''
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      string Linq101Aggregates01/longestLength@77::_arg1
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      string Linq101Aggregates01/longestLength@77::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Aggregates01/longestLength@77::pc
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Aggregates01/longestLength@77::pc
       .line 77,77 : 29,46 ''
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Aggregates01/longestLength@77::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      string Linq101Aggregates01/longestLength@77::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Aggregates01/longestLength@77::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Aggregates01/longestLength@77::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      string Linq101Aggregates01/longestLength@77::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method longestLength@77::GenerateNext
 
     .method public strict virtual instance void 
@@ -4904,7 +4894,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       200 (0xc8)
+      // Code size       192 (0xc0)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -4915,99 +4905,98 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009e
+      IL_0022:  br.s       IL_0096
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_0085
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_008d
+      IL_0028:  br         IL_00b7
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00bf
+      IL_002d:  nop
+      .line 84,84 : 42,55 ''
+      IL_002e:  ldarg.0
+      IL_002f:  ldarg.0
+      IL_0030:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::g
+      IL_0035:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_003a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
+      IL_003f:  ldarg.0
+      IL_0040:  ldc.i4.1
+      IL_0041:  stfld      int32 Linq101Aggregates01/mostExpensivePrice@84::pc
+      .line 84,84 : 42,55 ''
+      IL_0046:  ldarg.0
+      IL_0047:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
+      IL_004c:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0051:  brfalse.s  IL_0096
 
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_0053:  ldarg.0
+      IL_0054:  ldarg.0
+      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
+      IL_005a:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::_arg3
       .line 84,84 : 42,55 ''
-      IL_0031:  ldarg.0
-      IL_0032:  ldarg.0
-      IL_0033:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::g
-      IL_0038:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0042:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
-      IL_0047:  ldarg.0
-      IL_0048:  ldc.i4.1
-      IL_0049:  stfld      int32 Linq101Aggregates01/mostExpensivePrice@84::pc
-      .line 84,84 : 42,55 ''
-      IL_004e:  ldarg.0
-      IL_004f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
-      IL_0054:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0059:  brfalse.s  IL_009e
-
-      IL_005b:  ldarg.0
-      IL_005c:  ldarg.0
-      IL_005d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
-      IL_0062:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0067:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::_arg3
-      .line 84,84 : 42,55 ''
-      IL_006c:  ldarg.0
-      IL_006d:  ldarg.0
-      IL_006e:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::_arg3
-      IL_0073:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::x
-      IL_0078:  ldarg.0
-      IL_0079:  ldc.i4.2
-      IL_007a:  stfld      int32 Linq101Aggregates01/mostExpensivePrice@84::pc
+      IL_0064:  ldarg.0
+      IL_0065:  ldarg.0
+      IL_0066:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::_arg3
+      IL_006b:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::x
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Aggregates01/mostExpensivePrice@84::pc
       .line 84,84 : 56,73 ''
-      IL_007f:  ldarg.0
-      IL_0080:  ldarg.0
-      IL_0081:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::x
-      IL_0086:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::current
-      IL_008b:  ldc.i4.1
-      IL_008c:  ret
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::x
+      IL_007e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::current
+      IL_0083:  ldc.i4.1
+      IL_0084:  ret
 
-      IL_008d:  ldarg.0
-      IL_008e:  ldnull
-      IL_008f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::x
+      IL_0085:  ldarg.0
+      IL_0086:  ldnull
+      IL_0087:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::x
       .line 84,84 : 42,55 ''
-      IL_0094:  ldarg.0
-      IL_0095:  ldnull
-      IL_0096:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::_arg3
+      IL_008c:  ldarg.0
+      IL_008d:  ldnull
+      IL_008e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::_arg3
       .line 100001,100001 : 0,0 ''
-      IL_009b:  nop
-      IL_009c:  br.s       IL_004e
+      IL_0093:  nop
+      IL_0094:  br.s       IL_0046
 
-      IL_009e:  ldarg.0
-      IL_009f:  ldc.i4.3
-      IL_00a0:  stfld      int32 Linq101Aggregates01/mostExpensivePrice@84::pc
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.i4.3
+      IL_0098:  stfld      int32 Linq101Aggregates01/mostExpensivePrice@84::pc
       .line 84,84 : 42,55 ''
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
-      IL_00ab:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00b0:  nop
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldnull
-      IL_00b3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldc.i4.3
-      IL_00ba:  stfld      int32 Linq101Aggregates01/mostExpensivePrice@84::pc
-      IL_00bf:  ldarg.0
-      IL_00c0:  ldnull
-      IL_00c1:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::current
-      IL_00c6:  ldc.i4.0
-      IL_00c7:  ret
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
+      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a8:  nop
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldnull
+      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensivePrice@84::'enum'
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldc.i4.3
+      IL_00b2:  stfld      int32 Linq101Aggregates01/mostExpensivePrice@84::pc
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensivePrice@84::current
+      IL_00be:  ldc.i4.0
+      IL_00bf:  ret
     } // end of method mostExpensivePrice@84::GenerateNext
 
     .method public strict virtual instance void 
@@ -5513,7 +5502,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       200 (0xc8)
+      // Code size       192 (0xc0)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -5524,99 +5513,98 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009e
+      IL_0022:  br.s       IL_0096
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_0085
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_008d
+      IL_0028:  br         IL_00b7
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00bf
+      IL_002d:  nop
+      .line 93,93 : 32,45 ''
+      IL_002e:  ldarg.0
+      IL_002f:  ldarg.0
+      IL_0030:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::g
+      IL_0035:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_003a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
+      IL_003f:  ldarg.0
+      IL_0040:  ldc.i4.1
+      IL_0041:  stfld      int32 Linq101Aggregates01/maxPrice@93::pc
+      .line 93,93 : 32,45 ''
+      IL_0046:  ldarg.0
+      IL_0047:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
+      IL_004c:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0051:  brfalse.s  IL_0096
 
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_0053:  ldarg.0
+      IL_0054:  ldarg.0
+      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
+      IL_005a:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::_arg3
       .line 93,93 : 32,45 ''
-      IL_0031:  ldarg.0
-      IL_0032:  ldarg.0
-      IL_0033:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::g
-      IL_0038:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0042:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
-      IL_0047:  ldarg.0
-      IL_0048:  ldc.i4.1
-      IL_0049:  stfld      int32 Linq101Aggregates01/maxPrice@93::pc
-      .line 93,93 : 32,45 ''
-      IL_004e:  ldarg.0
-      IL_004f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
-      IL_0054:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0059:  brfalse.s  IL_009e
-
-      IL_005b:  ldarg.0
-      IL_005c:  ldarg.0
-      IL_005d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
-      IL_0062:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0067:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::_arg3
-      .line 93,93 : 32,45 ''
-      IL_006c:  ldarg.0
-      IL_006d:  ldarg.0
-      IL_006e:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::_arg3
-      IL_0073:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::x
-      IL_0078:  ldarg.0
-      IL_0079:  ldc.i4.2
-      IL_007a:  stfld      int32 Linq101Aggregates01/maxPrice@93::pc
+      IL_0064:  ldarg.0
+      IL_0065:  ldarg.0
+      IL_0066:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::_arg3
+      IL_006b:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::x
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Aggregates01/maxPrice@93::pc
       .line 93,93 : 46,63 ''
-      IL_007f:  ldarg.0
-      IL_0080:  ldarg.0
-      IL_0081:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::x
-      IL_0086:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::current
-      IL_008b:  ldc.i4.1
-      IL_008c:  ret
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::x
+      IL_007e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::current
+      IL_0083:  ldc.i4.1
+      IL_0084:  ret
 
-      IL_008d:  ldarg.0
-      IL_008e:  ldnull
-      IL_008f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::x
+      IL_0085:  ldarg.0
+      IL_0086:  ldnull
+      IL_0087:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::x
       .line 93,93 : 32,45 ''
-      IL_0094:  ldarg.0
-      IL_0095:  ldnull
-      IL_0096:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::_arg3
+      IL_008c:  ldarg.0
+      IL_008d:  ldnull
+      IL_008e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::_arg3
       .line 100001,100001 : 0,0 ''
-      IL_009b:  nop
-      IL_009c:  br.s       IL_004e
+      IL_0093:  nop
+      IL_0094:  br.s       IL_0046
 
-      IL_009e:  ldarg.0
-      IL_009f:  ldc.i4.3
-      IL_00a0:  stfld      int32 Linq101Aggregates01/maxPrice@93::pc
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.i4.3
+      IL_0098:  stfld      int32 Linq101Aggregates01/maxPrice@93::pc
       .line 93,93 : 32,45 ''
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
-      IL_00ab:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00b0:  nop
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldnull
-      IL_00b3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldc.i4.3
-      IL_00ba:  stfld      int32 Linq101Aggregates01/maxPrice@93::pc
-      IL_00bf:  ldarg.0
-      IL_00c0:  ldnull
-      IL_00c1:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::current
-      IL_00c6:  ldc.i4.0
-      IL_00c7:  ret
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
+      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a8:  nop
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldnull
+      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/maxPrice@93::'enum'
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldc.i4.3
+      IL_00b2:  stfld      int32 Linq101Aggregates01/maxPrice@93::pc
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      class [Utils]Utils/Product Linq101Aggregates01/maxPrice@93::current
+      IL_00be:  ldc.i4.0
+      IL_00bf:  ret
     } // end of method maxPrice@93::GenerateNext
 
     .method public strict virtual instance void 
@@ -5919,7 +5907,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       200 (0xc8)
+      // Code size       192 (0xc0)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -5930,99 +5918,98 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009e
+      IL_0022:  br.s       IL_0096
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_0085
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_008d
+      IL_0028:  br         IL_00b7
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00bf
+      IL_002d:  nop
+      .line 94,94 : 45,58 ''
+      IL_002e:  ldarg.0
+      IL_002f:  ldarg.0
+      IL_0030:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::g
+      IL_0035:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_003a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
+      IL_003f:  ldarg.0
+      IL_0040:  ldc.i4.1
+      IL_0041:  stfld      int32 Linq101Aggregates01/mostExpensiveProducts@94::pc
+      .line 94,94 : 45,58 ''
+      IL_0046:  ldarg.0
+      IL_0047:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
+      IL_004c:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0051:  brfalse.s  IL_0096
 
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_0053:  ldarg.0
+      IL_0054:  ldarg.0
+      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
+      IL_005a:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::_arg4
       .line 94,94 : 45,58 ''
-      IL_0031:  ldarg.0
-      IL_0032:  ldarg.0
-      IL_0033:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::g
-      IL_0038:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0042:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
-      IL_0047:  ldarg.0
-      IL_0048:  ldc.i4.1
-      IL_0049:  stfld      int32 Linq101Aggregates01/mostExpensiveProducts@94::pc
-      .line 94,94 : 45,58 ''
-      IL_004e:  ldarg.0
-      IL_004f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
-      IL_0054:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0059:  brfalse.s  IL_009e
-
-      IL_005b:  ldarg.0
-      IL_005c:  ldarg.0
-      IL_005d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
-      IL_0062:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0067:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::_arg4
-      .line 94,94 : 45,58 ''
-      IL_006c:  ldarg.0
-      IL_006d:  ldarg.0
-      IL_006e:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::_arg4
-      IL_0073:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::x
-      IL_0078:  ldarg.0
-      IL_0079:  ldc.i4.2
-      IL_007a:  stfld      int32 Linq101Aggregates01/mostExpensiveProducts@94::pc
+      IL_0064:  ldarg.0
+      IL_0065:  ldarg.0
+      IL_0066:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::_arg4
+      IL_006b:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::x
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Aggregates01/mostExpensiveProducts@94::pc
       .line 94,94 : 59,89 ''
-      IL_007f:  ldarg.0
-      IL_0080:  ldarg.0
-      IL_0081:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::x
-      IL_0086:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::current
-      IL_008b:  ldc.i4.1
-      IL_008c:  ret
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::x
+      IL_007e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::current
+      IL_0083:  ldc.i4.1
+      IL_0084:  ret
 
-      IL_008d:  ldarg.0
-      IL_008e:  ldnull
-      IL_008f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::x
+      IL_0085:  ldarg.0
+      IL_0086:  ldnull
+      IL_0087:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::x
       .line 94,94 : 45,58 ''
-      IL_0094:  ldarg.0
-      IL_0095:  ldnull
-      IL_0096:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::_arg4
+      IL_008c:  ldarg.0
+      IL_008d:  ldnull
+      IL_008e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::_arg4
       .line 100001,100001 : 0,0 ''
-      IL_009b:  nop
-      IL_009c:  br.s       IL_004e
+      IL_0093:  nop
+      IL_0094:  br.s       IL_0046
 
-      IL_009e:  ldarg.0
-      IL_009f:  ldc.i4.3
-      IL_00a0:  stfld      int32 Linq101Aggregates01/mostExpensiveProducts@94::pc
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.i4.3
+      IL_0098:  stfld      int32 Linq101Aggregates01/mostExpensiveProducts@94::pc
       .line 94,94 : 45,58 ''
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
-      IL_00ab:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00b0:  nop
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldnull
-      IL_00b3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldc.i4.3
-      IL_00ba:  stfld      int32 Linq101Aggregates01/mostExpensiveProducts@94::pc
-      IL_00bf:  ldarg.0
-      IL_00c0:  ldnull
-      IL_00c1:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::current
-      IL_00c6:  ldc.i4.0
-      IL_00c7:  ret
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
+      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a8:  nop
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldnull
+      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/mostExpensiveProducts@94::'enum'
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldc.i4.3
+      IL_00b2:  stfld      int32 Linq101Aggregates01/mostExpensiveProducts@94::pc
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      class [Utils]Utils/Product Linq101Aggregates01/mostExpensiveProducts@94::current
+      IL_00be:  ldc.i4.0
+      IL_00bf:  ret
     } // end of method mostExpensiveProducts@94::GenerateNext
 
     .method public strict virtual instance void 
@@ -6463,7 +6450,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<float64>& next) cil managed
     {
-      // Code size       223 (0xdf)
+      // Code size       218 (0xda)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -6485,17 +6472,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_00ad
+      IL_0022:  br         IL_00a8
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_008c
+      IL_0028:  br.s       IL_0087
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_002a:  nop
-      IL_002b:  br         IL_00ce
+      IL_002b:  br         IL_00c9
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -6503,69 +6490,68 @@
       .line 100,100 : 26,46 ''
       IL_0031:  ldarg.0
       IL_0032:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64> Linq101Aggregates01::get_numbers2()
-      IL_0037:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<float64>
-      IL_003c:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<float64>::GetEnumerator()
-      IL_0041:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
-      IL_0046:  ldarg.0
-      IL_0047:  ldc.i4.1
-      IL_0048:  stfld      int32 Linq101Aggregates01/averageNum@100::pc
+      IL_0037:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<float64>::GetEnumerator()
+      IL_003c:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
+      IL_0041:  ldarg.0
+      IL_0042:  ldc.i4.1
+      IL_0043:  stfld      int32 Linq101Aggregates01/averageNum@100::pc
       .line 100,100 : 26,46 ''
-      IL_004d:  ldarg.0
-      IL_004e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
-      IL_0053:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0058:  brfalse.s  IL_00ad
+      IL_0048:  ldarg.0
+      IL_0049:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
+      IL_004e:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0053:  brfalse.s  IL_00a8
 
-      IL_005a:  ldarg.0
-      IL_005b:  ldarg.0
-      IL_005c:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
-      IL_0061:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<float64>::get_Current()
-      IL_0066:  stfld      float64 Linq101Aggregates01/averageNum@100::_arg1
+      IL_0055:  ldarg.0
+      IL_0056:  ldarg.0
+      IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
+      IL_005c:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<float64>::get_Current()
+      IL_0061:  stfld      float64 Linq101Aggregates01/averageNum@100::_arg1
       .line 100,100 : 26,46 ''
-      IL_006b:  ldarg.0
-      IL_006c:  ldarg.0
-      IL_006d:  ldfld      float64 Linq101Aggregates01/averageNum@100::_arg1
-      IL_0072:  stfld      float64 Linq101Aggregates01/averageNum@100::n
-      IL_0077:  ldarg.0
-      IL_0078:  ldc.i4.2
-      IL_0079:  stfld      int32 Linq101Aggregates01/averageNum@100::pc
+      IL_0066:  ldarg.0
+      IL_0067:  ldarg.0
+      IL_0068:  ldfld      float64 Linq101Aggregates01/averageNum@100::_arg1
+      IL_006d:  stfld      float64 Linq101Aggregates01/averageNum@100::n
+      IL_0072:  ldarg.0
+      IL_0073:  ldc.i4.2
+      IL_0074:  stfld      int32 Linq101Aggregates01/averageNum@100::pc
       .line 100,100 : 47,58 ''
-      IL_007e:  ldarg.0
-      IL_007f:  ldarg.0
-      IL_0080:  ldfld      float64 Linq101Aggregates01/averageNum@100::n
-      IL_0085:  stfld      float64 Linq101Aggregates01/averageNum@100::current
-      IL_008a:  ldc.i4.1
-      IL_008b:  ret
+      IL_0079:  ldarg.0
+      IL_007a:  ldarg.0
+      IL_007b:  ldfld      float64 Linq101Aggregates01/averageNum@100::n
+      IL_0080:  stfld      float64 Linq101Aggregates01/averageNum@100::current
+      IL_0085:  ldc.i4.1
+      IL_0086:  ret
 
-      IL_008c:  ldarg.0
-      IL_008d:  ldc.r8     0.0
-      IL_0096:  stfld      float64 Linq101Aggregates01/averageNum@100::n
+      IL_0087:  ldarg.0
+      IL_0088:  ldc.r8     0.0
+      IL_0091:  stfld      float64 Linq101Aggregates01/averageNum@100::n
       .line 100,100 : 26,46 ''
-      IL_009b:  ldarg.0
-      IL_009c:  ldc.r8     0.0
-      IL_00a5:  stfld      float64 Linq101Aggregates01/averageNum@100::_arg1
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.r8     0.0
+      IL_00a0:  stfld      float64 Linq101Aggregates01/averageNum@100::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_00aa:  nop
-      IL_00ab:  br.s       IL_004d
+      IL_00a5:  nop
+      IL_00a6:  br.s       IL_0048
 
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldc.i4.3
-      IL_00af:  stfld      int32 Linq101Aggregates01/averageNum@100::pc
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldc.i4.3
+      IL_00aa:  stfld      int32 Linq101Aggregates01/averageNum@100::pc
       .line 100,100 : 26,46 ''
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
-      IL_00ba:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<float64>>(!!0)
-      IL_00bf:  nop
-      IL_00c0:  ldarg.0
-      IL_00c1:  ldnull
-      IL_00c2:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
-      IL_00c7:  ldarg.0
-      IL_00c8:  ldc.i4.3
-      IL_00c9:  stfld      int32 Linq101Aggregates01/averageNum@100::pc
-      IL_00ce:  ldarg.0
-      IL_00cf:  ldc.r8     0.0
-      IL_00d8:  stfld      float64 Linq101Aggregates01/averageNum@100::current
-      IL_00dd:  ldc.i4.0
-      IL_00de:  ret
+      IL_00af:  ldarg.0
+      IL_00b0:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
+      IL_00b5:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<float64>>(!!0)
+      IL_00ba:  nop
+      IL_00bb:  ldarg.0
+      IL_00bc:  ldnull
+      IL_00bd:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<float64> Linq101Aggregates01/averageNum@100::'enum'
+      IL_00c2:  ldarg.0
+      IL_00c3:  ldc.i4.3
+      IL_00c4:  stfld      int32 Linq101Aggregates01/averageNum@100::pc
+      IL_00c9:  ldarg.0
+      IL_00ca:  ldc.r8     0.0
+      IL_00d3:  stfld      float64 Linq101Aggregates01/averageNum@100::current
+      IL_00d8:  ldc.i4.0
+      IL_00d9:  ret
     } // end of method averageNum@100::GenerateNext
 
     .method public strict virtual instance void 
@@ -7046,7 +7032,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       200 (0xc8)
+      // Code size       192 (0xc0)
       .maxstack  6
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -7057,99 +7043,98 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009e
+      IL_0022:  br.s       IL_0096
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_0085
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_008d
+      IL_0028:  br         IL_00b7
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00bf
+      IL_002d:  nop
+      .line 115,115 : 36,49 ''
+      IL_002e:  ldarg.0
+      IL_002f:  ldarg.0
+      IL_0030:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::g
+      IL_0035:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_003a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
+      IL_003f:  ldarg.0
+      IL_0040:  ldc.i4.1
+      IL_0041:  stfld      int32 Linq101Aggregates01/averagePrice@115::pc
+      .line 115,115 : 36,49 ''
+      IL_0046:  ldarg.0
+      IL_0047:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
+      IL_004c:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0051:  brfalse.s  IL_0096
 
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_0053:  ldarg.0
+      IL_0054:  ldarg.0
+      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
+      IL_005a:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::_arg3
       .line 115,115 : 36,49 ''
-      IL_0031:  ldarg.0
-      IL_0032:  ldarg.0
-      IL_0033:  ldfld      class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::g
-      IL_0038:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0042:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
-      IL_0047:  ldarg.0
-      IL_0048:  ldc.i4.1
-      IL_0049:  stfld      int32 Linq101Aggregates01/averagePrice@115::pc
-      .line 115,115 : 36,49 ''
-      IL_004e:  ldarg.0
-      IL_004f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
-      IL_0054:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0059:  brfalse.s  IL_009e
-
-      IL_005b:  ldarg.0
-      IL_005c:  ldarg.0
-      IL_005d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
-      IL_0062:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0067:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::_arg3
-      .line 115,115 : 36,49 ''
-      IL_006c:  ldarg.0
-      IL_006d:  ldarg.0
-      IL_006e:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::_arg3
-      IL_0073:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::x
-      IL_0078:  ldarg.0
-      IL_0079:  ldc.i4.2
-      IL_007a:  stfld      int32 Linq101Aggregates01/averagePrice@115::pc
+      IL_0064:  ldarg.0
+      IL_0065:  ldarg.0
+      IL_0066:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::_arg3
+      IL_006b:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::x
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Aggregates01/averagePrice@115::pc
       .line 115,115 : 50,71 ''
-      IL_007f:  ldarg.0
-      IL_0080:  ldarg.0
-      IL_0081:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::x
-      IL_0086:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::current
-      IL_008b:  ldc.i4.1
-      IL_008c:  ret
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::x
+      IL_007e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::current
+      IL_0083:  ldc.i4.1
+      IL_0084:  ret
 
-      IL_008d:  ldarg.0
-      IL_008e:  ldnull
-      IL_008f:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::x
+      IL_0085:  ldarg.0
+      IL_0086:  ldnull
+      IL_0087:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::x
       .line 115,115 : 36,49 ''
-      IL_0094:  ldarg.0
-      IL_0095:  ldnull
-      IL_0096:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::_arg3
+      IL_008c:  ldarg.0
+      IL_008d:  ldnull
+      IL_008e:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::_arg3
       .line 100001,100001 : 0,0 ''
-      IL_009b:  nop
-      IL_009c:  br.s       IL_004e
+      IL_0093:  nop
+      IL_0094:  br.s       IL_0046
 
-      IL_009e:  ldarg.0
-      IL_009f:  ldc.i4.3
-      IL_00a0:  stfld      int32 Linq101Aggregates01/averagePrice@115::pc
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.i4.3
+      IL_0098:  stfld      int32 Linq101Aggregates01/averagePrice@115::pc
       .line 115,115 : 36,49 ''
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
-      IL_00ab:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00b0:  nop
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldnull
-      IL_00b3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldc.i4.3
-      IL_00ba:  stfld      int32 Linq101Aggregates01/averagePrice@115::pc
-      IL_00bf:  ldarg.0
-      IL_00c0:  ldnull
-      IL_00c1:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::current
-      IL_00c6:  ldc.i4.0
-      IL_00c7:  ret
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
+      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a8:  nop
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldnull
+      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Aggregates01/averagePrice@115::'enum'
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldc.i4.3
+      IL_00b2:  stfld      int32 Linq101Aggregates01/averagePrice@115::pc
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      class [Utils]Utils/Product Linq101Aggregates01/averagePrice@115::current
+      IL_00be:  ldc.i4.0
+      IL_00bf:  ret
     } // end of method averagePrice@115::GenerateNext
 
     .method public strict virtual instance void 
@@ -7971,7 +7956,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       1881 (0x759)
+    // Code size       1846 (0x736)
     .maxstack  13
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> factorsOf300,
              [1] int32 uniqueFactors,
@@ -8305,249 +8290,254 @@
     IL_01f0:  ldloc.s    V_39
     IL_01f2:  ldloc.s    V_39
     IL_01f4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
-    IL_01f9:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_01fe:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0203:  ldloc.s    V_39
-    IL_0205:  newobj     instance void Linq101Aggregates01/categories@39::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_020a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01f9:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01fe:  ldloc.s    V_39
+    IL_0200:  newobj     instance void Linq101Aggregates01/categories@39::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0205:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_020f:  newobj     instance void Linq101Aggregates01/'categories@40-1'::.ctor()
-    IL_0214:  newobj     instance void Linq101Aggregates01/'categories@40-2'::.ctor()
-    IL_0219:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_020a:  newobj     instance void Linq101Aggregates01/'categories@40-1'::.ctor()
+    IL_020f:  newobj     instance void Linq101Aggregates01/'categories@40-2'::.ctor()
+    IL_0214:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_021e:  ldloc.s    V_39
-    IL_0220:  newobj     instance void Linq101Aggregates01/'categories@40-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0225:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,int32>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0219:  ldloc.s    V_39
+    IL_021b:  newobj     instance void Linq101Aggregates01/'categories@40-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0220:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,int32>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_022a:  newobj     instance void Linq101Aggregates01/'categories@45-4'::.ctor()
-    IL_022f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,int32>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0225:  newobj     instance void Linq101Aggregates01/'categories@45-4'::.ctor()
+    IL_022a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,int32>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0234:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0239:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,int32>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_023e:  dup
-    IL_023f:  stsfld     class [mscorlib]System.Tuple`2<string,int32>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories@37
-    IL_0244:  stloc.s    categories
-    IL_0246:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_024b:  stloc.s    V_40
-    IL_024d:  ldloc.s    V_40
-    IL_024f:  ldc.i4.0
-    IL_0250:  ldc.i4.0
-    IL_0251:  ldnull
-    IL_0252:  ldc.i4.0
-    IL_0253:  ldc.i4.0
-    IL_0254:  newobj     instance void Linq101Aggregates01/minNum@49::.ctor(int32,
+    IL_022f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0234:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,int32>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0239:  dup
+    IL_023a:  stsfld     class [mscorlib]System.Tuple`2<string,int32>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories@37
+    IL_023f:  stloc.s    categories
+    IL_0241:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0246:  stloc.s    V_40
+    IL_0248:  ldloc.s    V_40
+    IL_024a:  ldc.i4.0
+    IL_024b:  ldc.i4.0
+    IL_024c:  ldnull
+    IL_024d:  ldc.i4.0
+    IL_024e:  ldc.i4.0
+    IL_024f:  newobj     instance void Linq101Aggregates01/minNum@49::.ctor(int32,
                                                                             int32,
                                                                             class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
                                                                             int32,
                                                                             int32)
-    IL_0259:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_025e:  newobj     instance void Linq101Aggregates01/'minNum@49-1'::.ctor()
-    IL_0263:  callvirt   instance !!2 [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::MinBy<int32,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0254:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_0259:  newobj     instance void Linq101Aggregates01/'minNum@49-1'::.ctor()
+    IL_025e:  callvirt   instance !!2 [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::MinBy<int32,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                          class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0268:  dup
-    IL_0269:  stsfld     int32 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::minNum@49
-    IL_026e:  stloc.s    minNum
-    IL_0270:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0275:  stloc.s    V_41
-    IL_0277:  ldloc.s    V_41
-    IL_0279:  ldnull
-    IL_027a:  ldnull
-    IL_027b:  ldnull
-    IL_027c:  ldc.i4.0
-    IL_027d:  ldnull
-    IL_027e:  newobj     instance void Linq101Aggregates01/shortestWord@52::.ctor(string,
+    IL_0263:  dup
+    IL_0264:  stsfld     int32 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::minNum@49
+    IL_0269:  stloc.s    minNum
+    IL_026b:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0270:  stloc.s    V_41
+    IL_0272:  ldloc.s    V_41
+    IL_0274:  ldnull
+    IL_0275:  ldnull
+    IL_0276:  ldnull
+    IL_0277:  ldc.i4.0
+    IL_0278:  ldnull
+    IL_0279:  newobj     instance void Linq101Aggregates01/shortestWord@52::.ctor(string,
                                                                                   string,
                                                                                   class [mscorlib]System.Collections.Generic.IEnumerator`1<string>,
                                                                                   int32,
                                                                                   string)
-    IL_0283:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_0288:  newobj     instance void Linq101Aggregates01/'shortestWord@52-1'::.ctor()
-    IL_028d:  callvirt   instance !!2 [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::MinBy<string,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_027e:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_0283:  newobj     instance void Linq101Aggregates01/'shortestWord@52-1'::.ctor()
+    IL_0288:  callvirt   instance !!2 [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::MinBy<string,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0292:  dup
-    IL_0293:  stsfld     int32 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::shortestWord@52
-    IL_0298:  stloc.s    shortestWord
+    IL_028d:  dup
+    IL_028e:  stsfld     int32 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::shortestWord@52
+    IL_0293:  stloc.s    shortestWord
     .line 55,61 : 1,21 ''
-    IL_029a:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_029f:  stloc.s    V_42
-    IL_02a1:  ldloc.s    V_42
-    IL_02a3:  ldloc.s    V_42
-    IL_02a5:  ldloc.s    V_42
-    IL_02a7:  ldloc.s    V_42
-    IL_02a9:  ldloc.s    V_42
-    IL_02ab:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
-    IL_02b0:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_02b5:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_02ba:  ldloc.s    V_42
-    IL_02bc:  newobj     instance void Linq101Aggregates01/categories2@57::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_02c1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0295:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_029a:  stloc.s    V_42
+    IL_029c:  ldloc.s    V_42
+    IL_029e:  ldloc.s    V_42
+    IL_02a0:  ldloc.s    V_42
+    IL_02a2:  ldloc.s    V_42
+    IL_02a4:  ldloc.s    V_42
+    IL_02a6:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
+    IL_02ab:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_02b0:  ldloc.s    V_42
+    IL_02b2:  newobj     instance void Linq101Aggregates01/categories2@57::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_02b7:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_02c6:  newobj     instance void Linq101Aggregates01/'categories2@58-1'::.ctor()
-    IL_02cb:  newobj     instance void Linq101Aggregates01/'categories2@58-2'::.ctor()
-    IL_02d0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_02bc:  newobj     instance void Linq101Aggregates01/'categories2@58-1'::.ctor()
+    IL_02c1:  newobj     instance void Linq101Aggregates01/'categories2@58-2'::.ctor()
+    IL_02c6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_02d5:  ldloc.s    V_42
-    IL_02d7:  newobj     instance void Linq101Aggregates01/'categories2@58-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_02dc:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02cb:  ldloc.s    V_42
+    IL_02cd:  newobj     instance void Linq101Aggregates01/'categories2@58-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_02d2:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                              class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_02e1:  newobj     instance void Linq101Aggregates01/'categories2@60-4'::.ctor()
-    IL_02e6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02d7:  newobj     instance void Linq101Aggregates01/'categories2@60-4'::.ctor()
+    IL_02dc:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_02eb:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_02f0:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_02f5:  dup
-    IL_02f6:  stsfld     class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories2@55
-    IL_02fb:  stloc.s    categories2
+    IL_02e1:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_02e6:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_02eb:  dup
+    IL_02ec:  stsfld     class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories2@55
+    IL_02f1:  stloc.s    categories2
     .line 64,71 : 1,21 ''
-    IL_02fd:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0302:  stloc.s    V_43
-    IL_0304:  ldloc.s    V_43
-    IL_0306:  ldloc.s    V_43
-    IL_0308:  ldloc.s    V_43
-    IL_030a:  ldloc.s    V_43
-    IL_030c:  ldloc.s    V_43
-    IL_030e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
-    IL_0313:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_0318:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_031d:  ldloc.s    V_43
-    IL_031f:  newobj     instance void Linq101Aggregates01/categories3@66::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0324:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02f3:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_02f8:  stloc.s    V_43
+    IL_02fa:  ldloc.s    V_43
+    IL_02fc:  ldloc.s    V_43
+    IL_02fe:  ldloc.s    V_43
+    IL_0300:  ldloc.s    V_43
+    IL_0302:  ldloc.s    V_43
+    IL_0304:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
+    IL_0309:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_030e:  ldloc.s    V_43
+    IL_0310:  newobj     instance void Linq101Aggregates01/categories3@66::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0315:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0329:  newobj     instance void Linq101Aggregates01/'categories3@67-1'::.ctor()
-    IL_032e:  newobj     instance void Linq101Aggregates01/'categories3@67-2'::.ctor()
-    IL_0333:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_031a:  newobj     instance void Linq101Aggregates01/'categories3@67-1'::.ctor()
+    IL_031f:  newobj     instance void Linq101Aggregates01/'categories3@67-2'::.ctor()
+    IL_0324:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_0338:  ldloc.s    V_43
-    IL_033a:  newobj     instance void Linq101Aggregates01/'categories3@67-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_033f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0329:  ldloc.s    V_43
+    IL_032b:  newobj     instance void Linq101Aggregates01/'categories3@67-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0330:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0344:  newobj     instance void Linq101Aggregates01/'categories3@70-4'::.ctor()
-    IL_0349:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0335:  newobj     instance void Linq101Aggregates01/'categories3@70-4'::.ctor()
+    IL_033a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_034e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0353:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0358:  dup
-    IL_0359:  stsfld     class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories3@64
-    IL_035e:  stloc.s    categories3
-    IL_0360:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0365:  stloc.s    V_44
-    IL_0367:  ldloc.s    V_44
-    IL_0369:  ldc.i4.0
-    IL_036a:  ldc.i4.0
-    IL_036b:  ldnull
-    IL_036c:  ldc.i4.0
-    IL_036d:  ldc.i4.0
-    IL_036e:  newobj     instance void Linq101Aggregates01/maxNum@74::.ctor(int32,
+    IL_033f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0344:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0349:  dup
+    IL_034a:  stsfld     class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories3@64
+    IL_034f:  stloc.s    categories3
+    IL_0351:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0356:  stloc.s    V_44
+    IL_0358:  ldloc.s    V_44
+    IL_035a:  ldc.i4.0
+    IL_035b:  ldc.i4.0
+    IL_035c:  ldnull
+    IL_035d:  ldc.i4.0
+    IL_035e:  ldc.i4.0
+    IL_035f:  newobj     instance void Linq101Aggregates01/maxNum@74::.ctor(int32,
                                                                             int32,
                                                                             class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
                                                                             int32,
                                                                             int32)
-    IL_0373:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_0378:  newobj     instance void Linq101Aggregates01/'maxNum@74-1'::.ctor()
-    IL_037d:  callvirt   instance !!2 [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::MaxBy<int32,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0364:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_0369:  newobj     instance void Linq101Aggregates01/'maxNum@74-1'::.ctor()
+    IL_036e:  callvirt   instance !!2 [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::MaxBy<int32,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                          class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0382:  dup
-    IL_0383:  stsfld     int32 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::maxNum@74
-    IL_0388:  stloc.s    maxNum
-    IL_038a:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_038f:  stloc.s    V_45
-    IL_0391:  ldloc.s    V_45
-    IL_0393:  ldnull
-    IL_0394:  ldnull
-    IL_0395:  ldnull
-    IL_0396:  ldc.i4.0
-    IL_0397:  ldnull
-    IL_0398:  newobj     instance void Linq101Aggregates01/longestLength@77::.ctor(string,
+    IL_0373:  dup
+    IL_0374:  stsfld     int32 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::maxNum@74
+    IL_0379:  stloc.s    maxNum
+    IL_037b:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0380:  stloc.s    V_45
+    IL_0382:  ldloc.s    V_45
+    IL_0384:  ldnull
+    IL_0385:  ldnull
+    IL_0386:  ldnull
+    IL_0387:  ldc.i4.0
+    IL_0388:  ldnull
+    IL_0389:  newobj     instance void Linq101Aggregates01/longestLength@77::.ctor(string,
                                                                                    string,
                                                                                    class [mscorlib]System.Collections.Generic.IEnumerator`1<string>,
                                                                                    int32,
                                                                                    string)
-    IL_039d:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_03a2:  newobj     instance void Linq101Aggregates01/'longestLength@77-1'::.ctor()
-    IL_03a7:  callvirt   instance !!2 [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::MaxBy<string,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_038e:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_0393:  newobj     instance void Linq101Aggregates01/'longestLength@77-1'::.ctor()
+    IL_0398:  callvirt   instance !!2 [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::MaxBy<string,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_03ac:  dup
-    IL_03ad:  stsfld     int32 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::longestLength@77
-    IL_03b2:  stloc.s    longestLength
+    IL_039d:  dup
+    IL_039e:  stsfld     int32 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::longestLength@77
+    IL_03a3:  stloc.s    longestLength
     .line 80,86 : 1,21 ''
-    IL_03b4:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_03b9:  stloc.s    V_46
-    IL_03bb:  ldloc.s    V_46
-    IL_03bd:  ldloc.s    V_46
-    IL_03bf:  ldloc.s    V_46
-    IL_03c1:  ldloc.s    V_46
-    IL_03c3:  ldloc.s    V_46
-    IL_03c5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
-    IL_03ca:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_03cf:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_03d4:  ldloc.s    V_46
-    IL_03d6:  newobj     instance void Linq101Aggregates01/categories4@82::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_03db:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03a5:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_03aa:  stloc.s    V_46
+    IL_03ac:  ldloc.s    V_46
+    IL_03ae:  ldloc.s    V_46
+    IL_03b0:  ldloc.s    V_46
+    IL_03b2:  ldloc.s    V_46
+    IL_03b4:  ldloc.s    V_46
+    IL_03b6:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
+    IL_03bb:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_03c0:  ldloc.s    V_46
+    IL_03c2:  newobj     instance void Linq101Aggregates01/categories4@82::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_03c7:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_03e0:  newobj     instance void Linq101Aggregates01/'categories4@83-1'::.ctor()
-    IL_03e5:  newobj     instance void Linq101Aggregates01/'categories4@83-2'::.ctor()
-    IL_03ea:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_03cc:  newobj     instance void Linq101Aggregates01/'categories4@83-1'::.ctor()
+    IL_03d1:  newobj     instance void Linq101Aggregates01/'categories4@83-2'::.ctor()
+    IL_03d6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_03ef:  ldloc.s    V_46
-    IL_03f1:  newobj     instance void Linq101Aggregates01/'categories4@83-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_03f6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03db:  ldloc.s    V_46
+    IL_03dd:  newobj     instance void Linq101Aggregates01/'categories4@83-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_03e2:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                              class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_03fb:  newobj     instance void Linq101Aggregates01/'categories4@85-4'::.ctor()
-    IL_0400:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03e7:  newobj     instance void Linq101Aggregates01/'categories4@85-4'::.ctor()
+    IL_03ec:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0405:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_040a:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_040f:  dup
-    IL_0410:  stsfld     class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories4@80
-    IL_0415:  stloc.s    categories4
+    IL_03f1:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_03f6:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_03fb:  dup
+    IL_03fc:  stsfld     class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories4@80
+    IL_0401:  stloc.s    categories4
     .line 89,96 : 1,21 ''
-    IL_0417:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_041c:  stloc.s    V_47
+    IL_0403:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0408:  stloc.s    V_47
+    IL_040a:  ldloc.s    V_47
+    IL_040c:  ldloc.s    V_47
+    IL_040e:  ldloc.s    V_47
+    IL_0410:  ldloc.s    V_47
+    IL_0412:  ldloc.s    V_47
+    IL_0414:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
+    IL_0419:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
     IL_041e:  ldloc.s    V_47
-    IL_0420:  ldloc.s    V_47
-    IL_0422:  ldloc.s    V_47
-    IL_0424:  ldloc.s    V_47
-    IL_0426:  ldloc.s    V_47
-    IL_0428:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
-    IL_042d:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_0432:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0437:  ldloc.s    V_47
-    IL_0439:  newobj     instance void Linq101Aggregates01/categories5@91::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_043e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0420:  newobj     instance void Linq101Aggregates01/categories5@91::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0425:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0443:  newobj     instance void Linq101Aggregates01/'categories5@92-1'::.ctor()
-    IL_0448:  newobj     instance void Linq101Aggregates01/'categories5@92-2'::.ctor()
-    IL_044d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_042a:  newobj     instance void Linq101Aggregates01/'categories5@92-1'::.ctor()
+    IL_042f:  newobj     instance void Linq101Aggregates01/'categories5@92-2'::.ctor()
+    IL_0434:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_0452:  ldloc.s    V_47
-    IL_0454:  newobj     instance void Linq101Aggregates01/'categories5@92-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0459:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0439:  ldloc.s    V_47
+    IL_043b:  newobj     instance void Linq101Aggregates01/'categories5@92-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0440:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_045e:  newobj     instance void Linq101Aggregates01/'categories5@95-4'::.ctor()
-    IL_0463:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0445:  newobj     instance void Linq101Aggregates01/'categories5@95-4'::.ctor()
+    IL_044a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`3<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0468:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_046d:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0472:  dup
-    IL_0473:  stsfld     class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories5@89
-    IL_0478:  stloc.s    categories5
+    IL_044f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0454:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0459:  dup
+    IL_045a:  stsfld     class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories5@89
+    IL_045f:  stloc.s    categories5
     .line 99,99 : 1,66 ''
-    IL_047a:  ldc.r8     5.
-    IL_0483:  ldc.r8     4.
-    IL_048c:  ldc.r8     1.
-    IL_0495:  ldc.r8     3.
-    IL_049e:  ldc.r8     9.
-    IL_04a7:  ldc.r8     8.
-    IL_04b0:  ldc.r8     6.
-    IL_04b9:  ldc.r8     7.
-    IL_04c2:  ldc.r8     2.
-    IL_04cb:  ldc.r8     0.0
-    IL_04d4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::get_Empty()
+    IL_0461:  ldc.r8     5.
+    IL_046a:  ldc.r8     4.
+    IL_0473:  ldc.r8     1.
+    IL_047c:  ldc.r8     3.
+    IL_0485:  ldc.r8     9.
+    IL_048e:  ldc.r8     8.
+    IL_0497:  ldc.r8     6.
+    IL_04a0:  ldc.r8     7.
+    IL_04a9:  ldc.r8     2.
+    IL_04b2:  ldc.r8     0.0
+    IL_04bb:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::get_Empty()
+    IL_04c0:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_04c5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_04ca:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_04cf:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_04d4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
+                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_04d9:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_04de:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
@@ -8558,304 +8548,292 @@
                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_04ed:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_04f2:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
-                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_04f7:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
-                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_04fc:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
-                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0501:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
-                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0506:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::Cons(!0,
-                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_050b:  dup
-    IL_050c:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64> '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::numbers2@99
-    IL_0511:  stloc.s    numbers2
-    IL_0513:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0518:  stloc.s    V_48
-    IL_051a:  ldloc.s    V_48
-    IL_051c:  stloc.s    V_49
-    IL_051e:  ldc.r8     0.0
-    IL_0527:  ldc.r8     0.0
-    IL_0530:  ldnull
-    IL_0531:  ldc.i4.0
-    IL_0532:  ldc.r8     0.0
-    IL_053b:  newobj     instance void Linq101Aggregates01/averageNum@100::.ctor(float64,
+    IL_04f2:  dup
+    IL_04f3:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64> '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::numbers2@99
+    IL_04f8:  stloc.s    numbers2
+    IL_04fa:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_04ff:  stloc.s    V_48
+    IL_0501:  ldloc.s    V_48
+    IL_0503:  stloc.s    V_49
+    IL_0505:  ldc.r8     0.0
+    IL_050e:  ldc.r8     0.0
+    IL_0517:  ldnull
+    IL_0518:  ldc.i4.0
+    IL_0519:  ldc.r8     0.0
+    IL_0522:  newobj     instance void Linq101Aggregates01/averageNum@100::.ctor(float64,
                                                                                  float64,
                                                                                  class [mscorlib]System.Collections.Generic.IEnumerator`1<float64>,
                                                                                  int32,
                                                                                  float64)
-    IL_0540:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<float64,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_0545:  stloc.s    V_50
-    IL_0547:  newobj     instance void Linq101Aggregates01/'averageNum@100-1'::.ctor()
-    IL_054c:  stloc.s    V_51
-    IL_054e:  ldloc.s    V_50
-    IL_0550:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<float64,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0555:  stloc.s    V_52
-    IL_0557:  ldloc.s    V_52
-    IL_0559:  box        class [mscorlib]System.Collections.Generic.IEnumerable`1<float64>
-    IL_055e:  brfalse.s  IL_0562
+    IL_0527:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<float64,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_052c:  stloc.s    V_50
+    IL_052e:  newobj     instance void Linq101Aggregates01/'averageNum@100-1'::.ctor()
+    IL_0533:  stloc.s    V_51
+    IL_0535:  ldloc.s    V_50
+    IL_0537:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<float64,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_053c:  stloc.s    V_52
+    IL_053e:  ldloc.s    V_52
+    IL_0540:  box        class [mscorlib]System.Collections.Generic.IEnumerable`1<float64>
+    IL_0545:  brfalse.s  IL_0549
 
-    IL_0560:  br.s       IL_0575
-
-    .line 100001,100001 : 0,0 ''
-    IL_0562:  ldstr      "source"
-    IL_0567:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
-    IL_056c:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Raise<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [mscorlib]System.Exception)
-    IL_0571:  pop
-    .line 100001,100001 : 0,0 ''
-    IL_0572:  nop
-    IL_0573:  br.s       IL_0576
+    IL_0547:  br.s       IL_055c
 
     .line 100001,100001 : 0,0 ''
+    IL_0549:  ldstr      "source"
+    IL_054e:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
+    IL_0553:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Raise<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [mscorlib]System.Exception)
+    IL_0558:  pop
     .line 100001,100001 : 0,0 ''
-    IL_0575:  nop
-    IL_0576:  ldloc.s    V_52
-    IL_0578:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<float64>::GetEnumerator()
-    IL_057d:  stloc.s    V_53
+    IL_0559:  nop
+    IL_055a:  br.s       IL_055d
+
+    .line 100001,100001 : 0,0 ''
+    .line 100001,100001 : 0,0 ''
+    IL_055c:  nop
+    IL_055d:  ldloc.s    V_52
+    IL_055f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<float64>::GetEnumerator()
+    IL_0564:  stloc.s    V_53
     .try
     {
-      IL_057f:  ldc.r8     0.0
-      IL_0588:  stloc.s    V_55
-      IL_058a:  ldc.i4.0
-      IL_058b:  stloc.s    V_56
-      IL_058d:  ldloc.s    V_53
-      IL_058f:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0594:  brfalse.s  IL_05b2
+      IL_0566:  ldc.r8     0.0
+      IL_056f:  stloc.s    V_55
+      IL_0571:  ldc.i4.0
+      IL_0572:  stloc.s    V_56
+      IL_0574:  ldloc.s    V_53
+      IL_0576:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_057b:  brfalse.s  IL_0599
 
-      IL_0596:  ldloc.s    V_55
-      IL_0598:  ldloc.s    V_51
-      IL_059a:  ldloc.s    V_53
-      IL_059c:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<float64>::get_Current()
-      IL_05a1:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<float64,float64>::Invoke(!0)
-      IL_05a6:  add
-      IL_05a7:  stloc.s    V_55
+      IL_057d:  ldloc.s    V_55
+      IL_057f:  ldloc.s    V_51
+      IL_0581:  ldloc.s    V_53
+      IL_0583:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<float64>::get_Current()
+      IL_0588:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<float64,float64>::Invoke(!0)
+      IL_058d:  add
+      IL_058e:  stloc.s    V_55
       .line 100,100 : 47,58 ''
-      IL_05a9:  ldloc.s    V_56
-      IL_05ab:  ldc.i4.1
-      IL_05ac:  add
-      IL_05ad:  stloc.s    V_56
+      IL_0590:  ldloc.s    V_56
+      IL_0592:  ldc.i4.1
+      IL_0593:  add
+      IL_0594:  stloc.s    V_56
       .line 100001,100001 : 0,0 ''
-      IL_05af:  nop
-      IL_05b0:  br.s       IL_058d
+      IL_0596:  nop
+      IL_0597:  br.s       IL_0574
 
-      IL_05b2:  ldloc.s    V_56
-      IL_05b4:  brtrue.s   IL_05b8
+      IL_0599:  ldloc.s    V_56
+      IL_059b:  brtrue.s   IL_059f
 
-      IL_05b6:  br.s       IL_05ba
+      IL_059d:  br.s       IL_05a1
 
-      IL_05b8:  br.s       IL_05cd
-
-      .line 100001,100001 : 0,0 ''
-      IL_05ba:  ldstr      "source"
-      IL_05bf:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
-      IL_05c4:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Raise<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [mscorlib]System.Exception)
-      IL_05c9:  pop
-      .line 100001,100001 : 0,0 ''
-      IL_05ca:  nop
-      IL_05cb:  br.s       IL_05ce
+      IL_059f:  br.s       IL_05b4
 
       .line 100001,100001 : 0,0 ''
+      IL_05a1:  ldstr      "source"
+      IL_05a6:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+      IL_05ab:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Raise<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [mscorlib]System.Exception)
+      IL_05b0:  pop
       .line 100001,100001 : 0,0 ''
-      IL_05cd:  nop
-      IL_05ce:  ldloc.s    V_55
-      IL_05d0:  stloc.s    V_57
-      IL_05d2:  ldloc.s    V_56
-      IL_05d4:  stloc.s    V_58
-      IL_05d6:  ldloc.s    V_57
-      IL_05d8:  ldloc.s    V_58
-      IL_05da:  conv.r8
-      IL_05db:  div
-      IL_05dc:  stloc.s    V_54
-      IL_05de:  leave.s    IL_05fe
+      IL_05b1:  nop
+      IL_05b2:  br.s       IL_05b5
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_05b4:  nop
+      IL_05b5:  ldloc.s    V_55
+      IL_05b7:  stloc.s    V_57
+      IL_05b9:  ldloc.s    V_56
+      IL_05bb:  stloc.s    V_58
+      IL_05bd:  ldloc.s    V_57
+      IL_05bf:  ldloc.s    V_58
+      IL_05c1:  conv.r8
+      IL_05c2:  div
+      IL_05c3:  stloc.s    V_54
+      IL_05c5:  leave.s    IL_05e5
 
     }  // end .try
     finally
     {
-      IL_05e0:  ldloc.s    V_53
-      IL_05e2:  isinst     [mscorlib]System.IDisposable
-      IL_05e7:  stloc.s    V_59
-      IL_05e9:  ldloc.s    V_59
-      IL_05eb:  brfalse.s  IL_05ef
+      IL_05c7:  ldloc.s    V_53
+      IL_05c9:  isinst     [mscorlib]System.IDisposable
+      IL_05ce:  stloc.s    V_59
+      IL_05d0:  ldloc.s    V_59
+      IL_05d2:  brfalse.s  IL_05d6
 
-      IL_05ed:  br.s       IL_05f1
+      IL_05d4:  br.s       IL_05d8
 
-      IL_05ef:  br.s       IL_05fb
+      IL_05d6:  br.s       IL_05e2
 
       .line 100001,100001 : 0,0 ''
-      IL_05f1:  ldloc.s    V_59
-      IL_05f3:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
-      IL_05f8:  ldnull
-      IL_05f9:  pop
-      IL_05fa:  endfinally
+      IL_05d8:  ldloc.s    V_59
+      IL_05da:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+      IL_05df:  ldnull
+      IL_05e0:  pop
+      IL_05e1:  endfinally
       .line 100001,100001 : 0,0 ''
-      IL_05fb:  ldnull
-      IL_05fc:  pop
-      IL_05fd:  endfinally
+      IL_05e2:  ldnull
+      IL_05e3:  pop
+      IL_05e4:  endfinally
       .line 100001,100001 : 0,0 ''
     }  // end handler
-    IL_05fe:  ldloc.s    V_54
-    IL_0600:  dup
-    IL_0601:  stsfld     float64 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::averageNum@100
-    IL_0606:  stloc.s    averageNum
-    IL_0608:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_060d:  stloc.s    V_60
-    IL_060f:  ldloc.s    V_60
-    IL_0611:  stloc.s    V_61
-    IL_0613:  ldloc.s    V_60
-    IL_0615:  ldloc.s    V_60
-    IL_0617:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Aggregates01::get_words()
-    IL_061c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-    IL_0621:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0626:  ldloc.s    V_60
-    IL_0628:  newobj     instance void Linq101Aggregates01/averageLength@105::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_062d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<string,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,float64>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_05e5:  ldloc.s    V_54
+    IL_05e7:  dup
+    IL_05e8:  stsfld     float64 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::averageNum@100
+    IL_05ed:  stloc.s    averageNum
+    IL_05ef:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_05f4:  stloc.s    V_60
+    IL_05f6:  ldloc.s    V_60
+    IL_05f8:  stloc.s    V_61
+    IL_05fa:  ldloc.s    V_60
+    IL_05fc:  ldloc.s    V_60
+    IL_05fe:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Aggregates01::get_words()
+    IL_0603:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0608:  ldloc.s    V_60
+    IL_060a:  newobj     instance void Linq101Aggregates01/averageLength@105::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_060f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<string,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,float64>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0632:  stloc.s    V_62
-    IL_0634:  newobj     instance void Linq101Aggregates01/'averageLength@107-1'::.ctor()
-    IL_0639:  stloc.s    V_63
-    IL_063b:  ldloc.s    V_62
-    IL_063d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,float64>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0642:  stloc.s    V_64
-    IL_0644:  ldloc.s    V_64
-    IL_0646:  box        class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,float64>>
-    IL_064b:  brfalse.s  IL_064f
+    IL_0614:  stloc.s    V_62
+    IL_0616:  newobj     instance void Linq101Aggregates01/'averageLength@107-1'::.ctor()
+    IL_061b:  stloc.s    V_63
+    IL_061d:  ldloc.s    V_62
+    IL_061f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,float64>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0624:  stloc.s    V_64
+    IL_0626:  ldloc.s    V_64
+    IL_0628:  box        class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,float64>>
+    IL_062d:  brfalse.s  IL_0631
 
-    IL_064d:  br.s       IL_0662
-
-    .line 100001,100001 : 0,0 ''
-    IL_064f:  ldstr      "source"
-    IL_0654:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
-    IL_0659:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Raise<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [mscorlib]System.Exception)
-    IL_065e:  pop
-    .line 100001,100001 : 0,0 ''
-    IL_065f:  nop
-    IL_0660:  br.s       IL_0663
+    IL_062f:  br.s       IL_0644
 
     .line 100001,100001 : 0,0 ''
+    IL_0631:  ldstr      "source"
+    IL_0636:  newobj     instance void [mscorlib]System.ArgumentNullException::.ctor(string)
+    IL_063b:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Raise<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [mscorlib]System.Exception)
+    IL_0640:  pop
     .line 100001,100001 : 0,0 ''
-    IL_0662:  nop
-    IL_0663:  ldloc.s    V_64
-    IL_0665:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,float64>>::GetEnumerator()
-    IL_066a:  stloc.s    V_65
+    IL_0641:  nop
+    IL_0642:  br.s       IL_0645
+
+    .line 100001,100001 : 0,0 ''
+    .line 100001,100001 : 0,0 ''
+    IL_0644:  nop
+    IL_0645:  ldloc.s    V_64
+    IL_0647:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,float64>>::GetEnumerator()
+    IL_064c:  stloc.s    V_65
     .try
     {
-      IL_066c:  ldc.r8     0.0
-      IL_0675:  stloc.s    V_67
-      IL_0677:  ldc.i4.0
-      IL_0678:  stloc.s    V_68
-      IL_067a:  ldloc.s    V_65
-      IL_067c:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0681:  brfalse.s  IL_069f
+      IL_064e:  ldc.r8     0.0
+      IL_0657:  stloc.s    V_67
+      IL_0659:  ldc.i4.0
+      IL_065a:  stloc.s    V_68
+      IL_065c:  ldloc.s    V_65
+      IL_065e:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0663:  brfalse.s  IL_0681
 
-      IL_0683:  ldloc.s    V_67
-      IL_0685:  ldloc.s    V_63
-      IL_0687:  ldloc.s    V_65
-      IL_0689:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [mscorlib]System.Tuple`2<string,float64>>::get_Current()
-      IL_068e:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [mscorlib]System.Tuple`2<string,float64>,float64>::Invoke(!0)
-      IL_0693:  add
-      IL_0694:  stloc.s    V_67
+      IL_0665:  ldloc.s    V_67
+      IL_0667:  ldloc.s    V_63
+      IL_0669:  ldloc.s    V_65
+      IL_066b:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [mscorlib]System.Tuple`2<string,float64>>::get_Current()
+      IL_0670:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [mscorlib]System.Tuple`2<string,float64>,float64>::Invoke(!0)
+      IL_0675:  add
+      IL_0676:  stloc.s    V_67
       .line 107,107 : 9,21 ''
-      IL_0696:  ldloc.s    V_68
-      IL_0698:  ldc.i4.1
-      IL_0699:  add
-      IL_069a:  stloc.s    V_68
+      IL_0678:  ldloc.s    V_68
+      IL_067a:  ldc.i4.1
+      IL_067b:  add
+      IL_067c:  stloc.s    V_68
+      .line 100001,100001 : 0,0 ''
+      IL_067e:  nop
+      IL_067f:  br.s       IL_065c
+
+      IL_0681:  ldloc.s    V_68
+      IL_0683:  brtrue.s   IL_0687
+
+      IL_0685:  br.s       IL_0689
+
+      IL_0687:  br.s       IL_069c
+
+      .line 100001,100001 : 0,0 ''
+      IL_0689:  ldstr      "source"
+      IL_068e:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
+      IL_0693:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Raise<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [mscorlib]System.Exception)
+      IL_0698:  pop
+      .line 100001,100001 : 0,0 ''
+      IL_0699:  nop
+      IL_069a:  br.s       IL_069d
+
+      .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_069c:  nop
-      IL_069d:  br.s       IL_067a
-
-      IL_069f:  ldloc.s    V_68
-      IL_06a1:  brtrue.s   IL_06a5
-
-      IL_06a3:  br.s       IL_06a7
-
-      IL_06a5:  br.s       IL_06ba
-
-      .line 100001,100001 : 0,0 ''
-      IL_06a7:  ldstr      "source"
-      IL_06ac:  newobj     instance void [mscorlib]System.InvalidOperationException::.ctor(string)
-      IL_06b1:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Raise<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [mscorlib]System.Exception)
-      IL_06b6:  pop
-      .line 100001,100001 : 0,0 ''
-      IL_06b7:  nop
-      IL_06b8:  br.s       IL_06bb
-
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_06ba:  nop
-      IL_06bb:  ldloc.s    V_67
-      IL_06bd:  stloc.s    V_69
-      IL_06bf:  ldloc.s    V_68
-      IL_06c1:  stloc.s    V_70
-      IL_06c3:  ldloc.s    V_69
-      IL_06c5:  ldloc.s    V_70
-      IL_06c7:  conv.r8
-      IL_06c8:  div
-      IL_06c9:  stloc.s    V_66
-      IL_06cb:  leave.s    IL_06eb
+      IL_069d:  ldloc.s    V_67
+      IL_069f:  stloc.s    V_69
+      IL_06a1:  ldloc.s    V_68
+      IL_06a3:  stloc.s    V_70
+      IL_06a5:  ldloc.s    V_69
+      IL_06a7:  ldloc.s    V_70
+      IL_06a9:  conv.r8
+      IL_06aa:  div
+      IL_06ab:  stloc.s    V_66
+      IL_06ad:  leave.s    IL_06cd
 
     }  // end .try
     finally
     {
-      IL_06cd:  ldloc.s    V_65
-      IL_06cf:  isinst     [mscorlib]System.IDisposable
-      IL_06d4:  stloc.s    V_71
-      IL_06d6:  ldloc.s    V_71
-      IL_06d8:  brfalse.s  IL_06dc
+      IL_06af:  ldloc.s    V_65
+      IL_06b1:  isinst     [mscorlib]System.IDisposable
+      IL_06b6:  stloc.s    V_71
+      IL_06b8:  ldloc.s    V_71
+      IL_06ba:  brfalse.s  IL_06be
 
-      IL_06da:  br.s       IL_06de
+      IL_06bc:  br.s       IL_06c0
 
-      IL_06dc:  br.s       IL_06e8
+      IL_06be:  br.s       IL_06ca
 
       .line 100001,100001 : 0,0 ''
-      IL_06de:  ldloc.s    V_71
-      IL_06e0:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
-      IL_06e5:  ldnull
-      IL_06e6:  pop
-      IL_06e7:  endfinally
+      IL_06c0:  ldloc.s    V_71
+      IL_06c2:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+      IL_06c7:  ldnull
+      IL_06c8:  pop
+      IL_06c9:  endfinally
       .line 100001,100001 : 0,0 ''
-      IL_06e8:  ldnull
-      IL_06e9:  pop
-      IL_06ea:  endfinally
+      IL_06ca:  ldnull
+      IL_06cb:  pop
+      IL_06cc:  endfinally
       .line 100001,100001 : 0,0 ''
     }  // end handler
-    IL_06eb:  ldloc.s    V_66
-    IL_06ed:  dup
-    IL_06ee:  stsfld     float64 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::averageLength@103
-    IL_06f3:  stloc.s    averageLength
+    IL_06cd:  ldloc.s    V_66
+    IL_06cf:  dup
+    IL_06d0:  stsfld     float64 '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::averageLength@103
+    IL_06d5:  stloc.s    averageLength
     .line 111,117 : 1,21 ''
-    IL_06f5:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_06fa:  stloc.s    V_72
-    IL_06fc:  ldloc.s    V_72
-    IL_06fe:  ldloc.s    V_72
-    IL_0700:  ldloc.s    V_72
-    IL_0702:  ldloc.s    V_72
-    IL_0704:  ldloc.s    V_72
-    IL_0706:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
-    IL_070b:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_0710:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0715:  ldloc.s    V_72
-    IL_0717:  newobj     instance void Linq101Aggregates01/categories6@113::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_071c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_06d7:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_06dc:  stloc.s    V_72
+    IL_06de:  ldloc.s    V_72
+    IL_06e0:  ldloc.s    V_72
+    IL_06e2:  ldloc.s    V_72
+    IL_06e4:  ldloc.s    V_72
+    IL_06e6:  ldloc.s    V_72
+    IL_06e8:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Aggregates01::get_products()
+    IL_06ed:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_06f2:  ldloc.s    V_72
+    IL_06f4:  newobj     instance void Linq101Aggregates01/categories6@113::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_06f9:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0721:  newobj     instance void Linq101Aggregates01/'categories6@114-1'::.ctor()
-    IL_0726:  newobj     instance void Linq101Aggregates01/'categories6@114-2'::.ctor()
-    IL_072b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_06fe:  newobj     instance void Linq101Aggregates01/'categories6@114-1'::.ctor()
+    IL_0703:  newobj     instance void Linq101Aggregates01/'categories6@114-2'::.ctor()
+    IL_0708:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_0730:  ldloc.s    V_72
-    IL_0732:  newobj     instance void Linq101Aggregates01/'categories6@114-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0737:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_070d:  ldloc.s    V_72
+    IL_070f:  newobj     instance void Linq101Aggregates01/'categories6@114-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0714:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                              class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_073c:  newobj     instance void Linq101Aggregates01/'categories6@116-4'::.ctor()
-    IL_0741:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0719:  newobj     instance void Linq101Aggregates01/'categories6@116-4'::.ctor()
+    IL_071e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0746:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_074b:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0750:  dup
-    IL_0751:  stsfld     class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories6@111
-    IL_0756:  stloc.s    categories6
-    IL_0758:  ret
+    IL_0723:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0728:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_072d:  dup
+    IL_072e:  stsfld     class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01::categories6@111
+    IL_0733:  stloc.s    categories6
+    IL_0735:  ret
   } // end of method $Linq101Aggregates01::main@
 
 } // end of class '<StartupCode$Linq101Aggregates01>'.$Linq101Aggregates01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101ElementOperators01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101ElementOperators01.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -26,27 +26,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Linq101ElementOperators01
 {
-  // Offset: 0x00000000 Length: 0x00000382
+  // Offset: 0x00000000 Length: 0x00000386
 }
 .mresource public FSharpOptimizationData.Linq101ElementOperators01
 {
-  // Offset: 0x00000388 Length: 0x00000127
+  // Offset: 0x00000390 Length: 0x00000127
 }
 .module Linq101ElementOperators01.exe
-// MVID: {5775BA25-19D7-C20D-A745-038325BA7557}
+// MVID: {590846DB-19D7-C20D-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00B40000
+// Image base: 0x00CD0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -108,10 +108,10 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101ElementOperators01.fs'
+      .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101ElementOperators01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101ElementOperators01/products12@12::pc
       IL_0006:  ldc.i4.1
@@ -128,90 +128,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 12,12 : 9,29
+      .line 12,12 : 9,29 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101ElementOperators01::get_products()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101ElementOperators01/products12@12::pc
-      .line 12,12 : 9,29
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101ElementOperators01/products12@12::pc
+      .line 12,12 : 9,29 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0063:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::_arg1
-      .line 12,12 : 9,29
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::_arg1
-      IL_006f:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::p
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101ElementOperators01/products12@12::pc
-      .line 13,13 : 9,33
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::p
-      IL_0082:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005e:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::_arg1
+      .line 12,12 : 9,29 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::_arg1
+      IL_006a:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::p
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101ElementOperators01/products12@12::pc
+      .line 13,13 : 9,33 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::p
+      IL_007d:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::p
-      .line 12,12 : 9,29
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::p
+      .line 12,12 : 9,29 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101ElementOperators01/products12@12::pc
-      .line 12,12 : 9,29
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101ElementOperators01/products12@12::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101ElementOperators01/products12@12::pc
+      .line 12,12 : 9,29 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101ElementOperators01/products12@12::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      class [Utils]Utils/Product Linq101ElementOperators01/products12@12::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method products12@12::GenerateNext
 
     .method public strict virtual instance void 
@@ -222,7 +221,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -233,13 +232,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -260,30 +259,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -292,7 +291,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101ElementOperators01/products12@12::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -309,18 +308,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 12,12 : 9,29
+        .line 12,12 : 9,29 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -333,11 +332,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method products12@12::Close
 
@@ -443,7 +442,7 @@
     {
       // Code size       12 (0xc)
       .maxstack  8
-      .line 13,13 : 16,32
+      .line 13,13 : 16,32 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance int32 [Utils]Utils/Product::get_ProductID()
@@ -507,9 +506,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101ElementOperators01/startsWithO@22::pc
       IL_0006:  ldc.i4.1
@@ -526,90 +525,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 22,22 : 9,28
+      .line 22,22 : 9,28 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101ElementOperators01::get_strings()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101ElementOperators01/startsWithO@22::pc
-      .line 22,22 : 9,28
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101ElementOperators01/startsWithO@22::pc
+      .line 22,22 : 9,28 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0063:  stfld      string Linq101ElementOperators01/startsWithO@22::_arg1
-      .line 22,22 : 9,28
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      string Linq101ElementOperators01/startsWithO@22::_arg1
-      IL_006f:  stfld      string Linq101ElementOperators01/startsWithO@22::s
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101ElementOperators01/startsWithO@22::pc
-      .line 23,23 : 9,28
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      string Linq101ElementOperators01/startsWithO@22::s
-      IL_0082:  stfld      string Linq101ElementOperators01/startsWithO@22::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_005e:  stfld      string Linq101ElementOperators01/startsWithO@22::_arg1
+      .line 22,22 : 9,28 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      string Linq101ElementOperators01/startsWithO@22::_arg1
+      IL_006a:  stfld      string Linq101ElementOperators01/startsWithO@22::s
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101ElementOperators01/startsWithO@22::pc
+      .line 23,23 : 9,28 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      string Linq101ElementOperators01/startsWithO@22::s
+      IL_007d:  stfld      string Linq101ElementOperators01/startsWithO@22::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      string Linq101ElementOperators01/startsWithO@22::s
-      .line 22,22 : 9,28
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      string Linq101ElementOperators01/startsWithO@22::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      string Linq101ElementOperators01/startsWithO@22::s
+      .line 22,22 : 9,28 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      string Linq101ElementOperators01/startsWithO@22::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101ElementOperators01/startsWithO@22::pc
-      .line 22,22 : 9,28
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101ElementOperators01/startsWithO@22::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      string Linq101ElementOperators01/startsWithO@22::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101ElementOperators01/startsWithO@22::pc
+      .line 22,22 : 9,28 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101ElementOperators01/startsWithO@22::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      string Linq101ElementOperators01/startsWithO@22::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method startsWithO@22::GenerateNext
 
     .method public strict virtual instance void 
@@ -620,7 +618,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -631,13 +629,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -658,30 +656,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -690,7 +688,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101ElementOperators01/startsWithO@22::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -707,18 +705,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 22,22 : 9,28
+        .line 22,22 : 9,28 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -731,11 +729,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method startsWithO@22::Close
 
@@ -841,7 +839,7 @@
     {
       // Code size       13 (0xd)
       .maxstack  8
-      .line 23,23 : 16,27
+      .line 23,23 : 16,27 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.0
@@ -906,9 +904,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
       IL_0006:  ldc.i4.1
@@ -925,90 +923,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 31,31 : 9,28
+      .line 31,31 : 9,28 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101ElementOperators01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
-      .line 31,31 : 9,28
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
+      .line 31,31 : 9,28 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::_arg1
-      .line 31,31 : 9,28
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::_arg1
-      IL_006f:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
-      .line 32,32 : 9,22
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::n
-      IL_0082:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::_arg1
+      .line 31,31 : 9,28 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::_arg1
+      IL_006a:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
+      .line 32,32 : 9,22 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::n
+      IL_007d:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::n
-      .line 31,31 : 9,28
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::n
+      .line 31,31 : 9,28 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
-      .line 31,31 : 9,28
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
+      .line 31,31 : 9,28 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101ElementOperators01/firstNumOrDefault@31::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method firstNumOrDefault@31::GenerateNext
 
     .method public strict virtual instance void 
@@ -1019,7 +1016,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -1030,13 +1027,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -1057,30 +1054,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -1089,7 +1086,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/firstNumOrDefault@31::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -1106,18 +1103,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 31,31 : 9,28
+        .line 31,31 : 9,28 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -1130,11 +1127,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method firstNumOrDefault@31::Close
 
@@ -1273,9 +1270,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
       IL_0006:  ldc.i4.1
@@ -1292,90 +1289,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 52,52 : 9,29
+      .line 52,52 : 9,29 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101ElementOperators01::get_numbers2()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
-      .line 52,52 : 9,29
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
+      .line 52,52 : 9,29 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::_arg1
-      .line 52,52 : 9,29
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101ElementOperators01/fourthLowNum@52::_arg1
-      IL_006f:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
-      .line 53,53 : 9,22
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101ElementOperators01/fourthLowNum@52::n
-      IL_0082:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::_arg1
+      .line 52,52 : 9,29 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101ElementOperators01/fourthLowNum@52::_arg1
+      IL_006a:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
+      .line 53,53 : 9,22 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101ElementOperators01/fourthLowNum@52::n
+      IL_007d:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::n
-      .line 52,52 : 9,29
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::n
+      .line 52,52 : 9,29 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
-      .line 52,52 : 9,29
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
+      .line 52,52 : 9,29 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101ElementOperators01/fourthLowNum@52::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method fourthLowNum@52::GenerateNext
 
     .method public strict virtual instance void 
@@ -1386,7 +1382,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -1397,13 +1393,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -1424,30 +1420,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -1456,7 +1452,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101ElementOperators01/fourthLowNum@52::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -1473,18 +1469,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 52,52 : 9,29
+        .line 52,52 : 9,29 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -1497,11 +1493,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method fourthLowNum@52::Close
 
@@ -1607,7 +1603,7 @@
     {
       // Code size       6 (0x6)
       .maxstack  8
-      .line 53,53 : 16,21
+      .line 53,53 : 16,21 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.5
@@ -1622,7 +1618,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::products@8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::'products@8-2'
     IL_0005:  ret
   } // end of method Linq101ElementOperators01::get_products
 
@@ -1679,7 +1675,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::numbers2@48
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::'numbers2@48-2'
     IL_0005:  ret
   } // end of method Linq101ElementOperators01::get_numbers2
 
@@ -1740,7 +1736,7 @@
 .class private abstract auto ansi sealed '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01
        extends [mscorlib]System.Object
 {
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> products@8
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@8-2'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [Utils]Utils/Product products12@10
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -1750,7 +1746,7 @@
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly int32 firstNumOrDefault@29
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numbers2@48
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers2@48-2'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly int32 fourthLowNum@50
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -1775,11 +1771,11 @@
              [9] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_9,
              [10] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_10,
              [11] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_11)
-    .line 8,8 : 1,32
+    .line 8,8 : 1,32 ''
     IL_0000:  nop
     IL_0001:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
     IL_0006:  dup
-    IL_0007:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::products@8
+    IL_0007:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::'products@8-2'
     IL_000c:  stloc.0
     IL_000d:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_0012:  stloc.s    builder@
@@ -1803,7 +1799,7 @@
     IL_0036:  dup
     IL_0037:  stsfld     class [Utils]Utils/Product '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::products12@10
     IL_003c:  stloc.1
-    .line 18,18 : 1,97
+    .line 18,18 : 1,97 ''
     IL_003d:  ldstr      "zero"
     IL_0042:  ldstr      "one"
     IL_0047:  ldstr      "two"
@@ -1860,7 +1856,7 @@
     IL_00d6:  dup
     IL_00d7:  stsfld     string '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::startsWithO@20
     IL_00dc:  stloc.3
-    .line 28,28 : 1,28
+    .line 28,28 : 1,28 ''
     IL_00dd:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101ElementOperators01::get_numbers()
     IL_00e2:  stloc.s    numbers
     IL_00e4:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
@@ -1881,7 +1877,7 @@
     IL_0101:  dup
     IL_0102:  stsfld     int32 '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::firstNumOrDefault@29
     IL_0107:  stloc.s    firstNumOrDefault
-    .line 48,48 : 1,48
+    .line 48,48 : 1,48 ''
     IL_0109:  ldc.i4.5
     IL_010a:  ldc.i4.4
     IL_010b:  ldc.i4.1
@@ -1914,7 +1910,7 @@
     IL_0146:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_014b:  dup
-    IL_014c:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::numbers2@48
+    IL_014c:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101ElementOperators01>'.$Linq101ElementOperators01::'numbers2@48-2'
     IL_0151:  stloc.s    numbers2
     IL_0153:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_0158:  stloc.s    V_11

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Grouping01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Grouping01.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -31,27 +31,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Linq101Grouping01
 {
-  // Offset: 0x00000000 Length: 0x00000407
+  // Offset: 0x00000000 Length: 0x0000040B
 }
 .mresource public FSharpOptimizationData.Linq101Grouping01
 {
   // Offset: 0x00000410 Length: 0x00000129
 }
 .module Linq101Grouping01.exe
-// MVID: {5775B6EF-FB79-E5BF-A745-0383EFB67557}
+// MVID: {590846DB-FB79-E5BF-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00D50000
+// Image base: 0x01110000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -86,11 +86,11 @@
       .maxstack  6
       .locals init ([0] int32 n)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 14,14 : 9,28 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Grouping01.fs'
+      .line 14,14 : 9,28 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Grouping01.fs'
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 15,15 : 9,29
+      .line 15,15 : 9,29 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/numberGroups@14::builder@
       IL_0009:  ldloc.0
@@ -121,7 +121,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 15,15 : 20,21
+      .line 15,15 : 20,21 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -149,7 +149,7 @@
     {
       // Code size       5 (0x5)
       .maxstack  8
-      .line 15,15 : 23,28
+      .line 15,15 : 23,28 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.5
@@ -184,7 +184,7 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<int32,int32> g)
-      .line 15,15 : 35,36
+      .line 15,15 : 35,36 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -218,7 +218,7 @@
     {
       // Code size       19 (0x13)
       .maxstack  8
-      .line 16,16 : 17,35
+      .line 16,16 : 17,35 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance !0 class [System.Core]System.Linq.IGrouping`2<int32,int32>::get_Key()
@@ -256,11 +256,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] string w)
-      .line 24,24 : 9,26
+      .line 24,24 : 9,26 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 25,25 : 9,29
+      .line 25,25 : 9,29 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/wordGroups@24::builder@
       IL_0009:  ldloc.0
@@ -291,7 +291,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 25,25 : 20,21
+      .line 25,25 : 20,21 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -319,7 +319,7 @@
     {
       // Code size       9 (0x9)
       .maxstack  8
-      .line 25,25 : 24,25
+      .line 25,25 : 24,25 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.0
@@ -354,7 +354,7 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<char,string> g)
-      .line 25,25 : 35,36
+      .line 25,25 : 35,36 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -388,7 +388,7 @@
     {
       // Code size       19 (0x13)
       .maxstack  8
-      .line 26,26 : 17,35
+      .line 26,26 : 17,35 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance !0 class [System.Core]System.Linq.IGrouping`2<char,string>::get_Key()
@@ -426,11 +426,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Product p)
-      .line 34,34 : 9,29
+      .line 34,34 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 35,35 : 9,32
+      .line 35,35 : 9,32 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/orderGroups@34::builder@
       IL_0009:  ldloc.0
@@ -461,7 +461,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 35,35 : 20,21
+      .line 35,35 : 20,21 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -489,7 +489,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 35,35 : 22,32
+      .line 35,35 : 22,32 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -524,7 +524,7 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> g)
-      .line 35,35 : 38,39
+      .line 35,35 : 38,39 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -558,7 +558,7 @@
     {
       // Code size       19 (0x13)
       .maxstack  8
-      .line 36,36 : 17,35
+      .line 36,36 : 17,35 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance !0 class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>::get_Key()
@@ -596,11 +596,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Order o)
-      .line 47,47 : 17,37
+      .line 47,47 : 17,37 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 48,48 : 17,48
+      .line 48,48 : 17,48 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/yearGroups@47::builder@
       IL_0009:  ldloc.0
@@ -631,7 +631,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 48,48 : 28,29
+      .line 48,48 : 28,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -660,7 +660,7 @@
       // Code size       16 (0x10)
       .maxstack  5
       .locals init ([0] valuetype [mscorlib]System.DateTime V_0)
-      .line 48,48 : 31,47
+      .line 48,48 : 31,47 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance valuetype [mscorlib]System.DateTime [Utils]Utils/Order::get_OrderDate()
@@ -697,11 +697,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Order o)
-      .line 51,51 : 25,39
+      .line 51,51 : 25,39 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 52,52 : 25,57
+      .line 52,52 : 25,57 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/monthGroups@51::builder@
       IL_0009:  ldloc.0
@@ -732,7 +732,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 52,52 : 36,37
+      .line 52,52 : 36,37 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -761,7 +761,7 @@
       // Code size       16 (0x10)
       .maxstack  5
       .locals init ([0] valuetype [mscorlib]System.DateTime V_0)
-      .line 52,52 : 39,56
+      .line 52,52 : 39,56 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance valuetype [mscorlib]System.DateTime [Utils]Utils/Order::get_OrderDate()
@@ -798,7 +798,7 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order> mg)
-      .line 52,52 : 63,65
+      .line 52,52 : 63,65 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -832,7 +832,7 @@
     {
       // Code size       19 (0x13)
       .maxstack  8
-      .line 53,53 : 33,53
+      .line 53,53 : 33,53 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance !0 class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>::get_Key()
@@ -867,12 +867,12 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>,object> 
             Invoke(class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order> _arg3) cil managed
     {
-      // Code size       99 (0x63)
+      // Code size       94 (0x5e)
       .maxstack  10
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order> yg,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>> monthGroups,
                [2] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder builder@)
-      .line 48,48 : 54,56
+      .line 48,48 : 54,56 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -884,36 +884,35 @@
       IL_000c:  ldloc.2
       IL_000d:  ldloc.2
       IL_000e:  ldloc.0
-      IL_000f:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Order>
-      IL_0014:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0019:  ldloc.2
-      IL_001a:  newobj     instance void Linq101Grouping01/monthGroups@51::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-      IL_001f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Order,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_000f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_0014:  ldloc.2
+      IL_0015:  newobj     instance void Linq101Grouping01/monthGroups@51::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+      IL_001a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Order,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0024:  newobj     instance void Linq101Grouping01/'monthGroups@52-1'::.ctor()
-      IL_0029:  newobj     instance void Linq101Grouping01/'monthGroups@52-2'::.ctor()
-      IL_002e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Order,int32,class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+      IL_001f:  newobj     instance void Linq101Grouping01/'monthGroups@52-1'::.ctor()
+      IL_0024:  newobj     instance void Linq101Grouping01/'monthGroups@52-2'::.ctor()
+      IL_0029:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Order,int32,class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-      IL_0033:  ldloc.2
-      IL_0034:  newobj     instance void Linq101Grouping01/'monthGroups@52-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-      IL_0039:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_002e:  ldloc.2
+      IL_002f:  newobj     instance void Linq101Grouping01/'monthGroups@52-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+      IL_0034:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_003e:  newobj     instance void Linq101Grouping01/'monthGroups@53-4'::.ctor()
-      IL_0043:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0039:  newobj     instance void Linq101Grouping01/'monthGroups@53-4'::.ctor()
+      IL_003e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-      IL_0048:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-      IL_004d:  stloc.1
-      .line 55,55 : 17,55
-      IL_004e:  ldarg.0
-      IL_004f:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/'yearGroups@48-3'::builder@
-      IL_0054:  ldloc.0
-      IL_0055:  ldloc.1
-      IL_0056:  newobj     instance void class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>::.ctor(!0,
+      IL_0043:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+      IL_0048:  stloc.1
+      .line 55,55 : 17,55 ''
+      IL_0049:  ldarg.0
+      IL_004a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/'yearGroups@48-3'::builder@
+      IL_004f:  ldloc.0
+      IL_0050:  ldloc.1
+      IL_0051:  newobj     instance void class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>::.ctor(!0,
                                                                                                                                                                                                                                                                                       !1)
-      IL_005b:  tail.
-      IL_005d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Yield<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>,object>(!!0)
-      IL_0062:  ret
+      IL_0056:  tail.
+      IL_0058:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Yield<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>,object>(!!0)
+      IL_005d:  ret
     } // end of method 'yearGroups@48-3'::Invoke
 
   } // end of class 'yearGroups@48-3'
@@ -940,7 +939,7 @@
       .maxstack  6
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order> yg,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>> monthGroups)
-      .line 55,55 : 25,54
+      .line 55,55 : 25,54 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>::get_Item1()
       IL_0006:  stloc.0
@@ -981,16 +980,16 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>,object> 
             Invoke(class [Utils]Utils/Customer _arg1) cil managed
     {
-      // Code size       104 (0x68)
+      // Code size       99 (0x63)
       .maxstack  10
       .locals init ([0] class [Utils]Utils/Customer c,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>> yearGroups,
                [2] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder builder@)
-      .line 44,44 : 9,30
+      .line 44,44 : 9,30 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 57,57 : 9,53
+      .line 57,57 : 9,53 ''
       IL_0003:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
       IL_0008:  stloc.2
       IL_0009:  ldloc.2
@@ -1000,36 +999,35 @@
       IL_000d:  ldloc.2
       IL_000e:  ldloc.0
       IL_000f:  callvirt   instance class [Utils]Utils/Order[] [Utils]Utils/Customer::get_Orders()
-      IL_0014:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Order>
-      IL_0019:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_001e:  ldloc.2
-      IL_001f:  newobj     instance void Linq101Grouping01/yearGroups@47::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-      IL_0024:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Order,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0014:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_0019:  ldloc.2
+      IL_001a:  newobj     instance void Linq101Grouping01/yearGroups@47::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+      IL_001f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Order,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0029:  newobj     instance void Linq101Grouping01/'yearGroups@48-1'::.ctor()
-      IL_002e:  newobj     instance void Linq101Grouping01/'yearGroups@48-2'::.ctor()
-      IL_0033:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Order,int32,class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+      IL_0024:  newobj     instance void Linq101Grouping01/'yearGroups@48-1'::.ctor()
+      IL_0029:  newobj     instance void Linq101Grouping01/'yearGroups@48-2'::.ctor()
+      IL_002e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Order,int32,class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-      IL_0038:  ldloc.2
-      IL_0039:  newobj     instance void Linq101Grouping01/'yearGroups@48-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-      IL_003e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0033:  ldloc.2
+      IL_0034:  newobj     instance void Linq101Grouping01/'yearGroups@48-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+      IL_0039:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0043:  newobj     instance void Linq101Grouping01/'yearGroups@55-4'::.ctor()
-      IL_0048:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_003e:  newobj     instance void Linq101Grouping01/'yearGroups@55-4'::.ctor()
+      IL_0043:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [System.Core]System.Linq.IGrouping`2<int32,class [Utils]Utils/Order>,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-      IL_004d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-      IL_0052:  stloc.1
-      .line 57,57 : 9,53
-      IL_0053:  ldarg.0
-      IL_0054:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/customerOrderGroups@44::builder@
-      IL_0059:  ldloc.0
-      IL_005a:  ldloc.1
-      IL_005b:  newobj     instance void class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>::.ctor(!0,
+      IL_0048:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+      IL_004d:  stloc.1
+      .line 57,57 : 9,53 ''
+      IL_004e:  ldarg.0
+      IL_004f:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Grouping01/customerOrderGroups@44::builder@
+      IL_0054:  ldloc.0
+      IL_0055:  ldloc.1
+      IL_0056:  newobj     instance void class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>::.ctor(!0,
                                                                                                                                                                                                                                                                                !1)
-      IL_0060:  tail.
-      IL_0062:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Yield<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>,object>(!!0)
-      IL_0067:  ret
+      IL_005b:  tail.
+      IL_005d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Yield<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>,object>(!!0)
+      IL_0062:  ret
     } // end of method customerOrderGroups@44::Invoke
 
   } // end of class customerOrderGroups@44
@@ -1056,7 +1054,7 @@
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Customer c,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>> yearGroups)
-      .line 57,57 : 17,52
+      .line 57,57 : 17,52 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>::get_Item1()
       IL_0006:  stloc.0
@@ -1089,7 +1087,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'numbers@10-1'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'numbers@10-3'
     IL_0005:  ret
   } // end of method Linq101Grouping01::get_numbers
 
@@ -1107,7 +1105,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::words@20
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'words@20-2'
     IL_0005:  ret
   } // end of method Linq101Grouping01::get_words
 
@@ -1125,7 +1123,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'products@30-2'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'products@30-4'
     IL_0005:  ret
   } // end of method Linq101Grouping01::get_products
 
@@ -1217,15 +1215,15 @@
 {
   .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> digits@7
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@10-1'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@10-3'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Tuple`2<int32,int32[]>[] numberGroups@12
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> words@20
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'words@20-2'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Tuple`2<char,string[]>[] wordGroups@22
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@30-2'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@30-4'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>[] orderGroups@32
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -1240,7 +1238,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       649 (0x289)
+    // Code size       629 (0x275)
     .maxstack  13
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> digits,
              [1] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numbers,
@@ -1255,7 +1253,7 @@
              [10] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_10,
              [11] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_11,
              [12] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_12)
-    .line 7,7 : 1,96
+    .line 7,7 : 1,96 ''
     IL_0000:  nop
     IL_0001:  ldstr      "zero"
     IL_0006:  ldstr      "one"
@@ -1291,7 +1289,7 @@
     IL_006a:  dup
     IL_006b:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::digits@7
     IL_0070:  stloc.0
-    .line 10,10 : 1,47
+    .line 10,10 : 1,47 ''
     IL_0071:  ldc.i4.5
     IL_0072:  ldc.i4.4
     IL_0073:  ldc.i4.1
@@ -1324,9 +1322,9 @@
     IL_00ae:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_00b3:  dup
-    IL_00b4:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'numbers@10-1'
+    IL_00b4:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'numbers@10-3'
     IL_00b9:  stloc.1
-    .line 12,17 : 1,21
+    .line 12,17 : 1,21 ''
     IL_00ba:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_00bf:  stloc.s    builder@
     IL_00c1:  ldloc.s    builder@
@@ -1335,37 +1333,38 @@
     IL_00c7:  ldloc.s    builder@
     IL_00c9:  ldloc.s    builder@
     IL_00cb:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Grouping01::get_numbers()
-    IL_00d0:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-    IL_00d5:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00da:  ldloc.s    builder@
-    IL_00dc:  newobj     instance void Linq101Grouping01/numberGroups@14::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_00e1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,int32,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00d0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00d5:  ldloc.s    builder@
+    IL_00d7:  newobj     instance void Linq101Grouping01/numberGroups@14::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_00dc:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,int32,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_00e6:  newobj     instance void Linq101Grouping01/'numberGroups@15-1'::.ctor()
-    IL_00eb:  newobj     instance void Linq101Grouping01/'numberGroups@15-2'::.ctor()
-    IL_00f0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<int32,int32,int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_00e1:  newobj     instance void Linq101Grouping01/'numberGroups@15-1'::.ctor()
+    IL_00e6:  newobj     instance void Linq101Grouping01/'numberGroups@15-2'::.ctor()
+    IL_00eb:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<int32,int32,int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_00f5:  ldloc.s    builder@
-    IL_00f7:  newobj     instance void Linq101Grouping01/'numberGroups@15-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_00fc:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<int32,int32>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00f0:  ldloc.s    builder@
+    IL_00f2:  newobj     instance void Linq101Grouping01/'numberGroups@15-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_00f7:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<int32,int32>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0101:  newobj     instance void Linq101Grouping01/'numberGroups@16-4'::.ctor()
-    IL_0106:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00fc:  newobj     instance void Linq101Grouping01/'numberGroups@16-4'::.ctor()
+    IL_0101:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_010b:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,int32[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0110:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<int32,int32[]>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0115:  dup
-    IL_0116:  stsfld     class [mscorlib]System.Tuple`2<int32,int32[]>[] '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::numberGroups@12
-    IL_011b:  stloc.2
-    .line 20,20 : 1,80
-    IL_011c:  ldstr      "blueberry"
-    IL_0121:  ldstr      "chimpanzee"
-    IL_0126:  ldstr      "abacus"
-    IL_012b:  ldstr      "banana"
-    IL_0130:  ldstr      "apple"
-    IL_0135:  ldstr      "cheese"
-    IL_013a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Empty()
+    IL_0106:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,int32[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_010b:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<int32,int32[]>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0110:  dup
+    IL_0111:  stsfld     class [mscorlib]System.Tuple`2<int32,int32[]>[] '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::numberGroups@12
+    IL_0116:  stloc.2
+    .line 20,20 : 1,80 ''
+    IL_0117:  ldstr      "blueberry"
+    IL_011c:  ldstr      "chimpanzee"
+    IL_0121:  ldstr      "abacus"
+    IL_0126:  ldstr      "banana"
+    IL_012b:  ldstr      "apple"
+    IL_0130:  ldstr      "cheese"
+    IL_0135:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Empty()
+    IL_013a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
+                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_013f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0144:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
@@ -1376,107 +1375,102 @@
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0153:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0158:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
-                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_015d:  dup
-    IL_015e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::words@20
-    IL_0163:  stloc.3
-    .line 22,27 : 1,21
-    IL_0164:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0169:  stloc.s    V_10
-    IL_016b:  ldloc.s    V_10
-    IL_016d:  ldloc.s    V_10
-    IL_016f:  ldloc.s    V_10
-    IL_0171:  ldloc.s    V_10
-    IL_0173:  ldloc.s    V_10
-    IL_0175:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Grouping01::get_words()
-    IL_017a:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-    IL_017f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0184:  ldloc.s    V_10
-    IL_0186:  newobj     instance void Linq101Grouping01/wordGroups@24::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_018b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<string,class [mscorlib]System.Collections.IEnumerable,string,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0158:  dup
+    IL_0159:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'words@20-2'
+    IL_015e:  stloc.3
+    .line 22,27 : 1,21 ''
+    IL_015f:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0164:  stloc.s    V_10
+    IL_0166:  ldloc.s    V_10
+    IL_0168:  ldloc.s    V_10
+    IL_016a:  ldloc.s    V_10
+    IL_016c:  ldloc.s    V_10
+    IL_016e:  ldloc.s    V_10
+    IL_0170:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Grouping01::get_words()
+    IL_0175:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_017a:  ldloc.s    V_10
+    IL_017c:  newobj     instance void Linq101Grouping01/wordGroups@24::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0181:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<string,class [mscorlib]System.Collections.IEnumerable,string,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0190:  newobj     instance void Linq101Grouping01/'wordGroups@25-1'::.ctor()
-    IL_0195:  newobj     instance void Linq101Grouping01/'wordGroups@25-2'::.ctor()
-    IL_019a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<string,char,string,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_0186:  newobj     instance void Linq101Grouping01/'wordGroups@25-1'::.ctor()
+    IL_018b:  newobj     instance void Linq101Grouping01/'wordGroups@25-2'::.ctor()
+    IL_0190:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<string,char,string,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                  class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                  class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_019f:  ldloc.s    V_10
-    IL_01a1:  newobj     instance void Linq101Grouping01/'wordGroups@25-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_01a6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<char,string>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<char,string>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0195:  ldloc.s    V_10
+    IL_0197:  newobj     instance void Linq101Grouping01/'wordGroups@25-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_019c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<char,string>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<char,string>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_01ab:  newobj     instance void Linq101Grouping01/'wordGroups@26-4'::.ctor()
-    IL_01b0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<char,string>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<char,string[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01a1:  newobj     instance void Linq101Grouping01/'wordGroups@26-4'::.ctor()
+    IL_01a6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<char,string>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<char,string[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_01b5:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<char,string[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_01ba:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<char,string[]>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01bf:  dup
-    IL_01c0:  stsfld     class [mscorlib]System.Tuple`2<char,string[]>[] '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::wordGroups@22
-    IL_01c5:  stloc.s    wordGroups
-    .line 30,30 : 1,32
-    IL_01c7:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
-    IL_01cc:  dup
-    IL_01cd:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'products@30-2'
-    IL_01d2:  stloc.s    products
-    .line 32,37 : 1,21
-    IL_01d4:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_01d9:  stloc.s    V_11
-    IL_01db:  ldloc.s    V_11
-    IL_01dd:  ldloc.s    V_11
-    IL_01df:  ldloc.s    V_11
-    IL_01e1:  ldloc.s    V_11
-    IL_01e3:  ldloc.s    V_11
-    IL_01e5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Grouping01::get_products()
-    IL_01ea:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_01ef:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01f4:  ldloc.s    V_11
-    IL_01f6:  newobj     instance void Linq101Grouping01/orderGroups@34::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_01fb:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01ab:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<char,string[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_01b0:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<char,string[]>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01b5:  dup
+    IL_01b6:  stsfld     class [mscorlib]System.Tuple`2<char,string[]>[] '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::wordGroups@22
+    IL_01bb:  stloc.s    wordGroups
+    .line 30,30 : 1,32 ''
+    IL_01bd:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
+    IL_01c2:  dup
+    IL_01c3:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::'products@30-4'
+    IL_01c8:  stloc.s    products
+    .line 32,37 : 1,21 ''
+    IL_01ca:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_01cf:  stloc.s    V_11
+    IL_01d1:  ldloc.s    V_11
+    IL_01d3:  ldloc.s    V_11
+    IL_01d5:  ldloc.s    V_11
+    IL_01d7:  ldloc.s    V_11
+    IL_01d9:  ldloc.s    V_11
+    IL_01db:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Grouping01::get_products()
+    IL_01e0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01e5:  ldloc.s    V_11
+    IL_01e7:  newobj     instance void Linq101Grouping01/orderGroups@34::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_01ec:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0200:  newobj     instance void Linq101Grouping01/'orderGroups@35-1'::.ctor()
-    IL_0205:  newobj     instance void Linq101Grouping01/'orderGroups@35-2'::.ctor()
-    IL_020a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_01f1:  newobj     instance void Linq101Grouping01/'orderGroups@35-1'::.ctor()
+    IL_01f6:  newobj     instance void Linq101Grouping01/'orderGroups@35-2'::.ctor()
+    IL_01fb:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_020f:  ldloc.s    V_11
-    IL_0211:  newobj     instance void Linq101Grouping01/'orderGroups@35-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0216:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0200:  ldloc.s    V_11
+    IL_0202:  newobj     instance void Linq101Grouping01/'orderGroups@35-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0207:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_021b:  newobj     instance void Linq101Grouping01/'orderGroups@36-4'::.ctor()
-    IL_0220:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_020c:  newobj     instance void Linq101Grouping01/'orderGroups@36-4'::.ctor()
+    IL_0211:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0225:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_022a:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_022f:  dup
-    IL_0230:  stsfld     class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>[] '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::orderGroups@32
-    IL_0235:  stloc.s    orderGroups
-    .line 40,40 : 1,34
-    IL_0237:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
-    IL_023c:  dup
-    IL_023d:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::customers@40
-    IL_0242:  stloc.s    customers
-    .line 42,58 : 1,21
-    IL_0244:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0249:  stloc.s    V_12
-    IL_024b:  ldloc.s    V_12
-    IL_024d:  ldloc.s    V_12
-    IL_024f:  ldloc.s    V_12
-    IL_0251:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Grouping01::get_customers()
-    IL_0256:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-    IL_025b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0260:  ldloc.s    V_12
-    IL_0262:  newobj     instance void Linq101Grouping01/customerOrderGroups@44::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0267:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0216:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_021b:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0220:  dup
+    IL_0221:  stsfld     class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product[]>[] '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::orderGroups@32
+    IL_0226:  stloc.s    orderGroups
+    .line 40,40 : 1,34 ''
+    IL_0228:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
+    IL_022d:  dup
+    IL_022e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::customers@40
+    IL_0233:  stloc.s    customers
+    .line 42,58 : 1,21 ''
+    IL_0235:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_023a:  stloc.s    V_12
+    IL_023c:  ldloc.s    V_12
+    IL_023e:  ldloc.s    V_12
+    IL_0240:  ldloc.s    V_12
+    IL_0242:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Grouping01::get_customers()
+    IL_0247:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_024c:  ldloc.s    V_12
+    IL_024e:  newobj     instance void Linq101Grouping01/customerOrderGroups@44::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0253:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                          class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_026c:  newobj     instance void Linq101Grouping01/'customerOrderGroups@57-1'::.ctor()
-    IL_0271:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0258:  newobj     instance void Linq101Grouping01/'customerOrderGroups@57-1'::.ctor()
+    IL_025d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>[]>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0276:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_027b:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>[]>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0280:  dup
-    IL_0281:  stsfld     class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>[]>[] '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::customerOrderGroups@42
-    IL_0286:  stloc.s    customerOrderGroups
-    IL_0288:  ret
+    IL_0262:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>[]>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0267:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>[]>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_026c:  dup
+    IL_026d:  stsfld     class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Tuple`2<int32,class [mscorlib]System.Tuple`2<int32,class [Utils]Utils/Order[]>[]>[]>[] '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01::customerOrderGroups@42
+    IL_0272:  stloc.s    customerOrderGroups
+    IL_0274:  ret
   } // end of method $Linq101Grouping01::main@
 
 } // end of class '<StartupCode$Linq101Grouping01>'.$Linq101Grouping01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Joins01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Joins01.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -31,27 +31,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Linq101Joins01
 {
-  // Offset: 0x00000000 Length: 0x0000030E
+  // Offset: 0x00000000 Length: 0x00000312
 }
 .mresource public FSharpOptimizationData.Linq101Joins01
 {
   // Offset: 0x00000318 Length: 0x000000C3
 }
 .module Linq101Joins01.exe
-// MVID: {5775B169-151B-685E-A745-038369B17557}
+// MVID: {590846DB-151B-685E-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x005C0000
+// Image base: 0x01880000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -81,7 +81,7 @@
       // Code size       3 (0x3)
       .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 14,14 : 32,33 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Joins01.fs'
+      .line 14,14 : 32,33 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Joins01.fs'
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -109,7 +109,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 14,14 : 36,46
+      .line 14,14 : 36,46 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -140,7 +140,7 @@
     {
       // Code size       9 (0x9)
       .maxstack  8
-      .line 14,14 : 9,47
+      .line 14,14 : 9,47 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
@@ -178,7 +178,7 @@
       .locals init ([0] class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product> V_0,
                [1] class [Utils]Utils/Product p,
                [2] string c)
-      .line 14,14 : 9,47
+      .line 14,14 : 9,47 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -223,7 +223,7 @@
       .maxstack  6
       .locals init ([0] string c,
                [1] class [Utils]Utils/Product p)
-      .line 15,15 : 17,33
+      .line 15,15 : 17,33 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>::get_Item1()
       IL_0006:  stloc.0
@@ -261,7 +261,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 22,22 : 37,38
+      .line 22,22 : 37,38 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -289,7 +289,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 22,22 : 41,51
+      .line 22,22 : 41,51 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -320,7 +320,7 @@
     {
       // Code size       9 (0x9)
       .maxstack  8
-      .line 22,22 : 9,60
+      .line 22,22 : 9,60 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
@@ -358,7 +358,7 @@
       .locals init ([0] class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>> V_0,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> ps,
                [2] string c)
-      .line 22,22 : 9,60
+      .line 22,22 : 9,60 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -403,7 +403,7 @@
       .maxstack  6
       .locals init ([0] string c,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> ps)
-      .line 23,23 : 17,22
+      .line 23,23 : 17,22 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>::get_Item1()
       IL_0006:  stloc.0
@@ -440,7 +440,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 30,30 : 37,38
+      .line 30,30 : 37,38 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -468,7 +468,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 30,30 : 41,51
+      .line 30,30 : 41,51 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -499,7 +499,7 @@
     {
       // Code size       9 (0x9)
       .maxstack  8
-      .line 30,30 : 9,60
+      .line 30,30 : 9,60 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
@@ -545,11 +545,11 @@
       // Code size       35 (0x23)
       .maxstack  8
       .locals init ([0] class [Utils]Utils/Product p)
-      .line 31,31 : 9,23
+      .line 31,31 : 9,23 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 32,32 : 9,34
+      .line 32,32 : 9,34 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Joins01/'q3@31-4'::builder@
       IL_0009:  ldarg.0
@@ -594,7 +594,7 @@
       .locals init ([0] class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>> V_0,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> ps,
                [2] string c)
-      .line 30,30 : 9,60
+      .line 30,30 : 9,60 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -648,7 +648,7 @@
       .locals init ([0] string c,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> ps,
                [2] class [Utils]Utils/Product p)
-      .line 32,32 : 17,33
+      .line 32,32 : 17,33 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`3<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>::get_Item1()
       IL_0006:  stloc.0
@@ -689,7 +689,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 39,39 : 37,38
+      .line 39,39 : 37,38 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -717,7 +717,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 39,39 : 41,51
+      .line 39,39 : 41,51 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -748,7 +748,7 @@
     {
       // Code size       9 (0x9)
       .maxstack  8
-      .line 39,39 : 9,60
+      .line 39,39 : 9,60 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
@@ -795,11 +795,11 @@
       .maxstack  9
       .locals init ([0] class [Utils]Utils/Product p,
                [1] string t)
-      .line 40,40 : 9,40
+      .line 40,40 : 9,40 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 41,41 : 17,39
+      .line 41,41 : 17,39 ''
       IL_0003:  ldloc.0
       IL_0004:  box        [Utils]Utils/Product
       IL_0009:  ldnull
@@ -811,20 +811,20 @@
 
       IL_0013:  br.s       IL_001d
 
-      .line 41,41 : 40,55
+      .line 41,41 : 40,55 ''
       IL_0015:  ldstr      "(No products)"
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_001a:  nop
       IL_001b:  br.s       IL_0024
 
-      .line 41,41 : 61,74
+      .line 41,41 : 61,74 ''
       IL_001d:  ldloc.0
       IL_001e:  callvirt   instance string [Utils]Utils/Product::get_ProductName()
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0023:  nop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0024:  stloc.1
-      .line 42,42 : 9,22
+      .line 42,42 : 9,22 ''
       IL_0025:  ldarg.0
       IL_0026:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Joins01/'q4@40-4'::builder@
       IL_002b:  ldarg.0
@@ -871,7 +871,7 @@
       .locals init ([0] class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>> V_0,
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> ps,
                [2] string c)
-      .line 39,39 : 9,60
+      .line 39,39 : 9,60 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -927,7 +927,7 @@
                [1] class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> ps,
                [2] class [Utils]Utils/Product p,
                [3] string t)
-      .line 42,42 : 17,21
+      .line 42,42 : 17,21 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`4<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product,string>::get_Item1()
       IL_0006:  stloc.0
@@ -955,7 +955,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Joins01>'.$Linq101Joins01::categories@8
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Joins01>'.$Linq101Joins01::'categories@8-2'
     IL_0005:  ret
   } // end of method Linq101Joins01::get_categories
 
@@ -964,7 +964,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Joins01>'.$Linq101Joins01::'products@9-4'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Joins01>'.$Linq101Joins01::'products@9-6'
     IL_0005:  ret
   } // end of method Linq101Joins01::get_products
 
@@ -1045,9 +1045,9 @@
 .class private abstract auto ansi sealed '<StartupCode$Linq101Joins01>'.$Linq101Joins01
        extends [mscorlib]System.Object
 {
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> categories@8
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'categories@8-2'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@9-4'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@9-6'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Tuple`2<string,string>[] q@11
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -1064,7 +1064,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       502 (0x1f6)
+    // Code size       462 (0x1ce)
     .maxstack  10
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> categories,
              [1] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> products,
@@ -1076,7 +1076,7 @@
              [7] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_7,
              [8] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_8,
              [9] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_9)
-    .line 8,8 : 1,88
+    .line 8,8 : 1,88 ''
     IL_0000:  nop
     IL_0001:  ldstr      "Beverages"
     IL_0006:  ldstr      "Condiments"
@@ -1095,14 +1095,14 @@
     IL_0033:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0038:  dup
-    IL_0039:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Joins01>'.$Linq101Joins01::categories@8
+    IL_0039:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Joins01>'.$Linq101Joins01::'categories@8-2'
     IL_003e:  stloc.0
-    .line 9,9 : 1,32
+    .line 9,9 : 1,32 ''
     IL_003f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
     IL_0044:  dup
-    IL_0045:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Joins01>'.$Linq101Joins01::'products@9-4'
+    IL_0045:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Joins01>'.$Linq101Joins01::'products@9-6'
     IL_004a:  stloc.1
-    .line 11,16 : 1,21
+    .line 11,16 : 1,21 ''
     IL_004b:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_0050:  stloc.s    builder@
     IL_0052:  ldloc.s    builder@
@@ -1110,135 +1110,127 @@
     IL_0056:  ldloc.s    builder@
     IL_0058:  ldloc.s    builder@
     IL_005a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Joins01::get_categories()
-    IL_005f:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-    IL_0064:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0069:  ldloc.s    builder@
-    IL_006b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Joins01::get_products()
-    IL_0070:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_0075:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_007a:  newobj     instance void Linq101Joins01/q@14::.ctor()
-    IL_007f:  newobj     instance void Linq101Joins01/'q@14-1'::.ctor()
-    IL_0084:  newobj     instance void Linq101Joins01/'q@14-2'::.ctor()
-    IL_0089:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!4,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Join<string,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,string,class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_005f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0064:  ldloc.s    builder@
+    IL_0066:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Joins01::get_products()
+    IL_006b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0070:  newobj     instance void Linq101Joins01/q@14::.ctor()
+    IL_0075:  newobj     instance void Linq101Joins01/'q@14-1'::.ctor()
+    IL_007a:  newobj     instance void Linq101Joins01/'q@14-2'::.ctor()
+    IL_007f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!4,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Join<string,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,string,class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1>,
                                                                                                                                                                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!2,!!3>,
                                                                                                                                                                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!2,!!4>>)
-    IL_008e:  ldloc.s    builder@
-    IL_0090:  newobj     instance void Linq101Joins01/'q@14-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0095:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0084:  ldloc.s    builder@
+    IL_0086:  newobj     instance void Linq101Joins01/'q@14-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_008b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_009a:  newobj     instance void Linq101Joins01/'q@15-4'::.ctor()
-    IL_009f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,string>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0090:  newobj     instance void Linq101Joins01/'q@15-4'::.ctor()
+    IL_0095:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,string>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_00a4:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,string>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_00a9:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,string>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00ae:  dup
-    IL_00af:  stsfld     class [mscorlib]System.Tuple`2<string,string>[] '<StartupCode$Linq101Joins01>'.$Linq101Joins01::q@11
-    IL_00b4:  stloc.2
-    .line 19,24 : 1,21
-    IL_00b5:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_00ba:  stloc.s    V_7
-    IL_00bc:  ldloc.s    V_7
-    IL_00be:  ldloc.s    V_7
-    IL_00c0:  ldloc.s    V_7
-    IL_00c2:  ldloc.s    V_7
-    IL_00c4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Joins01::get_categories()
-    IL_00c9:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-    IL_00ce:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00d3:  ldloc.s    V_7
-    IL_00d5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Joins01::get_products()
-    IL_00da:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_00df:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00e4:  newobj     instance void Linq101Joins01/q2@22::.ctor()
-    IL_00e9:  newobj     instance void Linq101Joins01/'q2@22-1'::.ctor()
-    IL_00ee:  newobj     instance void Linq101Joins01/'q2@22-2'::.ctor()
-    IL_00f3:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!4,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupJoin<string,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,string,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_009a:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,string>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_009f:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,string>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00a4:  dup
+    IL_00a5:  stsfld     class [mscorlib]System.Tuple`2<string,string>[] '<StartupCode$Linq101Joins01>'.$Linq101Joins01::q@11
+    IL_00aa:  stloc.2
+    .line 19,24 : 1,21 ''
+    IL_00ab:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_00b0:  stloc.s    V_7
+    IL_00b2:  ldloc.s    V_7
+    IL_00b4:  ldloc.s    V_7
+    IL_00b6:  ldloc.s    V_7
+    IL_00b8:  ldloc.s    V_7
+    IL_00ba:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Joins01::get_categories()
+    IL_00bf:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00c4:  ldloc.s    V_7
+    IL_00c6:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Joins01::get_products()
+    IL_00cb:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00d0:  newobj     instance void Linq101Joins01/q2@22::.ctor()
+    IL_00d5:  newobj     instance void Linq101Joins01/'q2@22-1'::.ctor()
+    IL_00da:  newobj     instance void Linq101Joins01/'q2@22-2'::.ctor()
+    IL_00df:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!4,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupJoin<string,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,string,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!2,!!3>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2>,!!4>>)
-    IL_00f8:  ldloc.s    V_7
-    IL_00fa:  newobj     instance void Linq101Joins01/'q2@22-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_00ff:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00e4:  ldloc.s    V_7
+    IL_00e6:  newobj     instance void Linq101Joins01/'q2@22-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_00eb:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0104:  newobj     instance void Linq101Joins01/'q2@23-4'::.ctor()
-    IL_0109:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00f0:  newobj     instance void Linq101Joins01/'q2@23-4'::.ctor()
+    IL_00f5:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_010e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0113:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0118:  dup
-    IL_0119:  stsfld     class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>[] '<StartupCode$Linq101Joins01>'.$Linq101Joins01::q2@19
-    IL_011e:  stloc.3
-    .line 27,33 : 1,21
-    IL_011f:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0124:  stloc.s    V_8
-    IL_0126:  ldloc.s    V_8
-    IL_0128:  ldloc.s    V_8
-    IL_012a:  ldloc.s    V_8
-    IL_012c:  ldloc.s    V_8
-    IL_012e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Joins01::get_categories()
-    IL_0133:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-    IL_0138:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_013d:  ldloc.s    V_8
-    IL_013f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Joins01::get_products()
-    IL_0144:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_0149:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_014e:  newobj     instance void Linq101Joins01/q3@30::.ctor()
-    IL_0153:  newobj     instance void Linq101Joins01/'q3@30-1'::.ctor()
-    IL_0158:  newobj     instance void Linq101Joins01/'q3@30-2'::.ctor()
-    IL_015d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!4,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupJoin<string,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,string,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00fa:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_00ff:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0104:  dup
+    IL_0105:  stsfld     class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>[] '<StartupCode$Linq101Joins01>'.$Linq101Joins01::q2@19
+    IL_010a:  stloc.3
+    .line 27,33 : 1,21 ''
+    IL_010b:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0110:  stloc.s    V_8
+    IL_0112:  ldloc.s    V_8
+    IL_0114:  ldloc.s    V_8
+    IL_0116:  ldloc.s    V_8
+    IL_0118:  ldloc.s    V_8
+    IL_011a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Joins01::get_categories()
+    IL_011f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0124:  ldloc.s    V_8
+    IL_0126:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Joins01::get_products()
+    IL_012b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0130:  newobj     instance void Linq101Joins01/q3@30::.ctor()
+    IL_0135:  newobj     instance void Linq101Joins01/'q3@30-1'::.ctor()
+    IL_013a:  newobj     instance void Linq101Joins01/'q3@30-2'::.ctor()
+    IL_013f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!4,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupJoin<string,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,string,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!2,!!3>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2>,!!4>>)
-    IL_0162:  ldloc.s    V_8
-    IL_0164:  newobj     instance void Linq101Joins01/'q3@30-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0169:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0144:  ldloc.s    V_8
+    IL_0146:  newobj     instance void Linq101Joins01/'q3@30-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_014b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_016e:  newobj     instance void Linq101Joins01/'q3@32-5'::.ctor()
-    IL_0173:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`3<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,string>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0150:  newobj     instance void Linq101Joins01/'q3@32-5'::.ctor()
+    IL_0155:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`3<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,string>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0178:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,string>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_017d:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,string>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0182:  dup
-    IL_0183:  stsfld     class [mscorlib]System.Tuple`2<string,string>[] '<StartupCode$Linq101Joins01>'.$Linq101Joins01::q3@27
-    IL_0188:  stloc.s    q3
-    .line 36,43 : 1,21
-    IL_018a:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_018f:  stloc.s    V_9
-    IL_0191:  ldloc.s    V_9
-    IL_0193:  ldloc.s    V_9
-    IL_0195:  ldloc.s    V_9
-    IL_0197:  ldloc.s    V_9
-    IL_0199:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Joins01::get_categories()
-    IL_019e:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-    IL_01a3:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01a8:  ldloc.s    V_9
-    IL_01aa:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Joins01::get_products()
-    IL_01af:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_01b4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01b9:  newobj     instance void Linq101Joins01/q4@39::.ctor()
-    IL_01be:  newobj     instance void Linq101Joins01/'q4@39-1'::.ctor()
-    IL_01c3:  newobj     instance void Linq101Joins01/'q4@39-2'::.ctor()
-    IL_01c8:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!4,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupJoin<string,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,string,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_015a:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,string>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_015f:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,string>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0164:  dup
+    IL_0165:  stsfld     class [mscorlib]System.Tuple`2<string,string>[] '<StartupCode$Linq101Joins01>'.$Linq101Joins01::q3@27
+    IL_016a:  stloc.s    q3
+    .line 36,43 : 1,21 ''
+    IL_016c:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0171:  stloc.s    V_9
+    IL_0173:  ldloc.s    V_9
+    IL_0175:  ldloc.s    V_9
+    IL_0177:  ldloc.s    V_9
+    IL_0179:  ldloc.s    V_9
+    IL_017b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Joins01::get_categories()
+    IL_0180:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0185:  ldloc.s    V_9
+    IL_0187:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Joins01::get_products()
+    IL_018c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0191:  newobj     instance void Linq101Joins01/q4@39::.ctor()
+    IL_0196:  newobj     instance void Linq101Joins01/'q4@39-1'::.ctor()
+    IL_019b:  newobj     instance void Linq101Joins01/'q4@39-2'::.ctor()
+    IL_01a0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!4,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupJoin<string,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,string,class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!2,!!3>,
                                                                                                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2>,!!4>>)
-    IL_01cd:  ldloc.s    V_9
-    IL_01cf:  newobj     instance void Linq101Joins01/'q4@39-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_01d4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`4<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product,string>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01a5:  ldloc.s    V_9
+    IL_01a7:  newobj     instance void Linq101Joins01/'q4@39-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_01ac:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [mscorlib]System.Tuple`2<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`4<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product,string>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_01d9:  newobj     instance void Linq101Joins01/'q4@42-5'::.ctor()
-    IL_01de:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`4<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product,string>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,string>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01b1:  newobj     instance void Linq101Joins01/'q4@42-5'::.ctor()
+    IL_01b6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`4<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product,string>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,string>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_01e3:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,string>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_01e8:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,string>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01ed:  dup
-    IL_01ee:  stsfld     class [mscorlib]System.Tuple`2<string,string>[] '<StartupCode$Linq101Joins01>'.$Linq101Joins01::q4@36
-    IL_01f3:  stloc.s    q4
-    IL_01f5:  ret
+    IL_01bb:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,string>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_01c0:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,string>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01c5:  dup
+    IL_01c6:  stsfld     class [mscorlib]System.Tuple`2<string,string>[] '<StartupCode$Linq101Joins01>'.$Linq101Joins01::q4@36
+    IL_01cb:  stloc.s    q4
+    IL_01cd:  ret
   } // end of method $Linq101Joins01::main@
 
 } // end of class '<StartupCode$Linq101Joins01>'.$Linq101Joins01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Ordering01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Ordering01.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -26,27 +26,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Linq101Ordering01
 {
-  // Offset: 0x00000000 Length: 0x000003B2
+  // Offset: 0x00000000 Length: 0x000003B6
 }
 .mresource public FSharpOptimizationData.Linq101Ordering01
 {
-  // Offset: 0x000003B8 Length: 0x00000134
+  // Offset: 0x000003C0 Length: 0x00000134
 }
 .module Linq101Ordering01.exe
-// MVID: {5775B16C-649A-6956-A745-03836CB17557}
+// MVID: {590846DB-649A-6956-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x006E0000
+// Image base: 0x030A0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -108,10 +108,10 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Ordering01.fs'
+      .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Ordering01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Ordering01/sortedWords@11::pc
       IL_0006:  ldc.i4.1
@@ -128,90 +128,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 11,11 : 9,26
+      .line 11,11 : 9,26 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Ordering01::get_words()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Ordering01/sortedWords@11::pc
-      .line 11,11 : 9,26
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Ordering01/sortedWords@11::pc
+      .line 11,11 : 9,26 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0063:  stfld      string Linq101Ordering01/sortedWords@11::_arg1
-      .line 11,11 : 9,26
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      string Linq101Ordering01/sortedWords@11::_arg1
-      IL_006f:  stfld      string Linq101Ordering01/sortedWords@11::w
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Ordering01/sortedWords@11::pc
-      .line 12,12 : 9,17
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      string Linq101Ordering01/sortedWords@11::w
-      IL_0082:  stfld      string Linq101Ordering01/sortedWords@11::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_005e:  stfld      string Linq101Ordering01/sortedWords@11::_arg1
+      .line 11,11 : 9,26 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      string Linq101Ordering01/sortedWords@11::_arg1
+      IL_006a:  stfld      string Linq101Ordering01/sortedWords@11::w
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Ordering01/sortedWords@11::pc
+      .line 12,12 : 9,17 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      string Linq101Ordering01/sortedWords@11::w
+      IL_007d:  stfld      string Linq101Ordering01/sortedWords@11::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      string Linq101Ordering01/sortedWords@11::w
-      .line 11,11 : 9,26
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      string Linq101Ordering01/sortedWords@11::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      string Linq101Ordering01/sortedWords@11::w
+      .line 11,11 : 9,26 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      string Linq101Ordering01/sortedWords@11::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Ordering01/sortedWords@11::pc
-      .line 11,11 : 9,26
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Ordering01/sortedWords@11::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      string Linq101Ordering01/sortedWords@11::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Ordering01/sortedWords@11::pc
+      .line 11,11 : 9,26 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Ordering01/sortedWords@11::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      string Linq101Ordering01/sortedWords@11::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method sortedWords@11::GenerateNext
 
     .method public strict virtual instance void 
@@ -222,7 +221,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -233,13 +232,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -260,30 +259,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -292,7 +291,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords@11::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -309,18 +308,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 11,11 : 9,26
+        .line 11,11 : 9,26 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -333,11 +332,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method sortedWords@11::Close
 
@@ -443,7 +442,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 12,12 : 16,17
+      .line 12,12 : 16,17 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -504,9 +503,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Ordering01/sortedWords2@18::pc
       IL_0006:  ldc.i4.1
@@ -523,90 +522,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 18,18 : 9,26
+      .line 18,18 : 9,26 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Ordering01::get_words()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Ordering01/sortedWords2@18::pc
-      .line 18,18 : 9,26
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Ordering01/sortedWords2@18::pc
+      .line 18,18 : 9,26 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0063:  stfld      string Linq101Ordering01/sortedWords2@18::_arg1
-      .line 18,18 : 9,26
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      string Linq101Ordering01/sortedWords2@18::_arg1
-      IL_006f:  stfld      string Linq101Ordering01/sortedWords2@18::w
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Ordering01/sortedWords2@18::pc
-      .line 19,19 : 9,26
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      string Linq101Ordering01/sortedWords2@18::w
-      IL_0082:  stfld      string Linq101Ordering01/sortedWords2@18::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_005e:  stfld      string Linq101Ordering01/sortedWords2@18::_arg1
+      .line 18,18 : 9,26 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      string Linq101Ordering01/sortedWords2@18::_arg1
+      IL_006a:  stfld      string Linq101Ordering01/sortedWords2@18::w
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Ordering01/sortedWords2@18::pc
+      .line 19,19 : 9,26 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      string Linq101Ordering01/sortedWords2@18::w
+      IL_007d:  stfld      string Linq101Ordering01/sortedWords2@18::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      string Linq101Ordering01/sortedWords2@18::w
-      .line 18,18 : 9,26
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      string Linq101Ordering01/sortedWords2@18::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      string Linq101Ordering01/sortedWords2@18::w
+      .line 18,18 : 9,26 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      string Linq101Ordering01/sortedWords2@18::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Ordering01/sortedWords2@18::pc
-      .line 18,18 : 9,26
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Ordering01/sortedWords2@18::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      string Linq101Ordering01/sortedWords2@18::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Ordering01/sortedWords2@18::pc
+      .line 18,18 : 9,26 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Ordering01/sortedWords2@18::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      string Linq101Ordering01/sortedWords2@18::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method sortedWords2@18::GenerateNext
 
     .method public strict virtual instance void 
@@ -617,7 +615,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -628,13 +626,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -655,30 +653,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -687,7 +685,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedWords2@18::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -704,18 +702,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 18,18 : 9,26
+        .line 18,18 : 9,26 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -728,11 +726,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method sortedWords2@18::Close
 
@@ -838,7 +836,7 @@
     {
       // Code size       8 (0x8)
       .maxstack  8
-      .line 19,19 : 17,25
+      .line 19,19 : 17,25 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance int32 [mscorlib]System.String::get_Length()
@@ -872,11 +870,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Product p)
-      .line 26,26 : 9,29
+      .line 26,26 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 27,27 : 9,29
+      .line 27,27 : 9,29 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Ordering01/sortedProducts@26::builder@
       IL_0009:  ldloc.0
@@ -907,7 +905,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 27,27 : 16,29
+      .line 27,27 : 16,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -937,7 +935,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 28,28 : 16,17
+      .line 28,28 : 16,17 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -998,9 +996,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Ordering01/sortedProducts2@44::pc
       IL_0006:  ldc.i4.1
@@ -1017,90 +1015,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 44,44 : 9,29
+      .line 44,44 : 9,29 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Ordering01::get_products()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Ordering01/sortedProducts2@44::pc
-      .line 44,44 : 9,29
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Ordering01/sortedProducts2@44::pc
+      .line 44,44 : 9,29 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0063:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::_arg1
-      .line 44,44 : 9,29
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::_arg1
-      IL_006f:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::p
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Ordering01/sortedProducts2@44::pc
-      .line 45,45 : 9,40
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::p
-      IL_0082:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_005e:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::_arg1
+      .line 44,44 : 9,29 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::_arg1
+      IL_006a:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::p
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Ordering01/sortedProducts2@44::pc
+      .line 45,45 : 9,40 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::p
+      IL_007d:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::p
-      .line 44,44 : 9,29
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::p
+      .line 44,44 : 9,29 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Ordering01/sortedProducts2@44::pc
-      .line 44,44 : 9,29
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Ordering01/sortedProducts2@44::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Ordering01/sortedProducts2@44::pc
+      .line 44,44 : 9,29 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Ordering01/sortedProducts2@44::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      class [Utils]Utils/Product Linq101Ordering01/sortedProducts2@44::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method sortedProducts2@44::GenerateNext
 
     .method public strict virtual instance void 
@@ -1111,7 +1108,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -1122,13 +1119,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -1149,30 +1146,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -1181,7 +1178,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Ordering01/sortedProducts2@44::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -1198,18 +1195,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 44,44 : 9,29
+        .line 44,44 : 9,29 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -1222,11 +1219,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method sortedProducts2@44::Close
 
@@ -1332,7 +1329,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 45,45 : 26,40
+      .line 45,45 : 26,40 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -1395,9 +1392,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Ordering01/sortedDigits@52::pc
       IL_0006:  ldc.i4.1
@@ -1414,90 +1411,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 52,52 : 9,27
+      .line 52,52 : 9,27 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Ordering01::get_digits()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Ordering01/sortedDigits@52::pc
-      .line 52,52 : 9,27
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Ordering01/sortedDigits@52::pc
+      .line 52,52 : 9,27 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0063:  stfld      string Linq101Ordering01/sortedDigits@52::_arg1
-      .line 52,52 : 9,27
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      string Linq101Ordering01/sortedDigits@52::_arg1
-      IL_006f:  stfld      string Linq101Ordering01/sortedDigits@52::d
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Ordering01/sortedDigits@52::pc
-      .line 53,53 : 9,24
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      string Linq101Ordering01/sortedDigits@52::d
-      IL_0082:  stfld      string Linq101Ordering01/sortedDigits@52::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_005e:  stfld      string Linq101Ordering01/sortedDigits@52::_arg1
+      .line 52,52 : 9,27 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      string Linq101Ordering01/sortedDigits@52::_arg1
+      IL_006a:  stfld      string Linq101Ordering01/sortedDigits@52::d
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Ordering01/sortedDigits@52::pc
+      .line 53,53 : 9,24 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      string Linq101Ordering01/sortedDigits@52::d
+      IL_007d:  stfld      string Linq101Ordering01/sortedDigits@52::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      string Linq101Ordering01/sortedDigits@52::d
-      .line 52,52 : 9,27
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      string Linq101Ordering01/sortedDigits@52::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      string Linq101Ordering01/sortedDigits@52::d
+      .line 52,52 : 9,27 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      string Linq101Ordering01/sortedDigits@52::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Ordering01/sortedDigits@52::pc
-      .line 52,52 : 9,27
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Ordering01/sortedDigits@52::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      string Linq101Ordering01/sortedDigits@52::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Ordering01/sortedDigits@52::pc
+      .line 52,52 : 9,27 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Ordering01/sortedDigits@52::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      string Linq101Ordering01/sortedDigits@52::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method sortedDigits@52::GenerateNext
 
     .method public strict virtual instance void 
@@ -1508,7 +1504,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -1519,13 +1515,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -1546,30 +1542,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -1578,7 +1574,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Ordering01/sortedDigits@52::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -1595,18 +1591,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 52,52 : 9,27
+        .line 52,52 : 9,27 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -1619,11 +1615,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method sortedDigits@52::Close
 
@@ -1729,7 +1725,7 @@
     {
       // Code size       8 (0x8)
       .maxstack  8
-      .line 53,53 : 16,24
+      .line 53,53 : 16,24 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance int32 [mscorlib]System.String::get_Length()
@@ -1758,7 +1754,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 54,54 : 16,17
+      .line 54,54 : 16,17 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -1791,11 +1787,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Product p)
-      .line 60,60 : 9,29
+      .line 60,60 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 61,61 : 9,26
+      .line 61,61 : 9,26 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Ordering01/sortedProducts3@60::builder@
       IL_0009:  ldloc.0
@@ -1826,7 +1822,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 61,61 : 16,26
+      .line 61,61 : 16,26 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -1856,7 +1852,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 62,62 : 26,37
+      .line 62,62 : 26,37 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -1886,7 +1882,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 63,63 : 16,17
+      .line 63,63 : 16,17 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -1899,7 +1895,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'words@8-2'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'words@8-4'
     IL_0005:  ret
   } // end of method Linq101Ordering01::get_words
 
@@ -1926,7 +1922,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'products@23-6'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'products@23-8'
     IL_0005:  ret
   } // end of method Linq101Ordering01::get_products
 
@@ -2031,13 +2027,13 @@
 .class private abstract auto ansi sealed '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01
        extends [mscorlib]System.Object
 {
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'words@8-2'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'words@8-4'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> sortedWords@9
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> sortedWords2@16
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@23-6'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@23-8'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [Utils]Utils/Product[] sortedProducts@24
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -2056,7 +2052,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       559 (0x22f)
+    // Code size       549 (0x225)
     .maxstack  13
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> words,
              [1] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> sortedWords,
@@ -2073,7 +2069,7 @@
              [12] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_12,
              [13] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_13,
              [14] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_14)
-    .line 8,8 : 1,45
+    .line 8,8 : 1,45 ''
     IL_0000:  nop
     IL_0001:  ldstr      "cherry"
     IL_0006:  ldstr      "apple"
@@ -2086,9 +2082,9 @@
     IL_001f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0024:  dup
-    IL_0025:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'words@8-2'
+    IL_0025:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'words@8-4'
     IL_002a:  stloc.0
-    .line 9,13 : 1,20
+    .line 9,13 : 1,20 ''
     IL_002b:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_0030:  stloc.s    builder@
     IL_0032:  ldloc.s    builder@
@@ -2111,7 +2107,7 @@
     IL_0057:  dup
     IL_0058:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedWords@9
     IL_005d:  stloc.1
-    .line 16,20 : 1,20
+    .line 16,20 : 1,20 ''
     IL_005e:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_0063:  stloc.s    V_10
     IL_0065:  ldloc.s    V_10
@@ -2134,12 +2130,12 @@
     IL_008a:  dup
     IL_008b:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedWords2@16
     IL_0090:  stloc.2
-    .line 23,23 : 1,32
+    .line 23,23 : 1,32 ''
     IL_0091:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
     IL_0096:  dup
-    IL_0097:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'products@23-6'
+    IL_0097:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'products@23-8'
     IL_009c:  stloc.3
-    .line 24,29 : 1,21
+    .line 24,29 : 1,21 ''
     IL_009d:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_00a2:  stloc.s    V_11
     IL_00a4:  ldloc.s    V_11
@@ -2147,58 +2143,59 @@
     IL_00a8:  ldloc.s    V_11
     IL_00aa:  ldloc.s    V_11
     IL_00ac:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Ordering01::get_products()
-    IL_00b1:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_00b6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00bb:  ldloc.s    V_11
-    IL_00bd:  newobj     instance void Linq101Ordering01/sortedProducts@26::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_00c2:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00b1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00b6:  ldloc.s    V_11
+    IL_00b8:  newobj     instance void Linq101Ordering01/sortedProducts@26::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_00bd:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_00c7:  newobj     instance void Linq101Ordering01/'sortedProducts@27-1'::.ctor()
-    IL_00cc:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SortBy<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,string>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00c2:  newobj     instance void Linq101Ordering01/'sortedProducts@27-1'::.ctor()
+    IL_00c7:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SortBy<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,string>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_00d1:  newobj     instance void Linq101Ordering01/'sortedProducts@28-2'::.ctor()
-    IL_00d6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00cc:  newobj     instance void Linq101Ordering01/'sortedProducts@28-2'::.ctor()
+    IL_00d1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_00db:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_00e0:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00e5:  dup
-    IL_00e6:  stsfld     class [Utils]Utils/Product[] '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedProducts@24
-    IL_00eb:  stloc.s    sortedProducts
-    .line 42,46 : 1,21
-    IL_00ed:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_00f2:  stloc.s    V_12
-    IL_00f4:  ldloc.s    V_12
-    IL_00f6:  ldnull
-    IL_00f7:  ldnull
-    IL_00f8:  ldnull
-    IL_00f9:  ldc.i4.0
-    IL_00fa:  ldnull
-    IL_00fb:  newobj     instance void Linq101Ordering01/sortedProducts2@44::.ctor(class [Utils]Utils/Product,
+    IL_00d6:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_00db:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00e0:  dup
+    IL_00e1:  stsfld     class [Utils]Utils/Product[] '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedProducts@24
+    IL_00e6:  stloc.s    sortedProducts
+    .line 42,46 : 1,21 ''
+    IL_00e8:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_00ed:  stloc.s    V_12
+    IL_00ef:  ldloc.s    V_12
+    IL_00f1:  ldnull
+    IL_00f2:  ldnull
+    IL_00f3:  ldnull
+    IL_00f4:  ldc.i4.0
+    IL_00f5:  ldnull
+    IL_00f6:  newobj     instance void Linq101Ordering01/sortedProducts2@44::.ctor(class [Utils]Utils/Product,
                                                                                    class [Utils]Utils/Product,
                                                                                    class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>,
                                                                                    int32,
                                                                                    class [Utils]Utils/Product)
-    IL_0100:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_0105:  newobj     instance void Linq101Ordering01/'sortedProducts2@45-1'::.ctor()
-    IL_010a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SortByDescending<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00fb:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_0100:  newobj     instance void Linq101Ordering01/'sortedProducts2@45-1'::.ctor()
+    IL_0105:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SortByDescending<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_010f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0114:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0119:  dup
-    IL_011a:  stsfld     class [Utils]Utils/Product[] '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedProducts2@42
-    IL_011f:  stloc.s    sortedProducts2
-    .line 49,49 : 1,96
-    IL_0121:  ldstr      "zero"
-    IL_0126:  ldstr      "one"
-    IL_012b:  ldstr      "two"
-    IL_0130:  ldstr      "three"
-    IL_0135:  ldstr      "four"
-    IL_013a:  ldstr      "five"
-    IL_013f:  ldstr      "six"
-    IL_0144:  ldstr      "seven"
-    IL_0149:  ldstr      "eight"
-    IL_014e:  ldstr      "nine"
-    IL_0153:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Empty()
+    IL_010a:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_010f:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0114:  dup
+    IL_0115:  stsfld     class [Utils]Utils/Product[] '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedProducts2@42
+    IL_011a:  stloc.s    sortedProducts2
+    .line 49,49 : 1,96 ''
+    IL_011c:  ldstr      "zero"
+    IL_0121:  ldstr      "one"
+    IL_0126:  ldstr      "two"
+    IL_012b:  ldstr      "three"
+    IL_0130:  ldstr      "four"
+    IL_0135:  ldstr      "five"
+    IL_013a:  ldstr      "six"
+    IL_013f:  ldstr      "seven"
+    IL_0144:  ldstr      "eight"
+    IL_0149:  ldstr      "nine"
+    IL_014e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Empty()
+    IL_0153:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
+                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0158:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_015d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
@@ -2217,68 +2214,65 @@
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0180:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0185:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
-                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_018a:  dup
-    IL_018b:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'digits@49-2'
-    IL_0190:  stloc.s    digits
-    .line 50,55 : 1,20
-    IL_0192:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0197:  stloc.s    V_13
-    IL_0199:  ldloc.s    V_13
-    IL_019b:  ldloc.s    V_13
-    IL_019d:  ldnull
-    IL_019e:  ldnull
-    IL_019f:  ldnull
-    IL_01a0:  ldc.i4.0
-    IL_01a1:  ldnull
-    IL_01a2:  newobj     instance void Linq101Ordering01/sortedDigits@52::.ctor(string,
+    IL_0185:  dup
+    IL_0186:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::'digits@49-2'
+    IL_018b:  stloc.s    digits
+    .line 50,55 : 1,20 ''
+    IL_018d:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0192:  stloc.s    V_13
+    IL_0194:  ldloc.s    V_13
+    IL_0196:  ldloc.s    V_13
+    IL_0198:  ldnull
+    IL_0199:  ldnull
+    IL_019a:  ldnull
+    IL_019b:  ldc.i4.0
+    IL_019c:  ldnull
+    IL_019d:  newobj     instance void Linq101Ordering01/sortedDigits@52::.ctor(string,
                                                                                 string,
                                                                                 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>,
                                                                                 int32,
                                                                                 string)
-    IL_01a7:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_01ac:  newobj     instance void Linq101Ordering01/'sortedDigits@53-1'::.ctor()
-    IL_01b1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SortBy<string,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01a2:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_01a7:  newobj     instance void Linq101Ordering01/'sortedDigits@53-1'::.ctor()
+    IL_01ac:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SortBy<string,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_01b6:  newobj     instance void Linq101Ordering01/'sortedDigits@54-2'::.ctor()
-    IL_01bb:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::ThenBy<string,class [mscorlib]System.Collections.IEnumerable,string>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01b1:  newobj     instance void Linq101Ordering01/'sortedDigits@54-2'::.ctor()
+    IL_01b6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::ThenBy<string,class [mscorlib]System.Collections.IEnumerable,string>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_01c0:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_01c5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01ca:  dup
-    IL_01cb:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedDigits@50
-    IL_01d0:  stloc.s    sortedDigits
-    .line 58,64 : 1,21
-    IL_01d2:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_01d7:  stloc.s    V_14
-    IL_01d9:  ldloc.s    V_14
-    IL_01db:  ldloc.s    V_14
-    IL_01dd:  ldloc.s    V_14
-    IL_01df:  ldloc.s    V_14
-    IL_01e1:  ldloc.s    V_14
-    IL_01e3:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Ordering01::get_products()
-    IL_01e8:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_01ed:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01f2:  ldloc.s    V_14
-    IL_01f4:  newobj     instance void Linq101Ordering01/sortedProducts3@60::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_01f9:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01bb:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_01c0:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01c5:  dup
+    IL_01c6:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedDigits@50
+    IL_01cb:  stloc.s    sortedDigits
+    .line 58,64 : 1,21 ''
+    IL_01cd:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_01d2:  stloc.s    V_14
+    IL_01d4:  ldloc.s    V_14
+    IL_01d6:  ldloc.s    V_14
+    IL_01d8:  ldloc.s    V_14
+    IL_01da:  ldloc.s    V_14
+    IL_01dc:  ldloc.s    V_14
+    IL_01de:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Ordering01::get_products()
+    IL_01e3:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01e8:  ldloc.s    V_14
+    IL_01ea:  newobj     instance void Linq101Ordering01/sortedProducts3@60::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_01ef:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_01fe:  newobj     instance void Linq101Ordering01/'sortedProducts3@61-1'::.ctor()
-    IL_0203:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SortBy<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,string>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01f4:  newobj     instance void Linq101Ordering01/'sortedProducts3@61-1'::.ctor()
+    IL_01f9:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SortBy<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,string>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0208:  newobj     instance void Linq101Ordering01/'sortedProducts3@62-2'::.ctor()
-    IL_020d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::ThenByDescending<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,valuetype [mscorlib]System.Decimal>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01fe:  newobj     instance void Linq101Ordering01/'sortedProducts3@62-2'::.ctor()
+    IL_0203:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::ThenByDescending<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,valuetype [mscorlib]System.Decimal>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0212:  newobj     instance void Linq101Ordering01/'sortedProducts3@63-3'::.ctor()
-    IL_0217:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0208:  newobj     instance void Linq101Ordering01/'sortedProducts3@63-3'::.ctor()
+    IL_020d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_021c:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0221:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0226:  dup
-    IL_0227:  stsfld     class [Utils]Utils/Product[] '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedProducts3@58
-    IL_022c:  stloc.s    sortedProducts3
-    IL_022e:  ret
+    IL_0212:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0217:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_021c:  dup
+    IL_021d:  stsfld     class [Utils]Utils/Product[] '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01::sortedProducts3@58
+    IL_0222:  stloc.s    sortedProducts3
+    IL_0224:  ret
   } // end of method $Linq101Ordering01::main@
 
 } // end of class '<StartupCode$Linq101Ordering01>'.$Linq101Ordering01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Partitioning01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Partitioning01.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -26,27 +26,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Linq101Partitioning01
 {
-  // Offset: 0x00000000 Length: 0x000003D6
+  // Offset: 0x00000000 Length: 0x000003DA
 }
 .mresource public FSharpOptimizationData.Linq101Partitioning01
 {
   // Offset: 0x000003E0 Length: 0x00000138
 }
 .module Linq101Partitioning01.exe
-// MVID: {5775BA4D-B280-A6A2-A745-03834DBA7557}
+// MVID: {590846DB-B280-A6A2-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00590000
+// Image base: 0x01490000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -108,10 +108,10 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Partitioning01.fs'
+      .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Partitioning01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Partitioning01/first3Numbers@12::pc
       IL_0006:  ldc.i4.1
@@ -128,90 +128,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 12,12 : 9,28
+      .line 12,12 : 9,28 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Partitioning01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Partitioning01/first3Numbers@12::pc
-      .line 12,12 : 9,28
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Partitioning01/first3Numbers@12::pc
+      .line 12,12 : 9,28 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Partitioning01/first3Numbers@12::_arg1
-      .line 12,12 : 9,28
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Partitioning01/first3Numbers@12::_arg1
-      IL_006f:  stfld      int32 Linq101Partitioning01/first3Numbers@12::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Partitioning01/first3Numbers@12::pc
-      .line 13,13 : 9,15
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Partitioning01/first3Numbers@12::n
-      IL_0082:  stfld      int32 Linq101Partitioning01/first3Numbers@12::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Partitioning01/first3Numbers@12::_arg1
+      .line 12,12 : 9,28 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Partitioning01/first3Numbers@12::_arg1
+      IL_006a:  stfld      int32 Linq101Partitioning01/first3Numbers@12::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Partitioning01/first3Numbers@12::pc
+      .line 13,13 : 9,15 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Partitioning01/first3Numbers@12::n
+      IL_007d:  stfld      int32 Linq101Partitioning01/first3Numbers@12::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Partitioning01/first3Numbers@12::n
-      .line 12,12 : 9,28
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Partitioning01/first3Numbers@12::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Partitioning01/first3Numbers@12::n
+      .line 12,12 : 9,28 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Partitioning01/first3Numbers@12::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Partitioning01/first3Numbers@12::pc
-      .line 12,12 : 9,28
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Partitioning01/first3Numbers@12::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Partitioning01/first3Numbers@12::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Partitioning01/first3Numbers@12::pc
+      .line 12,12 : 9,28 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Partitioning01/first3Numbers@12::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Partitioning01/first3Numbers@12::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method first3Numbers@12::GenerateNext
 
     .method public strict virtual instance void 
@@ -222,7 +221,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -233,13 +232,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -260,30 +259,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -292,7 +291,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/first3Numbers@12::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -309,18 +308,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 12,12 : 9,28
+        .line 12,12 : 9,28 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -333,11 +332,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method first3Numbers@12::Close
 
@@ -453,11 +452,11 @@
       // Code size       29 (0x1d)
       .maxstack  7
       .locals init ([0] class [Utils]Utils/Order o)
-      .line 21,21 : 9,29
+      .line 21,21 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 22,22 : 9,32
+      .line 22,22 : 9,32 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/'WAOrders@21-1'::builder@
       IL_0009:  ldarg.0
@@ -494,31 +493,30 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable> 
             Invoke(class [Utils]Utils/Customer _arg1) cil managed
     {
-      // Code size       51 (0x33)
+      // Code size       46 (0x2e)
       .maxstack  8
       .locals init ([0] class [Utils]Utils/Customer c)
-      .line 20,20 : 9,30
+      .line 20,20 : 9,30 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 21,21 : 9,29
+      .line 21,21 : 9,29 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/WAOrders@20::builder@
       IL_0009:  ldarg.0
       IL_000a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/WAOrders@20::builder@
       IL_000f:  ldloc.0
       IL_0010:  callvirt   instance class [Utils]Utils/Order[] [Utils]Utils/Customer::get_Orders()
-      IL_0015:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Order>
-      IL_001a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_001f:  ldarg.0
-      IL_0020:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/WAOrders@20::builder@
-      IL_0025:  ldloc.0
-      IL_0026:  newobj     instance void Linq101Partitioning01/'WAOrders@21-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
+      IL_0015:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_001a:  ldarg.0
+      IL_001b:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/WAOrders@20::builder@
+      IL_0020:  ldloc.0
+      IL_0021:  newobj     instance void Linq101Partitioning01/'WAOrders@21-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
                                                                                       class [Utils]Utils/Customer)
-      IL_002b:  tail.
-      IL_002d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0026:  tail.
+      IL_0028:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0032:  ret
+      IL_002d:  ret
     } // end of method WAOrders@20::Invoke
 
   } // end of class WAOrders@20
@@ -545,7 +543,7 @@
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Customer c,
                [1] class [Utils]Utils/Order o)
-      .line 22,22 : 16,31
+      .line 22,22 : 16,31 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>::get_Item1()
       IL_0006:  stloc.0
@@ -585,7 +583,7 @@
       .maxstack  7
       .locals init ([0] class [Utils]Utils/Customer c,
                [1] class [Utils]Utils/Order o)
-      .line 23,23 : 17,53
+      .line 23,23 : 17,53 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>::get_Item1()
       IL_0006:  stloc.0
@@ -660,9 +658,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
       IL_0006:  ldc.i4.1
@@ -679,90 +677,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 29,29 : 9,28
+      .line 29,29 : 9,28 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Partitioning01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
-      .line 29,29 : 9,28
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
+      .line 29,29 : 9,28 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::_arg1
-      .line 29,29 : 9,28
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::_arg1
-      IL_006f:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
-      .line 30,30 : 9,15
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::n
-      IL_0082:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::_arg1
+      .line 29,29 : 9,28 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::_arg1
+      IL_006a:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
+      .line 30,30 : 9,15 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::n
+      IL_007d:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::n
-      .line 29,29 : 9,28
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::n
+      .line 29,29 : 9,28 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
-      .line 29,29 : 9,28
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
+      .line 29,29 : 9,28 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Partitioning01/allButFirst4Numbers@29::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method allButFirst4Numbers@29::GenerateNext
 
     .method public strict virtual instance void 
@@ -773,7 +770,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -784,13 +781,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -811,30 +808,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -843,7 +840,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst4Numbers@29::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -860,18 +857,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 29,29 : 9,28
+        .line 29,29 : 9,28 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -884,11 +881,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method allButFirst4Numbers@29::Close
 
@@ -1004,11 +1001,11 @@
       // Code size       29 (0x1d)
       .maxstack  7
       .locals init ([0] class [Utils]Utils/Order o)
-      .line 37,37 : 9,29
+      .line 37,37 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 38,38 : 9,32
+      .line 38,38 : 9,32 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/'WAOrders2@37-1'::builder@
       IL_0009:  ldarg.0
@@ -1045,31 +1042,30 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable> 
             Invoke(class [Utils]Utils/Customer _arg1) cil managed
     {
-      // Code size       51 (0x33)
+      // Code size       46 (0x2e)
       .maxstack  8
       .locals init ([0] class [Utils]Utils/Customer c)
-      .line 36,36 : 9,30
+      .line 36,36 : 9,30 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 37,37 : 9,29
+      .line 37,37 : 9,29 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/WAOrders2@36::builder@
       IL_0009:  ldarg.0
       IL_000a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/WAOrders2@36::builder@
       IL_000f:  ldloc.0
       IL_0010:  callvirt   instance class [Utils]Utils/Order[] [Utils]Utils/Customer::get_Orders()
-      IL_0015:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Order>
-      IL_001a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_001f:  ldarg.0
-      IL_0020:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/WAOrders2@36::builder@
-      IL_0025:  ldloc.0
-      IL_0026:  newobj     instance void Linq101Partitioning01/'WAOrders2@37-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
+      IL_0015:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_001a:  ldarg.0
+      IL_001b:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Partitioning01/WAOrders2@36::builder@
+      IL_0020:  ldloc.0
+      IL_0021:  newobj     instance void Linq101Partitioning01/'WAOrders2@37-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
                                                                                        class [Utils]Utils/Customer)
-      IL_002b:  tail.
-      IL_002d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0026:  tail.
+      IL_0028:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0032:  ret
+      IL_002d:  ret
     } // end of method WAOrders2@36::Invoke
 
   } // end of class WAOrders2@36
@@ -1096,7 +1092,7 @@
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Customer c,
                [1] class [Utils]Utils/Order o)
-      .line 38,38 : 16,31
+      .line 38,38 : 16,31 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>::get_Item1()
       IL_0006:  stloc.0
@@ -1136,7 +1132,7 @@
       .maxstack  7
       .locals init ([0] class [Utils]Utils/Customer c,
                [1] class [Utils]Utils/Order o)
-      .line 39,39 : 17,53
+      .line 39,39 : 17,53 ''
       IL_0000:  ldarg.1
       IL_0001:  call       instance !0 class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>::get_Item1()
       IL_0006:  stloc.0
@@ -1211,9 +1207,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
       IL_0006:  ldc.i4.1
@@ -1230,90 +1226,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 45,45 : 9,28
+      .line 45,45 : 9,28 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Partitioning01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
-      .line 45,45 : 9,28
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
+      .line 45,45 : 9,28 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::_arg1
-      .line 45,45 : 9,28
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::_arg1
-      IL_006f:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
-      .line 46,46 : 9,26
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::n
-      IL_0082:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::_arg1
+      .line 45,45 : 9,28 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::_arg1
+      IL_006a:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
+      .line 46,46 : 9,26 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::n
+      IL_007d:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::n
-      .line 45,45 : 9,28
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::n
+      .line 45,45 : 9,28 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
-      .line 45,45 : 9,28
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
+      .line 45,45 : 9,28 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Partitioning01/firstNumbersLessThan6@45::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method firstNumbersLessThan6@45::GenerateNext
 
     .method public strict virtual instance void 
@@ -1324,7 +1319,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -1335,13 +1330,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -1362,30 +1357,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -1394,7 +1389,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/firstNumbersLessThan6@45::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -1411,18 +1406,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 45,45 : 9,28
+        .line 45,45 : 9,28 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -1435,11 +1430,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method firstNumbersLessThan6@45::Close
 
@@ -1545,7 +1540,7 @@
     {
       // Code size       6 (0x6)
       .maxstack  8
-      .line 46,46 : 20,25
+      .line 46,46 : 20,25 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.6
@@ -1608,9 +1603,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
       IL_0006:  ldc.i4.1
@@ -1627,90 +1622,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 52,52 : 9,28
+      .line 52,52 : 9,28 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Partitioning01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
-      .line 52,52 : 9,28
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
+      .line 52,52 : 9,28 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::_arg1
-      .line 52,52 : 9,28
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::_arg1
-      IL_006f:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
-      .line 53,53 : 9,31
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::n
-      IL_0082:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::_arg1
+      .line 52,52 : 9,28 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::_arg1
+      IL_006a:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
+      .line 53,53 : 9,31 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::n
+      IL_007d:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::n
-      .line 52,52 : 9,28
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::n
+      .line 52,52 : 9,28 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
-      .line 52,52 : 9,28
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
+      .line 52,52 : 9,28 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Partitioning01/allButFirst3Numbers@52::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method allButFirst3Numbers@52::GenerateNext
 
     .method public strict virtual instance void 
@@ -1721,7 +1715,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -1732,13 +1726,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -1759,30 +1753,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -1791,7 +1785,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Partitioning01/allButFirst3Numbers@52::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -1808,18 +1802,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 52,52 : 9,28
+        .line 52,52 : 9,28 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -1832,11 +1826,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method allButFirst3Numbers@52::Close
 
@@ -1942,7 +1936,7 @@
     {
       // Code size       11 (0xb)
       .maxstack  8
-      .line 53,53 : 20,30
+      .line 53,53 : 20,30 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.3
@@ -1961,7 +1955,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'numbers@7-3'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'numbers@7-5'
     IL_0005:  ret
   } // end of method Linq101Partitioning01::get_numbers
 
@@ -2081,7 +2075,7 @@
 .class private abstract auto ansi sealed '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01
        extends [mscorlib]System.Object
 {
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@7-3'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@7-5'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> first3Numbers@10
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -2104,7 +2098,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       451 (0x1c3)
+    // Code size       441 (0x1b9)
     .maxstack  13
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numbers,
              [1] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> first3Numbers,
@@ -2120,7 +2114,7 @@
              [11] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_11,
              [12] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_12,
              [13] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_13)
-    .line 7,7 : 1,47
+    .line 7,7 : 1,47 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.5
     IL_0002:  ldc.i4.4
@@ -2154,9 +2148,9 @@
     IL_003e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0043:  dup
-    IL_0044:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'numbers@7-3'
+    IL_0044:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'numbers@7-5'
     IL_0049:  stloc.0
-    .line 10,14 : 1,20
+    .line 10,14 : 1,20 ''
     IL_004a:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_004f:  stloc.s    builder@
     IL_0051:  ldloc.s    builder@
@@ -2179,12 +2173,12 @@
     IL_0072:  dup
     IL_0073:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::first3Numbers@10
     IL_0078:  stloc.1
-    .line 17,17 : 1,34
+    .line 17,17 : 1,34 ''
     IL_0079:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
     IL_007e:  dup
     IL_007f:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::'customers@17-2'
     IL_0084:  stloc.2
-    .line 18,24 : 1,21
+    .line 18,24 : 1,21 ''
     IL_0085:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_008a:  stloc.s    V_9
     IL_008c:  ldloc.s    V_9
@@ -2192,121 +2186,119 @@
     IL_0090:  ldloc.s    V_9
     IL_0092:  ldloc.s    V_9
     IL_0094:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Partitioning01::get_customers()
-    IL_0099:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-    IL_009e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00a3:  ldloc.s    V_9
-    IL_00a5:  newobj     instance void Linq101Partitioning01/WAOrders@20::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_00aa:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0099:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_009e:  ldloc.s    V_9
+    IL_00a0:  newobj     instance void Linq101Partitioning01/WAOrders@20::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_00a5:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_00af:  newobj     instance void Linq101Partitioning01/'WAOrders@22-2'::.ctor()
-    IL_00b4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00aa:  newobj     instance void Linq101Partitioning01/'WAOrders@22-2'::.ctor()
+    IL_00af:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_00b9:  newobj     instance void Linq101Partitioning01/'WAOrders@23-3'::.ctor()
-    IL_00be:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00b4:  newobj     instance void Linq101Partitioning01/'WAOrders@23-3'::.ctor()
+    IL_00b9:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_00c3:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_00c8:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00cd:  dup
-    IL_00ce:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>[] '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::WAOrders@18
-    IL_00d3:  stloc.3
-    .line 27,31 : 1,20
-    IL_00d4:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_00d9:  stloc.s    V_10
-    IL_00db:  ldloc.s    V_10
-    IL_00dd:  ldc.i4.0
-    IL_00de:  ldc.i4.0
-    IL_00df:  ldnull
-    IL_00e0:  ldc.i4.0
-    IL_00e1:  ldc.i4.0
-    IL_00e2:  newobj     instance void Linq101Partitioning01/allButFirst4Numbers@29::.ctor(int32,
+    IL_00be:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_00c3:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00c8:  dup
+    IL_00c9:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>[] '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::WAOrders@18
+    IL_00ce:  stloc.3
+    .line 27,31 : 1,20 ''
+    IL_00cf:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_00d4:  stloc.s    V_10
+    IL_00d6:  ldloc.s    V_10
+    IL_00d8:  ldc.i4.0
+    IL_00d9:  ldc.i4.0
+    IL_00da:  ldnull
+    IL_00db:  ldc.i4.0
+    IL_00dc:  ldc.i4.0
+    IL_00dd:  newobj     instance void Linq101Partitioning01/allButFirst4Numbers@29::.ctor(int32,
                                                                                            int32,
                                                                                            class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
                                                                                            int32,
                                                                                            int32)
-    IL_00e7:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_00ec:  ldc.i4.4
-    IL_00ed:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Skip<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00e2:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_00e7:  ldc.i4.4
+    IL_00e8:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Skip<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                               int32)
-    IL_00f2:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_00f7:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00fc:  dup
-    IL_00fd:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::allButFirst4Numbers@27
-    IL_0102:  stloc.s    allButFirst4Numbers
-    .line 34,40 : 1,34
-    IL_0104:  ldc.i4.2
-    IL_0105:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_010a:  stloc.s    V_11
-    IL_010c:  ldloc.s    V_11
-    IL_010e:  ldloc.s    V_11
-    IL_0110:  ldloc.s    V_11
-    IL_0112:  ldloc.s    V_11
-    IL_0114:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Partitioning01::get_customers()
-    IL_0119:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-    IL_011e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0123:  ldloc.s    V_11
-    IL_0125:  newobj     instance void Linq101Partitioning01/WAOrders2@36::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_012a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00ed:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_00f2:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00f7:  dup
+    IL_00f8:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::allButFirst4Numbers@27
+    IL_00fd:  stloc.s    allButFirst4Numbers
+    .line 34,40 : 1,34 ''
+    IL_00ff:  ldc.i4.2
+    IL_0100:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0105:  stloc.s    V_11
+    IL_0107:  ldloc.s    V_11
+    IL_0109:  ldloc.s    V_11
+    IL_010b:  ldloc.s    V_11
+    IL_010d:  ldloc.s    V_11
+    IL_010f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Partitioning01::get_customers()
+    IL_0114:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0119:  ldloc.s    V_11
+    IL_011b:  newobj     instance void Linq101Partitioning01/WAOrders2@36::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0120:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_012f:  newobj     instance void Linq101Partitioning01/'WAOrders2@38-2'::.ctor()
-    IL_0134:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0125:  newobj     instance void Linq101Partitioning01/'WAOrders2@38-2'::.ctor()
+    IL_012a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_0139:  newobj     instance void Linq101Partitioning01/'WAOrders2@39-3'::.ctor()
-    IL_013e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_012f:  newobj     instance void Linq101Partitioning01/'WAOrders2@39-3'::.ctor()
+    IL_0134:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0143:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0148:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Skip<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(int32,
+    IL_0139:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_013e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Skip<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(int32,
                                                                                                                                                                                                                                    class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_014d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0152:  dup
-    IL_0153:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::WAOrders2@34
-    IL_0158:  stloc.s    WAOrders2
-    .line 43,47 : 1,20
-    IL_015a:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_015f:  stloc.s    V_12
-    IL_0161:  ldloc.s    V_12
-    IL_0163:  ldc.i4.0
-    IL_0164:  ldc.i4.0
-    IL_0165:  ldnull
-    IL_0166:  ldc.i4.0
-    IL_0167:  ldc.i4.0
-    IL_0168:  newobj     instance void Linq101Partitioning01/firstNumbersLessThan6@45::.ctor(int32,
+    IL_0143:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0148:  dup
+    IL_0149:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::WAOrders2@34
+    IL_014e:  stloc.s    WAOrders2
+    .line 43,47 : 1,20 ''
+    IL_0150:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0155:  stloc.s    V_12
+    IL_0157:  ldloc.s    V_12
+    IL_0159:  ldc.i4.0
+    IL_015a:  ldc.i4.0
+    IL_015b:  ldnull
+    IL_015c:  ldc.i4.0
+    IL_015d:  ldc.i4.0
+    IL_015e:  newobj     instance void Linq101Partitioning01/firstNumbersLessThan6@45::.ctor(int32,
                                                                                              int32,
                                                                                              class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
                                                                                              int32,
                                                                                              int32)
-    IL_016d:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_0172:  newobj     instance void Linq101Partitioning01/'firstNumbersLessThan6@46-1'::.ctor()
-    IL_0177:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::TakeWhile<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0163:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_0168:  newobj     instance void Linq101Partitioning01/'firstNumbersLessThan6@46-1'::.ctor()
+    IL_016d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::TakeWhile<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_017c:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0181:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0186:  dup
-    IL_0187:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::firstNumbersLessThan6@43
-    IL_018c:  stloc.s    firstNumbersLessThan6
-    .line 50,54 : 1,20
-    IL_018e:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0193:  stloc.s    V_13
-    IL_0195:  ldloc.s    V_13
-    IL_0197:  ldc.i4.0
-    IL_0198:  ldc.i4.0
-    IL_0199:  ldnull
-    IL_019a:  ldc.i4.0
-    IL_019b:  ldc.i4.0
-    IL_019c:  newobj     instance void Linq101Partitioning01/allButFirst3Numbers@52::.ctor(int32,
+    IL_0172:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0177:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_017c:  dup
+    IL_017d:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::firstNumbersLessThan6@43
+    IL_0182:  stloc.s    firstNumbersLessThan6
+    .line 50,54 : 1,20 ''
+    IL_0184:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0189:  stloc.s    V_13
+    IL_018b:  ldloc.s    V_13
+    IL_018d:  ldc.i4.0
+    IL_018e:  ldc.i4.0
+    IL_018f:  ldnull
+    IL_0190:  ldc.i4.0
+    IL_0191:  ldc.i4.0
+    IL_0192:  newobj     instance void Linq101Partitioning01/allButFirst3Numbers@52::.ctor(int32,
                                                                                            int32,
                                                                                            class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
                                                                                            int32,
                                                                                            int32)
-    IL_01a1:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_01a6:  newobj     instance void Linq101Partitioning01/'allButFirst3Numbers@53-1'::.ctor()
-    IL_01ab:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SkipWhile<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0197:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_019c:  newobj     instance void Linq101Partitioning01/'allButFirst3Numbers@53-1'::.ctor()
+    IL_01a1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::SkipWhile<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_01b0:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_01b5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01ba:  dup
-    IL_01bb:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::allButFirst3Numbers@50
-    IL_01c0:  stloc.s    allButFirst3Numbers
-    IL_01c2:  ret
+    IL_01a6:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_01ab:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01b0:  dup
+    IL_01b1:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01::allButFirst3Numbers@50
+    IL_01b6:  stloc.s    allButFirst3Numbers
+    IL_01b8:  ret
   } // end of method $Linq101Partitioning01::main@
 
 } // end of class '<StartupCode$Linq101Partitioning01>'.$Linq101Partitioning01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Quantifiers01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Quantifiers01.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -31,27 +31,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Linq101Quantifiers01
 {
-  // Offset: 0x00000000 Length: 0x00000397
+  // Offset: 0x00000000 Length: 0x0000039B
 }
 .mresource public FSharpOptimizationData.Linq101Quantifiers01
 {
   // Offset: 0x000003A0 Length: 0x000000FF
 }
 .module Linq101Quantifiers01.exe
-// MVID: {5775B173-76DD-E373-A745-038373B17557}
+// MVID: {590846DB-76DD-E373-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x007D0000
+// Image base: 0x01290000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -113,10 +113,10 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Quantifiers01.fs'
+      .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Quantifiers01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Quantifiers01/iAfterE@12::pc
       IL_0006:  ldc.i4.1
@@ -133,90 +133,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 12,12 : 9,26
+      .line 12,12 : 9,26 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Quantifiers01::get_words()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Quantifiers01/iAfterE@12::pc
-      .line 12,12 : 9,26
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Quantifiers01/iAfterE@12::pc
+      .line 12,12 : 9,26 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0063:  stfld      string Linq101Quantifiers01/iAfterE@12::_arg1
-      .line 12,12 : 9,26
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      string Linq101Quantifiers01/iAfterE@12::_arg1
-      IL_006f:  stfld      string Linq101Quantifiers01/iAfterE@12::w
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Quantifiers01/iAfterE@12::pc
-      .line 13,13 : 9,34
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      string Linq101Quantifiers01/iAfterE@12::w
-      IL_0082:  stfld      string Linq101Quantifiers01/iAfterE@12::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_005e:  stfld      string Linq101Quantifiers01/iAfterE@12::_arg1
+      .line 12,12 : 9,26 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      string Linq101Quantifiers01/iAfterE@12::_arg1
+      IL_006a:  stfld      string Linq101Quantifiers01/iAfterE@12::w
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Quantifiers01/iAfterE@12::pc
+      .line 13,13 : 9,34 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      string Linq101Quantifiers01/iAfterE@12::w
+      IL_007d:  stfld      string Linq101Quantifiers01/iAfterE@12::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldnull
-      IL_008b:  stfld      string Linq101Quantifiers01/iAfterE@12::w
-      .line 12,12 : 9,26
-      IL_0090:  ldarg.0
-      IL_0091:  ldnull
-      IL_0092:  stfld      string Linq101Quantifiers01/iAfterE@12::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldnull
+      IL_0086:  stfld      string Linq101Quantifiers01/iAfterE@12::w
+      .line 12,12 : 9,26 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldnull
+      IL_008d:  stfld      string Linq101Quantifiers01/iAfterE@12::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Quantifiers01/iAfterE@12::pc
-      .line 12,12 : 9,26
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Quantifiers01/iAfterE@12::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldnull
-      IL_00bd:  stfld      string Linq101Quantifiers01/iAfterE@12::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Quantifiers01/iAfterE@12::pc
+      .line 12,12 : 9,26 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Quantifiers01/iAfterE@12::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldnull
+      IL_00b8:  stfld      string Linq101Quantifiers01/iAfterE@12::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method iAfterE@12::GenerateNext
 
     .method public strict virtual instance void 
@@ -227,7 +226,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -238,13 +237,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -265,30 +264,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -297,7 +296,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Quantifiers01/iAfterE@12::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -314,18 +313,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 12,12 : 9,26
+        .line 12,12 : 9,26 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -338,11 +337,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method iAfterE@12::Close
 
@@ -448,7 +447,7 @@
     {
       // Code size       13 (0xd)
       .maxstack  8
-      .line 13,13 : 17,33
+      .line 13,13 : 17,33 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldstr      "ei"
@@ -483,11 +482,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Product p)
-      .line 21,21 : 9,29
+      .line 21,21 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 22,22 : 9,32
+      .line 22,22 : 9,32 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Quantifiers01/productGroups@21::builder@
       IL_0009:  ldloc.0
@@ -518,7 +517,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 22,22 : 20,21
+      .line 22,22 : 20,21 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -546,7 +545,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 22,22 : 22,32
+      .line 22,22 : 22,32 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -581,7 +580,7 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> g)
-      .line 22,22 : 38,39
+      .line 22,22 : 38,39 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -614,7 +613,7 @@
     {
       // Code size       11 (0xb)
       .maxstack  8
-      .line 23,23 : 31,49
+      .line 23,23 : 31,49 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance int32 [Utils]Utils/Product::get_UnitsInStock()
@@ -645,7 +644,7 @@
     {
       // Code size       24 (0x18)
       .maxstack  8
-      .line 23,23 : 16,50
+      .line 23,23 : 16,50 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  newobj     instance void Linq101Quantifiers01/'productGroups@23-5'::.ctor()
@@ -679,7 +678,7 @@
     {
       // Code size       14 (0xe)
       .maxstack  8
-      .line 24,24 : 17,25
+      .line 24,24 : 17,25 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance !0 class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>::get_Key()
@@ -744,9 +743,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
       IL_0006:  ldc.i4.1
@@ -763,90 +762,89 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 32,32 : 9,28
+      .line 32,32 : 9,28 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Quantifiers01::get_numbers()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
-      .line 32,32 : 9,28
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
+      .line 32,32 : 9,28 ''
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::_arg1
-      .line 32,32 : 9,28
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101Quantifiers01/onlyOdd@32::_arg1
-      IL_006f:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
-      .line 33,33 : 9,24
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101Quantifiers01/onlyOdd@32::n
-      IL_0082:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::_arg1
+      .line 32,32 : 9,28 ''
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101Quantifiers01/onlyOdd@32::_arg1
+      IL_006a:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
+      .line 33,33 : 9,24 ''
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101Quantifiers01/onlyOdd@32::n
+      IL_007d:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::n
-      .line 32,32 : 9,28
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::_arg1
-      .line 100001,100001 : 0,0
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::n
+      .line 32,32 : 9,28 ''
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::_arg1
+      .line 100001,100001 : 0,0 ''
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
-      .line 32,32 : 9,28
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
+      .line 32,32 : 9,28 ''
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101Quantifiers01/onlyOdd@32::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method onlyOdd@32::GenerateNext
 
     .method public strict virtual instance void 
@@ -857,7 +855,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -868,13 +866,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -895,30 +893,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -927,7 +925,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Quantifiers01/onlyOdd@32::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -944,18 +942,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 32,32 : 9,28
+        .line 32,32 : 9,28 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -968,11 +966,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method onlyOdd@32::Close
 
@@ -1078,7 +1076,7 @@
     {
       // Code size       8 (0x8)
       .maxstack  8
-      .line 33,33 : 14,23
+      .line 33,33 : 14,23 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.2
@@ -1115,11 +1113,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Product p)
-      .line 39,39 : 9,29
+      .line 39,39 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 40,40 : 9,32
+      .line 40,40 : 9,32 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Quantifiers01/productGroups2@39::builder@
       IL_0009:  ldloc.0
@@ -1150,7 +1148,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 40,40 : 20,21
+      .line 40,40 : 20,21 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -1178,7 +1176,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 40,40 : 22,32
+      .line 40,40 : 22,32 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -1213,7 +1211,7 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product> g)
-      .line 40,40 : 38,39
+      .line 40,40 : 38,39 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -1246,7 +1244,7 @@
     {
       // Code size       11 (0xb)
       .maxstack  8
-      .line 41,41 : 31,49
+      .line 41,41 : 31,49 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance int32 [Utils]Utils/Product::get_UnitsInStock()
@@ -1277,7 +1275,7 @@
     {
       // Code size       24 (0x18)
       .maxstack  8
-      .line 41,41 : 16,50
+      .line 41,41 : 16,50 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  newobj     instance void Linq101Quantifiers01/'productGroups2@41-5'::.ctor()
@@ -1311,7 +1309,7 @@
     {
       // Code size       14 (0xe)
       .maxstack  8
-      .line 42,42 : 17,25
+      .line 42,42 : 17,25 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance !0 class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>::get_Key()
@@ -1328,7 +1326,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'words@8-4'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'words@8-6'
     IL_0005:  ret
   } // end of method Linq101Quantifiers01::get_words
 
@@ -1346,7 +1344,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'products@17-8'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'products@17-10'
     IL_0005:  ret
   } // end of method Linq101Quantifiers01::get_products
 
@@ -1364,7 +1362,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'numbers@28-5'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'numbers@28-7'
     IL_0005:  ret
   } // end of method Linq101Quantifiers01::get_numbers
 
@@ -1431,15 +1429,15 @@
 .class private abstract auto ansi sealed '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01
        extends [mscorlib]System.Object
 {
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'words@8-4'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'words@8-6'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly bool iAfterE@10
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@17-8'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@17-10'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>[] productGroups@19
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@28-5'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@28-7'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly bool onlyOdd@30
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -1452,7 +1450,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       430 (0x1ae)
+    // Code size       420 (0x1a4)
     .maxstack  10
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> words,
              [1] bool iAfterE,
@@ -1465,7 +1463,7 @@
              [8] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_8,
              [9] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_9,
              [10] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_10)
-    .line 8,8 : 1,54
+    .line 8,8 : 1,54 ''
     IL_0000:  nop
     IL_0001:  ldstr      "believe"
     IL_0006:  ldstr      "relief"
@@ -1481,7 +1479,7 @@
     IL_0029:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_002e:  dup
-    IL_002f:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'words@8-4'
+    IL_002f:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'words@8-6'
     IL_0034:  stloc.0
     IL_0035:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_003a:  stloc.s    builder@
@@ -1503,12 +1501,12 @@
     IL_0057:  dup
     IL_0058:  stsfld     bool '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::iAfterE@10
     IL_005d:  stloc.1
-    .line 17,17 : 1,32
+    .line 17,17 : 1,32 ''
     IL_005e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
     IL_0063:  dup
-    IL_0064:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'products@17-8'
+    IL_0064:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'products@17-10'
     IL_0069:  stloc.2
-    .line 19,25 : 1,21
+    .line 19,25 : 1,21 ''
     IL_006a:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_006f:  stloc.s    V_8
     IL_0071:  ldloc.s    V_8
@@ -1518,41 +1516,42 @@
     IL_0079:  ldloc.s    V_8
     IL_007b:  ldloc.s    V_8
     IL_007d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Quantifiers01::get_products()
-    IL_0082:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_0087:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_008c:  ldloc.s    V_8
-    IL_008e:  newobj     instance void Linq101Quantifiers01/productGroups@21::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0093:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0082:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0087:  ldloc.s    V_8
+    IL_0089:  newobj     instance void Linq101Quantifiers01/productGroups@21::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_008e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0098:  newobj     instance void Linq101Quantifiers01/'productGroups@22-1'::.ctor()
-    IL_009d:  newobj     instance void Linq101Quantifiers01/'productGroups@22-2'::.ctor()
-    IL_00a2:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_0093:  newobj     instance void Linq101Quantifiers01/'productGroups@22-1'::.ctor()
+    IL_0098:  newobj     instance void Linq101Quantifiers01/'productGroups@22-2'::.ctor()
+    IL_009d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_00a7:  ldloc.s    V_8
-    IL_00a9:  newobj     instance void Linq101Quantifiers01/'productGroups@22-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_00ae:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00a2:  ldloc.s    V_8
+    IL_00a4:  newobj     instance void Linq101Quantifiers01/'productGroups@22-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_00a9:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_00b3:  newobj     instance void Linq101Quantifiers01/'productGroups@23-4'::.ctor()
-    IL_00b8:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00ae:  newobj     instance void Linq101Quantifiers01/'productGroups@23-4'::.ctor()
+    IL_00b3:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_00bd:  newobj     instance void Linq101Quantifiers01/'productGroups@24-6'::.ctor()
-    IL_00c2:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00b8:  newobj     instance void Linq101Quantifiers01/'productGroups@24-6'::.ctor()
+    IL_00bd:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                              class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_00c7:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_00cc:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00d1:  dup
-    IL_00d2:  stsfld     class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>[] '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::productGroups@19
-    IL_00d7:  stloc.3
-    .line 28,28 : 1,35
-    IL_00d8:  ldc.i4.1
-    IL_00d9:  ldc.i4.s   11
-    IL_00db:  ldc.i4.3
-    IL_00dc:  ldc.i4.s   19
-    IL_00de:  ldc.i4.s   41
-    IL_00e0:  ldc.i4.s   65
-    IL_00e2:  ldc.i4.s   19
-    IL_00e4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_00c2:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_00c7:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00cc:  dup
+    IL_00cd:  stsfld     class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>[] '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::productGroups@19
+    IL_00d2:  stloc.3
+    .line 28,28 : 1,35 ''
+    IL_00d3:  ldc.i4.1
+    IL_00d4:  ldc.i4.s   11
+    IL_00d6:  ldc.i4.3
+    IL_00d7:  ldc.i4.s   19
+    IL_00d9:  ldc.i4.s   41
+    IL_00db:  ldc.i4.s   65
+    IL_00dd:  ldc.i4.s   19
+    IL_00df:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_00e4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_00e9:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_00ee:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
@@ -1565,68 +1564,65 @@
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0102:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0107:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
-                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_010c:  dup
-    IL_010d:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'numbers@28-5'
-    IL_0112:  stloc.s    numbers
-    IL_0114:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0119:  stloc.s    V_9
-    IL_011b:  ldloc.s    V_9
-    IL_011d:  ldc.i4.0
-    IL_011e:  ldc.i4.0
-    IL_011f:  ldnull
-    IL_0120:  ldc.i4.0
-    IL_0121:  ldc.i4.0
-    IL_0122:  newobj     instance void Linq101Quantifiers01/onlyOdd@32::.ctor(int32,
+    IL_0107:  dup
+    IL_0108:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::'numbers@28-7'
+    IL_010d:  stloc.s    numbers
+    IL_010f:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0114:  stloc.s    V_9
+    IL_0116:  ldloc.s    V_9
+    IL_0118:  ldc.i4.0
+    IL_0119:  ldc.i4.0
+    IL_011a:  ldnull
+    IL_011b:  ldc.i4.0
+    IL_011c:  ldc.i4.0
+    IL_011d:  newobj     instance void Linq101Quantifiers01/onlyOdd@32::.ctor(int32,
                                                                               int32,
                                                                               class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>,
                                                                               int32,
                                                                               int32)
-    IL_0127:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-    IL_012c:  newobj     instance void Linq101Quantifiers01/'onlyOdd@33-1'::.ctor()
-    IL_0131:  callvirt   instance bool [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::All<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0122:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_0127:  newobj     instance void Linq101Quantifiers01/'onlyOdd@33-1'::.ctor()
+    IL_012c:  callvirt   instance bool [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::All<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_0136:  dup
-    IL_0137:  stsfld     bool '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::onlyOdd@30
-    IL_013c:  stloc.s    onlyOdd
-    .line 37,43 : 1,21
-    IL_013e:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0143:  stloc.s    V_10
-    IL_0145:  ldloc.s    V_10
-    IL_0147:  ldloc.s    V_10
-    IL_0149:  ldloc.s    V_10
-    IL_014b:  ldloc.s    V_10
-    IL_014d:  ldloc.s    V_10
-    IL_014f:  ldloc.s    V_10
-    IL_0151:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Quantifiers01::get_products()
-    IL_0156:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_015b:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0160:  ldloc.s    V_10
-    IL_0162:  newobj     instance void Linq101Quantifiers01/productGroups2@39::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0167:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0131:  dup
+    IL_0132:  stsfld     bool '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::onlyOdd@30
+    IL_0137:  stloc.s    onlyOdd
+    .line 37,43 : 1,21 ''
+    IL_0139:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_013e:  stloc.s    V_10
+    IL_0140:  ldloc.s    V_10
+    IL_0142:  ldloc.s    V_10
+    IL_0144:  ldloc.s    V_10
+    IL_0146:  ldloc.s    V_10
+    IL_0148:  ldloc.s    V_10
+    IL_014a:  ldloc.s    V_10
+    IL_014c:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Quantifiers01::get_products()
+    IL_0151:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0156:  ldloc.s    V_10
+    IL_0158:  newobj     instance void Linq101Quantifiers01/productGroups2@39::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_015d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_016c:  newobj     instance void Linq101Quantifiers01/'productGroups2@40-1'::.ctor()
-    IL_0171:  newobj     instance void Linq101Quantifiers01/'productGroups2@40-2'::.ctor()
-    IL_0176:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
+    IL_0162:  newobj     instance void Linq101Quantifiers01/'productGroups2@40-1'::.ctor()
+    IL_0167:  newobj     instance void Linq101Quantifiers01/'productGroups2@40-2'::.ctor()
+    IL_016c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [System.Core]System.Linq.IGrouping`2<!!1,!!2>,!!3> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::GroupValBy<class [Utils]Utils/Product,string,class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!3>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>,
                                                                                                                                                                                                                                                                                                                            class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>)
-    IL_017b:  ldloc.s    V_10
-    IL_017d:  newobj     instance void Linq101Quantifiers01/'productGroups2@40-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0182:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0171:  ldloc.s    V_10
+    IL_0173:  newobj     instance void Linq101Quantifiers01/'productGroups2@40-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0178:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0187:  newobj     instance void Linq101Quantifiers01/'productGroups2@41-4'::.ctor()
-    IL_018c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_017d:  newobj     instance void Linq101Quantifiers01/'productGroups2@41-4'::.ctor()
+    IL_0182:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_0191:  newobj     instance void Linq101Quantifiers01/'productGroups2@42-6'::.ctor()
-    IL_0196:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0187:  newobj     instance void Linq101Quantifiers01/'productGroups2@42-6'::.ctor()
+    IL_018c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                                              class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_019b:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_01a0:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01a5:  dup
-    IL_01a6:  stsfld     class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>[] '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::productGroups2@37
-    IL_01ab:  stloc.s    productGroups2
-    IL_01ad:  ret
+    IL_0191:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0196:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_019b:  dup
+    IL_019c:  stsfld     class [mscorlib]System.Tuple`2<string,class [System.Core]System.Linq.IGrouping`2<string,class [Utils]Utils/Product>>[] '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01::productGroups2@37
+    IL_01a1:  stloc.s    productGroups2
+    IL_01a3:  ret
   } // end of method $Linq101Quantifiers01::main@
 
 } // end of class '<StartupCode$Linq101Quantifiers01>'.$Linq101Quantifiers01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Select01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Select01.il.netfx4.bsl
@@ -33,20 +33,20 @@
 }
 .mresource public FSharpSignatureData.Linq101Select01
 {
-  // Offset: 0x00000000 Length: 0x0000065B
+  // Offset: 0x00000000 Length: 0x0000065F
 }
 .mresource public FSharpOptimizationData.Linq101Select01
 {
-  // Offset: 0x00000660 Length: 0x00000204
+  // Offset: 0x00000668 Length: 0x00000204
 }
 .module Linq101Select01.exe
-// MVID: {58067926-6057-8F80-A745-038326790658}
+// MVID: {590846DB-6057-8F80-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x01120000
+// Image base: 0x00BA0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -77,7 +77,7 @@
       .maxstack  5
       .locals init ([0] int32 n)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 12,12 : 9,28 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Select01.fs'
+      .line 12,12 : 9,28 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Select01.fs'
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
@@ -135,7 +135,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       189 (0xbd)
+      // Code size       184 (0xb8)
       .maxstack  7
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -157,17 +157,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_0093
+      IL_0022:  br.s       IL_008e
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00b4
+      IL_0028:  br         IL_00af
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -176,65 +176,64 @@
       IL_002e:  ldarg.0
       IL_002f:  newobj     instance void Linq101Select01/'numsPlusOne@12-1'::.ctor()
       IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbers()
-      IL_0039:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_003e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<int32,class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_0039:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<int32,class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                    class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0043:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_0048:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
-      IL_004d:  ldarg.0
-      IL_004e:  ldc.i4.1
-      IL_004f:  stfld      int32 Linq101Select01/numsPlusOne@13::pc
+      IL_003e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0043:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
+      IL_0048:  ldarg.0
+      IL_0049:  ldc.i4.1
+      IL_004a:  stfld      int32 Linq101Select01/numsPlusOne@13::pc
       .line 13,13 : 9,23 ''
-      IL_0054:  ldarg.0
-      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
-      IL_005a:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_005f:  brfalse.s  IL_0093
+      IL_004f:  ldarg.0
+      IL_0050:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
+      IL_0055:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005a:  brfalse.s  IL_008e
 
-      IL_0061:  ldarg.0
-      IL_0062:  ldarg.0
-      IL_0063:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
-      IL_0068:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_006d:  stfld      int32 Linq101Select01/numsPlusOne@13::n
-      IL_0072:  ldarg.0
-      IL_0073:  ldc.i4.2
-      IL_0074:  stfld      int32 Linq101Select01/numsPlusOne@13::pc
+      IL_005c:  ldarg.0
+      IL_005d:  ldarg.0
+      IL_005e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
+      IL_0063:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_0068:  stfld      int32 Linq101Select01/numsPlusOne@13::n
+      IL_006d:  ldarg.0
+      IL_006e:  ldc.i4.2
+      IL_006f:  stfld      int32 Linq101Select01/numsPlusOne@13::pc
       .line 13,13 : 17,22 ''
-      IL_0079:  ldarg.0
-      IL_007a:  ldarg.0
-      IL_007b:  ldfld      int32 Linq101Select01/numsPlusOne@13::n
-      IL_0080:  ldc.i4.1
-      IL_0081:  add
-      IL_0082:  stfld      int32 Linq101Select01/numsPlusOne@13::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0074:  ldarg.0
+      IL_0075:  ldarg.0
+      IL_0076:  ldfld      int32 Linq101Select01/numsPlusOne@13::n
+      IL_007b:  ldc.i4.1
+      IL_007c:  add
+      IL_007d:  stfld      int32 Linq101Select01/numsPlusOne@13::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
       .line 13,13 : 9,23 ''
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101Select01/numsPlusOne@13::n
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101Select01/numsPlusOne@13::n
       .line 100001,100001 : 0,0 ''
-      IL_0090:  nop
-      IL_0091:  br.s       IL_0054
+      IL_008b:  nop
+      IL_008c:  br.s       IL_004f
 
-      IL_0093:  ldarg.0
-      IL_0094:  ldc.i4.3
-      IL_0095:  stfld      int32 Linq101Select01/numsPlusOne@13::pc
+      IL_008e:  ldarg.0
+      IL_008f:  ldc.i4.3
+      IL_0090:  stfld      int32 Linq101Select01/numsPlusOne@13::pc
       .line 13,13 : 9,23 ''
-      IL_009a:  ldarg.0
-      IL_009b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
-      IL_00a0:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00a5:  nop
-      IL_00a6:  ldarg.0
-      IL_00a7:  ldnull
-      IL_00a8:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldc.i4.3
-      IL_00af:  stfld      int32 Linq101Select01/numsPlusOne@13::pc
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.0
-      IL_00b6:  stfld      int32 Linq101Select01/numsPlusOne@13::current
-      IL_00bb:  ldc.i4.0
-      IL_00bc:  ret
+      IL_0095:  ldarg.0
+      IL_0096:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
+      IL_009b:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a0:  nop
+      IL_00a1:  ldarg.0
+      IL_00a2:  ldnull
+      IL_00a3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/numsPlusOne@13::'enum'
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldc.i4.3
+      IL_00aa:  stfld      int32 Linq101Select01/numsPlusOne@13::pc
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.0
+      IL_00b1:  stfld      int32 Linq101Select01/numsPlusOne@13::current
+      IL_00b6:  ldc.i4.0
+      IL_00b7:  ret
     } // end of method numsPlusOne@13::GenerateNext
 
     .method public strict virtual instance void 
@@ -523,7 +522,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       192 (0xc0)
+      // Code size       187 (0xbb)
       .maxstack  7
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -545,17 +544,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_0096
+      IL_0022:  br.s       IL_0091
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_008c
+      IL_0025:  br.s       IL_0087
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00b7
+      IL_0028:  br         IL_00b2
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -564,64 +563,63 @@
       IL_002e:  ldarg.0
       IL_002f:  newobj     instance void Linq101Select01/'productNames@21-1'::.ctor()
       IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Select01::get_products()
-      IL_0039:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Product,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_0039:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Product,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                   class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0043:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0048:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
-      IL_004d:  ldarg.0
-      IL_004e:  ldc.i4.1
-      IL_004f:  stfld      int32 Linq101Select01/productNames@22::pc
+      IL_003e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_0043:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
+      IL_0048:  ldarg.0
+      IL_0049:  ldc.i4.1
+      IL_004a:  stfld      int32 Linq101Select01/productNames@22::pc
       .line 22,22 : 9,31 ''
-      IL_0054:  ldarg.0
-      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
-      IL_005a:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_005f:  brfalse.s  IL_0096
+      IL_004f:  ldarg.0
+      IL_0050:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
+      IL_0055:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005a:  brfalse.s  IL_0091
 
-      IL_0061:  ldarg.0
-      IL_0062:  ldarg.0
-      IL_0063:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
-      IL_0068:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_006d:  stfld      class [Utils]Utils/Product Linq101Select01/productNames@22::p
-      IL_0072:  ldarg.0
-      IL_0073:  ldc.i4.2
-      IL_0074:  stfld      int32 Linq101Select01/productNames@22::pc
+      IL_005c:  ldarg.0
+      IL_005d:  ldarg.0
+      IL_005e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
+      IL_0063:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_0068:  stfld      class [Utils]Utils/Product Linq101Select01/productNames@22::p
+      IL_006d:  ldarg.0
+      IL_006e:  ldc.i4.2
+      IL_006f:  stfld      int32 Linq101Select01/productNames@22::pc
       .line 22,22 : 17,30 ''
-      IL_0079:  ldarg.0
-      IL_007a:  ldarg.0
-      IL_007b:  ldfld      class [Utils]Utils/Product Linq101Select01/productNames@22::p
-      IL_0080:  callvirt   instance string [Utils]Utils/Product::get_ProductName()
-      IL_0085:  stfld      string Linq101Select01/productNames@22::current
-      IL_008a:  ldc.i4.1
-      IL_008b:  ret
+      IL_0074:  ldarg.0
+      IL_0075:  ldarg.0
+      IL_0076:  ldfld      class [Utils]Utils/Product Linq101Select01/productNames@22::p
+      IL_007b:  callvirt   instance string [Utils]Utils/Product::get_ProductName()
+      IL_0080:  stfld      string Linq101Select01/productNames@22::current
+      IL_0085:  ldc.i4.1
+      IL_0086:  ret
 
       .line 22,22 : 9,31 ''
-      IL_008c:  ldarg.0
-      IL_008d:  ldnull
-      IL_008e:  stfld      class [Utils]Utils/Product Linq101Select01/productNames@22::p
+      IL_0087:  ldarg.0
+      IL_0088:  ldnull
+      IL_0089:  stfld      class [Utils]Utils/Product Linq101Select01/productNames@22::p
       .line 100001,100001 : 0,0 ''
-      IL_0093:  nop
-      IL_0094:  br.s       IL_0054
+      IL_008e:  nop
+      IL_008f:  br.s       IL_004f
 
-      IL_0096:  ldarg.0
-      IL_0097:  ldc.i4.3
-      IL_0098:  stfld      int32 Linq101Select01/productNames@22::pc
+      IL_0091:  ldarg.0
+      IL_0092:  ldc.i4.3
+      IL_0093:  stfld      int32 Linq101Select01/productNames@22::pc
       .line 22,22 : 9,31 ''
-      IL_009d:  ldarg.0
-      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
-      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00a8:  nop
-      IL_00a9:  ldarg.0
-      IL_00aa:  ldnull
-      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
-      IL_00b0:  ldarg.0
-      IL_00b1:  ldc.i4.3
-      IL_00b2:  stfld      int32 Linq101Select01/productNames@22::pc
-      IL_00b7:  ldarg.0
-      IL_00b8:  ldnull
-      IL_00b9:  stfld      string Linq101Select01/productNames@22::current
-      IL_00be:  ldc.i4.0
-      IL_00bf:  ret
+      IL_0098:  ldarg.0
+      IL_0099:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
+      IL_009e:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a3:  nop
+      IL_00a4:  ldarg.0
+      IL_00a5:  ldnull
+      IL_00a6:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productNames@22::'enum'
+      IL_00ab:  ldarg.0
+      IL_00ac:  ldc.i4.3
+      IL_00ad:  stfld      int32 Linq101Select01/productNames@22::pc
+      IL_00b2:  ldarg.0
+      IL_00b3:  ldnull
+      IL_00b4:  stfld      string Linq101Select01/productNames@22::current
+      IL_00b9:  ldc.i4.0
+      IL_00ba:  ret
     } // end of method productNames@22::GenerateNext
 
     .method public strict virtual instance void 
@@ -910,7 +908,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       200 (0xc8)
+      // Code size       192 (0xc0)
       .maxstack  7
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -921,95 +919,94 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009e
+      IL_0022:  br.s       IL_0096
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_008c
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_0094
+      IL_0028:  br         IL_00b7
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00bf
-
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_002d:  nop
       .line 30,30 : 9,29 ''
-      IL_0031:  ldarg.0
-      IL_0032:  newobj     instance void Linq101Select01/'textNums@29-1'::.ctor()
-      IL_0037:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbers()
-      IL_003c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0041:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<int32,class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_002e:  ldarg.0
+      IL_002f:  newobj     instance void Linq101Select01/'textNums@29-1'::.ctor()
+      IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbers()
+      IL_0039:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<int32,class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                    class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0046:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_004b:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
-      IL_0050:  ldarg.0
-      IL_0051:  ldc.i4.1
-      IL_0052:  stfld      int32 Linq101Select01/textNums@30::pc
+      IL_003e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0043:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
+      IL_0048:  ldarg.0
+      IL_0049:  ldc.i4.1
+      IL_004a:  stfld      int32 Linq101Select01/textNums@30::pc
       .line 30,30 : 9,29 ''
-      IL_0057:  ldarg.0
-      IL_0058:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
-      IL_005d:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0062:  brfalse.s  IL_009e
+      IL_004f:  ldarg.0
+      IL_0050:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
+      IL_0055:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005a:  brfalse.s  IL_0096
 
-      IL_0064:  ldarg.0
-      IL_0065:  ldarg.0
-      IL_0066:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
-      IL_006b:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0070:  stfld      int32 Linq101Select01/textNums@30::n
-      IL_0075:  ldarg.0
-      IL_0076:  ldc.i4.2
-      IL_0077:  stfld      int32 Linq101Select01/textNums@30::pc
+      IL_005c:  ldarg.0
+      IL_005d:  ldarg.0
+      IL_005e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
+      IL_0063:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_0068:  stfld      int32 Linq101Select01/textNums@30::n
+      IL_006d:  ldarg.0
+      IL_006e:  ldc.i4.2
+      IL_006f:  stfld      int32 Linq101Select01/textNums@30::pc
       .line 30,30 : 17,28 ''
-      IL_007c:  ldarg.0
-      IL_007d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Select01::get_strings()
-      IL_0082:  ldarg.0
-      IL_0083:  ldfld      int32 Linq101Select01/textNums@30::n
-      IL_0088:  callvirt   instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Item(int32)
-      IL_008d:  stfld      string Linq101Select01/textNums@30::current
-      IL_0092:  ldc.i4.1
-      IL_0093:  ret
+      IL_0074:  ldarg.0
+      IL_0075:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Select01::get_strings()
+      IL_007a:  ldarg.0
+      IL_007b:  ldfld      int32 Linq101Select01/textNums@30::n
+      IL_0080:  callvirt   instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Item(int32)
+      IL_0085:  stfld      string Linq101Select01/textNums@30::current
+      IL_008a:  ldc.i4.1
+      IL_008b:  ret
 
       .line 30,30 : 9,29 ''
-      IL_0094:  ldarg.0
-      IL_0095:  ldc.i4.0
-      IL_0096:  stfld      int32 Linq101Select01/textNums@30::n
+      IL_008c:  ldarg.0
+      IL_008d:  ldc.i4.0
+      IL_008e:  stfld      int32 Linq101Select01/textNums@30::n
       .line 100001,100001 : 0,0 ''
-      IL_009b:  nop
-      IL_009c:  br.s       IL_0057
+      IL_0093:  nop
+      IL_0094:  br.s       IL_004f
 
-      IL_009e:  ldarg.0
-      IL_009f:  ldc.i4.3
-      IL_00a0:  stfld      int32 Linq101Select01/textNums@30::pc
+      IL_0096:  ldarg.0
+      IL_0097:  ldc.i4.3
+      IL_0098:  stfld      int32 Linq101Select01/textNums@30::pc
       .line 30,30 : 9,29 ''
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
-      IL_00ab:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00b0:  nop
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldnull
-      IL_00b3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldc.i4.3
-      IL_00ba:  stfld      int32 Linq101Select01/textNums@30::pc
-      IL_00bf:  ldarg.0
-      IL_00c0:  ldnull
-      IL_00c1:  stfld      string Linq101Select01/textNums@30::current
-      IL_00c6:  ldc.i4.0
-      IL_00c7:  ret
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
+      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a8:  nop
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldnull
+      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/textNums@30::'enum'
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldc.i4.3
+      IL_00b2:  stfld      int32 Linq101Select01/textNums@30::pc
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      string Linq101Select01/textNums@30::current
+      IL_00be:  ldc.i4.0
+      IL_00bf:  ret
     } // end of method textNums@30::GenerateNext
 
     .method public strict virtual instance void 
@@ -1298,7 +1295,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,string>>& next) cil managed
     {
-      // Code size       211 (0xd3)
+      // Code size       206 (0xce)
       .maxstack  7
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -1320,17 +1317,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_00a9
+      IL_0022:  br         IL_00a4
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_009f
+      IL_0028:  br.s       IL_009a
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_002a:  nop
-      IL_002b:  br         IL_00ca
+      IL_002b:  br         IL_00c5
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -1339,69 +1336,68 @@
       IL_0031:  ldarg.0
       IL_0032:  newobj     instance void Linq101Select01/'upperLowerWords@38-1'::.ctor()
       IL_0037:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Select01::get_words()
-      IL_003c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_0041:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<string>,string>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_003c:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<string>,string>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0046:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_004b:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
-      IL_0050:  ldarg.0
-      IL_0051:  ldc.i4.1
-      IL_0052:  stfld      int32 Linq101Select01/upperLowerWords@39::pc
+      IL_0041:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0046:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
+      IL_004b:  ldarg.0
+      IL_004c:  ldc.i4.1
+      IL_004d:  stfld      int32 Linq101Select01/upperLowerWords@39::pc
       .line 39,39 : 8,41 ''
-      IL_0057:  ldarg.0
-      IL_0058:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
-      IL_005d:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0062:  brfalse.s  IL_00a9
+      IL_0052:  ldarg.0
+      IL_0053:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
+      IL_0058:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005d:  brfalse.s  IL_00a4
 
-      IL_0064:  ldarg.0
-      IL_0065:  ldarg.0
-      IL_0066:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
-      IL_006b:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_0070:  stfld      string Linq101Select01/upperLowerWords@39::w
-      IL_0075:  ldarg.0
-      IL_0076:  ldc.i4.2
-      IL_0077:  stfld      int32 Linq101Select01/upperLowerWords@39::pc
+      IL_005f:  ldarg.0
+      IL_0060:  ldarg.0
+      IL_0061:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
+      IL_0066:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_006b:  stfld      string Linq101Select01/upperLowerWords@39::w
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Select01/upperLowerWords@39::pc
       .line 39,39 : 16,40 ''
-      IL_007c:  ldarg.0
-      IL_007d:  ldarg.0
-      IL_007e:  ldfld      string Linq101Select01/upperLowerWords@39::w
-      IL_0083:  callvirt   instance string [mscorlib]System.String::ToUpper()
-      IL_0088:  ldarg.0
-      IL_0089:  ldfld      string Linq101Select01/upperLowerWords@39::w
-      IL_008e:  callvirt   instance string [mscorlib]System.String::ToLower()
-      IL_0093:  newobj     instance void class [mscorlib]System.Tuple`2<string,string>::.ctor(!0,
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      string Linq101Select01/upperLowerWords@39::w
+      IL_007e:  callvirt   instance string [mscorlib]System.String::ToUpper()
+      IL_0083:  ldarg.0
+      IL_0084:  ldfld      string Linq101Select01/upperLowerWords@39::w
+      IL_0089:  callvirt   instance string [mscorlib]System.String::ToLower()
+      IL_008e:  newobj     instance void class [mscorlib]System.Tuple`2<string,string>::.ctor(!0,
                                                                                               !1)
-      IL_0098:  stfld      class [mscorlib]System.Tuple`2<string,string> Linq101Select01/upperLowerWords@39::current
-      IL_009d:  ldc.i4.1
-      IL_009e:  ret
+      IL_0093:  stfld      class [mscorlib]System.Tuple`2<string,string> Linq101Select01/upperLowerWords@39::current
+      IL_0098:  ldc.i4.1
+      IL_0099:  ret
 
       .line 39,39 : 8,41 ''
-      IL_009f:  ldarg.0
-      IL_00a0:  ldnull
-      IL_00a1:  stfld      string Linq101Select01/upperLowerWords@39::w
+      IL_009a:  ldarg.0
+      IL_009b:  ldnull
+      IL_009c:  stfld      string Linq101Select01/upperLowerWords@39::w
       .line 100001,100001 : 0,0 ''
-      IL_00a6:  nop
-      IL_00a7:  br.s       IL_0057
+      IL_00a1:  nop
+      IL_00a2:  br.s       IL_0052
 
-      IL_00a9:  ldarg.0
-      IL_00aa:  ldc.i4.3
-      IL_00ab:  stfld      int32 Linq101Select01/upperLowerWords@39::pc
+      IL_00a4:  ldarg.0
+      IL_00a5:  ldc.i4.3
+      IL_00a6:  stfld      int32 Linq101Select01/upperLowerWords@39::pc
       .line 39,39 : 8,41 ''
-      IL_00b0:  ldarg.0
-      IL_00b1:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
-      IL_00b6:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00bb:  nop
-      IL_00bc:  ldarg.0
-      IL_00bd:  ldnull
-      IL_00be:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
-      IL_00c3:  ldarg.0
-      IL_00c4:  ldc.i4.3
-      IL_00c5:  stfld      int32 Linq101Select01/upperLowerWords@39::pc
-      IL_00ca:  ldarg.0
-      IL_00cb:  ldnull
-      IL_00cc:  stfld      class [mscorlib]System.Tuple`2<string,string> Linq101Select01/upperLowerWords@39::current
-      IL_00d1:  ldc.i4.0
-      IL_00d2:  ret
+      IL_00ab:  ldarg.0
+      IL_00ac:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
+      IL_00b1:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_00b6:  nop
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldnull
+      IL_00b9:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Select01/upperLowerWords@39::'enum'
+      IL_00be:  ldarg.0
+      IL_00bf:  ldc.i4.3
+      IL_00c0:  stfld      int32 Linq101Select01/upperLowerWords@39::pc
+      IL_00c5:  ldarg.0
+      IL_00c6:  ldnull
+      IL_00c7:  stfld      class [mscorlib]System.Tuple`2<string,string> Linq101Select01/upperLowerWords@39::current
+      IL_00cc:  ldc.i4.0
+      IL_00cd:  ret
     } // end of method upperLowerWords@39::GenerateNext
 
     .method public strict virtual instance void 
@@ -1690,7 +1686,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,bool>>& next) cil managed
     {
-      // Code size       216 (0xd8)
+      // Code size       211 (0xd3)
       .maxstack  8
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -1712,17 +1708,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_00ae
+      IL_0022:  br         IL_00a9
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_00a4
+      IL_0028:  br.s       IL_009f
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_002a:  nop
-      IL_002b:  br         IL_00cf
+      IL_002b:  br         IL_00ca
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -1731,73 +1727,72 @@
       IL_0031:  ldarg.0
       IL_0032:  newobj     instance void Linq101Select01/'digitOddEvens@45-1'::.ctor()
       IL_0037:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbers()
-      IL_003c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0041:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<int32,class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_003c:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<int32,class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>,int32>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                    class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0046:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_004b:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
-      IL_0050:  ldarg.0
-      IL_0051:  ldc.i4.1
-      IL_0052:  stfld      int32 Linq101Select01/digitOddEvens@46::pc
+      IL_0041:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0046:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
+      IL_004b:  ldarg.0
+      IL_004c:  ldc.i4.1
+      IL_004d:  stfld      int32 Linq101Select01/digitOddEvens@46::pc
       .line 46,46 : 9,42 ''
-      IL_0057:  ldarg.0
-      IL_0058:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
-      IL_005d:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0062:  brfalse.s  IL_00ae
+      IL_0052:  ldarg.0
+      IL_0053:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
+      IL_0058:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005d:  brfalse.s  IL_00a9
 
-      IL_0064:  ldarg.0
-      IL_0065:  ldarg.0
-      IL_0066:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
-      IL_006b:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0070:  stfld      int32 Linq101Select01/digitOddEvens@46::n
-      IL_0075:  ldarg.0
-      IL_0076:  ldc.i4.2
-      IL_0077:  stfld      int32 Linq101Select01/digitOddEvens@46::pc
+      IL_005f:  ldarg.0
+      IL_0060:  ldarg.0
+      IL_0061:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
+      IL_0066:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_006b:  stfld      int32 Linq101Select01/digitOddEvens@46::n
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Select01/digitOddEvens@46::pc
       .line 46,46 : 17,41 ''
-      IL_007c:  ldarg.0
-      IL_007d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Select01::get_strings()
-      IL_0082:  ldarg.0
-      IL_0083:  ldfld      int32 Linq101Select01/digitOddEvens@46::n
-      IL_0088:  callvirt   instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Item(int32)
-      IL_008d:  ldarg.0
-      IL_008e:  ldfld      int32 Linq101Select01/digitOddEvens@46::n
-      IL_0093:  ldc.i4.2
-      IL_0094:  rem
-      IL_0095:  ldc.i4.0
-      IL_0096:  ceq
-      IL_0098:  newobj     instance void class [mscorlib]System.Tuple`2<string,bool>::.ctor(!0,
+      IL_0077:  ldarg.0
+      IL_0078:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Select01::get_strings()
+      IL_007d:  ldarg.0
+      IL_007e:  ldfld      int32 Linq101Select01/digitOddEvens@46::n
+      IL_0083:  callvirt   instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Item(int32)
+      IL_0088:  ldarg.0
+      IL_0089:  ldfld      int32 Linq101Select01/digitOddEvens@46::n
+      IL_008e:  ldc.i4.2
+      IL_008f:  rem
+      IL_0090:  ldc.i4.0
+      IL_0091:  ceq
+      IL_0093:  newobj     instance void class [mscorlib]System.Tuple`2<string,bool>::.ctor(!0,
                                                                                             !1)
-      IL_009d:  stfld      class [mscorlib]System.Tuple`2<string,bool> Linq101Select01/digitOddEvens@46::current
-      IL_00a2:  ldc.i4.1
-      IL_00a3:  ret
+      IL_0098:  stfld      class [mscorlib]System.Tuple`2<string,bool> Linq101Select01/digitOddEvens@46::current
+      IL_009d:  ldc.i4.1
+      IL_009e:  ret
 
       .line 46,46 : 9,42 ''
-      IL_00a4:  ldarg.0
-      IL_00a5:  ldc.i4.0
-      IL_00a6:  stfld      int32 Linq101Select01/digitOddEvens@46::n
+      IL_009f:  ldarg.0
+      IL_00a0:  ldc.i4.0
+      IL_00a1:  stfld      int32 Linq101Select01/digitOddEvens@46::n
       .line 100001,100001 : 0,0 ''
-      IL_00ab:  nop
-      IL_00ac:  br.s       IL_0057
+      IL_00a6:  nop
+      IL_00a7:  br.s       IL_0052
 
-      IL_00ae:  ldarg.0
-      IL_00af:  ldc.i4.3
-      IL_00b0:  stfld      int32 Linq101Select01/digitOddEvens@46::pc
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldc.i4.3
+      IL_00ab:  stfld      int32 Linq101Select01/digitOddEvens@46::pc
       .line 46,46 : 9,42 ''
-      IL_00b5:  ldarg.0
-      IL_00b6:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
-      IL_00bb:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00c0:  nop
-      IL_00c1:  ldarg.0
-      IL_00c2:  ldnull
-      IL_00c3:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
-      IL_00c8:  ldarg.0
-      IL_00c9:  ldc.i4.3
-      IL_00ca:  stfld      int32 Linq101Select01/digitOddEvens@46::pc
-      IL_00cf:  ldarg.0
-      IL_00d0:  ldnull
-      IL_00d1:  stfld      class [mscorlib]System.Tuple`2<string,bool> Linq101Select01/digitOddEvens@46::current
-      IL_00d6:  ldc.i4.0
-      IL_00d7:  ret
+      IL_00b0:  ldarg.0
+      IL_00b1:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
+      IL_00b6:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00bb:  nop
+      IL_00bc:  ldarg.0
+      IL_00bd:  ldnull
+      IL_00be:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101Select01/digitOddEvens@46::'enum'
+      IL_00c3:  ldarg.0
+      IL_00c4:  ldc.i4.3
+      IL_00c5:  stfld      int32 Linq101Select01/digitOddEvens@46::pc
+      IL_00ca:  ldarg.0
+      IL_00cb:  ldnull
+      IL_00cc:  stfld      class [mscorlib]System.Tuple`2<string,bool> Linq101Select01/digitOddEvens@46::current
+      IL_00d1:  ldc.i4.0
+      IL_00d2:  ret
     } // end of method digitOddEvens@46::GenerateNext
 
     .method public strict virtual instance void 
@@ -2086,7 +2081,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`3<string,string,valuetype [mscorlib]System.Decimal>>& next) cil managed
     {
-      // Code size       225 (0xe1)
+      // Code size       217 (0xd9)
       .maxstack  8
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -2097,103 +2092,102 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0033
+      IL_0019:  br.s       IL_0030
 
       IL_001b:  br.s       IL_0021
 
       IL_001d:  br.s       IL_0027
 
-      IL_001f:  br.s       IL_002d
+      IL_001f:  br.s       IL_002a
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_00b7
+      IL_0022:  br         IL_00af
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00ad
+      IL_0028:  br.s       IL_00a5
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002d:  nop
-      IL_002e:  br         IL_00d8
+      IL_002a:  nop
+      IL_002b:  br         IL_00d0
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_0033:  nop
+      IL_0030:  nop
       .line 53,53 : 9,56 ''
-      IL_0034:  ldarg.0
-      IL_0035:  newobj     instance void Linq101Select01/'productInfos@52-1'::.ctor()
-      IL_003a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Select01::get_products()
-      IL_003f:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_0044:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Product,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_0031:  ldarg.0
+      IL_0032:  newobj     instance void Linq101Select01/'productInfos@52-1'::.ctor()
+      IL_0037:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Select01::get_products()
+      IL_003c:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Product,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                   class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0049:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_004e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
-      IL_0053:  ldarg.0
-      IL_0054:  ldc.i4.1
-      IL_0055:  stfld      int32 Linq101Select01/productInfos@53::pc
+      IL_0041:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_0046:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
+      IL_004b:  ldarg.0
+      IL_004c:  ldc.i4.1
+      IL_004d:  stfld      int32 Linq101Select01/productInfos@53::pc
       .line 53,53 : 9,56 ''
-      IL_005a:  ldarg.0
-      IL_005b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
-      IL_0060:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0065:  brfalse.s  IL_00b7
+      IL_0052:  ldarg.0
+      IL_0053:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
+      IL_0058:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005d:  brfalse.s  IL_00af
 
-      IL_0067:  ldarg.0
-      IL_0068:  ldarg.0
-      IL_0069:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
-      IL_006e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0073:  stfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
-      IL_0078:  ldarg.0
-      IL_0079:  ldc.i4.2
-      IL_007a:  stfld      int32 Linq101Select01/productInfos@53::pc
+      IL_005f:  ldarg.0
+      IL_0060:  ldarg.0
+      IL_0061:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
+      IL_0066:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_006b:  stfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
+      IL_0070:  ldarg.0
+      IL_0071:  ldc.i4.2
+      IL_0072:  stfld      int32 Linq101Select01/productInfos@53::pc
       .line 53,53 : 17,55 ''
-      IL_007f:  ldarg.0
-      IL_0080:  ldarg.0
-      IL_0081:  ldfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
-      IL_0086:  callvirt   instance string [Utils]Utils/Product::get_ProductName()
-      IL_008b:  ldarg.0
-      IL_008c:  ldfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
-      IL_0091:  callvirt   instance string [Utils]Utils/Product::get_Category()
-      IL_0096:  ldarg.0
-      IL_0097:  ldfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
-      IL_009c:  callvirt   instance valuetype [mscorlib]System.Decimal [Utils]Utils/Product::get_UnitPrice()
-      IL_00a1:  newobj     instance void class [mscorlib]System.Tuple`3<string,string,valuetype [mscorlib]System.Decimal>::.ctor(!0,
+      IL_0077:  ldarg.0
+      IL_0078:  ldarg.0
+      IL_0079:  ldfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
+      IL_007e:  callvirt   instance string [Utils]Utils/Product::get_ProductName()
+      IL_0083:  ldarg.0
+      IL_0084:  ldfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
+      IL_0089:  callvirt   instance string [Utils]Utils/Product::get_Category()
+      IL_008e:  ldarg.0
+      IL_008f:  ldfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
+      IL_0094:  callvirt   instance valuetype [mscorlib]System.Decimal [Utils]Utils/Product::get_UnitPrice()
+      IL_0099:  newobj     instance void class [mscorlib]System.Tuple`3<string,string,valuetype [mscorlib]System.Decimal>::.ctor(!0,
                                                                                                                                  !1,
                                                                                                                                  !2)
-      IL_00a6:  stfld      class [mscorlib]System.Tuple`3<string,string,valuetype [mscorlib]System.Decimal> Linq101Select01/productInfos@53::current
-      IL_00ab:  ldc.i4.1
-      IL_00ac:  ret
+      IL_009e:  stfld      class [mscorlib]System.Tuple`3<string,string,valuetype [mscorlib]System.Decimal> Linq101Select01/productInfos@53::current
+      IL_00a3:  ldc.i4.1
+      IL_00a4:  ret
 
       .line 53,53 : 9,56 ''
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
+      IL_00a5:  ldarg.0
+      IL_00a6:  ldnull
+      IL_00a7:  stfld      class [Utils]Utils/Product Linq101Select01/productInfos@53::p
       .line 100001,100001 : 0,0 ''
-      IL_00b4:  nop
-      IL_00b5:  br.s       IL_005a
+      IL_00ac:  nop
+      IL_00ad:  br.s       IL_0052
 
-      IL_00b7:  ldarg.0
-      IL_00b8:  ldc.i4.3
-      IL_00b9:  stfld      int32 Linq101Select01/productInfos@53::pc
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101Select01/productInfos@53::pc
       .line 53,53 : 9,56 ''
-      IL_00be:  ldarg.0
-      IL_00bf:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
-      IL_00c4:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00c9:  nop
-      IL_00ca:  ldarg.0
-      IL_00cb:  ldnull
-      IL_00cc:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
-      IL_00d1:  ldarg.0
-      IL_00d2:  ldc.i4.3
-      IL_00d3:  stfld      int32 Linq101Select01/productInfos@53::pc
-      IL_00d8:  ldarg.0
-      IL_00d9:  ldnull
-      IL_00da:  stfld      class [mscorlib]System.Tuple`3<string,string,valuetype [mscorlib]System.Decimal> Linq101Select01/productInfos@53::current
-      IL_00df:  ldc.i4.0
-      IL_00e0:  ret
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
+      IL_00bc:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00c1:  nop
+      IL_00c2:  ldarg.0
+      IL_00c3:  ldnull
+      IL_00c4:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101Select01/productInfos@53::'enum'
+      IL_00c9:  ldarg.0
+      IL_00ca:  ldc.i4.3
+      IL_00cb:  stfld      int32 Linq101Select01/productInfos@53::pc
+      IL_00d0:  ldarg.0
+      IL_00d1:  ldnull
+      IL_00d2:  stfld      class [mscorlib]System.Tuple`3<string,string,valuetype [mscorlib]System.Decimal> Linq101Select01/productInfos@53::current
+      IL_00d7:  ldc.i4.0
+      IL_00d8:  ret
     } // end of method productInfos@53::GenerateNext
 
     .method public strict virtual instance void 
@@ -2575,7 +2569,7 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable> 
             Invoke(int32 _arg1) cil managed
     {
-      // Code size       50 (0x32)
+      // Code size       45 (0x2d)
       .maxstack  8
       .locals init ([0] int32 a)
       .line 72,72 : 9,29 ''
@@ -2588,17 +2582,16 @@
       IL_0009:  ldarg.0
       IL_000a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/pairs@72::builder@
       IL_000f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbersB()
-      IL_0014:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0019:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_001e:  ldarg.0
-      IL_001f:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/pairs@72::builder@
-      IL_0024:  ldloc.0
-      IL_0025:  newobj     instance void Linq101Select01/'pairs@73-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
+      IL_0014:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_0019:  ldarg.0
+      IL_001a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/pairs@72::builder@
+      IL_001f:  ldloc.0
+      IL_0020:  newobj     instance void Linq101Select01/'pairs@73-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
                                                                              int32)
-      IL_002a:  tail.
-      IL_002c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0025:  tail.
+      IL_0027:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0031:  ret
+      IL_002c:  ret
     } // end of method pairs@72::Invoke
 
   } // end of class pairs@72
@@ -2751,7 +2744,7 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable> 
             Invoke(class [Utils]Utils/Customer _arg1) cil managed
     {
-      // Code size       51 (0x33)
+      // Code size       46 (0x2e)
       .maxstack  8
       .locals init ([0] class [Utils]Utils/Customer c)
       .line 82,82 : 9,30 ''
@@ -2765,17 +2758,16 @@
       IL_000a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/'orders@82-2'::builder@
       IL_000f:  ldloc.0
       IL_0010:  callvirt   instance class [Utils]Utils/Order[] [Utils]Utils/Customer::get_Orders()
-      IL_0015:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Order>
-      IL_001a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_001f:  ldarg.0
-      IL_0020:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/'orders@82-2'::builder@
-      IL_0025:  ldloc.0
-      IL_0026:  newobj     instance void Linq101Select01/'orders@83-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
+      IL_0015:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_001a:  ldarg.0
+      IL_001b:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/'orders@82-2'::builder@
+      IL_0020:  ldloc.0
+      IL_0021:  newobj     instance void Linq101Select01/'orders@83-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
                                                                               class [Utils]Utils/Customer)
-      IL_002b:  tail.
-      IL_002d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0026:  tail.
+      IL_0028:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0032:  ret
+      IL_002d:  ret
     } // end of method 'orders@82-2'::Invoke
 
   } // end of class 'orders@82-2'
@@ -2944,7 +2936,7 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable> 
             Invoke(class [Utils]Utils/Customer _arg1) cil managed
     {
-      // Code size       51 (0x33)
+      // Code size       46 (0x2e)
       .maxstack  8
       .locals init ([0] class [Utils]Utils/Customer c)
       .line 91,91 : 9,30 ''
@@ -2958,17 +2950,16 @@
       IL_000a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/orders2@91::builder@
       IL_000f:  ldloc.0
       IL_0010:  callvirt   instance class [Utils]Utils/Order[] [Utils]Utils/Customer::get_Orders()
-      IL_0015:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Order>
-      IL_001a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_001f:  ldarg.0
-      IL_0020:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/orders2@91::builder@
-      IL_0025:  ldloc.0
-      IL_0026:  newobj     instance void Linq101Select01/'orders2@92-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
+      IL_0015:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_001a:  ldarg.0
+      IL_001b:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/orders2@91::builder@
+      IL_0020:  ldloc.0
+      IL_0021:  newobj     instance void Linq101Select01/'orders2@92-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
                                                                                class [Utils]Utils/Customer)
-      IL_002b:  tail.
-      IL_002d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0026:  tail.
+      IL_0028:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0032:  ret
+      IL_002d:  ret
     } // end of method orders2@91::Invoke
 
   } // end of class orders2@91
@@ -3134,7 +3125,7 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable> 
             Invoke(class [Utils]Utils/Customer _arg1) cil managed
     {
-      // Code size       51 (0x33)
+      // Code size       46 (0x2e)
       .maxstack  8
       .locals init ([0] class [Utils]Utils/Customer c)
       .line 100,100 : 9,30 ''
@@ -3148,17 +3139,16 @@
       IL_000a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/orders3@100::builder@
       IL_000f:  ldloc.0
       IL_0010:  callvirt   instance class [Utils]Utils/Order[] [Utils]Utils/Customer::get_Orders()
-      IL_0015:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Order>
-      IL_001a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_001f:  ldarg.0
-      IL_0020:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/orders3@100::builder@
-      IL_0025:  ldloc.0
-      IL_0026:  newobj     instance void Linq101Select01/'orders3@101-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
+      IL_0015:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_001a:  ldarg.0
+      IL_001b:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/orders3@100::builder@
+      IL_0020:  ldloc.0
+      IL_0021:  newobj     instance void Linq101Select01/'orders3@101-1'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
                                                                                 class [Utils]Utils/Customer)
-      IL_002b:  tail.
-      IL_002d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0026:  tail.
+      IL_0028:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0032:  ret
+      IL_002d:  ret
     } // end of method orders3@100::Invoke
 
   } // end of class orders3@100
@@ -3399,7 +3389,7 @@
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable> 
             Invoke(class [Utils]Utils/Customer _arg2) cil managed
     {
-      // Code size       51 (0x33)
+      // Code size       46 (0x2e)
       .maxstack  8
       .locals init ([0] class [Utils]Utils/Customer c)
       .line 111,111 : 13,14 ''
@@ -3412,17 +3402,16 @@
       IL_000a:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/'orders4@111-2'::builder@
       IL_000f:  ldloc.0
       IL_0010:  callvirt   instance class [Utils]Utils/Order[] [Utils]Utils/Customer::get_Orders()
-      IL_0015:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Order>
-      IL_001a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_001f:  ldarg.0
-      IL_0020:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/'orders4@111-2'::builder@
-      IL_0025:  ldloc.0
-      IL_0026:  newobj     instance void Linq101Select01/'orders4@113-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
+      IL_0015:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Order>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+      IL_001a:  ldarg.0
+      IL_001b:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Select01/'orders4@111-2'::builder@
+      IL_0020:  ldloc.0
+      IL_0021:  newobj     instance void Linq101Select01/'orders4@113-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder,
                                                                                 class [Utils]Utils/Customer)
-      IL_002b:  tail.
-      IL_002d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+      IL_0026:  tail.
+      IL_0028:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Order,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-      IL_0032:  ret
+      IL_002d:  ret
     } // end of method 'orders4@111-2'::Invoke
 
   } // end of class 'orders4@111-2'
@@ -3878,7 +3867,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       1165 (0x48d)
+    // Code size       1135 (0x46f)
     .maxstack  13
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numbers,
              [1] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numsPlusOne,
@@ -4106,32 +4095,33 @@
     IL_01b1:  ldloc.s    V_27
     IL_01b3:  ldloc.s    V_27
     IL_01b5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbers()
-    IL_01ba:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-    IL_01bf:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01c4:  ldloc.s    V_27
-    IL_01c6:  newobj     instance void Linq101Select01/lowNums@60::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_01cb:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,int32,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01ba:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01bf:  ldloc.s    V_27
+    IL_01c1:  newobj     instance void Linq101Select01/lowNums@60::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_01c6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,int32,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_01d0:  newobj     instance void Linq101Select01/'lowNums@61-1'::.ctor()
-    IL_01d5:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01cb:  newobj     instance void Linq101Select01/'lowNums@61-1'::.ctor()
+    IL_01d0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_01da:  newobj     instance void Linq101Select01/'lowNums@62-2'::.ctor()
-    IL_01df:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<int32,class [mscorlib]System.Collections.IEnumerable,string>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_01d5:  newobj     instance void Linq101Select01/'lowNums@62-2'::.ctor()
+    IL_01da:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<int32,class [mscorlib]System.Collections.IEnumerable,string>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_01e4:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_01e9:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_01ee:  dup
-    IL_01ef:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Select01>'.$Linq101Select01::lowNums@58
-    IL_01f4:  stloc.s    lowNums
+    IL_01df:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<string,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_01e4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToList<string>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_01e9:  dup
+    IL_01ea:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Select01>'.$Linq101Select01::lowNums@58
+    IL_01ef:  stloc.s    lowNums
     .line 64,64 : 1,59 ''
-    IL_01f6:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Select01::get_lowNums()
-    IL_01fb:  stloc.s    V_28
-    IL_01fd:  ldstr      "four"
-    IL_0202:  ldstr      "one"
-    IL_0207:  ldstr      "three"
-    IL_020c:  ldstr      "two"
-    IL_0211:  ldstr      "zero"
-    IL_0216:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Empty()
+    IL_01f1:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Select01::get_lowNums()
+    IL_01f6:  stloc.s    V_28
+    IL_01f8:  ldstr      "four"
+    IL_01fd:  ldstr      "one"
+    IL_0202:  ldstr      "three"
+    IL_0207:  ldstr      "two"
+    IL_020c:  ldstr      "zero"
+    IL_0211:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Empty()
+    IL_0216:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
+                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_021b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0220:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
@@ -4140,47 +4130,47 @@
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_022a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_022f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
-                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0234:  stloc.s    V_29
-    IL_0236:  ldloc.s    V_28
-    IL_0238:  ldloc.s    V_29
-    IL_023a:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-    IL_023f:  callvirt   instance bool class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Equals(object,
+    IL_022f:  stloc.s    V_29
+    IL_0231:  ldloc.s    V_28
+    IL_0233:  ldloc.s    V_29
+    IL_0235:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+    IL_023a:  callvirt   instance bool class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Equals(object,
                                                                                                                     class [mscorlib]System.Collections.IEqualityComparer)
-    IL_0244:  ldc.i4.0
-    IL_0245:  ceq
-    IL_0247:  brfalse.s  IL_024b
+    IL_023f:  ldc.i4.0
+    IL_0240:  ceq
+    IL_0242:  brfalse.s  IL_0246
 
-    IL_0249:  br.s       IL_024d
+    IL_0244:  br.s       IL_0248
 
-    IL_024b:  br.s       IL_0267
+    IL_0246:  br.s       IL_0262
 
     .line 64,64 : 60,84 ''
-    IL_024d:  ldstr      "lowNums failed"
-    IL_0252:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-    IL_0257:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-    IL_025c:  pop
+    IL_0248:  ldstr      "lowNums failed"
+    IL_024d:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+    IL_0252:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+    IL_0257:  pop
     .line 64,64 : 86,92 ''
-    IL_025d:  ldc.i4.1
-    IL_025e:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Exit<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(int32)
-    IL_0263:  pop
+    IL_0258:  ldc.i4.1
+    IL_0259:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.Operators::Exit<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(int32)
+    IL_025e:  pop
     .line 100001,100001 : 0,0 ''
-    IL_0264:  nop
-    IL_0265:  br.s       IL_0268
+    IL_025f:  nop
+    IL_0260:  br.s       IL_0263
 
     .line 100001,100001 : 0,0 ''
     .line 100001,100001 : 0,0 ''
-    IL_0267:  nop
+    IL_0262:  nop
     .line 67,67 : 1,37 ''
-    IL_0268:  ldc.i4.0
-    IL_0269:  ldc.i4.2
-    IL_026a:  ldc.i4.4
-    IL_026b:  ldc.i4.5
-    IL_026c:  ldc.i4.6
-    IL_026d:  ldc.i4.8
-    IL_026e:  ldc.i4.s   9
-    IL_0270:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_0263:  ldc.i4.0
+    IL_0264:  ldc.i4.2
+    IL_0265:  ldc.i4.4
+    IL_0266:  ldc.i4.5
+    IL_0267:  ldc.i4.6
+    IL_0268:  ldc.i4.8
+    IL_0269:  ldc.i4.s   9
+    IL_026b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_0270:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0275:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_027a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
@@ -4193,18 +4183,18 @@
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_028e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0293:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
-                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0298:  dup
-    IL_0299:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Select01>'.$Linq101Select01::numbersA@67
-    IL_029e:  stloc.s    numbersA
+    IL_0293:  dup
+    IL_0294:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Select01>'.$Linq101Select01::numbersA@67
+    IL_0299:  stloc.s    numbersA
     .line 68,68 : 1,31 ''
-    IL_02a0:  ldc.i4.1
-    IL_02a1:  ldc.i4.3
-    IL_02a2:  ldc.i4.5
-    IL_02a3:  ldc.i4.7
-    IL_02a4:  ldc.i4.8
-    IL_02a5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_029b:  ldc.i4.1
+    IL_029c:  ldc.i4.3
+    IL_029d:  ldc.i4.5
+    IL_029e:  ldc.i4.7
+    IL_029f:  ldc.i4.8
+    IL_02a0:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_02a5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_02aa:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_02af:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
@@ -4213,157 +4203,150 @@
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_02b9:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_02be:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
-                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_02c3:  dup
-    IL_02c4:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Select01>'.$Linq101Select01::numbersB@68
-    IL_02c9:  stloc.s    numbersB
+    IL_02be:  dup
+    IL_02bf:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Select01>'.$Linq101Select01::numbersB@68
+    IL_02c4:  stloc.s    numbersB
     .line 70,76 : 1,21 ''
-    IL_02cb:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_02d0:  stloc.s    V_30
-    IL_02d2:  ldloc.s    V_30
-    IL_02d4:  ldloc.s    V_30
-    IL_02d6:  ldloc.s    V_30
-    IL_02d8:  ldloc.s    V_30
-    IL_02da:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbersA()
-    IL_02df:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-    IL_02e4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_02e9:  ldloc.s    V_30
-    IL_02eb:  newobj     instance void Linq101Select01/pairs@72::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_02f0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02c6:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_02cb:  stloc.s    V_30
+    IL_02cd:  ldloc.s    V_30
+    IL_02cf:  ldloc.s    V_30
+    IL_02d1:  ldloc.s    V_30
+    IL_02d3:  ldloc.s    V_30
+    IL_02d5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Select01::get_numbersA()
+    IL_02da:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_02df:  ldloc.s    V_30
+    IL_02e1:  newobj     instance void Linq101Select01/pairs@72::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_02e6:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_02f5:  newobj     instance void Linq101Select01/'pairs@74-2'::.ctor()
-    IL_02fa:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02eb:  newobj     instance void Linq101Select01/'pairs@74-2'::.ctor()
+    IL_02f0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_02ff:  newobj     instance void Linq101Select01/'pairs@75-3'::.ctor()
-    IL_0304:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_02f5:  newobj     instance void Linq101Select01/'pairs@75-3'::.ctor()
+    IL_02fa:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<int32,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0309:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_030e:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<int32,int32>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0313:  dup
-    IL_0314:  stsfld     class [mscorlib]System.Tuple`2<int32,int32>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::pairs@70
-    IL_0319:  stloc.s    pairs
+    IL_02ff:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<int32,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0304:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`2<int32,int32>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0309:  dup
+    IL_030a:  stsfld     class [mscorlib]System.Tuple`2<int32,int32>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::pairs@70
+    IL_030f:  stloc.s    pairs
     .line 79,79 : 1,34 ''
-    IL_031b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
-    IL_0320:  dup
-    IL_0321:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Select01>'.$Linq101Select01::'customers@79-4'
-    IL_0326:  stloc.s    customers
+    IL_0311:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
+    IL_0316:  dup
+    IL_0317:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Select01>'.$Linq101Select01::'customers@79-4'
+    IL_031c:  stloc.s    customers
     .line 80,86 : 1,21 ''
-    IL_0328:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_032d:  stloc.s    V_31
-    IL_032f:  ldloc.s    V_31
-    IL_0331:  ldloc.s    V_31
-    IL_0333:  ldloc.s    V_31
-    IL_0335:  ldloc.s    V_31
-    IL_0337:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
-    IL_033c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-    IL_0341:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0346:  ldloc.s    V_31
-    IL_0348:  newobj     instance void Linq101Select01/'orders@82-2'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_034d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_031e:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0323:  stloc.s    V_31
+    IL_0325:  ldloc.s    V_31
+    IL_0327:  ldloc.s    V_31
+    IL_0329:  ldloc.s    V_31
+    IL_032b:  ldloc.s    V_31
+    IL_032d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
+    IL_0332:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0337:  ldloc.s    V_31
+    IL_0339:  newobj     instance void Linq101Select01/'orders@82-2'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_033e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0352:  newobj     instance void Linq101Select01/'orders@84-4'::.ctor()
-    IL_0357:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0343:  newobj     instance void Linq101Select01/'orders@84-4'::.ctor()
+    IL_0348:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_035c:  newobj     instance void Linq101Select01/'orders@85-5'::.ctor()
-    IL_0361:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_034d:  newobj     instance void Linq101Select01/'orders@85-5'::.ctor()
+    IL_0352:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0366:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_036b:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0370:  dup
-    IL_0371:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::orders@80
-    IL_0376:  stloc.s    orders
+    IL_0357:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_035c:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0361:  dup
+    IL_0362:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::orders@80
+    IL_0367:  stloc.s    orders
     .line 89,95 : 1,21 ''
-    IL_0378:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_037d:  stloc.s    V_32
-    IL_037f:  ldloc.s    V_32
-    IL_0381:  ldloc.s    V_32
-    IL_0383:  ldloc.s    V_32
-    IL_0385:  ldloc.s    V_32
-    IL_0387:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
-    IL_038c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-    IL_0391:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0396:  ldloc.s    V_32
-    IL_0398:  newobj     instance void Linq101Select01/orders2@91::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_039d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0369:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_036e:  stloc.s    V_32
+    IL_0370:  ldloc.s    V_32
+    IL_0372:  ldloc.s    V_32
+    IL_0374:  ldloc.s    V_32
+    IL_0376:  ldloc.s    V_32
+    IL_0378:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
+    IL_037d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0382:  ldloc.s    V_32
+    IL_0384:  newobj     instance void Linq101Select01/orders2@91::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0389:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_03a2:  newobj     instance void Linq101Select01/'orders2@93-2'::.ctor()
-    IL_03a7:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_038e:  newobj     instance void Linq101Select01/'orders2@93-2'::.ctor()
+    IL_0393:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_03ac:  newobj     instance void Linq101Select01/'orders2@94-3'::.ctor()
-    IL_03b1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0398:  newobj     instance void Linq101Select01/'orders2@94-3'::.ctor()
+    IL_039d:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_03b6:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_03bb:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_03c0:  dup
-    IL_03c1:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::orders2@89
-    IL_03c6:  stloc.s    orders2
-    IL_03c8:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_03cd:  stloc.s    V_33
-    IL_03cf:  ldloc.s    V_33
-    IL_03d1:  ldloc.s    V_33
-    IL_03d3:  ldloc.s    V_33
-    IL_03d5:  ldloc.s    V_33
-    IL_03d7:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
-    IL_03dc:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-    IL_03e1:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_03e6:  ldloc.s    V_33
-    IL_03e8:  newobj     instance void Linq101Select01/orders3@100::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_03ed:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03a2:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_03a7:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_03ac:  dup
+    IL_03ad:  stsfld     class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.DateTime>[] '<StartupCode$Linq101Select01>'.$Linq101Select01::orders2@89
+    IL_03b2:  stloc.s    orders2
+    IL_03b4:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_03b9:  stloc.s    V_33
+    IL_03bb:  ldloc.s    V_33
+    IL_03bd:  ldloc.s    V_33
+    IL_03bf:  ldloc.s    V_33
+    IL_03c1:  ldloc.s    V_33
+    IL_03c3:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
+    IL_03c8:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_03cd:  ldloc.s    V_33
+    IL_03cf:  newobj     instance void Linq101Select01/orders3@100::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_03d4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_03f2:  newobj     instance void Linq101Select01/'orders3@102-2'::.ctor()
-    IL_03f7:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03d9:  newobj     instance void Linq101Select01/'orders3@102-2'::.ctor()
+    IL_03de:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_03fc:  newobj     instance void Linq101Select01/'orders3@103-3'::.ctor()
-    IL_0401:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_03e3:  newobj     instance void Linq101Select01/'orders3@103-3'::.ctor()
+    IL_03e8:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0406:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_040b:  dup
-    IL_040c:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>> '<StartupCode$Linq101Select01>'.$Linq101Select01::orders3@98
-    IL_0411:  stloc.s    orders3
+    IL_03ed:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_03f2:  dup
+    IL_03f3:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`3<string,int32,valuetype [mscorlib]System.Decimal>> '<StartupCode$Linq101Select01>'.$Linq101Select01::orders3@98
+    IL_03f8:  stloc.s    orders3
     .line 107,107 : 1,38 ''
-    IL_0413:  ldc.i4     0x7cd
-    IL_0418:  ldc.i4.1
-    IL_0419:  ldc.i4.1
-    IL_041a:  newobj     instance void [mscorlib]System.DateTime::.ctor(int32,
+    IL_03fa:  ldc.i4     0x7cd
+    IL_03ff:  ldc.i4.1
+    IL_0400:  ldc.i4.1
+    IL_0401:  newobj     instance void [mscorlib]System.DateTime::.ctor(int32,
                                                                         int32,
                                                                         int32)
-    IL_041f:  dup
-    IL_0420:  stsfld     valuetype [mscorlib]System.DateTime '<StartupCode$Linq101Select01>'.$Linq101Select01::cutOffDate@107
-    IL_0425:  stloc.s    cutOffDate
-    IL_0427:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_042c:  stloc.s    V_34
-    IL_042e:  ldloc.s    V_34
-    IL_0430:  ldloc.s    V_34
-    IL_0432:  ldloc.s    V_34
-    IL_0434:  ldloc.s    V_34
-    IL_0436:  ldloc.s    V_34
-    IL_0438:  ldloc.s    V_34
-    IL_043a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
-    IL_043f:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-    IL_0444:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0449:  ldloc.s    V_34
-    IL_044b:  newobj     instance void Linq101Select01/orders4@111::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0450:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Customer,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0406:  dup
+    IL_0407:  stsfld     valuetype [mscorlib]System.DateTime '<StartupCode$Linq101Select01>'.$Linq101Select01::cutOffDate@107
+    IL_040c:  stloc.s    cutOffDate
+    IL_040e:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0413:  stloc.s    V_34
+    IL_0415:  ldloc.s    V_34
+    IL_0417:  ldloc.s    V_34
+    IL_0419:  ldloc.s    V_34
+    IL_041b:  ldloc.s    V_34
+    IL_041d:  ldloc.s    V_34
+    IL_041f:  ldloc.s    V_34
+    IL_0421:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Select01::get_customers()
+    IL_0426:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_042b:  ldloc.s    V_34
+    IL_042d:  newobj     instance void Linq101Select01/orders4@111::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0432:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Customer,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0455:  newobj     instance void Linq101Select01/'orders4@112-1'::.ctor()
-    IL_045a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0437:  newobj     instance void Linq101Select01/'orders4@112-1'::.ctor()
+    IL_043c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_045f:  ldloc.s    V_34
-    IL_0461:  newobj     instance void Linq101Select01/'orders4@111-2'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0466:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0441:  ldloc.s    V_34
+    IL_0443:  newobj     instance void Linq101Select01/'orders4@111-2'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0448:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                                                        class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_046b:  newobj     instance void Linq101Select01/'orders4@114-4'::.ctor()
-    IL_0470:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_044d:  newobj     instance void Linq101Select01/'orders4@114-4'::.ctor()
+    IL_0452:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                               class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_0475:  newobj     instance void Linq101Select01/'orders4@115-5'::.ctor()
-    IL_047a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0457:  newobj     instance void Linq101Select01/'orders4@115-5'::.ctor()
+    IL_045c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [mscorlib]System.Tuple`2<class [Utils]Utils/Customer,class [Utils]Utils/Order>,class [mscorlib]System.Collections.IEnumerable,class [mscorlib]System.Tuple`2<string,int32>>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                                                             class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_047f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0484:  dup
-    IL_0485:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,int32>> '<StartupCode$Linq101Select01>'.$Linq101Select01::orders4@109
-    IL_048a:  stloc.s    orders4
-    IL_048c:  ret
+    IL_0461:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [mscorlib]System.Tuple`2<string,int32>,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0466:  dup
+    IL_0467:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [mscorlib]System.Tuple`2<string,int32>> '<StartupCode$Linq101Select01>'.$Linq101Select01::orders4@109
+    IL_046c:  stloc.s    orders4
+    IL_046e:  ret
   } // end of method $Linq101Select01::main@
 
 } // end of class '<StartupCode$Linq101Select01>'.$Linq101Select01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101SetOperators01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101SetOperators01.il.netfx4.bsl
@@ -33,20 +33,20 @@
 }
 .mresource public FSharpSignatureData.Linq101SetOperators01
 {
-  // Offset: 0x00000000 Length: 0x00000390
+  // Offset: 0x00000000 Length: 0x00000394
 }
 .mresource public FSharpOptimizationData.Linq101SetOperators01
 {
   // Offset: 0x00000398 Length: 0x0000011E
 }
 .module Linq101SetOperators01.exe
-// MVID: {58067926-4EE5-349F-A745-038326790658}
+// MVID: {590846DB-4EE5-349F-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00640000
+// Image base: 0x02FD0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -108,10 +108,10 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
     {
-      // Code size       196 (0xc4)
+      // Code size       191 (0xbf)
       .maxstack  6
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101SetOperators01.fs'
+      .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101SetOperators01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
       IL_0006:  ldc.i4.1
@@ -131,17 +131,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_009a
+      IL_0022:  br.s       IL_0095
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0089
+      IL_0025:  br.s       IL_0084
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00bb
+      IL_0028:  br         IL_00b6
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -149,69 +149,68 @@
       .line 13,13 : 9,33 ''
       IL_002e:  ldarg.0
       IL_002f:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101SetOperators01::get_factorsOf300()
-      IL_0034:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-      IL_0039:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-      IL_003e:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
-      IL_0043:  ldarg.0
-      IL_0044:  ldc.i4.1
-      IL_0045:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
+      IL_0034:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+      IL_0039:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.1
+      IL_0040:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
       .line 13,13 : 9,33 ''
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
-      IL_0050:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0055:  brfalse.s  IL_009a
+      IL_0045:  ldarg.0
+      IL_0046:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
+      IL_004b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_0050:  brfalse.s  IL_0095
 
-      IL_0057:  ldarg.0
-      IL_0058:  ldarg.0
-      IL_0059:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
-      IL_005e:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-      IL_0063:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::_arg1
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
+      IL_0059:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+      IL_005e:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::_arg1
       .line 13,13 : 9,33 ''
-      IL_0068:  ldarg.0
-      IL_0069:  ldarg.0
-      IL_006a:  ldfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::_arg1
-      IL_006f:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::n
-      IL_0074:  ldarg.0
-      IL_0075:  ldc.i4.2
-      IL_0076:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
+      IL_0063:  ldarg.0
+      IL_0064:  ldarg.0
+      IL_0065:  ldfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::_arg1
+      IL_006a:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::n
+      IL_006f:  ldarg.0
+      IL_0070:  ldc.i4.2
+      IL_0071:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
       .line 14,14 : 9,17 ''
-      IL_007b:  ldarg.0
-      IL_007c:  ldarg.0
-      IL_007d:  ldfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::n
-      IL_0082:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::current
-      IL_0087:  ldc.i4.1
-      IL_0088:  ret
+      IL_0076:  ldarg.0
+      IL_0077:  ldarg.0
+      IL_0078:  ldfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::n
+      IL_007d:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::current
+      IL_0082:  ldc.i4.1
+      IL_0083:  ret
 
-      IL_0089:  ldarg.0
-      IL_008a:  ldc.i4.0
-      IL_008b:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::n
+      IL_0084:  ldarg.0
+      IL_0085:  ldc.i4.0
+      IL_0086:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::n
       .line 13,13 : 9,33 ''
-      IL_0090:  ldarg.0
-      IL_0091:  ldc.i4.0
-      IL_0092:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::_arg1
+      IL_008b:  ldarg.0
+      IL_008c:  ldc.i4.0
+      IL_008d:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::_arg1
       .line 100001,100001 : 0,0 ''
-      IL_0097:  nop
-      IL_0098:  br.s       IL_004a
+      IL_0092:  nop
+      IL_0093:  br.s       IL_0045
 
-      IL_009a:  ldarg.0
-      IL_009b:  ldc.i4.3
-      IL_009c:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
+      IL_0095:  ldarg.0
+      IL_0096:  ldc.i4.3
+      IL_0097:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
       .line 13,13 : 9,33 ''
-      IL_00a1:  ldarg.0
-      IL_00a2:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
-      IL_00a7:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-      IL_00ac:  nop
-      IL_00ad:  ldarg.0
-      IL_00ae:  ldnull
-      IL_00af:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldc.i4.3
-      IL_00b6:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldc.i4.0
-      IL_00bd:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::current
-      IL_00c2:  ldc.i4.0
-      IL_00c3:  ret
+      IL_009c:  ldarg.0
+      IL_009d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
+      IL_00a2:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+      IL_00a7:  nop
+      IL_00a8:  ldarg.0
+      IL_00a9:  ldnull
+      IL_00aa:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> Linq101SetOperators01/'uniqueFactors@13-1'::'enum'
+      IL_00af:  ldarg.0
+      IL_00b0:  ldc.i4.3
+      IL_00b1:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::pc
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.0
+      IL_00b8:  stfld      int32 Linq101SetOperators01/'uniqueFactors@13-1'::current
+      IL_00bd:  ldc.i4.0
+      IL_00be:  ret
     } // end of method 'uniqueFactors@13-1'::GenerateNext
 
     .method public strict virtual instance void 
@@ -502,7 +501,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       192 (0xc0)
+      // Code size       187 (0xbb)
       .maxstack  7
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -524,17 +523,17 @@
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_0096
+      IL_0022:  br.s       IL_0091
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_008c
+      IL_0025:  br.s       IL_0087
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00b7
+      IL_0028:  br         IL_00b2
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
@@ -543,64 +542,63 @@
       IL_002e:  ldarg.0
       IL_002f:  newobj     instance void Linq101SetOperators01/'categoryNames@22-1'::.ctor()
       IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101SetOperators01::get_products()
-      IL_0039:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_003e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Product,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_0039:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Product,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                   class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0043:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_0048:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
-      IL_004d:  ldarg.0
-      IL_004e:  ldc.i4.1
-      IL_004f:  stfld      int32 Linq101SetOperators01/categoryNames@23::pc
+      IL_003e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_0043:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
+      IL_0048:  ldarg.0
+      IL_0049:  ldc.i4.1
+      IL_004a:  stfld      int32 Linq101SetOperators01/categoryNames@23::pc
       .line 23,23 : 9,26 ''
-      IL_0054:  ldarg.0
-      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
-      IL_005a:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_005f:  brfalse.s  IL_0096
+      IL_004f:  ldarg.0
+      IL_0050:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
+      IL_0055:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005a:  brfalse.s  IL_0091
 
-      IL_0061:  ldarg.0
-      IL_0062:  ldarg.0
-      IL_0063:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
-      IL_0068:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_006d:  stfld      class [Utils]Utils/Product Linq101SetOperators01/categoryNames@23::p
-      IL_0072:  ldarg.0
-      IL_0073:  ldc.i4.2
-      IL_0074:  stfld      int32 Linq101SetOperators01/categoryNames@23::pc
+      IL_005c:  ldarg.0
+      IL_005d:  ldarg.0
+      IL_005e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
+      IL_0063:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_0068:  stfld      class [Utils]Utils/Product Linq101SetOperators01/categoryNames@23::p
+      IL_006d:  ldarg.0
+      IL_006e:  ldc.i4.2
+      IL_006f:  stfld      int32 Linq101SetOperators01/categoryNames@23::pc
       .line 23,23 : 16,26 ''
-      IL_0079:  ldarg.0
-      IL_007a:  ldarg.0
-      IL_007b:  ldfld      class [Utils]Utils/Product Linq101SetOperators01/categoryNames@23::p
-      IL_0080:  callvirt   instance string [Utils]Utils/Product::get_Category()
-      IL_0085:  stfld      string Linq101SetOperators01/categoryNames@23::current
-      IL_008a:  ldc.i4.1
-      IL_008b:  ret
+      IL_0074:  ldarg.0
+      IL_0075:  ldarg.0
+      IL_0076:  ldfld      class [Utils]Utils/Product Linq101SetOperators01/categoryNames@23::p
+      IL_007b:  callvirt   instance string [Utils]Utils/Product::get_Category()
+      IL_0080:  stfld      string Linq101SetOperators01/categoryNames@23::current
+      IL_0085:  ldc.i4.1
+      IL_0086:  ret
 
       .line 23,23 : 9,26 ''
-      IL_008c:  ldarg.0
-      IL_008d:  ldnull
-      IL_008e:  stfld      class [Utils]Utils/Product Linq101SetOperators01/categoryNames@23::p
+      IL_0087:  ldarg.0
+      IL_0088:  ldnull
+      IL_0089:  stfld      class [Utils]Utils/Product Linq101SetOperators01/categoryNames@23::p
       .line 100001,100001 : 0,0 ''
-      IL_0093:  nop
-      IL_0094:  br.s       IL_0054
+      IL_008e:  nop
+      IL_008f:  br.s       IL_004f
 
-      IL_0096:  ldarg.0
-      IL_0097:  ldc.i4.3
-      IL_0098:  stfld      int32 Linq101SetOperators01/categoryNames@23::pc
+      IL_0091:  ldarg.0
+      IL_0092:  ldc.i4.3
+      IL_0093:  stfld      int32 Linq101SetOperators01/categoryNames@23::pc
       .line 23,23 : 9,26 ''
-      IL_009d:  ldarg.0
-      IL_009e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
-      IL_00a3:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00a8:  nop
-      IL_00a9:  ldarg.0
-      IL_00aa:  ldnull
-      IL_00ab:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
-      IL_00b0:  ldarg.0
-      IL_00b1:  ldc.i4.3
-      IL_00b2:  stfld      int32 Linq101SetOperators01/categoryNames@23::pc
-      IL_00b7:  ldarg.0
-      IL_00b8:  ldnull
-      IL_00b9:  stfld      string Linq101SetOperators01/categoryNames@23::current
-      IL_00be:  ldc.i4.0
-      IL_00bf:  ret
+      IL_0098:  ldarg.0
+      IL_0099:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
+      IL_009e:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a3:  nop
+      IL_00a4:  ldarg.0
+      IL_00a5:  ldnull
+      IL_00a6:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/categoryNames@23::'enum'
+      IL_00ab:  ldarg.0
+      IL_00ac:  ldc.i4.3
+      IL_00ad:  stfld      int32 Linq101SetOperators01/categoryNames@23::pc
+      IL_00b2:  ldarg.0
+      IL_00b3:  ldnull
+      IL_00b4:  stfld      string Linq101SetOperators01/categoryNames@23::current
+      IL_00b9:  ldc.i4.0
+      IL_00ba:  ret
     } // end of method categoryNames@23::GenerateNext
 
     .method public strict virtual instance void 
@@ -889,7 +887,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<char>& next) cil managed
     {
-      // Code size       201 (0xc9)
+      // Code size       193 (0xc1)
       .maxstack  7
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -900,96 +898,95 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009f
+      IL_0022:  br.s       IL_0097
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_008d
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_0095
+      IL_0028:  br         IL_00b8
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00c0
-
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_002d:  nop
       .line 33,33 : 9,33 ''
-      IL_0031:  ldarg.0
-      IL_0032:  newobj     instance void Linq101SetOperators01/'productFirstChars@32-1'::.ctor()
-      IL_0037:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101SetOperators01::get_products()
-      IL_003c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-      IL_0041:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Product,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_002e:  ldarg.0
+      IL_002f:  newobj     instance void Linq101SetOperators01/'productFirstChars@32-1'::.ctor()
+      IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101SetOperators01::get_products()
+      IL_0039:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Product,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                   class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0046:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
-      IL_004b:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
-      IL_0050:  ldarg.0
-      IL_0051:  ldc.i4.1
-      IL_0052:  stfld      int32 Linq101SetOperators01/productFirstChars@33::pc
+      IL_003e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>::GetEnumerator()
+      IL_0043:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
+      IL_0048:  ldarg.0
+      IL_0049:  ldc.i4.1
+      IL_004a:  stfld      int32 Linq101SetOperators01/productFirstChars@33::pc
       .line 33,33 : 9,33 ''
-      IL_0057:  ldarg.0
-      IL_0058:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
-      IL_005d:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0062:  brfalse.s  IL_009f
+      IL_004f:  ldarg.0
+      IL_0050:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
+      IL_0055:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005a:  brfalse.s  IL_0097
 
-      IL_0064:  ldarg.0
-      IL_0065:  ldarg.0
-      IL_0066:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
-      IL_006b:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
-      IL_0070:  stfld      class [Utils]Utils/Product Linq101SetOperators01/productFirstChars@33::p
-      IL_0075:  ldarg.0
-      IL_0076:  ldc.i4.2
-      IL_0077:  stfld      int32 Linq101SetOperators01/productFirstChars@33::pc
+      IL_005c:  ldarg.0
+      IL_005d:  ldarg.0
+      IL_005e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
+      IL_0063:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>::get_Current()
+      IL_0068:  stfld      class [Utils]Utils/Product Linq101SetOperators01/productFirstChars@33::p
+      IL_006d:  ldarg.0
+      IL_006e:  ldc.i4.2
+      IL_006f:  stfld      int32 Linq101SetOperators01/productFirstChars@33::pc
       .line 33,33 : 29,30 ''
-      IL_007c:  ldarg.0
-      IL_007d:  ldarg.0
-      IL_007e:  ldfld      class [Utils]Utils/Product Linq101SetOperators01/productFirstChars@33::p
-      IL_0083:  callvirt   instance string [Utils]Utils/Product::get_ProductName()
-      IL_0088:  ldc.i4.0
-      IL_0089:  callvirt   instance char [mscorlib]System.String::get_Chars(int32)
-      IL_008e:  stfld      char Linq101SetOperators01/productFirstChars@33::current
-      IL_0093:  ldc.i4.1
-      IL_0094:  ret
+      IL_0074:  ldarg.0
+      IL_0075:  ldarg.0
+      IL_0076:  ldfld      class [Utils]Utils/Product Linq101SetOperators01/productFirstChars@33::p
+      IL_007b:  callvirt   instance string [Utils]Utils/Product::get_ProductName()
+      IL_0080:  ldc.i4.0
+      IL_0081:  callvirt   instance char [mscorlib]System.String::get_Chars(int32)
+      IL_0086:  stfld      char Linq101SetOperators01/productFirstChars@33::current
+      IL_008b:  ldc.i4.1
+      IL_008c:  ret
 
       .line 33,33 : 9,33 ''
-      IL_0095:  ldarg.0
-      IL_0096:  ldnull
-      IL_0097:  stfld      class [Utils]Utils/Product Linq101SetOperators01/productFirstChars@33::p
+      IL_008d:  ldarg.0
+      IL_008e:  ldnull
+      IL_008f:  stfld      class [Utils]Utils/Product Linq101SetOperators01/productFirstChars@33::p
       .line 100001,100001 : 0,0 ''
-      IL_009c:  nop
-      IL_009d:  br.s       IL_0057
+      IL_0094:  nop
+      IL_0095:  br.s       IL_004f
 
-      IL_009f:  ldarg.0
-      IL_00a0:  ldc.i4.3
-      IL_00a1:  stfld      int32 Linq101SetOperators01/productFirstChars@33::pc
+      IL_0097:  ldarg.0
+      IL_0098:  ldc.i4.3
+      IL_0099:  stfld      int32 Linq101SetOperators01/productFirstChars@33::pc
       .line 33,33 : 9,33 ''
-      IL_00a6:  ldarg.0
-      IL_00a7:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
-      IL_00ac:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
-      IL_00b1:  nop
-      IL_00b2:  ldarg.0
-      IL_00b3:  ldnull
-      IL_00b4:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
-      IL_00b9:  ldarg.0
-      IL_00ba:  ldc.i4.3
-      IL_00bb:  stfld      int32 Linq101SetOperators01/productFirstChars@33::pc
-      IL_00c0:  ldarg.0
-      IL_00c1:  ldc.i4.0
-      IL_00c2:  stfld      char Linq101SetOperators01/productFirstChars@33::current
-      IL_00c7:  ldc.i4.0
-      IL_00c8:  ret
+      IL_009e:  ldarg.0
+      IL_009f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
+      IL_00a4:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product>>(!!0)
+      IL_00a9:  nop
+      IL_00aa:  ldarg.0
+      IL_00ab:  ldnull
+      IL_00ac:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Product> Linq101SetOperators01/productFirstChars@33::'enum'
+      IL_00b1:  ldarg.0
+      IL_00b2:  ldc.i4.3
+      IL_00b3:  stfld      int32 Linq101SetOperators01/productFirstChars@33::pc
+      IL_00b8:  ldarg.0
+      IL_00b9:  ldc.i4.0
+      IL_00ba:  stfld      char Linq101SetOperators01/productFirstChars@33::current
+      IL_00bf:  ldc.i4.0
+      IL_00c0:  ret
     } // end of method productFirstChars@33::GenerateNext
 
     .method public strict virtual instance void 
@@ -1278,7 +1275,7 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<char>& next) cil managed
     {
-      // Code size       201 (0xc9)
+      // Code size       193 (0xc1)
       .maxstack  7
       .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
@@ -1289,96 +1286,95 @@
                             IL_001b,
                             IL_001d,
                             IL_001f)
-      IL_0019:  br.s       IL_0030
+      IL_0019:  br.s       IL_002d
 
       IL_001b:  br.s       IL_0021
 
-      IL_001d:  br.s       IL_0027
+      IL_001d:  br.s       IL_0024
 
-      IL_001f:  br.s       IL_002a
+      IL_001f:  br.s       IL_0027
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br         IL_009f
+      IL_0022:  br.s       IL_0097
+
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
+      IL_0024:  nop
+      IL_0025:  br.s       IL_008d
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br.s       IL_0095
+      IL_0028:  br         IL_00b8
 
       .line 100001,100001 : 0,0 ''
       .line 100001,100001 : 0,0 ''
-      IL_002a:  nop
-      IL_002b:  br         IL_00c0
-
-      .line 100001,100001 : 0,0 ''
-      .line 100001,100001 : 0,0 ''
-      IL_0030:  nop
+      IL_002d:  nop
       .line 39,39 : 9,33 ''
-      IL_0031:  ldarg.0
-      IL_0032:  newobj     instance void Linq101SetOperators01/'customerFirstChars@38-1'::.ctor()
-      IL_0037:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101SetOperators01::get_customers()
-      IL_003c:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-      IL_0041:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>,class [Utils]Utils/Customer>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_002e:  ldarg.0
+      IL_002f:  newobj     instance void Linq101SetOperators01/'customerFirstChars@38-1'::.ctor()
+      IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101SetOperators01::get_customers()
+      IL_0039:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<class [Utils]Utils/Customer,class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>,class [Utils]Utils/Customer>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                                                                                      class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0046:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>::GetEnumerator()
-      IL_004b:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
-      IL_0050:  ldarg.0
-      IL_0051:  ldc.i4.1
-      IL_0052:  stfld      int32 Linq101SetOperators01/customerFirstChars@39::pc
+      IL_003e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>::GetEnumerator()
+      IL_0043:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
+      IL_0048:  ldarg.0
+      IL_0049:  ldc.i4.1
+      IL_004a:  stfld      int32 Linq101SetOperators01/customerFirstChars@39::pc
       .line 39,39 : 9,33 ''
-      IL_0057:  ldarg.0
-      IL_0058:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
-      IL_005d:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_0062:  brfalse.s  IL_009f
+      IL_004f:  ldarg.0
+      IL_0050:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
+      IL_0055:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005a:  brfalse.s  IL_0097
 
-      IL_0064:  ldarg.0
-      IL_0065:  ldarg.0
-      IL_0066:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
-      IL_006b:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer>::get_Current()
-      IL_0070:  stfld      class [Utils]Utils/Customer Linq101SetOperators01/customerFirstChars@39::c
-      IL_0075:  ldarg.0
-      IL_0076:  ldc.i4.2
-      IL_0077:  stfld      int32 Linq101SetOperators01/customerFirstChars@39::pc
+      IL_005c:  ldarg.0
+      IL_005d:  ldarg.0
+      IL_005e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
+      IL_0063:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer>::get_Current()
+      IL_0068:  stfld      class [Utils]Utils/Customer Linq101SetOperators01/customerFirstChars@39::c
+      IL_006d:  ldarg.0
+      IL_006e:  ldc.i4.2
+      IL_006f:  stfld      int32 Linq101SetOperators01/customerFirstChars@39::pc
       .line 39,39 : 29,30 ''
-      IL_007c:  ldarg.0
-      IL_007d:  ldarg.0
-      IL_007e:  ldfld      class [Utils]Utils/Customer Linq101SetOperators01/customerFirstChars@39::c
-      IL_0083:  callvirt   instance string [Utils]Utils/Customer::get_CompanyName()
-      IL_0088:  ldc.i4.0
-      IL_0089:  callvirt   instance char [mscorlib]System.String::get_Chars(int32)
-      IL_008e:  stfld      char Linq101SetOperators01/customerFirstChars@39::current
-      IL_0093:  ldc.i4.1
-      IL_0094:  ret
+      IL_0074:  ldarg.0
+      IL_0075:  ldarg.0
+      IL_0076:  ldfld      class [Utils]Utils/Customer Linq101SetOperators01/customerFirstChars@39::c
+      IL_007b:  callvirt   instance string [Utils]Utils/Customer::get_CompanyName()
+      IL_0080:  ldc.i4.0
+      IL_0081:  callvirt   instance char [mscorlib]System.String::get_Chars(int32)
+      IL_0086:  stfld      char Linq101SetOperators01/customerFirstChars@39::current
+      IL_008b:  ldc.i4.1
+      IL_008c:  ret
 
       .line 39,39 : 9,33 ''
-      IL_0095:  ldarg.0
-      IL_0096:  ldnull
-      IL_0097:  stfld      class [Utils]Utils/Customer Linq101SetOperators01/customerFirstChars@39::c
+      IL_008d:  ldarg.0
+      IL_008e:  ldnull
+      IL_008f:  stfld      class [Utils]Utils/Customer Linq101SetOperators01/customerFirstChars@39::c
       .line 100001,100001 : 0,0 ''
-      IL_009c:  nop
-      IL_009d:  br.s       IL_0057
+      IL_0094:  nop
+      IL_0095:  br.s       IL_004f
 
-      IL_009f:  ldarg.0
-      IL_00a0:  ldc.i4.3
-      IL_00a1:  stfld      int32 Linq101SetOperators01/customerFirstChars@39::pc
+      IL_0097:  ldarg.0
+      IL_0098:  ldc.i4.3
+      IL_0099:  stfld      int32 Linq101SetOperators01/customerFirstChars@39::pc
       .line 39,39 : 9,33 ''
-      IL_00a6:  ldarg.0
-      IL_00a7:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
-      IL_00ac:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer>>(!!0)
-      IL_00b1:  nop
-      IL_00b2:  ldarg.0
-      IL_00b3:  ldnull
-      IL_00b4:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
-      IL_00b9:  ldarg.0
-      IL_00ba:  ldc.i4.3
-      IL_00bb:  stfld      int32 Linq101SetOperators01/customerFirstChars@39::pc
-      IL_00c0:  ldarg.0
-      IL_00c1:  ldc.i4.0
-      IL_00c2:  stfld      char Linq101SetOperators01/customerFirstChars@39::current
-      IL_00c7:  ldc.i4.0
-      IL_00c8:  ret
+      IL_009e:  ldarg.0
+      IL_009f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
+      IL_00a4:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer>>(!!0)
+      IL_00a9:  nop
+      IL_00aa:  ldarg.0
+      IL_00ab:  ldnull
+      IL_00ac:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<class [Utils]Utils/Customer> Linq101SetOperators01/customerFirstChars@39::'enum'
+      IL_00b1:  ldarg.0
+      IL_00b2:  ldc.i4.3
+      IL_00b3:  stfld      int32 Linq101SetOperators01/customerFirstChars@39::pc
+      IL_00b8:  ldarg.0
+      IL_00b9:  ldc.i4.0
+      IL_00ba:  stfld      char Linq101SetOperators01/customerFirstChars@39::current
+      IL_00bf:  ldc.i4.0
+      IL_00c0:  ret
     } // end of method customerFirstChars@39::GenerateNext
 
     .method public strict virtual instance void 

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Where01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Where01.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.81.0
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -26,27 +26,27 @@
                                                                                                       int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
 
   // --- The following custom attribute is added automatically, do not uncomment -------
-  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 00 01 00 00 00 00 ) 
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 01 00 00 00 00 ) 
 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .mresource public FSharpSignatureData.Linq101Where01
 {
-  // Offset: 0x00000000 Length: 0x000003CE
+  // Offset: 0x00000000 Length: 0x000003D2
 }
 .mresource public FSharpOptimizationData.Linq101Where01
 {
   // Offset: 0x000003D8 Length: 0x0000012E
 }
 .module Linq101Where01.exe
-// MVID: {5775B177-FF23-CD21-A745-038377B17557}
+// MVID: {590846DB-FF23-CD21-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00FE0000
+// Image base: 0x00DC0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -55,7 +55,7 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto ansi serializable nested assembly beforefieldinit lowNums@14
+  .class auto ansi serializable nested assembly beforefieldinit 'lowNums@14-3'
          extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,object>>
   {
     .field public class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder builder@
@@ -70,9 +70,9 @@
       IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,object>>::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
-      IL_0008:  stfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Where01/lowNums@14::builder@
+      IL_0008:  stfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Where01/'lowNums@14-3'::builder@
       IL_000d:  ret
-    } // end of method lowNums@14::.ctor
+    } // end of method 'lowNums@14-3'::.ctor
 
     .method public strict virtual instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,object> 
             Invoke(int32 _arg1) cil managed
@@ -81,22 +81,22 @@
       .maxstack  6
       .locals init ([0] int32 n)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 14,14 : 9,28 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Where01.fs'
+      .line 14,14 : 9,28 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Where01.fs'
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 15,15 : 9,22
+      .line 15,15 : 9,22 ''
       IL_0003:  ldarg.0
-      IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Where01/lowNums@14::builder@
+      IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Where01/'lowNums@14-3'::builder@
       IL_0009:  ldloc.0
       IL_000a:  tail.
       IL_000c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Yield<int32,object>(!!0)
       IL_0011:  ret
-    } // end of method lowNums@14::Invoke
+    } // end of method 'lowNums@14-3'::Invoke
 
-  } // end of class lowNums@14
+  } // end of class 'lowNums@14-3'
 
-  .class auto ansi serializable nested assembly beforefieldinit 'lowNums@15-1'
+  .class auto ansi serializable nested assembly beforefieldinit 'lowNums@15-4'
          extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
   {
     .method assembly specialname rtspecialname 
@@ -109,24 +109,24 @@
       IL_0000:  ldarg.0
       IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
       IL_0006:  ret
-    } // end of method 'lowNums@15-1'::.ctor
+    } // end of method 'lowNums@15-4'::.ctor
 
     .method public strict virtual instance bool 
             Invoke(int32 n) cil managed
     {
       // Code size       6 (0x6)
       .maxstack  8
-      .line 15,15 : 16,21
+      .line 15,15 : 16,21 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.5
       IL_0003:  clt
       IL_0005:  ret
-    } // end of method 'lowNums@15-1'::Invoke
+    } // end of method 'lowNums@15-4'::Invoke
 
-  } // end of class 'lowNums@15-1'
+  } // end of class 'lowNums@15-4'
 
-  .class auto ansi serializable nested assembly beforefieldinit 'lowNums@16-2'
+  .class auto ansi serializable nested assembly beforefieldinit 'lowNums@16-5'
          extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,int32>
   {
     .method assembly specialname rtspecialname 
@@ -139,20 +139,20 @@
       IL_0000:  ldarg.0
       IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,int32>::.ctor()
       IL_0006:  ret
-    } // end of method 'lowNums@16-2'::.ctor
+    } // end of method 'lowNums@16-5'::.ctor
 
     .method public strict virtual instance int32 
             Invoke(int32 n) cil managed
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 16,16 : 16,17
+      .line 16,16 : 16,17 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
-    } // end of method 'lowNums@16-2'::Invoke
+    } // end of method 'lowNums@16-5'::Invoke
 
-  } // end of class 'lowNums@16-2'
+  } // end of class 'lowNums@16-5'
 
   .class auto ansi serializable nested assembly beforefieldinit soldOutProducts@24
          extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [Utils]Utils/Product,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,object>>
@@ -179,11 +179,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Product p)
-      .line 24,24 : 9,29
+      .line 24,24 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 25,25 : 9,35
+      .line 25,25 : 9,35 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Where01/soldOutProducts@24::builder@
       IL_0009:  ldloc.0
@@ -214,7 +214,7 @@
     {
       // Code size       11 (0xb)
       .maxstack  8
-      .line 25,25 : 16,34
+      .line 25,25 : 16,34 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance int32 [Utils]Utils/Product::get_UnitsInStock()
@@ -245,7 +245,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 26,26 : 16,17
+      .line 26,26 : 16,17 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -278,11 +278,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Product p)
-      .line 32,32 : 9,29
+      .line 32,32 : 9,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 33,33 : 9,58
+      .line 33,33 : 9,58 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Where01/expensiveInStockProducts@32::builder@
       IL_0009:  ldloc.0
@@ -365,7 +365,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 34,34 : 16,17
+      .line 34,34 : 16,17 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -398,11 +398,11 @@
       // Code size       18 (0x12)
       .maxstack  6
       .locals init ([0] class [Utils]Utils/Customer c)
-      .line 42,42 : 9,30
+      .line 42,42 : 9,30 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 43,43 : 9,32
+      .line 43,43 : 9,32 ''
       IL_0003:  ldarg.0
       IL_0004:  ldfld      class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder Linq101Where01/waCustomers@42::builder@
       IL_0009:  ldloc.0
@@ -433,7 +433,7 @@
     {
       // Code size       18 (0x12)
       .maxstack  8
-      .line 43,43 : 16,31
+      .line 43,43 : 16,31 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  callvirt   instance string [Utils]Utils/Customer::get_Region()
@@ -465,7 +465,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 44,44 : 16,17
+      .line 44,44 : 16,17 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -493,7 +493,7 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      .line 55,55 : 19,21
+      .line 55,55 : 19,21 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  tail.
@@ -524,7 +524,7 @@
     {
       // Code size       23 (0x17)
       .maxstack  8
-      .line 54,54 : 29,49
+      .line 54,54 : 29,49 ''
       IL_0000:  nop
       IL_0001:  ldarg.2
       IL_0002:  callvirt   instance int32 [mscorlib]System.String::get_Length()
@@ -535,12 +535,12 @@
 
       IL_000c:  br.s       IL_0015
 
-      .line 54,54 : 50,57
+      .line 54,54 : 50,57 ''
       IL_000e:  ldarg.2
       IL_000f:  call       class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<!0> class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string>::Some(!0)
       IL_0014:  ret
 
-      .line 54,54 : 63,67
+      .line 54,54 : 63,67 ''
       IL_0015:  ldnull
       IL_0016:  ret
     } // end of method 'shortDigits@54-1'::Invoke
@@ -568,11 +568,11 @@
       // Code size       12 (0xc)
       .maxstack  5
       .locals init ([0] string d)
-      .line 51,51 : 9,27
+      .line 51,51 : 9,27 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  stloc.0
-      .line 52,52 : 9,17
+      .line 52,52 : 9,17 ''
       IL_0003:  ldloc.0
       IL_0004:  tail.
       IL_0006:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Singleton<string>(!!0)
@@ -626,9 +626,9 @@
     .method public strict virtual instance int32 
             GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<string>& next) cil managed
     {
-      // Code size       187 (0xbb)
+      // Code size       182 (0xb6)
       .maxstack  7
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Where01/'shortDigits@52-2'::pc
       IL_0006:  ldc.i4.1
@@ -645,85 +645,84 @@
 
       IL_001f:  br.s       IL_0027
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0021:  nop
-      IL_0022:  br.s       IL_0091
+      IL_0022:  br.s       IL_008c
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0024:  nop
-      IL_0025:  br.s       IL_0087
+      IL_0025:  br.s       IL_0082
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0027:  nop
-      IL_0028:  br         IL_00b2
+      IL_0028:  br         IL_00ad
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_002d:  nop
-      .line 52,52 : 9,17
+      .line 52,52 : 9,17 ''
       IL_002e:  ldarg.0
       IL_002f:  newobj     instance void Linq101Where01/'shortDigits@51-3'::.ctor()
       IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> Linq101Where01::get_digits()
-      IL_0039:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<string>
-      IL_003e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<string>,string>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
+      IL_0039:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!2> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Collect<string,class [mscorlib]System.Collections.Generic.IEnumerable`1<string>,string>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>,
                                                                                                                                                                                                                                       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-      IL_0043:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-      IL_0048:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
-      IL_004d:  ldarg.0
-      IL_004e:  ldc.i4.1
-      IL_004f:  stfld      int32 Linq101Where01/'shortDigits@52-2'::pc
-      .line 52,52 : 9,17
-      IL_0054:  ldarg.0
-      IL_0055:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
-      IL_005a:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-      IL_005f:  brfalse.s  IL_0091
+      IL_003e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+      IL_0043:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
+      IL_0048:  ldarg.0
+      IL_0049:  ldc.i4.1
+      IL_004a:  stfld      int32 Linq101Where01/'shortDigits@52-2'::pc
+      .line 52,52 : 9,17 ''
+      IL_004f:  ldarg.0
+      IL_0050:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
+      IL_0055:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+      IL_005a:  brfalse.s  IL_008c
 
-      IL_0061:  ldarg.0
-      IL_0062:  ldarg.0
-      IL_0063:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
-      IL_0068:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-      IL_006d:  stfld      string Linq101Where01/'shortDigits@52-2'::d
-      IL_0072:  ldarg.0
-      IL_0073:  ldc.i4.2
-      IL_0074:  stfld      int32 Linq101Where01/'shortDigits@52-2'::pc
-      .line 52,52 : 16,17
-      IL_0079:  ldarg.0
-      IL_007a:  ldarg.0
-      IL_007b:  ldfld      string Linq101Where01/'shortDigits@52-2'::d
-      IL_0080:  stfld      string Linq101Where01/'shortDigits@52-2'::current
-      IL_0085:  ldc.i4.1
-      IL_0086:  ret
+      IL_005c:  ldarg.0
+      IL_005d:  ldarg.0
+      IL_005e:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
+      IL_0063:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+      IL_0068:  stfld      string Linq101Where01/'shortDigits@52-2'::d
+      IL_006d:  ldarg.0
+      IL_006e:  ldc.i4.2
+      IL_006f:  stfld      int32 Linq101Where01/'shortDigits@52-2'::pc
+      .line 52,52 : 16,17 ''
+      IL_0074:  ldarg.0
+      IL_0075:  ldarg.0
+      IL_0076:  ldfld      string Linq101Where01/'shortDigits@52-2'::d
+      IL_007b:  stfld      string Linq101Where01/'shortDigits@52-2'::current
+      IL_0080:  ldc.i4.1
+      IL_0081:  ret
 
-      .line 52,52 : 9,17
-      IL_0087:  ldarg.0
-      IL_0088:  ldnull
-      IL_0089:  stfld      string Linq101Where01/'shortDigits@52-2'::d
-      .line 100001,100001 : 0,0
-      IL_008e:  nop
-      IL_008f:  br.s       IL_0054
+      .line 52,52 : 9,17 ''
+      IL_0082:  ldarg.0
+      IL_0083:  ldnull
+      IL_0084:  stfld      string Linq101Where01/'shortDigits@52-2'::d
+      .line 100001,100001 : 0,0 ''
+      IL_0089:  nop
+      IL_008a:  br.s       IL_004f
 
-      IL_0091:  ldarg.0
-      IL_0092:  ldc.i4.3
-      IL_0093:  stfld      int32 Linq101Where01/'shortDigits@52-2'::pc
-      .line 52,52 : 9,17
-      IL_0098:  ldarg.0
-      IL_0099:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
-      IL_009e:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
-      IL_00a3:  nop
-      IL_00a4:  ldarg.0
-      IL_00a5:  ldnull
-      IL_00a6:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
-      IL_00ab:  ldarg.0
-      IL_00ac:  ldc.i4.3
-      IL_00ad:  stfld      int32 Linq101Where01/'shortDigits@52-2'::pc
-      IL_00b2:  ldarg.0
-      IL_00b3:  ldnull
-      IL_00b4:  stfld      string Linq101Where01/'shortDigits@52-2'::current
-      IL_00b9:  ldc.i4.0
-      IL_00ba:  ret
+      IL_008c:  ldarg.0
+      IL_008d:  ldc.i4.3
+      IL_008e:  stfld      int32 Linq101Where01/'shortDigits@52-2'::pc
+      .line 52,52 : 9,17 ''
+      IL_0093:  ldarg.0
+      IL_0094:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
+      IL_0099:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
+      IL_009e:  nop
+      IL_009f:  ldarg.0
+      IL_00a0:  ldnull
+      IL_00a1:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
+      IL_00a6:  ldarg.0
+      IL_00a7:  ldc.i4.3
+      IL_00a8:  stfld      int32 Linq101Where01/'shortDigits@52-2'::pc
+      IL_00ad:  ldarg.0
+      IL_00ae:  ldnull
+      IL_00af:  stfld      string Linq101Where01/'shortDigits@52-2'::current
+      IL_00b4:  ldc.i4.0
+      IL_00b5:  ret
     } // end of method 'shortDigits@52-2'::GenerateNext
 
     .method public strict virtual instance void 
@@ -734,7 +733,7 @@
       .locals init ([0] class [mscorlib]System.Exception V_0,
                [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                [2] class [mscorlib]System.Exception e)
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0000:  ldnull
       IL_0001:  stloc.0
       IL_0002:  ldarg.0
@@ -745,13 +744,13 @@
                             IL_0015)
       IL_0013:  br.s       IL_001b
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_0015:  nop
       IL_0016:  br         IL_0089
 
-      .line 100001,100001 : 0,0
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
+      .line 100001,100001 : 0,0 ''
       IL_001b:  nop
       .try
       {
@@ -772,30 +771,30 @@
 
         IL_003f:  br.s       IL_004a
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0041:  nop
         IL_0042:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0044:  nop
         IL_0045:  br.s       IL_004f
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0047:  nop
         IL_0048:  br.s       IL_004e
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004a:  nop
         IL_004b:  br.s       IL_0063
 
-        .line 100001,100001 : 0,0
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_004d:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_004e:  nop
         IL_004f:  ldarg.0
         IL_0050:  ldc.i4.3
@@ -804,7 +803,7 @@
         IL_0057:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<string> Linq101Where01/'shortDigits@52-2'::'enum'
         IL_005c:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<string>>(!!0)
         IL_0061:  nop
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
         IL_0062:  nop
         IL_0063:  ldarg.0
         IL_0064:  ldc.i4.3
@@ -821,18 +820,18 @@
       {
         IL_0075:  castclass  [mscorlib]System.Exception
         IL_007a:  stloc.2
-        .line 52,52 : 9,17
+        .line 52,52 : 9,17 ''
         IL_007b:  ldloc.2
         IL_007c:  stloc.0
         IL_007d:  ldnull
         IL_007e:  stloc.1
         IL_007f:  leave.s    IL_0081
 
-        .line 100001,100001 : 0,0
+        .line 100001,100001 : 0,0 ''
       }  // end handler
       IL_0081:  ldloc.1
       IL_0082:  pop
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0083:  nop
       IL_0084:  br         IL_0002
 
@@ -845,11 +844,11 @@
 
       IL_0091:  br.s       IL_0095
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0093:  ldloc.0
       IL_0094:  throw
 
-      .line 100001,100001 : 0,0
+      .line 100001,100001 : 0,0 ''
       IL_0095:  ret
     } // end of method 'shortDigits@52-2'::Close
 
@@ -938,7 +937,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Where01>'.$Linq101Where01::'numbers@9-7'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Where01>'.$Linq101Where01::'numbers@9-11'
     IL_0005:  ret
   } // end of method Linq101Where01::get_numbers
 
@@ -947,7 +946,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Where01>'.$Linq101Where01::lowNums@12
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Where01>'.$Linq101Where01::'lowNums@12-2'
     IL_0005:  ret
   } // end of method Linq101Where01::get_lowNums
 
@@ -956,7 +955,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Where01>'.$Linq101Where01::'products@20-10'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Where01>'.$Linq101Where01::'products@20-16'
     IL_0005:  ret
   } // end of method Linq101Where01::get_products
 
@@ -983,7 +982,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Where01>'.$Linq101Where01::'customers@38-4'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Where01>'.$Linq101Where01::'customers@38-8'
     IL_0005:  ret
   } // end of method Linq101Where01::get_customers
 
@@ -1001,7 +1000,7 @@
   {
     // Code size       6 (0x6)
     .maxstack  8
-    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Where01>'.$Linq101Where01::'digits@48-4'
+    IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Where01>'.$Linq101Where01::'digits@48-6'
     IL_0005:  ret
   } // end of method Linq101Where01::get_digits
 
@@ -1073,21 +1072,21 @@
 .class private abstract auto ansi sealed '<StartupCode$Linq101Where01>'.$Linq101Where01
        extends [mscorlib]System.Object
 {
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@9-7'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'numbers@9-11'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> lowNums@12
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'lowNums@12-2'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@20-10'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> 'products@20-16'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> soldOutProducts@22
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> expensiveInStockProducts@30
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> 'customers@38-4'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> 'customers@38-8'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [Utils]Utils/Customer[] waCustomers@40
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'digits@48-4'
+  .field static assembly class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> 'digits@48-6'
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
   .field static assembly class [mscorlib]System.Collections.Generic.IEnumerable`1<string> shortDigits@49
   .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
@@ -1098,7 +1097,7 @@
   .method public static void  main@() cil managed
   {
     .entrypoint
-    // Code size       565 (0x235)
+    // Code size       545 (0x221)
     .maxstack  13
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> numbers,
              [1] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> lowNums,
@@ -1114,7 +1113,7 @@
              [11] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_11,
              [12] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_12,
              [13] class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder V_13)
-    .line 9,9 : 1,47
+    .line 9,9 : 1,47 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.5
     IL_0002:  ldc.i4.4
@@ -1148,9 +1147,9 @@
     IL_003e:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_0043:  dup
-    IL_0044:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Where01>'.$Linq101Where01::'numbers@9-7'
+    IL_0044:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Where01>'.$Linq101Where01::'numbers@9-11'
     IL_0049:  stloc.0
-    .line 12,17 : 1,20
+    .line 12,17 : 1,20 ''
     IL_004a:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
     IL_004f:  stloc.s    builder@
     IL_0051:  ldloc.s    builder@
@@ -1158,116 +1157,120 @@
     IL_0055:  ldloc.s    builder@
     IL_0057:  ldloc.s    builder@
     IL_0059:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> Linq101Where01::get_numbers()
-    IL_005e:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-    IL_0063:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0068:  ldloc.s    builder@
-    IL_006a:  newobj     instance void Linq101Where01/lowNums@14::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_006f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,int32,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_005e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0063:  ldloc.s    builder@
+    IL_0065:  newobj     instance void Linq101Where01/'lowNums@14-3'::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_006a:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<int32,class [mscorlib]System.Collections.IEnumerable,int32,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                           class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0074:  newobj     instance void Linq101Where01/'lowNums@15-1'::.ctor()
-    IL_0079:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_006f:  newobj     instance void Linq101Where01/'lowNums@15-4'::.ctor()
+    IL_0074:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<int32,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_007e:  newobj     instance void Linq101Where01/'lowNums@16-2'::.ctor()
-    IL_0083:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<int32,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0079:  newobj     instance void Linq101Where01/'lowNums@16-5'::.ctor()
+    IL_007e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<int32,class [mscorlib]System.Collections.IEnumerable,int32>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0088:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_008d:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.ListModule::OfSeq<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0092:  dup
-    IL_0093:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Where01>'.$Linq101Where01::lowNums@12
-    IL_0098:  stloc.1
-    .line 20,20 : 1,32
-    IL_0099:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
-    IL_009e:  dup
-    IL_009f:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Where01>'.$Linq101Where01::'products@20-10'
-    IL_00a4:  stloc.2
-    IL_00a5:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_00aa:  stloc.s    V_10
-    IL_00ac:  ldloc.s    V_10
-    IL_00ae:  ldloc.s    V_10
-    IL_00b0:  ldloc.s    V_10
-    IL_00b2:  ldloc.s    V_10
-    IL_00b4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Where01::get_products()
-    IL_00b9:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_00be:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_00c3:  ldloc.s    V_10
-    IL_00c5:  newobj     instance void Linq101Where01/soldOutProducts@24::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_00ca:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0083:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<int32,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0088:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!0> [FSharp.Core]Microsoft.FSharp.Collections.ListModule::OfSeq<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_008d:  dup
+    IL_008e:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$Linq101Where01>'.$Linq101Where01::'lowNums@12-2'
+    IL_0093:  stloc.1
+    .line 20,20 : 1,32 ''
+    IL_0094:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> [Utils]Utils::getProductList()
+    IL_0099:  dup
+    IL_009a:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> '<StartupCode$Linq101Where01>'.$Linq101Where01::'products@20-16'
+    IL_009f:  stloc.2
+    IL_00a0:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_00a5:  stloc.s    V_10
+    IL_00a7:  ldloc.s    V_10
+    IL_00a9:  ldloc.s    V_10
+    IL_00ab:  ldloc.s    V_10
+    IL_00ad:  ldloc.s    V_10
+    IL_00af:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Where01::get_products()
+    IL_00b4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00b9:  ldloc.s    V_10
+    IL_00bb:  newobj     instance void Linq101Where01/soldOutProducts@24::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_00c0:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_00cf:  newobj     instance void Linq101Where01/'soldOutProducts@25-1'::.ctor()
-    IL_00d4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00c5:  newobj     instance void Linq101Where01/'soldOutProducts@25-1'::.ctor()
+    IL_00ca:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_00d9:  newobj     instance void Linq101Where01/'soldOutProducts@26-2'::.ctor()
-    IL_00de:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00cf:  newobj     instance void Linq101Where01/'soldOutProducts@26-2'::.ctor()
+    IL_00d4:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_00e3:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_00e8:  dup
-    IL_00e9:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> '<StartupCode$Linq101Where01>'.$Linq101Where01::soldOutProducts@22
-    IL_00ee:  stloc.3
-    IL_00ef:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_00f4:  stloc.s    V_11
-    IL_00f6:  ldloc.s    V_11
-    IL_00f8:  ldloc.s    V_11
-    IL_00fa:  ldloc.s    V_11
-    IL_00fc:  ldloc.s    V_11
-    IL_00fe:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Where01::get_products()
-    IL_0103:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product>
-    IL_0108:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_010d:  ldloc.s    V_11
-    IL_010f:  newobj     instance void Linq101Where01/expensiveInStockProducts@32::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_0114:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_00d9:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_00de:  dup
+    IL_00df:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> '<StartupCode$Linq101Where01>'.$Linq101Where01::soldOutProducts@22
+    IL_00e4:  stloc.3
+    IL_00e5:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_00ea:  stloc.s    V_11
+    IL_00ec:  ldloc.s    V_11
+    IL_00ee:  ldloc.s    V_11
+    IL_00f0:  ldloc.s    V_11
+    IL_00f2:  ldloc.s    V_11
+    IL_00f4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Product> Linq101Where01::get_products()
+    IL_00f9:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Product>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00fe:  ldloc.s    V_11
+    IL_0100:  newobj     instance void Linq101Where01/expensiveInStockProducts@32::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0105:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0119:  newobj     instance void Linq101Where01/'expensiveInStockProducts@33-1'::.ctor()
-    IL_011e:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_010a:  newobj     instance void Linq101Where01/'expensiveInStockProducts@33-1'::.ctor()
+    IL_010f:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_0123:  newobj     instance void Linq101Where01/'expensiveInStockProducts@34-2'::.ctor()
-    IL_0128:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0114:  newobj     instance void Linq101Where01/'expensiveInStockProducts@34-2'::.ctor()
+    IL_0119:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Product>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_012d:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_0132:  dup
-    IL_0133:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> '<StartupCode$Linq101Where01>'.$Linq101Where01::expensiveInStockProducts@30
-    IL_0138:  stloc.s    expensiveInStockProducts
-    .line 38,38 : 1,34
-    IL_013a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
-    IL_013f:  dup
-    IL_0140:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Where01>'.$Linq101Where01::'customers@38-4'
-    IL_0145:  stloc.s    customers
-    .line 40,45 : 1,21
-    IL_0147:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_014c:  stloc.s    V_12
-    IL_014e:  ldloc.s    V_12
-    IL_0150:  ldloc.s    V_12
-    IL_0152:  ldloc.s    V_12
-    IL_0154:  ldloc.s    V_12
-    IL_0156:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Where01::get_customers()
-    IL_015b:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Customer>
-    IL_0160:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0165:  ldloc.s    V_12
-    IL_0167:  newobj     instance void Linq101Where01/waCustomers@42::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
-    IL_016c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Customer,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_011e:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Product,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0123:  dup
+    IL_0124:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<class [Utils]Utils/Product> '<StartupCode$Linq101Where01>'.$Linq101Where01::expensiveInStockProducts@30
+    IL_0129:  stloc.s    expensiveInStockProducts
+    .line 38,38 : 1,34 ''
+    IL_012b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> [Utils]Utils::getCustomerList()
+    IL_0130:  dup
+    IL_0131:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> '<StartupCode$Linq101Where01>'.$Linq101Where01::'customers@38-8'
+    IL_0136:  stloc.s    customers
+    .line 40,45 : 1,21 ''
+    IL_0138:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_013d:  stloc.s    V_12
+    IL_013f:  ldloc.s    V_12
+    IL_0141:  ldloc.s    V_12
+    IL_0143:  ldloc.s    V_12
+    IL_0145:  ldloc.s    V_12
+    IL_0147:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<class [Utils]Utils/Customer> Linq101Where01::get_customers()
+    IL_014c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,class [mscorlib]System.Collections.IEnumerable> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Source<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0151:  ldloc.s    V_12
+    IL_0153:  newobj     instance void Linq101Where01/waCustomers@42::.ctor(class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder)
+    IL_0158:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::For<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Customer,object>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!3>>)
-    IL_0171:  newobj     instance void Linq101Where01/'waCustomers@43-1'::.ctor()
-    IL_0176:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_015d:  newobj     instance void Linq101Where01/'waCustomers@43-1'::.ctor()
+    IL_0162:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Where<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,bool>)
-    IL_017b:  newobj     instance void Linq101Where01/'waCustomers@44-2'::.ctor()
-    IL_0180:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Customer>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
+    IL_0167:  newobj     instance void Linq101Where01/'waCustomers@44-2'::.ctor()
+    IL_016c:  callvirt   instance class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!2,!!1> [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder::Select<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable,class [Utils]Utils/Customer>(class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<!!0,!!1>,
                                                                                                                                                                                                                                                                   class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!2>)
-    IL_0185:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable>::get_Source()
-    IL_018a:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_018f:  dup
-    IL_0190:  stsfld     class [Utils]Utils/Customer[] '<StartupCode$Linq101Where01>'.$Linq101Where01::waCustomers@40
-    IL_0195:  stloc.s    waCustomers
-    .line 48,48 : 1,96
-    IL_0197:  ldstr      "zero"
-    IL_019c:  ldstr      "one"
-    IL_01a1:  ldstr      "two"
-    IL_01a6:  ldstr      "three"
-    IL_01ab:  ldstr      "four"
-    IL_01b0:  ldstr      "five"
-    IL_01b5:  ldstr      "six"
-    IL_01ba:  ldstr      "seven"
-    IL_01bf:  ldstr      "eight"
-    IL_01c4:  ldstr      "nine"
-    IL_01c9:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Empty()
+    IL_0171:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerable`1<!0> class [FSharp.Core]Microsoft.FSharp.Linq.QuerySource`2<class [Utils]Utils/Customer,class [mscorlib]System.Collections.IEnumerable>::get_Source()
+    IL_0176:  call       !!0[] [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::ToArray<class [Utils]Utils/Customer>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_017b:  dup
+    IL_017c:  stsfld     class [Utils]Utils/Customer[] '<StartupCode$Linq101Where01>'.$Linq101Where01::waCustomers@40
+    IL_0181:  stloc.s    waCustomers
+    .line 48,48 : 1,96 ''
+    IL_0183:  ldstr      "zero"
+    IL_0188:  ldstr      "one"
+    IL_018d:  ldstr      "two"
+    IL_0192:  ldstr      "three"
+    IL_0197:  ldstr      "four"
+    IL_019c:  ldstr      "five"
+    IL_01a1:  ldstr      "six"
+    IL_01a6:  ldstr      "seven"
+    IL_01ab:  ldstr      "eight"
+    IL_01b0:  ldstr      "nine"
+    IL_01b5:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::get_Empty()
+    IL_01ba:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
+                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_01bf:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
+                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_01c4:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
+                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_01c9:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
+                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_01ce:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_01d3:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
@@ -1280,38 +1283,30 @@
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
     IL_01e7:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
                                                                                                                                                                      class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_01ec:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
-                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_01f1:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
-                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_01f6:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
-                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_01fb:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string>::Cons(!0,
-                                                                                                                                                                     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0200:  dup
-    IL_0201:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Where01>'.$Linq101Where01::'digits@48-4'
-    IL_0206:  stloc.s    digits
-    .line 49,55 : 1,21
-    IL_0208:  newobj     instance void Linq101Where01/shortDigits@55::.ctor()
-    IL_020d:  newobj     instance void Linq101Where01/'shortDigits@54-1'::.ctor()
-    IL_0212:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
-    IL_0217:  stloc.s    V_13
-    IL_0219:  ldnull
-    IL_021a:  ldnull
-    IL_021b:  ldc.i4.0
-    IL_021c:  ldnull
-    IL_021d:  newobj     instance void Linq101Where01/'shortDigits@52-2'::.ctor(string,
+    IL_01ec:  dup
+    IL_01ed:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<string> '<StartupCode$Linq101Where01>'.$Linq101Where01::'digits@48-6'
+    IL_01f2:  stloc.s    digits
+    .line 49,55 : 1,21 ''
+    IL_01f4:  newobj     instance void Linq101Where01/shortDigits@55::.ctor()
+    IL_01f9:  newobj     instance void Linq101Where01/'shortDigits@54-1'::.ctor()
+    IL_01fe:  call       class [FSharp.Core]Microsoft.FSharp.Linq.QueryBuilder [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::get_query()
+    IL_0203:  stloc.s    V_13
+    IL_0205:  ldnull
+    IL_0206:  ldnull
+    IL_0207:  ldc.i4.0
+    IL_0208:  ldnull
+    IL_0209:  newobj     instance void Linq101Where01/'shortDigits@52-2'::.ctor(string,
                                                                                 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>,
                                                                                 int32,
                                                                                 string)
-    IL_0222:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::MapIndexed<string,class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string>>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>>,
+    IL_020e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::MapIndexed<string,class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string>>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,!!1>>,
                                                                                                                                                                                                                                class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_0227:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Choose<class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string>,string>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<!!1>>,
+    IL_0213:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Choose<class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<string>,string>(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<!!0,class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<!!1>>,
                                                                                                                                                                                                                            class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
-    IL_022c:  dup
-    IL_022d:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<string> '<StartupCode$Linq101Where01>'.$Linq101Where01::shortDigits@49
-    IL_0232:  stloc.s    shortDigits
-    IL_0234:  ret
+    IL_0218:  dup
+    IL_0219:  stsfld     class [mscorlib]System.Collections.Generic.IEnumerable`1<string> '<StartupCode$Linq101Where01>'.$Linq101Where01::shortDigits@49
+    IL_021e:  stloc.s    shortDigits
+    IL_0220:  ret
   } // end of method $Linq101Where01::main@
 
 } // end of class '<StartupCode$Linq101Where01>'.$Linq101Where01

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/SeqExpressionStepping/SeqExpressionSteppingTest6.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/SeqExpressionStepping/SeqExpressionSteppingTest6.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.16774
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:0:0
+  .ver 4:4:1:0
 }
 .assembly SeqExpressionSteppingTest6
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.SeqExpressionSteppingTest6
 {
-  // Offset: 0x00000000 Length: 0x000002C1
+  // Offset: 0x00000000 Length: 0x000002A0
 }
 .mresource public FSharpOptimizationData.SeqExpressionSteppingTest6
 {
-  // Offset: 0x000002C8 Length: 0x000000BA
+  // Offset: 0x000002A8 Length: 0x000000BA
 }
 .module SeqExpressionSteppingTest6.exe
-// MVID: {4DAC1464-2432-94A2-A745-03836414AC4D}
+// MVID: {590846DB-2432-94A2-A745-0383DB460859}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000000000160000
+// Image base: 0x03320000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -113,10 +113,10 @@
       .method public strict virtual instance int32 
               GenerateNext(class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>& next) cil managed
       {
-        // Code size       351 (0x15f)
+        // Code size       341 (0x155)
         .maxstack  6
         .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\SeqExpressionStepping\\SeqExpressionSteppingTest6.fs'
         IL_0000:  ldarg.0
         IL_0001:  ldfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
         IL_0006:  ldc.i4.1
@@ -139,152 +139,150 @@
 
         IL_002b:  br.s       IL_0042
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_002d:  nop
-        IL_002e:  br         IL_00b2
+        IL_002e:  br         IL_00ad
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0033:  nop
-        IL_0034:  br.s       IL_00a8
+        IL_0034:  br.s       IL_00a3
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0036:  nop
-        IL_0037:  br         IL_0135
+        IL_0037:  br         IL_012b
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_003c:  nop
-        IL_003d:  br         IL_012b
+        IL_003d:  br         IL_0121
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0042:  nop
-        IL_0043:  br         IL_0156
+        IL_0043:  br         IL_014c
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0048:  nop
-        .line 6,8 : 15,25 
+        .line 6,8 : 15,25 ''
         IL_0049:  ldarg.0
         IL_004a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6::get_es()
-        IL_004f:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-        IL_0054:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-        IL_0059:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
-        IL_005e:  ldarg.0
-        IL_005f:  ldc.i4.1
-        IL_0060:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
-        .line 6,8 : 15,25 
-        IL_0065:  ldarg.0
-        IL_0066:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
-        IL_006b:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-        IL_0070:  brfalse.s  IL_00b2
+        IL_004f:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+        IL_0054:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
+        IL_0059:  ldarg.0
+        IL_005a:  ldc.i4.1
+        IL_005b:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
+        .line 6,8 : 15,25 ''
+        IL_0060:  ldarg.0
+        IL_0061:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
+        IL_0066:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+        IL_006b:  brfalse.s  IL_00ad
 
-        IL_0072:  ldarg.0
-        IL_0073:  ldarg.0
-        IL_0074:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
-        IL_0079:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-        IL_007e:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x
-        .line 7,7 : 18,33 
-        IL_0083:  ldstr      "hello"
-        IL_0088:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-        IL_008d:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-        IL_0092:  pop
-        IL_0093:  ldarg.0
-        IL_0094:  ldc.i4.2
-        IL_0095:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
-        .line 8,8 : 18,25 
-        IL_009a:  ldarg.0
-        IL_009b:  ldarg.0
-        IL_009c:  ldfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x
-        IL_00a1:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::current
-        IL_00a6:  ldc.i4.1
-        IL_00a7:  ret
+        IL_006d:  ldarg.0
+        IL_006e:  ldarg.0
+        IL_006f:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
+        IL_0074:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+        IL_0079:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x
+        .line 7,7 : 18,33 ''
+        IL_007e:  ldstr      "hello"
+        IL_0083:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+        IL_0088:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+        IL_008d:  pop
+        IL_008e:  ldarg.0
+        IL_008f:  ldc.i4.2
+        IL_0090:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
+        .line 8,8 : 18,25 ''
+        IL_0095:  ldarg.0
+        IL_0096:  ldarg.0
+        IL_0097:  ldfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x
+        IL_009c:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::current
+        IL_00a1:  ldc.i4.1
+        IL_00a2:  ret
 
-        .line 6,8 : 15,25 
-        IL_00a8:  ldarg.0
-        IL_00a9:  ldc.i4.0
-        IL_00aa:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x
-        .line 100001,100001 : 0,0 
-        IL_00af:  nop
-        IL_00b0:  br.s       IL_0065
+        .line 6,8 : 15,25 ''
+        IL_00a3:  ldarg.0
+        IL_00a4:  ldc.i4.0
+        IL_00a5:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x
+        .line 100001,100001 : 0,0 ''
+        IL_00aa:  nop
+        IL_00ab:  br.s       IL_0060
 
-        IL_00b2:  ldarg.0
-        IL_00b3:  ldc.i4.5
-        IL_00b4:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
-        .line 6,8 : 15,25 
-        IL_00b9:  ldarg.0
-        IL_00ba:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
-        IL_00bf:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-        IL_00c4:  nop
-        IL_00c5:  ldarg.0
-        IL_00c6:  ldnull
-        IL_00c7:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
-        .line 9,11 : 15,25 
-        IL_00cc:  ldarg.0
-        IL_00cd:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6::get_es()
-        IL_00d2:  unbox.any  class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>
-        IL_00d7:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
-        IL_00dc:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
-        IL_00e1:  ldarg.0
-        IL_00e2:  ldc.i4.3
-        IL_00e3:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
-        .line 9,11 : 15,25 
-        IL_00e8:  ldarg.0
-        IL_00e9:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
-        IL_00ee:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-        IL_00f3:  brfalse.s  IL_0135
+        IL_00ad:  ldarg.0
+        IL_00ae:  ldc.i4.5
+        IL_00af:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
+        .line 6,8 : 15,25 ''
+        IL_00b4:  ldarg.0
+        IL_00b5:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
+        IL_00ba:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+        IL_00bf:  nop
+        IL_00c0:  ldarg.0
+        IL_00c1:  ldnull
+        IL_00c2:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
+        .line 9,11 : 15,25 ''
+        IL_00c7:  ldarg.0
+        IL_00c8:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6::get_es()
+        IL_00cd:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
+        IL_00d2:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
+        IL_00d7:  ldarg.0
+        IL_00d8:  ldc.i4.3
+        IL_00d9:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
+        .line 9,11 : 15,25 ''
+        IL_00de:  ldarg.0
+        IL_00df:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
+        IL_00e4:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+        IL_00e9:  brfalse.s  IL_012b
 
-        IL_00f5:  ldarg.0
-        IL_00f6:  ldarg.0
-        IL_00f7:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
-        IL_00fc:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
-        IL_0101:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x0
-        .line 10,10 : 18,35 
-        IL_0106:  ldstr      "goodbye"
-        IL_010b:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-        IL_0110:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-        IL_0115:  pop
-        IL_0116:  ldarg.0
-        IL_0117:  ldc.i4.4
-        IL_0118:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
-        .line 11,11 : 18,25 
-        IL_011d:  ldarg.0
-        IL_011e:  ldarg.0
-        IL_011f:  ldfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x0
-        IL_0124:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::current
-        IL_0129:  ldc.i4.1
-        IL_012a:  ret
+        IL_00eb:  ldarg.0
+        IL_00ec:  ldarg.0
+        IL_00ed:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
+        IL_00f2:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
+        IL_00f7:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x0
+        .line 10,10 : 18,35 ''
+        IL_00fc:  ldstr      "goodbye"
+        IL_0101:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+        IL_0106:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatLine<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [mscorlib]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+        IL_010b:  pop
+        IL_010c:  ldarg.0
+        IL_010d:  ldc.i4.4
+        IL_010e:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
+        .line 11,11 : 18,25 ''
+        IL_0113:  ldarg.0
+        IL_0114:  ldarg.0
+        IL_0115:  ldfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x0
+        IL_011a:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::current
+        IL_011f:  ldc.i4.1
+        IL_0120:  ret
 
-        .line 9,11 : 15,25 
+        .line 9,11 : 15,25 ''
+        IL_0121:  ldarg.0
+        IL_0122:  ldc.i4.0
+        IL_0123:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x0
+        .line 100001,100001 : 0,0 ''
+        IL_0128:  nop
+        IL_0129:  br.s       IL_00de
+
         IL_012b:  ldarg.0
-        IL_012c:  ldc.i4.0
-        IL_012d:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::x0
-        .line 100001,100001 : 0,0 
-        IL_0132:  nop
-        IL_0133:  br.s       IL_00e8
-
-        IL_0135:  ldarg.0
-        IL_0136:  ldc.i4.5
-        IL_0137:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
-        .line 9,11 : 15,25 
-        IL_013c:  ldarg.0
-        IL_013d:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
-        IL_0142:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
-        IL_0147:  nop
-        IL_0148:  ldarg.0
-        IL_0149:  ldnull
-        IL_014a:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
-        IL_014f:  ldarg.0
-        IL_0150:  ldc.i4.5
-        IL_0151:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
-        IL_0156:  ldarg.0
-        IL_0157:  ldc.i4.0
-        IL_0158:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::current
-        IL_015d:  ldc.i4.0
-        IL_015e:  ret
+        IL_012c:  ldc.i4.5
+        IL_012d:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
+        .line 9,11 : 15,25 ''
+        IL_0132:  ldarg.0
+        IL_0133:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
+        IL_0138:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
+        IL_013d:  nop
+        IL_013e:  ldarg.0
+        IL_013f:  ldnull
+        IL_0140:  stfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
+        IL_0145:  ldarg.0
+        IL_0146:  ldc.i4.5
+        IL_0147:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::pc
+        IL_014c:  ldarg.0
+        IL_014d:  ldc.i4.0
+        IL_014e:  stfld      int32 SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::current
+        IL_0153:  ldc.i4.0
+        IL_0154:  ret
       } // end of method f7@6::GenerateNext
 
       .method public strict virtual instance void 
@@ -295,7 +293,7 @@
         .locals init ([0] class [mscorlib]System.Exception V_0,
                  [1] class [FSharp.Core]Microsoft.FSharp.Core.Unit V_1,
                  [2] class [mscorlib]System.Exception e)
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
         IL_0000:  ldnull
         IL_0001:  stloc.0
         IL_0002:  ldarg.0
@@ -306,13 +304,13 @@
                               IL_0015)
         IL_0013:  br.s       IL_001b
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_0015:  nop
         IL_0016:  br         IL_00b2
 
-        .line 100001,100001 : 0,0 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
+        .line 100001,100001 : 0,0 ''
         IL_001b:  nop
         .try
         {
@@ -339,40 +337,40 @@
 
           IL_004b:  br.s       IL_005c
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_004d:  nop
           IL_004e:  br.s       IL_008c
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_0050:  nop
           IL_0051:  br.s       IL_0078
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_0053:  nop
           IL_0054:  br.s       IL_0077
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_0056:  nop
           IL_0057:  br.s       IL_0061
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_0059:  nop
           IL_005a:  br.s       IL_0060
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_005c:  nop
           IL_005d:  br.s       IL_008c
 
-          .line 100001,100001 : 0,0 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
+          .line 100001,100001 : 0,0 ''
           IL_005f:  nop
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
           IL_0060:  nop
           IL_0061:  ldarg.0
           IL_0062:  ldc.i4.5
@@ -381,11 +379,11 @@
           IL_0069:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::enum0
           IL_006e:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
           IL_0073:  nop
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
           IL_0074:  nop
           IL_0075:  br.s       IL_008c
 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
           IL_0077:  nop
           IL_0078:  ldarg.0
           IL_0079:  ldc.i4.5
@@ -394,7 +392,7 @@
           IL_0080:  ldfld      class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6/f7@6::'enum'
           IL_0085:  call       void [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/IntrinsicFunctions::Dispose<class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>>(!!0)
           IL_008a:  nop
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
           IL_008b:  nop
           IL_008c:  ldarg.0
           IL_008d:  ldc.i4.5
@@ -411,18 +409,18 @@
         {
           IL_009e:  castclass  [mscorlib]System.Exception
           IL_00a3:  stloc.2
-          .line 6,8 : 15,25 
+          .line 6,8 : 15,25 ''
           IL_00a4:  ldloc.2
           IL_00a5:  stloc.0
           IL_00a6:  ldnull
           IL_00a7:  stloc.1
           IL_00a8:  leave.s    IL_00aa
 
-          .line 100001,100001 : 0,0 
+          .line 100001,100001 : 0,0 ''
         }  // end handler
         IL_00aa:  ldloc.1
         IL_00ab:  pop
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
         IL_00ac:  nop
         IL_00ad:  br         IL_0002
 
@@ -435,11 +433,11 @@
 
         IL_00ba:  br.s       IL_00be
 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
         IL_00bc:  ldloc.0
         IL_00bd:  throw
 
-        .line 100001,100001 : 0,0 
+        .line 100001,100001 : 0,0 ''
         IL_00be:  ret
       } // end of method f7@6::Close
 
@@ -559,7 +557,7 @@
     {
       // Code size       13 (0xd)
       .maxstack  8
-      .line 6,11 : 9,27 
+      .line 6,11 : 9,27 ''
       IL_0000:  nop
       IL_0001:  ldc.i4.0
       IL_0002:  ldc.i4.0
@@ -601,7 +599,7 @@
     // Code size       43 (0x2b)
     .maxstack  6
     .locals init ([0] class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> es)
-    .line 4,4 : 5,21 
+    .line 4,4 : 5,21 ''
     IL_0000:  nop
     IL_0001:  ldc.i4.1
     IL_0002:  ldc.i4.2
@@ -616,7 +614,7 @@
     IL_0018:  dup
     IL_0019:  stsfld     class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> '<StartupCode$SeqExpressionSteppingTest6>'.$SeqExpressionSteppingTest6::es@4
     IL_001e:  stloc.0
-    .line 13,13 : 13,31 
+    .line 13,13 : 13,31 ''
     IL_001f:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> SeqExpressionSteppingTest6/SeqExpressionSteppingTest6::f7()
     IL_0024:  call       int32 [FSharp.Core]Microsoft.FSharp.Collections.SeqModule::Length<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
     IL_0029:  pop


### PR DESCRIPTION
As commented upon [here](https://github.com/Microsoft/visualfsharp/issues/871#issuecomment-171846149) and manually avoided in #2587 (Such as [this](https://github.com/manofstick/visualfsharp/blob/7c60386c01669f9543b095998a469875da038260/src/fsharp/FSharp.Core/iseq.fs#L105-L110)) this PR removes the IL instruction `unbox.any` from `upcast`s to interface types.

Previously code like:

    let f b : seq<_> =
        if b then upcast [||] else upcast []

Would insert the upcast.any statement into the result of both branches, but from my reading of "III.1.8.1.3 Merging stack states" of ECMA-335 the runtime automatically will merge the stacks to the common subtype. This appears to be borne out in practice.

This PR will simplify the #2587 by removing all the manual Upcast hacks that are done.