### PR TITLE
slightly improve QuickInfo secondary tooltip 

### DIFF
--- a/vsintegration/src/FSharp.Editor/QuickInfo/Navigation.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Navigation.fs
@@ -1,7 +1,8 @@
 ﻿namespace Microsoft.VisualStudio.FSharp.Editor
 
-open Microsoft.CodeAnalysis
 open System
+
+open Microsoft.CodeAnalysis
 
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Navigation.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Navigation.fs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.VisualStudio.FSharp.Editor
 
 open Microsoft.CodeAnalysis
+open System
 
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler
@@ -18,6 +19,11 @@ type internal QuickInfoNavigation
         range <> rangeStartup &&
         range <> thisSymbolUseRange &&
         solution.TryGetDocumentIdFromFSharpRange (range, initialDoc.Project.Id) |> Option.isSome
+
+    member __.RelativePath (range: range) =
+        let targetUri = Uri(range.FileName)
+        Uri(solution.FilePath).MakeRelativeUri(targetUri).ToString()
+        |> Uri.UnescapeDataString
 
     member __.NavigateTo (range: range) = 
         asyncMaybe { 

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
@@ -71,6 +71,13 @@ type internal QuickInfoViewProvider
             navigation.NavigateTo range
             SessionHandling.currentSession |> Option.iter ( fun session -> session.Dismiss() )
 
+        let createTooltip text =
+            let t = ToolTip(Content = text)
+            DependencyObjectExtensions.SetDefaultTextProperties(t, formatMap.Value)
+            let color = Microsoft.VisualStudio.PlatformUI.VSColorTheme.GetThemedColor(Microsoft.VisualStudio.PlatformUI.EnvironmentColors.ToolTipBrushKey)
+            t.Background <- Media.SolidColorBrush(Media.Color.FromRgb(color.R, color.G, color.B))
+            t
+
         let inlines = 
             seq { 
                 for taggedText in content do
@@ -78,7 +85,7 @@ type internal QuickInfoViewProvider
                     let inl =
                         match taggedText with
                         | :? Layout.NavigableTaggedText as nav when navigation.IsTargetValid nav.Range ->                        
-                            let h = Documents.Hyperlink(run, ToolTip = nav.Range.FileName)
+                            let h = Documents.Hyperlink(run, ToolTip = createTooltip nav.Range.FileName)
                             h.Click.Add <| navigateAndDismiss nav.Range
                             h :> Documents.Inline
                         | _ -> run :> _

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
@@ -16,7 +16,6 @@ open Microsoft.VisualStudio.Language.Intellisense
 open Microsoft.VisualStudio.Utilities
 open Microsoft.VisualStudio.PlatformUI
 
-open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler
 
 open Internal.Utilities.StructuredFormat
@@ -113,9 +112,9 @@ type internal QuickInfoViewProvider
         let glyphContent = SymbolGlyphDeferredContent(glyph, glyphService)
         QuickInfoDisplayDeferredContent
             (glyphContent, null, 
-             mainDescription=navigableText description, 
-             documentation=navigableText documentation,
-             typeParameterMap=navigableText typeParameterMap, 
-             anonymousTypes= empty, 
-             usageText=navigableText usage, 
-             exceptionText=navigableText exceptions)
+             mainDescription = navigableText description, 
+             documentation = navigableText documentation,
+             typeParameterMap = navigableText typeParameterMap, 
+             anonymousTypes = empty, 
+             usageText = navigableText usage, 
+             exceptionText = navigableText exceptions)

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
@@ -14,6 +14,7 @@ open Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 
 open Microsoft.VisualStudio.Language.Intellisense
 open Microsoft.VisualStudio.Utilities
+open Microsoft.VisualStudio.PlatformUI
 
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler
@@ -71,10 +72,10 @@ type internal QuickInfoViewProvider
             navigation.NavigateTo range
             SessionHandling.currentSession |> Option.iter ( fun session -> session.Dismiss() )
 
-        let createTooltip text =
-            let t = ToolTip(Content = text)
+        let secondaryToolTip range =
+            let t = ToolTip(Content = navigation.RelativePath range)
             DependencyObjectExtensions.SetDefaultTextProperties(t, formatMap.Value)
-            let color = Microsoft.VisualStudio.PlatformUI.VSColorTheme.GetThemedColor(Microsoft.VisualStudio.PlatformUI.EnvironmentColors.ToolTipBrushKey)
+            let color = VSColorTheme.GetThemedColor(EnvironmentColors.ToolTipBrushKey)
             t.Background <- Media.SolidColorBrush(Media.Color.FromRgb(color.R, color.G, color.B))
             t
 
@@ -85,7 +86,7 @@ type internal QuickInfoViewProvider
                     let inl =
                         match taggedText with
                         | :? Layout.NavigableTaggedText as nav when navigation.IsTargetValid nav.Range ->                        
-                            let h = Documents.Hyperlink(run, ToolTip = createTooltip nav.Range.FileName)
+                            let h = Documents.Hyperlink(run, ToolTip = secondaryToolTip nav.Range)
                             h.Click.Add <| navigateAndDismiss nav.Range
                             h :> Documents.Inline
                         | _ -> run :> _


### PR DESCRIPTION
Secondary tooltip has theme colored background.
Displayed file path is relative to the solution.
![tooltip](https://cloud.githubusercontent.com/assets/1760221/25703306/589ad228-30d5-11e7-841f-2503aaa68818.gif)
