### PR TITLE
fix span bug #3180

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
@@ -45,8 +45,11 @@ type internal FSharpColorizationService
                 let colorizationData = checkResults.GetSemanticClassification (Some targetRange) |> Array.distinctBy fst
                 
                 for (range, classificationType) in colorizationData do
-                    let span = Tokenizer.fixupSpan(sourceText, RoslynHelpers.FSharpRangeToTextSpan(sourceText, range))
-                    result.Add(ClassifiedSpan(span, FSharpClassificationTypes.getClassificationTypeName(classificationType)))
+                    match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, range) with
+                    | None -> ()
+                    | Some span -> 
+                        let span = Tokenizer.fixupSpan(sourceText, span)
+                        result.Add(ClassifiedSpan(span, FSharpClassificationTypes.getClassificationTypeName(classificationType)))
             } 
             |> Async.Ignore |> RoslynHelpers.StartAsyncUnitAsTask cancellationToken
 

--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -21,8 +21,8 @@ module internal RoslynHelpers =
 
     let FSharpRangeToTextSpan(sourceText: SourceText, range: range) =
         // Roslyn TextLineCollection is zero-based, F# range lines are one-based
-        let startPosition = sourceText.Lines.[range.StartLine - 1].Start + range.StartColumn
-        let endPosition = sourceText.Lines.[range.EndLine - 1].Start + range.EndColumn
+        let startPosition = sourceText.Lines.[max 0 (range.StartLine - 1)].Start + range.StartColumn
+        let endPosition = sourceText.Lines.[min (range.EndLine - 1) (sourceText.Lines.Count - 1)].Start + range.EndColumn
         TextSpan(startPosition, endPosition - startPosition)
 
     let TryFSharpRangeToTextSpan(sourceText: SourceText, range: range) : TextSpan option =

--- a/vsintegration/src/FSharp.Editor/Debugging/BreakpointResolutionService.fs
+++ b/vsintegration/src/FSharp.Editor/Debugging/BreakpointResolutionService.fs
@@ -52,7 +52,8 @@ type internal FSharpBreakpointResolutionService
                 let! options = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)
                 let! range = FSharpBreakpointResolutionService.GetBreakpointLocation(checkerProvider.Checker, sourceText, document.Name, textSpan, options)
-                return BreakpointResolutionResult.CreateSpanResult(document, RoslynHelpers.FSharpRangeToTextSpan(sourceText, range))
+                let! span = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, range)
+                return BreakpointResolutionResult.CreateSpanResult(document, span)
             } 
             |> Async.map Option.toObj 
             |> RoslynHelpers.StartAsyncAsTask cancellationToken

--- a/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
@@ -64,8 +64,11 @@ type internal FSharpDocumentHighlightsService [<ImportingConstructor>] (checkerP
             let! symbolUses = checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol) |> liftAsync
             return 
                 [| for symbolUse in symbolUses do
-                     yield { IsDefinition = symbolUse.IsFromDefinition
-                             TextSpan = RoslynHelpers.FSharpRangeToTextSpan(sourceText, symbolUse.RangeAlternate) } |]
+                     match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, symbolUse.RangeAlternate) with 
+                     | None -> ()
+                     | Some span -> 
+                         yield { IsDefinition = symbolUse.IsFromDefinition
+                                 TextSpan = span } |]
                 |> fixInvalidSymbolSpans sourceText symbol.Ident.idText
         }
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -95,9 +95,12 @@ module internal SymbolHelpers =
                             let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
                             let mutable sourceText = sourceText
                             for symbolUse in symbolUses do
-                                let textSpan = Tokenizer.fixupSpan(sourceText, RoslynHelpers.FSharpRangeToTextSpan(sourceText, symbolUse.RangeAlternate))
-                                sourceText <- sourceText.Replace(textSpan, newText)
-                                solution <- solution.WithDocumentText(documentId, sourceText)
+                                match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, symbolUse.RangeAlternate) with 
+                                | None -> ()
+                                | Some span -> 
+                                    let textSpan = Tokenizer.fixupSpan(sourceText, span)
+                                    sourceText <- sourceText.Replace(textSpan, newText)
+                                    solution <- solution.WithDocumentText(documentId, sourceText)
                         return solution
                     } |> RoslynHelpers.StartAsyncAsTask cancellationToken),
                originalText

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinitionService.fs
@@ -49,8 +49,9 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: Project
                 let refDocument = document.Project.Solution.GetDocument refDocumentId
                 let! cancellationToken = Async.CancellationToken
                 let! refSourceText = refDocument.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                let refTextSpan = RoslynHelpers.FSharpRangeToTextSpan (refSourceText, range)
-                return Some (FSharpNavigableItem (refDocument, refTextSpan))
+                match RoslynHelpers.TryFSharpRangeToTextSpan (refSourceText, range) with 
+                | None -> return None
+                | Some refTextSpan -> return Some (FSharpNavigableItem (refDocument, refTextSpan))
             else return None
         }
 
