### PR TITLE
Remove unnecessary warnings for LayoutKind.Auto and Sequential

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -15031,8 +15031,6 @@ module EstablishTypeDefinitionCores =
             let hasCLIMutable = HasFSharpAttribute cenv.g cenv.g.attrib_CLIMutableAttribute attrs
             
             let structLayoutAttr = TryFindFSharpInt32Attribute cenv.g cenv.g.attrib_StructLayoutAttribute attrs
-            let hasStructLayoutAttr = Option.isSome structLayoutAttr
-            let hasExplicitLayout = structLayoutAttr = Some(int32 System.Runtime.InteropServices.LayoutKind.Explicit)
             let hasAllowNullLiteralAttr = TryFindFSharpBoolAttribute cenv.g cenv.g.attrib_AllowNullLiteralAttribute attrs = Some(true)
 
             if hasAbstractAttr then 
@@ -15053,14 +15051,17 @@ module EstablishTypeDefinitionCores =
                 
                 
             let structLayoutAttributeCheck(allowed) = 
-                if hasStructLayoutAttr  then 
+                let explicitKind = int32 System.Runtime.InteropServices.LayoutKind.Explicit
+                match structLayoutAttr with
+                | Some kind ->
                     if allowed then 
-                        if hasExplicitLayout then
+                        if kind = explicitKind then
                             warning(PossibleUnverifiableCode(m))
                     elif thisTyconRef.Typars(m).Length > 0 then 
                         errorR (Error(FSComp.SR.tcGenericTypesCannotHaveStructLayout(),m))
                     else
                         errorR (Error(FSComp.SR.tcOnlyStructsCanHaveStructLayout(),m))
+                | None -> ()
                 
             let hiddenReprChecks(hasRepr) =
                  structLayoutAttributeCheck(false)

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -15030,7 +15030,9 @@ module EstablishTypeDefinitionCores =
             let hasMeasureableAttr = HasFSharpAttribute cenv.g cenv.g.attrib_MeasureableAttribute attrs
             let hasCLIMutable = HasFSharpAttribute cenv.g cenv.g.attrib_CLIMutableAttribute attrs
             
-            let hasStructLayoutAttr = HasFSharpAttribute cenv.g cenv.g.attrib_StructLayoutAttribute attrs
+            let structLayoutAttr = TryFindFSharpInt32Attribute cenv.g cenv.g.attrib_StructLayoutAttribute attrs
+            let hasStructLayoutAttr = Option.isSome structLayoutAttr
+            let hasExplicitLayout = structLayoutAttr = Some(int32 System.Runtime.InteropServices.LayoutKind.Explicit)
             let hasAllowNullLiteralAttr = TryFindFSharpBoolAttribute cenv.g cenv.g.attrib_AllowNullLiteralAttribute attrs = Some(true)
 
             if hasAbstractAttr then 
@@ -15053,7 +15055,8 @@ module EstablishTypeDefinitionCores =
             let structLayoutAttributeCheck(allowed) = 
                 if hasStructLayoutAttr  then 
                     if allowed then 
-                        warning(PossibleUnverifiableCode(m))
+                        if hasExplicitLayout then
+                            warning(PossibleUnverifiableCode(m))
                     elif thisTyconRef.Typars(m).Length > 0 then 
                         errorR (Error(FSComp.SR.tcGenericTypesCannotHaveStructLayout(),m))
                     else

--- a/tests/fsharp/typecheck/sigs/neg06.bsl
+++ b/tests/fsharp/typecheck/sigs/neg06.bsl
@@ -117,9 +117,7 @@ neg06.fs(215,10,215,18): typecheck error FS0954: This type definition involves a
 
 neg06.fs(223,13,223,21): typecheck error FS0039: The value or constructor 'BadType3' is not defined.
 
-neg06.fs(294,10,294,12): typecheck error FS0009: Uses of this construct may result in the generation of unverifiable .NET IL code. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'.
-
-neg06.fs(298,10,298,12): typecheck error FS0009: Uses of this construct may result in the generation of unverifiable .NET IL code. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'.
+neg06.fs(300,10,300,12): typecheck error FS0009: Uses of this construct may result in the generation of unverifiable .NET IL code. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'.
 
 neg06.fs(304,10,304,12): typecheck error FS0937: Only structs and classes without primary constructors may be given the 'StructLayout' attribute
 

--- a/tests/fsharp/typecheck/sigs/neg06.fs
+++ b/tests/fsharp/typecheck/sigs/neg06.fs
@@ -286,8 +286,6 @@ end
 
 
 
-
-
 module PositiveTests = 
 
     [<System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)>]
@@ -298,6 +296,8 @@ module PositiveTests =
     type X2 = 
         abstract M : unit -> 'a
 
+    [<System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit)>]
+    type X1 =  { r : int }
 
 module NegativeTests = 
     [<System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)>]

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/W_StructLayoutSequentialPos_AbstractClass.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/W_StructLayoutSequentialPos_AbstractClass.fs
@@ -1,15 +1,14 @@
-// #Regression #Conformance #DeclarationElements #Attributes 
+// #Regression #Conformance #DeclarationElements #Attributes
 // Regression: FSB 4014
 // Need to tighten up our imlementation of StructLayout.Sequential.
-//<Expects id="FS0009" span="(10,10-10,12)" status="warning">Uses of this construct may result in the generation of unverifiable \.NET IL code\. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'\.</Expects>
 
