### PR TITLE
Build stability --- remove maxcpucount from msbuild switches

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -527,7 +527,7 @@ if defined TF_BUILD (
     git fetch --all
 )
 
-set msbuildflags=/maxcpucount %_nrswitch% /nologo
+set msbuildflags=%_nrswitch% /nologo
 REM set msbuildflags=%_nrswitch% /nologo
 set _ngenexe="%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ngen.exe"
 if not exist %_ngenexe% echo Error: Could not find ngen.exe. && goto :failure


### PR DESCRIPTION
Build has been quite unstable, locally and on the CI for a few days.

trying to revert the maxcpu change.