### PR TITLE
Intellisense should not commit completion when user type name of property in Record definition

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -53,7 +53,7 @@ type internal FSharpCompletionProvider
     let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(xmlMemberIndexService, serviceProvider.DTE)
     
     static let noCommitOnSpaceRules = 
-        CompletionItemRules.Default.WithCommitCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, ' ', '.', '<', '>', '(', ')', '!'))
+        CompletionItemRules.Default.WithCommitCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, ' ', '.', '<', '>', '(', ')', '!', ':'))
     
     static let getRules() = if Settings.IntelliSense.ShowAfterCharIsTyped then noCommitOnSpaceRules else CompletionItemRules.Default
 


### PR DESCRIPTION
Intellisense should not commit completion when user type name of property in Record definition and press `:`

### Sample:
```fsharp
type MyRecord = {name:string;  mode:int}
```

### Incorrect behavior:
![intel](https://cloud.githubusercontent.com/assets/1197905/26028957/dd71bfc0-3832-11e7-9809-982a07b913de.gif)

P.S. Thank you @vasily-kirichenko for pointing me to the right place where code should be changed.