### PR TITLE
Fix the build events property page and the targetframework dropdown in the application page

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
@@ -563,6 +563,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If moniker = "" Or moniker = Nothing Then
                 Return False
             End If
+            ' .NET Core and .NETStandard don't need redists to be installed.
+            If moniker.StartsWith(".NETCoreApp") OrElse moniker.StartsWith(".NETStandard") Then
+                Return True
+            End If
             If moniker.Contains("v2") Then
                 Return Me.m_v20FSharpRedistInstalled
             End If
@@ -656,7 +660,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Dim isPortable As Boolean = IsDotNetPortable(currentFrameworkName)
                     targetFrameworkSupported = True
 
-                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject)
+                    Dim supportedTargetFrameworksDescriptor As PropertyDescriptor = GetPropertyDescriptor("SupportedTargetFrameworks")
+                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, supportedTargetFrameworksDescriptor)
 
                     For Each supportedFramework As TargetFrameworkMoniker In supportedFrameworks
                         If Me.ValidateTargetFrameworkMoniker(supportedFramework.Moniker) Then

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildEventsPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildEventsPropPage.vb
@@ -188,10 +188,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
-                    m_ControlData = New PropertyControlData() { _
-                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_PreBuildEvent, "PreBuildEvent", Me.txtPreBuildEventCommandLine, ControlDataFlags.None, New Control() {btnPreBuildBuilder, lblPreBuildEventCommandLine}), _
-                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_PostBuildEvent, "PostBuildEvent", Me.txtPostBuildEventCommandLine, ControlDataFlags.None, New Control() {btnPostBuildBuilder, lblPostBuildEventCommandLine}), _
-                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_RunPostBuildEvent, "RunPostBuildEvent", Me.cboRunPostBuildEvent, AddressOf RunPostBuildEventSet, AddressOf RunPostBuildEventGet, ControlDataFlags.None, New Control() {Me.lblRunPostBuildEvent}) _
+                    m_ControlData = New PropertyControlData() {
+                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_PreBuildEvent, "PreBuildEvent", Me.txtPreBuildEventCommandLine, ControlDataFlags.None, New Control() {btnPreBuildBuilder, lblPreBuildEventCommandLine}),
+                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_PostBuildEvent, "PostBuildEvent", Me.txtPostBuildEventCommandLine, ControlDataFlags.None, New Control() {btnPostBuildBuilder, lblPostBuildEventCommandLine}),
+                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_RunPostBuildEvent, "RunPostBuildEvent", Me.cboRunPostBuildEvent, AddressOf RunPostBuildEventSet, AddressOf RunPostBuildEventGet, ControlDataFlags.None, New Control() {Me.lblRunPostBuildEvent})
                     }
                 End If
 
@@ -211,7 +211,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="value"></param>
         ''' <remarks></remarks>
         Private Function RunPostBuildEventSet(ByVal control As Control, ByVal prop As PropertyDescriptor, ByVal value As Object) As Boolean
-            If (Not (PropertyControlData.IsSpecialValue(value))) Then
+            If (Not (PropertyControlData.IsSpecialValue(value) OrElse String.IsNullOrEmpty(TryCast(value, String)))) Then
                 Me.cboRunPostBuildEvent.SelectedIndex = CType(value, Integer)
                 Return True
             Else


### PR DESCRIPTION
The target framework is populated by asking the multi-targeting service for the TFMs and the multi-targeting service doesn't know about .NET Core\Standard. We now also query a property that's set by the SDK that lists the known .NET Core\.NET STandard version. This change is similar to [the change to C#\VB pages ](https://github.com/dotnet/project-system/pull/2097/commits/aee40ba336d0b94a20f416060213e0b9cf6369a1) 

The build events prop page was failing to load because the RunPostBuildEvents property is not set normally and in that case, CPS returns an empty string whereas the old project system returned a specific missing value. This changes the page to handle both cases.

@KevinRansom @brettfo @Pilchie @dsyme 

Fixes #3276, Fixes #3277 