-module PositiveTests = 
+module PositiveTests =
 
     [<System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)>]
     [<AbstractClass>]
-    type P2 = 
+    type P2 =
         abstract M : unit -> 'a
-    
+
     exit 0
 
 

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/W_StructLayoutSequentialPos_ClassExpliCtr.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/W_StructLayoutSequentialPos_ClassExpliCtr.fs
@@ -1,15 +1,14 @@
-// #Regression #Conformance #DeclarationElements #Attributes 
+// #Regression #Conformance #DeclarationElements #Attributes
 // Regression: FSB 4014
 // Need to tighten up our imlementation of StructLayout.Sequential.
-//<Expects id="FS0009" span="(9,10-9,12)" status="warning">Uses of this construct may result in the generation of unverifiable \.NET IL code\. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'\.</Expects>
 
-module PositiveTests = 
+module PositiveTests =
 
     [<System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)>]
-    type P4 = 
+    type P4 =
         member this.M = 1
         new()   = {}
-    
+
     exit 0
 
 

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/W_StructLayoutSequentialPos_ClassnoCtr.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/W_StructLayoutSequentialPos_ClassnoCtr.fs
@@ -1,14 +1,13 @@
-// #Regression #Conformance #DeclarationElements #Attributes 
+// #Regression #Conformance #DeclarationElements #Attributes
 // Regression: FSB 4014
 // Need to tighten up our imlementation of StructLayout.Sequential.
-//<Expects id="FS0009" span="(9,10-9,12)" status="warning">Uses of this construct may result in the generation of unverifiable \.NET IL code\. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'\.</Expects>
 
-module PositiveTests = 
+module PositiveTests =
 
     [<System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)>]
-    type P3 = 
+    type P3 =
         member this.M = 1
-    
+
     exit 0
 
 

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/W_StructLayoutSequentialPos_Record.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/W_StructLayoutSequentialPos_Record.fs
@@ -1,9 +1,8 @@
-// #Regression #Conformance #DeclarationElements #Attributes 
+// #Regression #Conformance #DeclarationElements #Attributes
 // Regression: FSB 4014
 // Need to tighten up our imlementation of StructLayout.Sequential.
-//<Expects id="FS0009" span="(9,10-9,12)" status="warning">Uses of this construct may result in the generation of unverifiable \.NET IL code\. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'\.</Expects>
 
-module PositiveTests = 
+module PositiveTests =
 
     [<System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)>]
     type P1 =  { r : int option ; name : string}

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/env.lst
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/Basic/env.lst
@@ -26,10 +26,10 @@
 	SOURCE=E_AttributeTargetSpecifications.fs						# E_AttributeTargetSpecifications.fs
 	SOURCE=W_StructLayoutExplicit01.fs   SCFLAGS="--test:ErrorRanges" PEVER="/Exp_Fail"	# W_StructLayoutExplicit01.fs
 	SOURCE=ParamArrayAttrUsage.fs   							# ParamArrayAttrUsage.fs
-	SOURCE=W_StructLayoutSequentialPos_Record.fs SCFLAGS="--test:ErrorRanges"		# W_StructLayoutSequentialPos_Record.fs
-	SOURCE=W_StructLayoutSequentialPos_AbstractClass.fs SCFLAGS="--test:ErrorRanges"	# W_StructLayoutSequentialPos_AbstractClass.fs
-	SOURCE=W_StructLayoutSequentialPos_ClassnoCtr.fs SCFLAGS="--test:ErrorRanges"		# W_StructLayoutSequentialPos_ClassnoCtr.fs
-	SOURCE=W_StructLayoutSequentialPos_ClassExpliCtr.fs SCFLAGS="--test:ErrorRanges"	# E_StructLayoutSequential.fs
+	SOURCE=W_StructLayoutSequentialPos_Record.fs SCFLAGS="--test:ErrorRanges --warnaserror+"		# W_StructLayoutSequentialPos_Record.fs
+	SOURCE=W_StructLayoutSequentialPos_AbstractClass.fs SCFLAGS="--test:ErrorRanges --warnaserror+"	# W_StructLayoutSequentialPos_AbstractClass.fs
+	SOURCE=W_StructLayoutSequentialPos_ClassnoCtr.fs SCFLAGS="--test:ErrorRanges --warnaserror+"		# W_StructLayoutSequentialPos_ClassnoCtr.fs
+	SOURCE=W_StructLayoutSequentialPos_ClassExpliCtr.fs SCFLAGS="--test:ErrorRanges --warnaserror+"	# E_StructLayoutSequential.fs
 	SOURCE=StructLayoutSequentialPos_Exception.fs						# StructLayoutSequentialPos_Exception.fs
 	SOURCE=E_StructLayoutSequentialNeg_Interface.fs SCFLAGS="--test:ErrorRanges"		# E_StructLayoutSequentialNeg_Interface.fs
 	SOURCE=E_StructLayoutSequentialNeg_AbstractClass.fs SCFLAGS="--test:ErrorRanges"	# E_StructLayoutSequentialNeg_AbstractClass.fs


### PR DESCRIPTION
According to ECMA-335, only `LayoutKind.Explicit` may produce unverifiable code. So, this PR removes the unncessary warnings for `LayoutKind.Auto` and `Sequential`.

See fsharp/fslang-suggestions#596.

Not sure if I did the right thing with `fsharpqa`, but all the tests are fixed.