@@ -59,7 +60,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: Project
         asyncMaybe {
             let! projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject originDocument
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing (originDocument.FilePath, projectOptions.OtherOptions |> Seq.toList)
-            let originTextSpan = RoslynHelpers.FSharpRangeToTextSpan (sourceText, originRange)
+            let! originTextSpan = RoslynHelpers.TryFSharpRangeToTextSpan (sourceText, originRange)
             let position = originTextSpan.Start
             let! lexerSymbol = Tokenizer.getSymbolAtPosition (originDocument.Id, sourceText, position, originDocument.FilePath, defines, SymbolLookupKind.Greedy, false)
             
@@ -83,7 +84,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: Project
                 let! _, _, checkFileResults = checker.ParseAndCheckDocument (implDoc, projectOptions, allowStaleResults=true, sourceText=implSourceText, userOpName = userOpName)
                 let! symbolUses = checkFileResults.GetUsesOfSymbolInFile symbol |> liftAsync
                 let! implSymbol  = symbolUses |> Array.tryHead 
-                let implTextSpan = RoslynHelpers.FSharpRangeToTextSpan (implSourceText, implSymbol.RangeAlternate)
+                let! implTextSpan = RoslynHelpers.TryFSharpRangeToTextSpan (implSourceText, implSymbol.RangeAlternate)
                 return FSharpNavigableItem (implDoc, implTextSpan)
             else
                 let! targetDocument = originDocument.Project.Solution.TryGetDocumentFromFSharpRange fsSymbolUse.RangeAlternate
@@ -241,7 +242,7 @@ type internal FSharpGoToDefinitionService
                         let! targetRange = 
                             gotoDefinition.FindSymbolDeclarationInFile(targetSymbolUse, implFilePath, implSourceText.ToString(), projectOptions, implVersion.GetHashCode())
 
-                        let implTextSpan = RoslynHelpers.FSharpRangeToTextSpan (implSourceText, targetRange)
+                        let! implTextSpan = RoslynHelpers.TryFSharpRangeToTextSpan (implSourceText, targetRange)
                         let navItem = FSharpNavigableItem (implDocument, implTextSpan)
                         return navItem
                     else // jump from implementation to the corresponding signature
@@ -250,7 +251,7 @@ type internal FSharpGoToDefinitionService
                         | FSharpFindDeclResult.DeclFound targetRange -> 
                             let! sigDocument = originDocument.Project.Solution.TryGetDocumentFromPath targetRange.FileName
                             let! sigSourceText = sigDocument.GetTextAsync () |> liftTaskAsync
-                            let sigTextSpan = RoslynHelpers.FSharpRangeToTextSpan (sigSourceText, targetRange)
+                            let! sigTextSpan = RoslynHelpers.TryFSharpRangeToTextSpan (sigSourceText, targetRange)
                             let navItem = FSharpNavigableItem (sigDocument, sigTextSpan)
                             return navItem
                         | _ -> return! None
@@ -260,7 +261,7 @@ type internal FSharpGoToDefinitionService
                 else
                     let! sigDocument = originDocument.Project.Solution.TryGetDocumentFromPath targetRange.FileName
                     let! sigSourceText = sigDocument.GetTextAsync () |> liftTaskAsync
-                    let sigTextSpan = RoslynHelpers.FSharpRangeToTextSpan (sigSourceText, targetRange)
+                    let! sigTextSpan = RoslynHelpers.TryFSharpRangeToTextSpan (sigSourceText, targetRange)
                     // if the gotodef call originated from a signature and the returned target is a signature, navigate there
                     if isSignatureFile targetRange.FileName && preferSignature then 
                         let navItem = FSharpNavigableItem (sigDocument, sigTextSpan)
@@ -280,7 +281,7 @@ type internal FSharpGoToDefinitionService
                         let! targetRange = 
                             gotoDefinition.FindSymbolDeclarationInFile(targetSymbolUse, implFilePath, implSourceText.ToString(), projectOptions, implVersion.GetHashCode())                               
                         
-                        let implTextSpan = RoslynHelpers.FSharpRangeToTextSpan (implSourceText, targetRange)
+                        let! implTextSpan = RoslynHelpers.TryFSharpRangeToTextSpan (implSourceText, targetRange)
                         let navItem = FSharpNavigableItem (implDocument, implTextSpan)
                         return navItem
                 | _ -> return! None

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
@@ -196,11 +196,13 @@ type internal FSharpNavigateToSearchService
                 match parseResults.ParseTree |> Option.map NavigateTo.getNavigableItems with
                 | Some items ->
                     [| for item in items do
-                         let sourceSpan = RoslynHelpers.FSharpRangeToTextSpan(sourceText, item.Range)
-                         let glyph = Utils.navigateToItemKindToGlyph item.Kind
-                         let kind = Utils.navigateToItemKindToRoslynKind item.Kind
-                         let additionalInfo = Utils.containerToString item.Container document.Project
-                         yield NavigableItem(document, sourceSpan, glyph, item.Name, kind, additionalInfo) |]
+                         match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, item.Range) with 
+                         | None -> ()
+                         | Some sourceSpan ->
+                             let glyph = Utils.navigateToItemKindToGlyph item.Kind
+                             let kind = Utils.navigateToItemKindToRoslynKind item.Kind
+                             let additionalInfo = Utils.containerToString item.Container document.Project
+                             yield NavigableItem(document, sourceSpan, glyph, item.Name, kind, additionalInfo) |]
                 | None -> [||]
         }
 


### PR DESCRIPTION
This is a stabilization fix to ensure that problems with spans are not catastrophic

See https://github.com/Microsoft/visualfsharp/issues/3180

The technique is simply to use the "Try" version of the FSharpRangeToTextSpan function everywhere, and to make FSharpRangeToTextSpan itself fail less often, trimming to the range of the document

