### PR TITLE
Check for non-empty paths when stripping ending semicolon

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -1012,7 +1012,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
 
                 let stripEndingSemicolon (sb : StringBuilder) =
                     let len = sb.Length
-                    if sb.[len - 1] = ';' then sb.Remove(len - 1, 1) |> ignore
+                    if len > 0 && sb.[len - 1] = ';' then sb.Remove(len - 1, 1) |> ignore
                     ()
 
                 let targetFrameworkMoniker = this.GetTargetFrameworkMoniker()


### PR DESCRIPTION
In some projects (Android in particular) the framework paths are empty. This results in an exception when trying to open the Add References dialog. This behavior is reported in issue https://github.com/Microsoft/visualfsharp/issues/3318. This commit resolves that issue.