### PR TITLE
add another test for #3254

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/Cancellation.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/Cancellation.fs
@@ -274,7 +274,7 @@ type CancellationType() =
             do! Async.Sleep 100
             cts.Cancel()
             do! Async.Sleep 100
-            tcs.TrySetException (TimeoutException "Cancellation was requested, but wasn't honered after 1 second. We finish the task forcefully (requests might still run in the background).")
+            tcs.TrySetException (TimeoutException "Task timed out after token.")
                 |> ignore
         } |> Async.Start
 

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/Cancellation.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/Cancellation.fs
@@ -229,7 +229,60 @@ type CancellationType() =
                     yield async { do linkedCts.Dispose() }                     
             }               
         asyncs |> Async.Parallel |> Async.RunSynchronously |> ignore
-        
+
+    [<Test>]
+    member this.AwaitTaskCancellationAfterAsyncTokenCancellation() =
+        let StartCatchCancellation cancellationToken (work) =
+            Async.FromContinuations(fun (cont, econt, _) ->
+              // When the child is cancelled, report OperationCancelled
+              // as an ordinary exception to "error continuation" rather
+              // than using "cancellation continuation"
+              let ccont e = econt e
+              // Start the workflow using a provided cancellation token
+              Async.StartWithContinuations( work, cont, econt, ccont,
+                                            ?cancellationToken=cancellationToken) )
+
+        /// Like StartAsTask but gives the computation time to so some regular cancellation work
+        let StartAsTaskProperCancel taskCreationOptions  cancellationToken (computation : Async<_>) : System.Threading.Tasks.Task<_> =
+            let token = defaultArg cancellationToken Async.DefaultCancellationToken
+            let taskCreationOptions = defaultArg taskCreationOptions System.Threading.Tasks.TaskCreationOptions.None
+            let tcs = new System.Threading.Tasks.TaskCompletionSource<_>("StartAsTaskProperCancel", taskCreationOptions)
+
+            let a =
+                async {
+                    try
+                        // To ensure we don't cancel this very async (which is required to properly forward the error condition)
+                        let! result = StartCatchCancellation (Some token) computation
+                        do
+                            tcs.SetResult(result)
+                    with exn ->
+                        tcs.SetException(exn)
+                }
+            Async.Start(a)
+            tcs.Task
+
+        let cts = new CancellationTokenSource()
+        let tcs = System.Threading.Tasks.TaskCompletionSource<_>()
+        let t =
+            async {
+                do! tcs.Task |> Async.AwaitTask
+            }
+            |> StartAsTaskProperCancel None (Some cts.Token)
+
+        // First cancel the token, then set the task as cancelled.
+        async {
+            do! Async.Sleep 100
+            cts.Cancel()
+            do! Async.Sleep 100
+            tcs.TrySetException (TimeoutException "Cancellation was requested, but wasn't honered after 1 second. We finish the task forcefully (requests might still run in the background).")
+                |> ignore
+        } |> Async.Start
+
+        try
+            let res = t.Wait(1000)
+            Assert.Fail (sprintf "Excepted TimeoutException wrapped in an AggregateException, but got %A" res)
+        with :? AggregateException as agg -> ()
+
     [<Test>]
     member this.Equality() =
         let cts1 = new CancellationTokenSource()


### PR DESCRIPTION
#3254 is a regression in FSharp.Core 4.2.1, this means paket needs a new release before we can update to the 4.2.X branch.

ported from paket. related to #3350 and https://github.com/fsprojects/Paket/pull/2553 (same test is added there but it fails)