### PR TITLE
multiproc build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -527,8 +527,8 @@ if defined TF_BUILD (
     git fetch --all
 )
 
-REM set msbuildflags=/maxcpucount %_nrswitch% /nologo
-set msbuildflags=%_nrswitch% /nologo
+set msbuildflags=/maxcpucount %_nrswitch% /nologo
+REM set msbuildflags=%_nrswitch% /nologo
 set _ngenexe="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ngen.exe"
 if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure
 


### PR DESCRIPTION
Is there any reason that ``build.cmd`` doesn't do a multiproc build?  (When building from VS it is already multiproc)