### PR TITLE
use default package colors to avoid perf hit

### DIFF
--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -170,6 +170,7 @@
 [$RootKey$\Languages\Language Services\FSharpInteractive]
 "Package"="{91a04a73-4f2c-4e7c-ad38-c1a68e7da05c}"
 "NotALanguage"="1"
+"RequestStockColors"=dword:00000001
 @="{35a5e6b8-4012-41fc-a652-2cdc56d74e9f}"
 
 [$RootKey$\FontAndColors\FSharpInteractive]

--- a/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/Common/LanguageService.fs
@@ -208,6 +208,7 @@ type
                              DefaultToInsertSpaces = true,
                              CodeSense = true,
                              DefaultToNonHotURLs = true,
+                             RequestStockColors = true,
                              EnableCommenting = true,
                              CodeSenseDelay = 100,
                              ShowDropDownOptions = true)>]


### PR DESCRIPTION
This change has already been included in a servicing patch and is here now so it can flow to other releases.