### PR TITLE
Show field types in tooltips

### DIFF
--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -1069,7 +1069,7 @@ module internal SymbolHelpers =
                 SepL.dot ^^
                 wordL (tagField finfo.FieldName) ^^
                 RightL.colon ^^
-                NicePrint.layoutTyconRef denv (tcrefOfAppTy g finfo.EnclosingType) ^^
+                NicePrint.layoutType denv (finfo.FieldType(amap, m)) ^^
                 (
                     match finfo.LiteralValue with
                     | None -> emptyL

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -1068,6 +1068,8 @@ module internal SymbolHelpers =
                 NicePrint.layoutILTypeRef denv finfo.ILTypeRef ^^
                 SepL.dot ^^
                 wordL (tagField finfo.FieldName) ^^
+                RightL.colon ^^
+                NicePrint.layoutTyconRef denv (tcrefOfAppTy g finfo.EnclosingType) ^^
                 (
                     match finfo.LiteralValue with
                     | None -> emptyL


### PR DESCRIPTION
Fixes #3058 

![field](https://cloud.githubusercontent.com/assets/1186411/26137119/2dd1cc2e-3afb-11e7-9c3c-690564d9f356.png)
