### PR TITLE
improve VS update performance after project changes 

### DIFF
--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -31,7 +31,7 @@ type internal ReactorCommands =
 /// There is one global Reactor for the entire language service, no matter how many projects or files
 /// are open. 
 type Reactor() = 
-    static let pauseBeforeBackgroundWorkDefault = GetEnvInteger "FCS_PauseBeforeBackgroundWorkMilliseconds" 1000
+    static let pauseBeforeBackgroundWorkDefault = GetEnvInteger "FCS_PauseBeforeBackgroundWorkMilliseconds" 10
     static let theReactor = Reactor()
     let mutable pauseBeforeBackgroundWork = pauseBeforeBackgroundWorkDefault
 
@@ -59,7 +59,11 @@ type Reactor() =
                                 | _, Some _ -> 
                                     return! inbox.TryReceive(0) 
                                 | Some _, _ -> 
-                                    let timeout = (if bg then 0 else pauseBeforeBackgroundWork)
+                                    let timeout = 
+                                        if bg then 0 
+                                        else 
+                                            Trace.TraceInformation("Reactor: {0:n3} pausing {1} milliseconds", DateTime.Now.TimeOfDay.TotalSeconds, pauseBeforeBackgroundWork)
+                                            pauseBeforeBackgroundWork
                                     return! inbox.TryReceive(timeout) }
 #if FX_RESHAPED_GLOBALIZATION
                     CultureInfo.CurrentUICulture <- culture
@@ -72,7 +76,7 @@ type Reactor() =
                         return! loop (bgOpOpt, onComplete, false)
                     | Some (Op (userOpName, opName, opArg, ct, op, ccont)) -> 
                         if ct.IsCancellationRequested then ccont() else
-                        Trace.TraceInformation("Reactor: --> {0}.{1} ({2}), remaining {3}", userOpName, opName, opArg, inbox.CurrentQueueLength)
+                        Trace.TraceInformation("Reactor: {0:n3} --> {1}.{2} ({3}), remaining {4}", DateTime.Now.TimeOfDay.TotalSeconds, userOpName, opName, opArg, inbox.CurrentQueueLength)
                         let time = Stopwatch()
                         time.Start()
                         op ctok
@@ -81,25 +85,25 @@ type Reactor() =
                         //if span.TotalMilliseconds > 100.0 then 
                         let taken = span.TotalMilliseconds
                         let msg = (if taken > 10000.0 then "BAD-OP: >10s " elif taken > 3000.0 then "BAD-OP: >3s " elif taken > 1000.0 then "BAD-OP: > 1s " elif taken > 500.0 then "BAD-OP: >0.5s " else "")
-                        Trace.TraceInformation("Reactor: {0}<-- {1}.{2}, took {3} ms", msg, userOpName, opName, span.TotalMilliseconds)
+                        Trace.TraceInformation("Reactor: {0:n3} {1}<-- {2}.{3}, took {4} ms", DateTime.Now.TimeOfDay.TotalSeconds, msg, userOpName, opName, span.TotalMilliseconds)
                         return! loop (bgOpOpt, onComplete, false)
                     | Some (WaitForBackgroundOpCompletion channel) -> 
                         match bgOpOpt with 
                         | None -> ()
                         | Some (bgUserOpName, bgOpName, bgOpArg, bgOp) -> 
-                            Trace.TraceInformation("Reactor: --> wait for background {0}.{1} ({2}), remaining {3}", bgUserOpName, bgOpName, bgOpArg, inbox.CurrentQueueLength)
+                            Trace.TraceInformation("Reactor: {0:n3} --> wait for background {1}.{2} ({3}), remaining {4}", DateTime.Now.TimeOfDay.TotalSeconds, bgUserOpName, bgOpName, bgOpArg, inbox.CurrentQueueLength)
                             while bgOp ctok do 
                                 ()
                         channel.Reply(())
                         return! loop (None, onComplete, false)
                     | Some (CompleteAllQueuedOps channel) -> 
-                        Trace.TraceInformation("Reactor: --> stop background work and complete all queued ops, remaining {0}", inbox.CurrentQueueLength)
+                        Trace.TraceInformation("Reactor: {0:n3} --> stop background work and complete all queued ops, remaining {1}", DateTime.Now.TimeOfDay.TotalSeconds, inbox.CurrentQueueLength)
                         return! loop (None, Some channel, false)
                     | None -> 
                         match bgOpOpt, onComplete with 
                         | _, Some onComplete -> onComplete.Reply()
                         | Some  (bgUserOpName, bgOpName, bgOpArg, bgOp), None -> 
