### PR TITLE
enable publishing VSIX packages from the vs2017-rtm->microbuild-dev15-rtm branch

### DIFF
--- a/setup/publish-assets.ps1
+++ b/setup/publish-assets.ps1
@@ -24,9 +24,15 @@ $ErrorActionPreference = "Stop"
 
 try {
     $branchName = $branchName -Replace "refs/heads/" # get rid of prefix
+    $requestUrl = ""
 
     switch ($branchName) {
-        "microbuild" { }
+        "microbuild" {
+            $requestUrl = "https://dotnet.myget.org/F/fsharp/vsix/upload"
+        }
+        "microbuild-dev15-rtm" {
+            $requestUrl = "https://dotnet.myget.org/F/fsharp-preview/vsix/upload"
+        }
         default {
             Write-Host "Branch [$branchName] is not supported for publishing."
             exit 0 # non-fatal
@@ -34,7 +40,6 @@ try {
     }
 
     $branchName = $branchName.Replace("/", "_") # can't have slashes in the branch name
-    $requestUrl = "https://dotnet.myget.org/F/fsharp/vsix/upload"
     $vsix = Join-Path $binariesPath "net40\bin\VisualFSharpFull.vsix"
 
     Write-Host "  Uploading '$vsix' to '$requestUrl'."


### PR DESCRIPTION
The `vs2017-rtm` branch is merged daily into the internal `microbuild-dev15-rtm` branch.  This PR will enable changes made to that branch to be published to a separate MyGet feed.

I've already created the `fsharp-preview` feed and updated the internal build definition.