### PR TITLE
use BuildDependsOn for CopyLocalizationResources dependency

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
@@ -34,7 +34,7 @@
   <Import Project="$(VSSDKTargets)" />
   <PropertyGroup>
     <BuildingProject>true</BuildingProject>
-    <BuildDependsOn>VSCTCompile;CopyCtoFile;$(BuildDependsOn)</BuildDependsOn>
+    <BuildDependsOn>VSCTCompile;CopyCtoFile;CopyLocalizationResources;$(BuildDependsOn)</BuildDependsOn>
   </PropertyGroup>
   <Target Name="CopyCtoFile">
     <Copy SourceFiles="@(VSCTCompile->'$(IntermediateOutputPath)%(FileName).cto')" DestinationFiles="@(VSCTCompile->'ctofiles\%(FileName).cto')" />
@@ -57,7 +57,7 @@
       </FilesToSign>
     </ItemGroup>
   </Target>
-  <Target Name="CopyLocalizationResources" BeforeTargets="Localize">
+  <Target Name="CopyLocalizationResources">
     <ItemGroup>
       <LocalizationResources Include="MenusAndCommands.vsct" />
     </ItemGroup>


### PR DESCRIPTION
This change fixes the build errors that the MicroBuild Localization Plugin experienced when we tried to deploy a newer version.
The problem is that the Localize task now has a DependsOnTargets attribute for a target that computes its inputs and outputs. Those targets actually run before any BeforeTargets=“Localize” targets run, and since CopyLocalizationResources needs to run before that to put a required file in the correct place one of the new targets failed because that file was missing.
I was able to fix this by changing to a BuildDependsOn pattern instead of BeforeTargets. This works with both the older version of the plugin and the newer version. I validated this was a modified FSharp-Microbuild build definition. You can see the results here:

[Old Plugin Build](https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=874529&_a=summary)
[New Plugin Build](https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=874828&_a=summary)