### PR TITLE
re-enable FSharp.Core unit tests 

### DIFF
--- a/build-everything.proj
+++ b/build-everything.proj
@@ -3,8 +3,11 @@
 
   <!-- +++++++++++++++++++++++ Project selection for building +++++++++++++++++++++++++++++++ -->
 
-  <ItemGroup Condition="'$(BUILD_NET40)'=='1'">
+  <ItemGroup Condition="'$(BUILD_NET40_FSHARP_CORE)'=='1'">
     <ProjectsWithNet40 Include="src/fsharp/FSharp.Core/FSharp.Core.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BUILD_NET40)'=='1'">
     <ProjectsWithNet40 Include="src/fsharp/FSharp.Build/FSharp.Build.fsproj" />
     <ProjectsWithNet40 Include="src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj" />
     <ProjectsWithNet40 Include="src/fsharp/FSharp.Compiler.Server.Shared/FSharp.Compiler.Server.Shared.fsproj"/>

--- a/build.cmd
+++ b/build.cmd
@@ -57,6 +57,7 @@ if "%BUILD_PROTO_WITH_CORECLR_LKG%" =="" (set BUILD_PROTO_WITH_CORECLR_LKG=0)
 set BUILD_PROTO=0
 set BUILD_PHASE=1
 set BUILD_NET40=0
+set BUILD_NET40_FSHARP_CORE=0
 set BUILD_CORECLR=0
 set BUILD_PORTABLE=0
 set BUILD_VS=0
