### PR TITLE
Add items to to new item dialog on dotnet sdk

### DIFF
--- a/vsintegration/ItemTemplates/AppConfig/Template/AppConfig.vstemplate
+++ b/vsintegration/ItemTemplates/AppConfig/Template/AppConfig.vstemplate
@@ -6,7 +6,6 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4010" />
     <TemplateID>Microsoft.FSharp.AppConfig</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>App.config</DefaultName>
   </TemplateData>

--- a/vsintegration/ItemTemplates/CodeFile/Template/CodeFile.vstemplate
+++ b/vsintegration/ItemTemplates/CodeFile/Template/CodeFile.vstemplate
@@ -6,7 +6,6 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4005" />
     <TemplateID>Microsoft.FSharp.CodeFile</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>10</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>File.fs</DefaultName>

--- a/vsintegration/ItemTemplates/ScriptFile/Template/ScriptFile.vstemplate
+++ b/vsintegration/ItemTemplates/ScriptFile/Template/ScriptFile.vstemplate
@@ -6,7 +6,6 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4006" />
     <TemplateID>Microsoft.FSharp.ScriptFile</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>30</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>Script.fsx</DefaultName>

--- a/vsintegration/ItemTemplates/SignatureFile/Template/SignatureFile.vstemplate
+++ b/vsintegration/ItemTemplates/SignatureFile/Template/SignatureFile.vstemplate
@@ -6,7 +6,6 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4007" />
     <TemplateID>Microsoft.FSharp.SignatureFile</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>50</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>File.fsi</DefaultName>

--- a/vsintegration/ItemTemplates/TextFile/Template/TextFile.vstemplate
+++ b/vsintegration/ItemTemplates/TextFile/Template/TextFile.vstemplate
@@ -6,7 +6,6 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4009" />
     <TemplateID>Microsoft.FSharp.TextFile</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>TextFile.txt</DefaultName>
   </TemplateData>

--- a/vsintegration/ItemTemplates/XMLFile/Template/XMLFile.vstemplate
+++ b/vsintegration/ItemTemplates/XMLFile/Template/XMLFile.vstemplate
@@ -6,7 +6,6 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4011" />
     <TemplateID>Microsoft.FSharp.XMLFile</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>XMLFile.xml</DefaultName>
   </TemplateData>


### PR DESCRIPTION
Add new item project dialog has no items for F# dotnet sdk projects.

The issue is the project templates have a MinimumRequiredFramework set, that is not really useful any more.

This PR addresses that:

![image](https://user-images.githubusercontent.com/5175830/27878386-f1c73374-6172-11e7-8411-55d0f8da9f29.png)


Fixes: #3310 


Please note: this addresses the selectability of project items.  The project system doesn't add them correctly once selected.  That is a further issue.

Update:  it does in fact add them, however, it needs the latest props and targets files to be in the sdk/f#/ folder