### PR TITLE
fix building from source on unix systems

### DIFF
--- a/src/buildfromsource.sh
+++ b/src/buildfromsource.sh
@@ -1,7 +1,8 @@
+#!/bin/sh -e
+
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 
-
-# build tools                               ç
+# build tools
 dotnet restore $__scriptpath/buildtools/fssrgen/fssrgen.fsproj
 dotnet publish $__scriptpath/buildtools/fssrgen/fssrgen.fsproj -o $__scriptpath/../Tools/fssrgen
 dotnet restore $__scriptpath/buildtools/fslex/fslex.fsproj
@@ -9,7 +10,7 @@ dotnet publish $__scriptpath/buildtools/fslex/fslex.fsproj -o $__scriptpath/../T
 dotnet restore $__scriptpath/buildtools/fsyacc/fsyacc.fsproj
 dotnet publish $__scriptpath/buildtools/fsyacc/fsyacc.fsproj -o $__scriptpath/../Tools/fsyacc
 
-rem build tools
+# build tools
 dotnet restore $__scriptpath/fsharp/FSharp.Build/FSharp.Build.BuildFromSource.fsproj
 dotnet publish $__scriptpath/fsharp/FSharp.Build/FSharp.Build.BuildFromSource.fsproj
 
@@ -18,7 +19,7 @@ dotnet publish fsharp/fsi/Fsi.BuildFromSource.fsproj
 
 dotnet restore $__scriptpath/fsharp/Fsc/Fsc.BuildFromSource.fsproj
 dotnet publish $__scriptpath/fsharp/Fsc/Fsc.BuildFromSource.fsproj
+
 # build and pack tools
 dotnet restore $__scriptpath/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.BuildFromSource.fsproj
 dotnet pack $__scriptpath/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.BuildFromSource.fsproj -c release
-


### PR DESCRIPTION
Add hash-bang that will abort the script when errors occur and correct a comment.

Tested on Ubuntu 16.04.