### PR TITLE
Color F# exceptions as ref types / fix coloring of backticked enum fields

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1231,6 +1231,8 @@ type TypeCheckInfo
                 if minfos |> List.exists (fun minfo -> isStructTy g minfo.EnclosingType) then
                     Some (m, SemanticClassificationType.ValueType)
                 else Some (m, SemanticClassificationType.ReferenceType)
+            | CNR(_, Item.ExnCase _, LegitTypeOccurence, _, _, _, m) ->
+                Some (m, SemanticClassificationType.ReferenceType)
             | CNR(_, Item.ModuleOrNamespaces refs, LegitTypeOccurence, _, _, _, m) when refs |> List.exists (fun x -> x.IsModule) ->
                 Some (m, SemanticClassificationType.Module)
             | CNR(_, (Item.ActivePatternCase _ | Item.UnionCase _ | Item.ActivePatternResult _), _, _, _, _, m) ->

--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -610,9 +610,15 @@ module internal Tokenizer =
     /// Fix invalid span if it appears to have redundant suffix and prefix.
     let fixupSpan (sourceText: SourceText, span: TextSpan) : TextSpan =
         let text = sourceText.GetSubText(span).ToString()
-        match text.LastIndexOf '.' with
-        | -1 | 0 -> span
-        | index -> TextSpan(span.Start + index + 1, text.Length - index - 1)
+        // backticked ident
+        if text.EndsWith "``" then
+            match text.[..text.Length - 3].LastIndexOf "``" with
+            | -1 | 0 -> span
+            | index -> TextSpan(span.Start + index, text.Length - index)
+        else 
+            match text.LastIndexOf '.' with
+            | -1 | 0 -> span
+            | index -> TextSpan(span.Start + index + 1, text.Length - index - 1)
 
     let isValidNameForSymbol (lexerSymbolKind: LexerSymbolKind, symbol: FSharpSymbol, name: string) : bool =
         let doubleBackTickDelimiter = "``"


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/873919/26321395/51e7ebf6-3f2f-11e7-8a6c-c55b4a955ebb.png)