@@ -94,10 +95,15 @@ for %%i in (%BUILD_FSC_DEFAULT%) do ( call :PROCESS_ARG %%i )
 REM apply defaults
 
 if /i "%_autoselect%" == "1" (
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_NET40=1
 )
 
 if /i "%_autoselect_tests%" == "1" (
+    if /i "%BUILD_NET40_FSHARP_CORE%" == "1" (
+        set TEST_NET40_COREUNIT_SUITE=1
+    )
+
     if /i "%BUILD_NET40%" == "1" (
         set TEST_NET40_COMPILERUNIT_SUITE=1
         set TEST_NET40_COREUNIT_SUITE=1
@@ -129,8 +135,14 @@ set ARG2=%~2
 if "%ARG%" == "1" if "%2" == "" (set ARG=default)
 if "%2" == "" if not "%ARG%" == "default" goto :EOF
 
+if /i "%ARG%" == "net40-lib" (
+    set _autoselect=0
+    set BUILD_NET40_FSHARP_CORE=1
+)
+
 if /i "%ARG%" == "net40" (
     set _autoselect=0
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_NET40=1
 )
 
@@ -174,6 +186,7 @@ if /i "%ARG%" == "microbuild" (
     set _autoselect=0
     set BUILD_PROTO=1
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_PROTO_WITH_CORECLR_LKG=1
     set BUILD_CORECLR=1
     set BUILD_PORTABLE=1
@@ -203,6 +216,7 @@ if /i "%ARG%" == "ci_part1" (
     REM what we do
     set BUILD_PROTO=1
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_PORTABLE=1
     set BUILD_VS=1
     set BUILD_SETUP=%FSC_BUILD_SETUP%
@@ -216,6 +230,7 @@ if /i "%ARG%" == "ci_part2" (
     REM what we do
     set BUILD_PROTO=1
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
 
     set TEST_NET40_COREUNIT_SUITE=1
     set TEST_NET40_FSHARP_SUITE=1
@@ -241,6 +256,7 @@ if /i "%ARG%" == "ci_part4" (
     REM what we do
     set BUILD_PROTO=1
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_PORTABLE=1
 
     set TEST_NET40_COMPILERUNIT_SUITE=1
@@ -282,6 +298,7 @@ if /i "%ARG%" == "test-all" (
     set BUILD_PROTO=1
     set BUILD_PROTO_WITH_CORECLR_LKG=1
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_CORECLR=1
     set BUILD_PORTABLE=1
     set BUILD_VS=1
@@ -297,47 +314,60 @@ if /i "%ARG%" == "test-all" (
 )
 
 if /i "%ARG%" == "test-net40-fsharpqa" (
+    set _autoselect=0
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_PORTABLE=1
     set TEST_NET40_FSHARPQA_SUITE=1
 )
 
 if /i "%ARG%" == "test-compiler-unit" (
+    set _autoselect=0
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set TEST_NET40_COMPILERUNIT_SUITE=1
 )
 
 if /i "%ARG%" == "test-net40-ideunit" (
+    set _autoselect=0
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_VS=1
     set BUILD_PORTABLE=1
     set TEST_VS_IDEUNIT_SUITE=1
 )
 
 if /i "%ARG%" == "test-net40-coreunit" (
-    set BUILD_NET40=1
+    set _autoselect=0
+    set BUILD_NET40_FSHARP_CORE=1
     set TEST_NET40_COREUNIT_SUITE=1
 )
 
 if /i "%ARG%" == "test-coreclr-coreunit" (
+    set _autoselect=0
     set BUILD_PROTO_WITH_CORECLR_LKG=1
     set BUILD_CORECLR=1
     set TEST_CORECLR_COREUNIT_SUITE=1
 )
 
 if /i "%ARG%" == "test-pcl-coreunit" (
+    set _autoselect=0
     set BUILD_PORTABLE=1
     set TEST_PORTABLE_COREUNIT_SUITE=1
 )
 
 if /i "%ARG%" == "test-net40-fsharp" (
+    set _autoselect=0
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_PORTABLE=1
     set TEST_NET40_FSHARP_SUITE=1
 )
 
 if /i "%ARG%" == "test-coreclr-fsharp" (
+    set _autoselect=0
     set BUILD_NET40=1
+    set BUILD_NET40_FSHARP_CORE=1
     set BUILD_PROTO_WITH_CORECLR_LKG=1
     set BUILD_CORECLR=1
     set TEST_CORECLR_FSHARP_SUITE=1
@@ -370,6 +400,7 @@ echo.
 echo BUILD_PROTO=%BUILD_PROTO%
 echo BUILD_PROTO_WITH_CORECLR_LKG=%BUILD_PROTO_WITH_CORECLR_LKG%
 echo BUILD_NET40=%BUILD_NET40%
+echo BUILD_NET40_FSHARP_CORE=%BUILD_NET40_FSHARP_CORE%
 echo BUILD_CORECLR=%BUILD_CORECLR%
 echo BUILD_PORTABLE=%BUILD_PORTABLE%
 echo BUILD_VS=%BUILD_VS%
@@ -595,7 +626,7 @@ if "%BUILD_PHASE%" == "1" (
 
 echo ---------------- Done with build, starting update/prepare ---------------
 
-if "%BUILD_NET40%" == "1" (
+if "%BUILD_NET40_FSHARP_CORE%" == "1" (
     call src\update.cmd %BUILD_CONFIG% -ngen
 )
 
@@ -646,7 +677,7 @@ echo SNEXE64:           %SNEXE64%
 echo ILDASM:            %ILDASM%
 echo
 
-if "%TEST_NET40_COMPILERUNIT_SUITE%" == "0" if "%TEST_PORTABLE_COREUNIT_SUITE%" == "0" if "%TEST_CORECLR_COREUNIT_SUITE%" == "0" if "%TEST_VS_IDEUNIT_SUITE%" == "0" if "%TEST_NET40_FSHARP_SUITE%" == "0" if "%TEST_NET40_FSHARPQA_SUITE%" == "0" goto :success
+if "%TEST_NET40_COMPILERUNIT_SUITE%" == "0" if "%TEST_NET40_COREUNIT_SUITE%" == "0" if "%TEST_PORTABLE_COREUNIT_SUITE%" == "0" if "%TEST_CORECLR_COREUNIT_SUITE%" == "0" if "%TEST_VS_IDEUNIT_SUITE%" == "0" if "%TEST_NET40_FSHARP_SUITE%" == "0" if "%TEST_NET40_FSHARPQA_SUITE%" == "0" goto :success
 
 echo ---------------- Done with update, starting tests -----------------------
 

--- a/build.sh
+++ b/build.sh
@@ -81,6 +81,7 @@ fi
 
 export BUILD_PROTO=0
 export BUILD_PHASE=1
+export BUILD_NET40_FSHARP_CORE=0
 export BUILD_NET40=0
 export BUILD_CORECLR=0
 export BUILD_PORTABLE=0
@@ -114,6 +115,7 @@ do
         "net40")
             _autoselect=0
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             ;;
         "coreclr")
             _autoselect=0
@@ -127,6 +129,7 @@ do
         "vs")
             _autoselect=0
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_VS=1
             ;;
         "vstest")
@@ -140,6 +143,7 @@ do
             export BUILD_PROTO=1
             export BUILD_PROTO_WITH_CORECLR_LKG=1
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_CORECLR=1
             export BUILD_PORTABLE=1
             export BUILD_VS=1
@@ -150,6 +154,7 @@ do
             _autoselect=0
             export BUILD_PROTO=1
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_PROTO_WITH_CORECLR_LKG=1
             export BUILD_CORECLR=1
             export BUILD_PORTABLE=1
@@ -174,6 +179,7 @@ do
             # what we do
             export BUILD_PROTO=1
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_PORTABLE=1
             export BUILD_VS=1
             export BUILD_SETUP=$FSC_BUILD_SETUP
@@ -189,6 +195,7 @@ do
             export BUILD_PROTO_WITH_CORECLR_LKG=1
             export BUILD_PROTO=1
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_PORTABLE=1
 
             export TEST_NET40_COREUNIT_SUITE=1
@@ -203,6 +210,7 @@ do
             export BUILD_PROTO_WITH_CORECLR_LKG=1
             export BUILD_PROTO=1
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_CORECLR=1
 
             export TEST_CORECLR_FSHARP_SUITE=1
@@ -248,6 +256,7 @@ do
             export BUILD_PROTO=1
             export BUILD_PROTO_WITH_CORECLR_LKG=1
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_CORECLR=1
             export BUILD_PORTABLE=1
             export BUILD_VS=1
@@ -263,15 +272,17 @@ do
             ;;
         "test-net40-fsharpqa")
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_PORTABLE=1
             export TEST_NET40_FSHARPQA_SUITE=1
             ;;
         "test-compiler-unit")
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export TEST_NET40_COMPILERUNIT_SUITE=1
             ;;
         "test-net40-coreunit")
-            export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export TEST_NET40_COREUNIT_SUITE=1
             ;;
         "test-coreclr-coreunit")
@@ -285,11 +296,13 @@ do
             ;;
         "test-net40-fsharp")
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_PORTABLE=1
             export TEST_NET40_FSHARP_SUITE=1
             ;;
         "test-coreclr-fsharp")
             export BUILD_NET40=1
