### PR TITLE
Add fsharp.core build to proto

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -564,8 +564,8 @@ if "%BUILD_PROTO%" == "1" (
     pushd .\lkg\fsc & %_dotnetexe% publish project.json --no-build -o %~dp0Tools\lkg -r !_architecture! & popd & if ERRORLEVEL 1 echo Error: dotnet publish failed  & goto :failure
     pushd .\lkg\fsi & %_dotnetexe% publish project.json --no-build -o %~dp0Tools\lkg -r !_architecture! & popd & if ERRORLEVEL 1 echo Error: dotnet publish failed  & goto :failure
 
-    echo %_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj
-         %_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj
+    echo %_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj /p:BUILD_PROTO_WITH_CORECLR_LKG=%BUILD_PROTO_WITH_CORECLR_LKG% /p:Configuration=Proto
+         %_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj /p:BUILD_PROTO_WITH_CORECLR_LKG=%BUILD_PROTO_WITH_CORECLR_LKG% /p:Configuration=Proto
     @if ERRORLEVEL 1 echo Error: compiler proto build failed && goto :failure
 
     echo %_ngenexe% install Proto\net40\bin\fsc-proto.exe /nologo 
@@ -579,8 +579,8 @@ if "%BUILD_PROTO%" == "1" (
     echo %_ngenexe% install packages\FSharp.Compiler.Tools.4.1.5\tools\fsc.exe /nologo 
          %_ngenexe% install packages\FSharp.Compiler.Tools.4.1.5\tools\fsc.exe /nologo 
 
-    echo %_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj
-         %_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj
+    echo %_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj /p:BUILD_PROTO_WITH_CORECLR_LKG=%BUILD_PROTO_WITH_CORECLR_LKG% /p:Configuration=Proto
+         %_msbuildexe% %msbuildflags% src\fsharp-proto-build.proj /p:BUILD_PROTO_WITH_CORECLR_LKG=%BUILD_PROTO_WITH_CORECLR_LKG% /p:Configuration=Proto
     @if ERRORLEVEL 1 echo Error: compiler proto build failed && goto :failure
 
     echo %_ngenexe% install Proto\net40\bin\fsc-proto.exe /nologo 

--- a/build.sh
+++ b/build.sh
@@ -471,7 +471,7 @@ if [ "$BUILD_PROTO" = '1' ]; then
 #        { printeval "$_ngenexe install Proto/net40/bin/fsc-proto.exe /nologo"; } || failwith "NGen of proto failed"
     else
         # Build proto-compiler and libs
-        { printeval "$_msbuildexe $msbuildflags src/fsharp-proto-build.proj /p:UseMonoPackaging=true"; } || failwith "compiler proto build failed"
+        { printeval "$_msbuildexe $msbuildflags src/fsharp-proto-build.proj /p:UseMonoPackaging=true /p:Configuration=Proto;" } || failwith "compiler proto build failed"
     fi
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -471,7 +471,7 @@ if [ "$BUILD_PROTO" = '1' ]; then
 #        { printeval "$_ngenexe install Proto/net40/bin/fsc-proto.exe /nologo"; } || failwith "NGen of proto failed"
     else
         # Build proto-compiler and libs
-        { printeval "$_msbuildexe $msbuildflags src/fsharp-proto-build.proj /p:UseMonoPackaging=true /p:Configuration=Proto;" } || failwith "compiler proto build failed"
+        { printeval "$_msbuildexe $msbuildflags src/fsharp-proto-build.proj /p:UseMonoPackaging=true /p:Configuration=Proto"; } || failwith "compiler proto build failed"
     fi
 fi
 

--- a/lkg/fsc/project.json
+++ b/lkg/fsc/project.json
@@ -6,7 +6,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.FSharp.Compiler.netcore": "1.0.0-rc-170122",
+    "Microsoft.FSharp.Compiler": "4.2.0-rc-170619-0",
   },
   "runtimes": {
     "win7-x86": { },
@@ -25,6 +25,6 @@
     }
   },
   "scripts": {
-    "postpublish": [ "cmd /c copy %publish:OutputPath%\\runtimes\\any\\native\\* %publish:OutputPath%" ] 
+    "postpublish": [ "cmd /c copy %publish:OutputPath%\\contentFiles\\any\\any\\* %publish:OutputPath%" ] 
   }
 }

--- a/lkg/fsi/project.json
+++ b/lkg/fsi/project.json
@@ -6,7 +6,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.FSharp.Interactive.netcore": "1.0.0-rc-170122",
+    "Microsoft.FSharp.Compiler": "4.2.0-rc-170619-0",
   },
   "runtimes": {
     "win7-x86": { },
@@ -25,6 +25,6 @@
     }
   },
   "scripts": {
-    "postpublish": [ "cmd /c copy %publish:OutputPath%\\runtimes\\any\\native\\* %publish:OutputPath%" ] 
+    "postpublish": [ "cmd /c copy %publish:OutputPath%\\contentFiles\\any\\any\\* %publish:OutputPath%" ] 
   }
 }

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -203,9 +203,9 @@
       <PropertyGroup >
         <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(ProtoFlavour)\bin</OutputPath>
         <!-- When using coreclr to bootstrap to proto. We acquire the FSharp.Core LKG, targets LKG, the FSharp.Build LKG from the .NET Framework compiler tools LKG package. -->
