### PR TITLE
Only request reanalysis of open docs

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -59,9 +59,11 @@ type internal FSharpCheckerProvider
                         let solution = workspace.CurrentSolution
                         let documentIds = solution.GetDocumentIdsWithFilePath(fileName)
                         if not documentIds.IsEmpty then 
-                            for documentId in documentIds do
-                                Trace.TraceInformation("Requesting Roslyn reanalysis of {0}", documentId)
-                            analyzerService.Reanalyze(workspace,documentIds=documentIds)
+                            let docuentIdsFiltered = documentIds |> Seq.filter workspace.IsDocumentOpen |> Seq.toArray
+                            for documentId in docuentIdsFiltered do
+                                Trace.TraceInformation("{0:n3} Requesting Roslyn reanalysis of {0}", DateTime.Now.TimeOfDay.TotalSeconds, documentId)
+                            if docuentIdsFiltered.Length > 0 then 
+                                analyzerService.Reanalyze(workspace,documentIds=docuentIdsFiltered)
                     | _ -> ()
                 with ex -> 
                     Assert.Exception(ex)

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -61,7 +61,7 @@ type internal FSharpCheckerProvider
                         if not documentIds.IsEmpty then 
                             let docuentIdsFiltered = documentIds |> Seq.filter workspace.IsDocumentOpen |> Seq.toArray
                             for documentId in docuentIdsFiltered do
-                                Trace.TraceInformation("{0:n3} Requesting Roslyn reanalysis of {0}", DateTime.Now.TimeOfDay.TotalSeconds, documentId)
+                                Trace.TraceInformation("{0:n3} Requesting Roslyn reanalysis of {1}", DateTime.Now.TimeOfDay.TotalSeconds, documentId)
                             if docuentIdsFiltered.Length > 0 then 
                                 analyzerService.Reanalyze(workspace,documentIds=docuentIdsFiltered)
                     | _ -> ()


### PR DESCRIPTION
In the Visual F# tools we only request re-analysis of open documents. 

Without this we see lots of requests for re-analysis, e.g. see https://gist.github.com/dsyme/ac50baba8542f90b37cf8eedb944ff79