+            export BUILD_NET40_FSHARP_CORE=1
             export BUILD_PROTO_WITH_CORECLR_LKG=1
             export BUILD_CORECLR=1
             export TEST_CORECLR_FSHARP_SUITE=1
@@ -310,6 +323,7 @@ done
 # Apply defaults, if necessary.
 if [ $_autoselect -eq 1 ]; then
     export BUILD_NET40=1
+    export BUILD_NET40_FSHARP_CORE=1
 fi
 
 if [ $_autoselect_tests -eq 1 ]; then
@@ -322,6 +336,7 @@ if [ $_autoselect_tests -eq 1 ]; then
 
     if [ $BUILD_CORECLR -eq 1 ]; then
         export BUILD_NET40=1
+        export BUILD_NET40_FSHARP_CORE=1
         export TEST_CORECLR_FSHARP_SUITE=1
         export TEST_CORECLR_COREUNIT_SUITE=1
     fi
@@ -344,6 +359,7 @@ printf "\n"
 printf "BUILD_PROTO=%s\n" "$BUILD_PROTO"
 printf "BUILD_PROTO_WITH_CORECLR_LKG=%s\n" "$BUILD_PROTO_WITH_CORECLR_LKG"
 printf "BUILD_NET40=%s\n" "$BUILD_NET40"
+printf "BUILD_NET40_FSHARP_CORE=%s\n" "$BUILD_NET40_FSHARP_CORE"
 printf "BUILD_CORECLR=%s\n" "$BUILD_CORECLR"
 printf "BUILD_PORTABLE=%s\n" "$BUILD_PORTABLE"
 printf "BUILD_VS=%s\n" "$BUILD_VS"

--- a/mono/build.bat
+++ b/mono/build.bat
@@ -21,6 +21,7 @@ if not exist %_ngenexe% echo Note: Could not find ngen.exe.
 %_ngenexe% install packages\FSharp.Compiler.Tools.4.0.1.21\tools\fsc.exe
 
 set BUILD_NET40=1
+set BUILD_NET40_FSHARP_CORE=1
 set BUILD_PORTABLE=1
 set TEST_NET40_COREUNIT_SUITE=1
 set TEST_PORTABLE_COREUNIT_SUITE=1

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -36,6 +36,15 @@
                 <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
               </PropertyGroup>
             </When>
+            <!-- Some unit test assemblies must not have strong names since they reference other assemblies that don't have strong names -->
+            <!-- These unit test assemblies can't use InternalsVisibleTo into assemblies with strong names. -->
+            <When Condition="'$(StrongNames)' == 'false'" >
+              <PropertyGroup>
+                <DefineConstants>NO_STRONG_NAMES;$(DefineConstants)</DefineConstants>
+                <MicroBuildAssemblyVersion>$(FSCoreVersion)</MicroBuildAssemblyVersion>
+                <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
+              </PropertyGroup>
+            </When>
             <!-- In the Microsoft build we just delay-sign everything with the MSFT key -->
             <!-- We have to do unit test DLLs well because they can see the internals of other strong-named DLLs -->
             <Otherwise>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -26,21 +26,20 @@
       <Choose>
         <When Condition="'$(ProjectLanguage)' == 'FSharp'">
           <Choose>
