### PR TITLE
remove pattern match

### DIFF
--- a/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
+++ b/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
@@ -55,7 +55,7 @@
     <Compile Include="CodeFixesOptionControl.xaml.cs">
       <DependentUpon>CodeFixesOptionControl.xaml</DependentUpon>
     </Compile>
-    <Compile Include="IntergerCheckValidationRule.cs" />
+    <Compile Include="IntegerRangeValidationRule.cs" />
     <Compile Include="LanguageServicePerformanceOptionControl.xaml.cs">
       <DependentUpon>LanguageServicePerformanceOptionControl.xaml</DependentUpon>
     </Compile>

--- a/vsintegration/src/FSharp.UIResources/IntegerRangeValidationRule.cs
+++ b/vsintegration/src/FSharp.UIResources/IntegerRangeValidationRule.cs
@@ -17,8 +17,9 @@ namespace Microsoft.VisualStudio.FSharp.UIResources
 
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
-            if (value is string text)
+            if (value is string)
             {
+                var text = (string)value;
                 if (int.TryParse(text, out int i) &&
                     i >= Min && i <= Max)
                 {


### PR DESCRIPTION
The signed build can't consume C# pattern matches.  Also rename the file to match the class name.

This was causing a failure in our nightly signed build.