### PR TITLE
Fix Application Property Page for dotnet sdk projects

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
@@ -619,10 +619,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             VSErrorHandler.ThrowOnFailure(MyBase.ProjectHierarchy.GetSite(siteServiceProvider))
 
             Dim sp As System.IServiceProvider = GetServiceProvider()
+            Dim canUseTargetFSharpCoreVersionString As String = CType(dteproject.Properties.Item(ProjectSystemConstants.CanUseTargetFSharpCoreVersion).Value, String)
+            Dim canUseTargetFSharpCoreVersion As Boolean = False
 
-            Dim canUseTargetFSharpCoreVersionProperty As Boolean = CType(DTEProject.Properties.Item(ProjectSystemConstants.CanUseTargetFSharpCoreVersion).Value, Boolean)
-
-            If canUseTargetFSharpCoreVersionProperty Then
+            If String.IsNullOrWhiteSpace(canUseTargetFSharpCoreVersionString) <> True Then
+                canUseTargetFSharpCoreVersion = CType(canUseTargetFSharpCoreVersionString, Boolean)
+            End If
+            If canUseTargetFSharpCoreVersion Then
                 Try
                     Dim fsharpVersionLookup As IFSharpCoreVersionLookupService = CType(sp.GetService(GetType(IFSharpCoreVersionLookupService)), IFSharpCoreVersionLookupService)
                     For Each fsharpCoreVersion As FSharpCoreVersion In fsharpVersionLookup.ListAvailableFSharpCoreVersions(currentFrameworkName)
@@ -641,8 +644,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 TargetFSharpCoreVersion.SelectedIndex = 0
                 TargetFSharpCoreVersion.Enabled = False
             End If
-
-
         End Sub
 
         Private Sub PopulateTargetFrameworkAssemblies()


### PR DESCRIPTION
When displaying the Application Property page for a dotnet sdk project the page failes to display:
![image](https://user-images.githubusercontent.com/5175830/27760209-b7cd0c4a-5df6-11e7-8a33-1c0d43395788.png)

The issue was an exception when deciding whether to enable the FSharpCore version selector:
The fix here correctly treats an empty project item keyed on ProjectSystemConstants.CanUseTargetFSharpCoreVersion as disable  the FSharpCore version selector.

After this change the page looks like:
![image](https://user-images.githubusercontent.com/5175830/27760242-74ed8872-5df7-11e7-8b61-4913ce7eb43d.png)

/cc @brettfo , @cartermp , @Pilchie , @srivatsn 

This PR will need cherry picking.