-                            Trace.TraceInformation("Reactor: --> background step {0}.{1} ({2})", bgUserOpName, bgOpName, bgOpArg)
+                            Trace.TraceInformation("Reactor: {0:n3} --> background step {1}.{2} ({3})", DateTime.Now.TimeOfDay.TotalSeconds, bgUserOpName, bgOpName, bgOpArg)
                             let time = Stopwatch()
                             time.Start()
                             let res = bgOp ctok
@@ -107,7 +111,7 @@ type Reactor() =
                             let taken = time.Elapsed.TotalMilliseconds
                             //if span.TotalMilliseconds > 100.0 then 
                             let msg = (if taken > 10000.0 then "BAD-BG-SLICE: >10s " elif taken > 3000.0 then "BAD-BG-SLICE: >3s " elif taken > 1000.0 then "BAD-BG-SLICE: > 1s " else "")
-                            Trace.TraceInformation("Reactor: {0}<-- background step, took {1}ms", msg, taken)
+                            Trace.TraceInformation("Reactor: {0:n3} {1}<-- background step, took {2}ms", DateTime.Now.TimeOfDay.TotalSeconds, msg, taken)
                             return! loop ((if res then bgOpOpt else None), onComplete, true)
                         | None, None -> failwith "unreachable, should have used inbox.Receive"
                     }
@@ -121,15 +125,15 @@ type Reactor() =
 
     // [Foreground Mailbox Accessors] -----------------------------------------------------------                
     member r.SetBackgroundOp(bgOpOpt) = 
-        Trace.TraceInformation("Reactor: enqueue start background, length {0}", builder.CurrentQueueLength)
+        Trace.TraceInformation("Reactor: {0:n3} enqueue start background, length {1}", DateTime.Now.TimeOfDay.TotalSeconds, builder.CurrentQueueLength)
         builder.Post(SetBackgroundOp bgOpOpt)
 
     member r.EnqueueOp(userOpName, opName, opArg, op) =
-        Trace.TraceInformation("Reactor: enqueue {0}.{1} ({2}), length {3}", userOpName, opName, opArg, builder.CurrentQueueLength)
+        Trace.TraceInformation("Reactor: {0:n3} enqueue {1}.{2} ({3}), length {4}", DateTime.Now.TimeOfDay.TotalSeconds, userOpName, opName, opArg, builder.CurrentQueueLength)
         builder.Post(Op(userOpName, opName, opArg, CancellationToken.None, op, (fun () -> ()))) 
 
     member r.EnqueueOpPrim(userOpName, opName, opArg, ct, op, ccont) =
-        Trace.TraceInformation("Reactor: enqueue {0}.{1} ({2}), length {3}", userOpName, opName, opArg, builder.CurrentQueueLength)
+        Trace.TraceInformation("Reactor: {0:n3} enqueue {1}.{2} ({3}), length {4}", DateTime.Now.TimeOfDay.TotalSeconds, userOpName, opName, opArg, builder.CurrentQueueLength)
         builder.Post(Op(userOpName, opName, opArg, ct, op, ccont)) 
 
     member r.CurrentQueueLength =
@@ -137,12 +141,12 @@ type Reactor() =
 
     // This is for testing only
     member r.WaitForBackgroundOpCompletion() =
-        Trace.TraceInformation("Reactor: enqueue wait for background, length {0}", builder.CurrentQueueLength)
+        Trace.TraceInformation("Reactor: {0:n3} enqueue wait for background, length {0}", DateTime.Now.TimeOfDay.TotalSeconds, builder.CurrentQueueLength)
         builder.PostAndReply WaitForBackgroundOpCompletion 
 
     // This is for testing only
     member r.CompleteAllQueuedOps() =
-        Trace.TraceInformation("Reactor: enqueue wait for all ops, length {0}", builder.CurrentQueueLength)
+        Trace.TraceInformation("Reactor: {0:n3} enqueue wait for all ops, length {0}", DateTime.Now.TimeOfDay.TotalSeconds, builder.CurrentQueueLength)
         builder.PostAndReply CompleteAllQueuedOps
 
     member r.EnqueueAndAwaitOpAsync (userOpName, opName, opArg, f) = 

