### PR TITLE
Add FindEntityByPath to FSharpAssemblySignature

### DIFF
--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2147,6 +2147,18 @@ and FSharpAssemblySignature private (cenv, topAttribs: TypeChecker.TopAttribs op
             tA.assemblyAttrs
             |> List.map (fun a -> FSharpAttribute(cenv,  AttribInfo.FSAttribInfo(cenv.g, a))) |> makeReadOnlyCollection
 
+    member __.FindEntityByPath path =
+        let inline findNested name = function
+            | Some (e : Entity) when e.IsModuleOrNamespace ->
+                e.ModuleOrNamespaceType.AllEntitiesByCompiledAndLogicalMangledNames.TryFind name
+            | _ -> None
+
+        match path with
+        | hd :: tl ->
+             List.fold (fun a x -> findNested x a) (mtyp.AllEntitiesByCompiledAndLogicalMangledNames.TryFind hd) tl
+             |> Option.map (fun e -> FSharpEntity(cenv, rescopeEntity optViewedCcu e))
+        | _ -> None
+
     override x.ToString() = "<assembly signature>"
 
 and FSharpAssembly internal (cenv, ccu: CcuThunk) = 

--- a/src/fsharp/symbols/Symbols.fsi
+++ b/src/fsharp/symbols/Symbols.fsi
@@ -151,7 +151,10 @@ and [<Class>] internal FSharpAssemblySignature =
 
     /// Get the declared attributes for the assembly.
     /// Only available when parsing an entire project. 
-    member Attributes: IList<FSharpAttribute>     
+    member Attributes: IList<FSharpAttribute>
+
+    /// Find entity using compiled names
+    member FindEntityByPath: string list -> FSharpEntity option
 
 
 /// A subtype of FSharpSymbol that represents a type definition or module as seen by the F# language


### PR DESCRIPTION
I'm trying to get entities using their compiled paths.
Entities hidden by signature files cannot be found using this approach, any advice how get them properly?