### PR TITLE
Fix #669. 

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -12306,6 +12306,11 @@ module IncrClassChecking =
         member localRep.IsValWithRepresentation (v:Val) = 
                 localRep.ValsWithRepresentation.Contains(v) 
 
+        member localRep.IsValRepresentedAsLocalVar  (v:Val) =
+            match localRep.LookupRepr v with 
+            | InVar false -> true
+            | _ -> false
+
         /// Make the elaborated expression that represents a use of a 
         /// a "let v = ..." class binding
         member localRep.MakeValueLookup thisValOpt tinst safeStaticInitInfo v tyargs m =
@@ -12744,14 +12749,14 @@ module IncrClassChecking =
                 //    (c) rely on the fact that there are no 'let' bindings prior to the inherits expr.
                 let inheritsExpr = 
                     match ctorInfo.InstanceCtorSafeThisValOpt with 
-                    | None -> 
-                        inheritsExpr
-                    | Some v -> 
+                    | Some v when not (reps.IsValRepresentedAsLocalVar (v)) -> 
                         // Rewrite the expression to convert it to a load of a field if needed.
                         // We are allowed to load fields from our own object even though we haven't called
                         // the super class constructor yet.
                         let ldexpr = reps.FixupIncrClassExprPhase2C (Some(thisVal)) safeStaticInitInfo thisTyInst (exprForVal m v) 
                         mkInvisibleLet m v ldexpr inheritsExpr
+                    | _ -> 
+                        inheritsExpr
 
                 let spAtSuperInit = (if inheritsIsVisible then SequencePointsAtSeq else SuppressSequencePointOnExprOfSequential)
                 mkSequential spAtSuperInit m inheritsExpr ctorBody

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/ObjectConstructors/ImplicitCtorsCallingBaseclassPassingSelf.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/ObjectConstructors/ImplicitCtorsCallingBaseclassPassingSelf.fs
@@ -1,0 +1,62 @@
+﻿// #Regression #Conformance #DeclarationElements #ObjectConstructors
+
+// verify passing self to base class constructors works, see https://github.com/Microsoft/visualfsharp/issues/669
+
+open System
+
+type Parent(o:obj) = class end
+
+type Parent<'t>(t:'t) = 
+    member val T = t
+
+// this used to not work, causing NullReferenceException
+module Implicit = 
+
+    // Instantiating this type should throw InvalidOperationException.
+    type Broken() as bself = 
+        inherit Parent(bself)
+
+    // this should work.
+    type Ok() as self = 
+        inherit Parent<unit->Ok>(fun () -> self)
+
+module Explicit =
+
+    // should throw InvalidOperationException.
+    type Broken = 
+        inherit Parent
+        new() as gself = { inherit Parent(gself) }
+
+    // this should work.
+    type Ok = 
+        inherit Parent<unit->Ok>
+        new() as self = { inherit Parent<unit->Ok>(fun () -> self) }
+
+    
+let case1() = 
+  try
+    let r = Implicit.Broken()
+    false
+  with 
+    | :? InvalidOperationException -> true 
+    | _ -> false
+  
+let case2() = 
+  try
+    let r = Explicit.Broken()
+    false
+  with 
+    | :? InvalidOperationException -> true 
+    | _ -> false
+
+let case3() = 
+  let r = Implicit.Ok().T()
+  true
+  
+let case4() =
+  let r = Explicit.Ok().T()
+  true
+
+let results = [ case1(); case2(); case3(); case4()]
+
+do if not (List.forall id results) then exit 1 else exit 0

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/ObjectConstructors/env.lst
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/ObjectConstructors/env.lst
@@ -13,7 +13,9 @@
 
 	SOURCE=AlternateGenericTypeSyntax01.fs		# AlternateGenericTypeSyntax01.fs
 	SOURCE=MutuallyRecursive01.fs			# MutuallyRecursive01.fs
+	SOURCE=ImplicitCtorsCallingBaseclassPassingSelf.fs # ImplicitCtorsCallingBaseclassPassingSelf.fs
 
 	SOURCE=ExplicitCtors01.fs			# ExplicitCtors01.fs
 	SOURCE=WarningforLessGenericthanIndicated.fs	# WarningforLessGenericthanIndicated.fs
 	SOURCE=E_ExtraneousFields01.fs   SCFLAGS="--test:ErrorRanges"	# E_ExtraneousFields01.fs
+


### PR DESCRIPTION
Don't introduce another let to ref for base calls if ref is represented as a local var.

Fixes #669.