+            <!-- Some unit test assemblies must not have strong names since they reference other assemblies that don't have strong names -->
+            <!-- These unit test assemblies can't use InternalsVisibleTo into assemblies with strong names. -->
+            <When Condition="'$(StrongNames)' == 'false'" >
+              <PropertyGroup>
+                <SkipSigning>true</SkipSigning>
+                <UseOpenSourceSign>false</UseOpenSourceSign>
+              </PropertyGroup>
+            </When>
             <!-- In the open source "Mono" build we always fully sign the binaries with the public test.snk, apart from FSharp.Core, which gets the MSFT key -->
             <When Condition="'$(MonoPackaging)' == 'true' AND '$(AssemblyName)'!='FSharp.Core'" >
               <PropertyGroup>
                 <OtherFlags>$(OtherFlags) --keyfile:"$(FSharpSourcesRoot)\fsharp\test.snk"</OtherFlags>
                 <DefineConstants>STRONG_NAME_FSHARP_COMPILER_WITH_TEST_KEY;$(DefineConstants)</DefineConstants>
                 <StrongNames>true</StrongNames>
-                <MicroBuildAssemblyVersion>$(FSCoreVersion)</MicroBuildAssemblyVersion>
-                <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
-              </PropertyGroup>
-            </When>
-            <!-- Some unit test assemblies must not have strong names since they reference other assemblies that don't have strong names -->
-            <!-- These unit test assemblies can't use InternalsVisibleTo into assemblies with strong names. -->
-            <When Condition="'$(StrongNames)' == 'false'" >
-              <PropertyGroup>
-                <DefineConstants>NO_STRONG_NAMES;$(DefineConstants)</DefineConstants>
                 <MicroBuildAssemblyVersion>$(FSCoreVersion)</MicroBuildAssemblyVersion>
                 <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
               </PropertyGroup>
@@ -79,7 +78,6 @@
     <Otherwise>
       <PropertyGroup Condition="'$(StrongNames)' != 'true'">
         <!-- For the proto build we don't use strong names. -->
-        <DefineConstants>NO_STRONG_NAMES;$(DefineConstants)</DefineConstants>
         <MicroBuildAssemblyVersion>$(FSCoreVersion)</MicroBuildAssemblyVersion>
         <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
       </PropertyGroup>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -32,6 +32,8 @@
               <PropertyGroup>
                 <SkipSigning>true</SkipSigning>
                 <UseOpenSourceSign>false</UseOpenSourceSign>
+                <MicroBuildAssemblyVersion>$(FSCoreVersion)</MicroBuildAssemblyVersion>
+                <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
               </PropertyGroup>
             </When>
             <!-- In the open source "Mono" build we always fully sign the binaries with the public test.snk, apart from FSharp.Core, which gets the MSFT key -->
@@ -78,6 +80,7 @@
     <Otherwise>
       <PropertyGroup Condition="'$(StrongNames)' != 'true'">
         <!-- For the proto build we don't use strong names. -->
+        <DefineConstants>NO_STRONG_NAMES;$(DefineConstants)</DefineConstants>
         <MicroBuildAssemblyVersion>$(FSCoreVersion)</MicroBuildAssemblyVersion>
         <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
       </PropertyGroup>

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
@@ -15,6 +15,7 @@
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <ReferenceVsAssemblies>true</ReferenceVsAssemblies>
     <OutputType>Library</OutputType>
+    <StrongNames>false</StrongNames>
     <AssemblyName>FSharp.Core.Unittests</AssemblyName>
     <!-- Prevent compiler from inlining calls to FSharp.Core to improve code coverage accuracy -->
     <Optimize>false</Optimize>

--- a/src/fsharp/FSharp.Core.Unittests/StructTuples.fs
+++ b/src/fsharp/FSharp.Core.Unittests/StructTuples.fs
@@ -141,3 +141,4 @@ type StructTuplesCSharpInterop() =
         Assert.IsTrue( (one=1) && (two=2) && (three=3) && (four=4) && (five = 5) && (six=6) && (seven=7) && (eight=8) && (nine=9) && (ten=10) && (eleven=11) && (twelve=12) && (thirteen=13) && (fourteen=14) && (fifteen=15) && (sixteen=16) )
         ()
 #endif
+

--- a/src/fsharp/FSharp.Core/array2.fsi
+++ b/src/fsharp/FSharp.Core/array2.fsi
@@ -226,3 +226,4 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Get")>]
         val get: array:'T[,] -> index1:int -> index2:int -> 'T
 
+


### PR DESCRIPTION
FSharp.Core.Unittests were not running correctly ("invalid tests") because one of the FCS changes had turned on strong names for that assembly

Relevant new comment:

            <!-- Some unit test assemblies must not have strong names since they reference other assemblies that don't have strong names -->
            <!-- These unit test assemblies can't use InternalsVisibleTo into assemblies with strong names. -->

https://github.com/Microsoft/visualfsharp/compare/master...dsyme:fixtests1?expand=1#diff-fedb0bcf69880ee867fb43bae64ca6f8R18

For some reason the CI didn't register an overall failure when all the tests in the DLL were invalid