### PR TITLE
Fix 3267: only add project if needed

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -448,10 +448,17 @@ and
                                                 optionsAssociation.Remove(projectContext) |> ignore
                                                 project.Disconnect()))
                 for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider) do
-                    let referencedProjectId = setup referencedSite                    
+                    let referencedProjectFileName = referencedSite.ProjectFileName()
+                    let referencedProjectDisplayName = projectDisplayNameOf referencedProjectFileName
+                    let referencedProjectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(referencedProjectFileName, referencedProjectDisplayName)
                     project.AddProjectReference(ProjectReference referencedProjectId)
-                workspace.ProjectTracker.AddProject(project)
-            projectId
+
+                if not (workspace.ProjectTracker.ContainsProject(project)) then 
+                    workspace.ProjectTracker.AddProject(project)
+
+                for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider) do
+                    setup referencedSite                    
+
         setup (siteProvider.GetProjectSite()) |> ignore
 
     member this.SetupStandAloneFile(fileName: string, fileContents: string, workspace: VisualStudioWorkspaceImpl, hier: IVsHierarchy) =

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -450,7 +450,7 @@ and
 
                 let referencedProjectSites = ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider)
                 
-                for referencedSite in referencedProjects do
+                for referencedSite in referencedProjectSites do
                     let referencedProjectFileName = referencedSite.ProjectFileName()
                     let referencedProjectDisplayName = projectDisplayNameOf referencedProjectFileName
                     let referencedProjectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(referencedProjectFileName, referencedProjectDisplayName)

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -447,7 +447,10 @@ and
                                                 projectInfoManager.ClearInfoForProject(project.Id)
                                                 optionsAssociation.Remove(projectContext) |> ignore
                                                 project.Disconnect()))
-                for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider) do
+
+                let referencedProjectSites = ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider)
+                
+                for referencedSite in referencedProjects do
                     let referencedProjectFileName = referencedSite.ProjectFileName()
                     let referencedProjectDisplayName = projectDisplayNameOf referencedProjectFileName
                     let referencedProjectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(referencedProjectFileName, referencedProjectDisplayName)
@@ -456,7 +459,7 @@ and
                 if not (workspace.ProjectTracker.ContainsProject(project)) then 
                     workspace.ProjectTracker.AddProject(project)
 
-                for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider) do
+                for referencedSite in referencedProjectSites do
                     setup referencedSite                    
 
         setup (siteProvider.GetProjectSite()) |> ignore


### PR DESCRIPTION
Seems to fix https://github.com/Microsoft/visualfsharp/issues/3267

The problem must be that the given project already exists in the workspace if there is a DAG dependency structure, and we should not be adding it twice.