--- a/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ColorizationService.fs
@@ -2,8 +2,10 @@
 
 namespace Microsoft.VisualStudio.FSharp.Editor
 
+open System
 open System.Composition
 open System.Collections.Generic
+open System.Diagnostics
 open System.Threading
 
 open Microsoft.CodeAnalysis
@@ -36,6 +38,7 @@ type internal FSharpColorizationService
 
         member this.AddSemanticClassificationsAsync(document: Document, textSpan: TextSpan, result: List<ClassifiedSpan>, cancellationToken: CancellationToken) =
             asyncMaybe {
+                do Trace.TraceInformation("{0:n3} (start) SemanticColorization", DateTime.Now.TimeOfDay.TotalSeconds)
                 do! Async.Sleep DefaultTuning.SemanticColorizationInitialDelay |> liftAsync // be less intrusive, give other work priority most of the time
                 let! options = projectInfoManager.TryGetOptionsForDocumentOrProject(document)
                 let! sourceText = document.GetTextAsync(cancellationToken)

--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -4,6 +4,7 @@ namespace rec Microsoft.VisualStudio.FSharp.Editor
 
 open System
 open System.Collections.Immutable
+open System.Diagnostics
 open System.Threading
 open System.Threading.Tasks
 open System.Runtime.CompilerServices
@@ -18,7 +19,8 @@ open Microsoft.VisualStudio.FSharp.LanguageService
 
 type private TextVersionHash = int
 
-[<DiagnosticAnalyzer(FSharpConstants.FSharpLanguageName)>]
+// Disable until we work out how to make this low priority
+//[<DiagnosticAnalyzer(FSharpConstants.FSharpLanguageName)>]
 type internal SimplifyNameDiagnosticAnalyzer() =
     inherit DocumentDiagnosticAnalyzer()
     
@@ -47,6 +49,7 @@ type internal SimplifyNameDiagnosticAnalyzer() =
 
     override this.AnalyzeSemanticsAsync(document: Document, cancellationToken: CancellationToken) =
         asyncMaybe {
+            do Trace.TraceInformation("{0:n3} (start) SimplifyName", DateTime.Now.TimeOfDay.TotalSeconds)
             do! Async.Sleep DefaultTuning.SimplifyNameInitialDelay |> liftAsync 
             do! Option.guard Settings.CodeFixes.SimplifyName
             let! options = getProjectInfoManager(document).TryGetOptionsForEditingDocumentOrProject(document)

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
@@ -3,9 +3,10 @@
 namespace rec Microsoft.VisualStudio.FSharp.Editor
 
 open System
-open System.Collections.Immutable
-open System.Threading.Tasks
 open System.Collections.Generic
+open System.Collections.Immutable
+open System.Diagnostics
+open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Diagnostics
@@ -99,6 +100,7 @@ type internal UnusedDeclarationsAnalyzer() =
 
     override __.AnalyzeSemanticsAsync(document, cancellationToken) =
         asyncMaybe {
+            do Trace.TraceInformation("{0:n3} (start) UnusedDeclarationsAnalyzer", DateTime.Now.TimeOfDay.TotalSeconds)
             do! Async.Sleep DefaultTuning.UnusedDeclarationsAnalyzerInitialDelay |> liftAsync // be less intrusive, give other work priority most of the time
             match getProjectInfoManager(document).TryGetOptionsForEditingDocumentOrProject(document) with
             | Some options ->

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
@@ -4,6 +4,7 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
 open System.Collections.Immutable
+open System.Diagnostics
 open System.Threading
 open System.Threading.Tasks
 
@@ -170,6 +171,7 @@ type internal UnusedOpensDiagnosticAnalyzer() =
 
     override this.AnalyzeSemanticsAsync(document: Document, cancellationToken: CancellationToken) =
         asyncMaybe {
+            do Trace.TraceInformation("{0:n3} (start) UnusedOpensAnalyzer", DateTime.Now.TimeOfDay.TotalSeconds)
             do! Async.Sleep DefaultTuning.UnusedOpensAnalyzerInitialDelay |> liftAsync // be less intrusive, give other work priority most of the time
             let! options = getProjectInfoManager(document).TryGetOptionsForEditingDocumentOrProject(document)
             let! sourceText = document.GetTextAsync()

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -61,7 +61,7 @@ type internal FSharpCheckerProvider
                         if not documentIds.IsEmpty then 
                             for documentId in documentIds do
                                 Trace.TraceInformation("Requesting Roslyn reanalysis of {0}", documentId)
-                            analyzerService.Reanalyze(workspace,documentIds=documentIds,highPriority=true)
+                            analyzerService.Reanalyze(workspace,documentIds=documentIds)
                     | _ -> ()
                 with ex -> 
                     Assert.Exception(ex)

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -59,7 +59,9 @@ type internal FSharpCheckerProvider
                         let solution = workspace.CurrentSolution
                         let documentIds = solution.GetDocumentIdsWithFilePath(fileName)
                         if not documentIds.IsEmpty then 
-                            analyzerService.Reanalyze(workspace,documentIds=documentIds)
+                            for documentId in documentIds do
+                                Trace.TraceInformation("Requesting Roslyn reanalysis of {0}", documentId)
+                            analyzerService.Reanalyze(workspace,documentIds=documentIds,highPriority=true)
                     | _ -> ()
                 with ex -> 
                     Assert.Exception(ex)
@@ -446,6 +448,7 @@ and
                 for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider) do
                     let referencedProjectId = setup referencedSite                    
                     project.AddProjectReference(ProjectReference referencedProjectId)
+                workspace.ProjectTracker.AddProject(project)
             projectId
         setup (siteProvider.GetProjectSite()) |> ignore
 

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -10,8 +10,8 @@ open OptionsUIHelpers
 
 module DefaultTuning = 
     let SemanticColorizationInitialDelay = 0 (* milliseconds *)
-    let UnusedDeclarationsAnalyzerInitialDelay = 1000 (* milliseconds *)
-    let UnusedOpensAnalyzerInitialDelay = 2000 (* milliseconds *)
+    let UnusedDeclarationsAnalyzerInitialDelay = 0 (* 1000 *) (* milliseconds *)
+    let UnusedOpensAnalyzerInitialDelay = 0 (* 2000 *) (* milliseconds *)
     let SimplifyNameInitialDelay = 2000 (* milliseconds *)
     let SimplifyNameEachItemDelay = 5 (* milliseconds *)
 


### PR DESCRIPTION
This is a set of improvements to VS perf, initially for https://github.com/Microsoft/visualfsharp/issues/3094 but also https://github.com/Microsoft/visualfsharp/issues/2107 and https://github.com/Microsoft/visualfsharp/issues/3054, and indeed any situation where you're editing code across multiple files in a project.

1. Remove the 1 second pauses before background work is started when the queue is empty, and use a 5msec pause instead.  The intention of the 1sec pause was to allow foreground UI intellisense requests to come in before starting background work.  However we are relying on background work to happen to propagate some things in the UI  (e.g. to push through changes in solution options by incrementally type checking the project and triggering a Reanalyze).  Further, I suspect the 1 second pauses were happening all the time, especially when SimplifyName diagnostic analyzer was being used.  

2. Remove the startup pauses for some of the analyzers. Normally these analyzers get run in parallel, and the async startup pause was effectively a cheapshot way of specifying priorities.  However these analyers get run in sequence after a Reanalyze has been requested.  Further they get run before semantic colorization is done. This means no colors get updated until all of them have been completed

3. Disable the SimplifyName analyzer. This can take a a long time to run because the names are checked one-by-one (and there is currently a pause checking each name). I strongly suspect that this is a real problem and a major cause of "lag" in different ways.  If analyzers are run in sequence (e.g. when Reanalyze is called) , then any long-running analyzers are a real problem 

@vasily-kirichenko From what I've seen in debugging we can't afford to have SimplifyName analyzer on if document diagnostic analyzers are being run in sequence in response to Reanalyze.  Perhaps we could have an option to explicitly enable it, we could double check whether Roslyn really is running the analyzers in sequence and why.  I'm a bit concerned about the other analyzers too for large files.

All in all the changes in this PR _seem_ to significantly improve the performance of red-squiggly update speed in the face of 
* edits in other files
* project configuration changes (from 10sec down to 5sec, see https://github.com/Microsoft/visualfsharp/issues/3094)
* project option changes