-        <FSharpCoreLkgPath>$(FSharpSourcesRoot)\..\packages\FSharp.Compiler.Tools.4.1.5\tools</FSharpCoreLkgPath>
         <FSharpNetCoreLkgPath>$(FSharpSourcesRoot)\..\Tools\lkg</FSharpNetCoreLkgPath>
         <FSharpTargetsPath>..\packages\FSharp.Compiler.Tools.4.1.5\tools\Microsoft.FSharp.Targets</FSharpTargetsPath>
+
         <!-- When using coreclr to bootstrap, the compiler binary comes from the coreclr LKG, invoked using corehost.exe -->
         <FscToolPath>$(FSharpSourcesRoot)\..\Tools\dotnetcli</FscToolPath>
         <FscToolExe Condition="'$(OS)' != 'Unix'">dotnet.exe</FscToolExe>
@@ -217,7 +217,6 @@
        <!-- Use .NET Framework to bootstrap to proto -->
       <PropertyGroup >
         <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(ProtoFlavour)\bin</OutputPath>
-        <FSharpCoreLkgPath>$(FSharpSourcesRoot)\..\packages\FSharp.Compiler.Tools.4.1.5\tools</FSharpCoreLkgPath>
         <FSharpTargetsPath>..\packages\FSharp.Compiler.Tools.4.1.5\tools\Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </When>

--- a/src/fsharp-proto-build.proj
+++ b/src/fsharp-proto-build.proj
@@ -1,20 +1,14 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-         ToolsVersion="4.0">
-
-  <PropertyGroup>
-    <Configuration>Proto</Configuration>
-  </PropertyGroup>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
 
   <!-- Define all ProjectFiles here -->
   <ItemGroup>
+    <ProjectFiles Include="fsharp\FSharp.Core\FSharp.Core.fsproj"/>
     <ProjectFiles Include="fsharp\FSharp.Build-proto\FSharp.Build-proto.fsproj"/>
     <ProjectFiles Include="fsharp\Fsc-proto\Fsc-proto.fsproj"/>
   </ItemGroup>
 
-
   <!-- Insert any customizations for targets here -->
-
   <Import Project="root.traversal.targets"/>
 
 </Project>

--- a/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
+++ b/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
@@ -61,7 +61,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="$(FSharpCoreLkgPath)\FSharp.Core.dll" />
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
   </ItemGroup>
@@ -78,6 +77,10 @@
     <Reference Include="Microsoft.Build.Tasks.Core, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Tasks.Core.dll</HintPath>
     </Reference>
+    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
+      <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
+      <Name>FSharp.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetDotnetProfile)' != 'coreclr' AND '$(MonoPackaging)' == 'true' ">
     <Reference Include="Microsoft.Build.Framework, Version=$(MonoPackagingMSBuildVersionFull), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
     <ProjectLanguage>FSharp</ProjectLanguage>
+    <BuildWith Condition=" '$(Configuration)' == 'Proto' ">LKG</BuildWith>
   </PropertyGroup>
 
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.targets" />

--- a/src/fsharp/Fsc-proto/Fsc-proto.fsproj
+++ b/src/fsharp/Fsc-proto/Fsc-proto.fsproj
@@ -450,7 +450,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="$(FSharpCoreLkgPath)\FSharp.Core.dll" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -471,6 +470,10 @@
     <Reference Include="System.ValueTuple">
       <HintPath>$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
+    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
+      <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
+      <Name>FSharp.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetDotnetProfile)' != 'coreclr' AND '$(MonoPackaging)' != 'true' ">
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -505,15 +508,4 @@
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
   <Import Project="$(FsLexToolPath)\FsLexYacc.targets" />
-
-  <Target Name="CopyFSharpCoreOptSigFiles" AfterTargets="Build">
-    <ItemGroup>
-        <FSharpCoreOptSigFiles Include="$(FSharpCoreLkgPath)\FSharp.Core.dll" />
-        <FSharpCoreOptSigFiles Include="$(FSharpCoreLkgPath)\FSharp.Core.optdata" />
-        <FSharpCoreOptSigFiles Include="$(FSharpCoreLkgPath)\FSharp.Core.sigdata" />
-        <FSharpCoreOptSigFiles Include="$(FSharpCoreLkgPath)\FSharp.Core.xml" />
-    </ItemGroup>
-    
-    <Copy SourceFiles="@(FSharpCoreOptSigFiles)" DestinationFolder="$(OutputPath)" />
-  </Target>
 </Project>


### PR DESCRIPTION
Proto build used an lkg for it's fsharp.core.  This fixes that.
Also updates the lkg to the latest version of the F# compiler.