### PR TITLE
Fix 3219 - make StartAsTask wait for cancellation to take effect on task

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -132,7 +132,7 @@ type AsyncType() =
 
     member private this.WaitASec (t:Task) =
         let result = t.Wait(TimeSpan(hours=0,minutes=0,seconds=1))
-        Assert.IsTrue(result)        
+        Assert.IsTrue(result, "Task did not finish after waiting for a second.")
       
     
     [<Test>]


### PR DESCRIPTION
This fixes that `StartAsTask` will not wait properly for cancellation to finish, see https://github.com/Microsoft/visualfsharp/issues/3219#issuecomment-310844300

/cc @eiriktsarpalis 