### PR TITLE
Deploy debug instances to "RoslynDev" instead of "FSharpDev" hive?

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -111,7 +111,7 @@ Note: if you face this error [#2351](https://github.com/Microsoft/visualfsharp/i
 
 Or hard crash on launch ("Unknown Error"), delete these folders:
 
-* `%localappdata%\Microsoft\VisualStudio\15.0_(some number here)FSharpDev`
+* `%localappdata%\Microsoft\VisualStudio\15.0_(some number here)RoslynDev`
 * `%localappdata%\Microsoft\VisualStudio\15.0_(some number here)`
 
 #### [Optional] Install the Visual F# IDE Tools  (Windows Only)
@@ -138,9 +138,14 @@ Restart Visual Studio, it should now be running your freshly-built Visual F# IDE
 
 #### [Optional] F5 testing of local changes
 
-To test your changes locally _without_ overwriting your default installed F# tools, set the `VisualFSharp\Vsix\VisualFSharpOpenSource`
-project as the startup project.  When you hit F5 a new instance of Visual Studio will be started in the `FSharpDev` hive with your
-changes, but the root (default) hive will remain untouched.
+To test your changes locally _without_ overwriting your default installed Visual F# tools, set the `VisualFSharp\Vsix\VisualFSharpOpenSource`
+project as the startup project.  When you hit F5 a new instance of Visual Studio will be started in the `RoslynDev` hive with your
+changes, but the root (default) hive will remain untouched. You can also start this hive automatically using
+
+    devenv.exe /rootsuffix:RoslynDev
+    
+Because this uses the "RoslynDev" hive you can simultaneously test changes to an appropriate build of Roslyn binaries.
+
 
 #### [Optional] Rapid deployment of incremental changes to Visual F# IDE Tools components
 

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -43,7 +43,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <VSRootSuffix>FSharpDev</VSRootSuffix>
+    <VSRootSuffix>RoslynDev</VSRootSuffix>
     <UseCodebase>true</UseCodebase>
     <DeployExtension Condition=" '$(DeployExtension)' == '' and ('$(AppVeyor)' != '' or '$(HUDSON_COOKIE)' != '' or '$(UsingMicrobuild)' != '') ">False</DeployExtension>
     <DeployExtension Condition=" '$(DeployExtension)' == '' and '$(AppVeyor)' == '' and '$(HUDSON_COOKIE)' == '' and '$(UsingMicrobuild)' == '' ">True</DeployExtension>

--- a/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
+++ b/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
@@ -43,7 +43,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <VSRootSuffix>FSharpDev</VSRootSuffix>
+    <VSRootSuffix>RoslynDev</VSRootSuffix>
     <UseCodebase>true</UseCodebase>
     <DeployExtension Condition=" '$(DeployExtension)' == '' and ('$(AppVeyor)' != '' or '$(HUDSON_COOKIE)' != '' or '$(UsingMicrobuild)' != '') ">False</DeployExtension>
     <DeployExtension Condition=" '$(DeployExtension)' == '' and '$(AppVeyor)' == '' and '$(HUDSON_COOKIE)' == '' and '$(UsingMicrobuild)' == '' ">True</DeployExtension>


### PR DESCRIPTION
I'm hitting a situation where I need to co-develop a build of Roslyn with F#.

I suggest we just always deploy the F# experimental bits to the "RoslynDev" hive all the time to enable this scenario without even thinking about it.  THis can also make it easier to debug Roslyn source code (you don't need to use Microsoft Symbol Servers - which can be slow - and can just use a local build of Roslyn instead - and can use debug bits)

I don't see any specific downside to doing things this way
