### PR TITLE
better error protection for language service

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3400,6 +3400,7 @@ type ResolveCompletionTargets =
 
 /// Resolve a (possibly incomplete) long identifier to a set of possible resolutions, qualified by type.
 let ResolveCompletionsInType (ncenv: NameResolver) nenv (completionTargets: ResolveCompletionTargets) m ad statics typ =
+  protectAssemblyExploration [] <| fun () -> 
     let g = ncenv.g
     let amap = ncenv.amap
     
@@ -4439,9 +4440,11 @@ let rec GetCompletionForItem (ncenv: NameResolver) (nenv: NameResolutionEnv) m a
     }
 
 let IsItemResolvable (ncenv: NameResolver) (nenv: NameResolutionEnv) m ad plid (item: Item) : bool = 
+  protectAssemblyExploration false <| fun () -> 
     GetCompletionForItem ncenv nenv m ad plid item |> Seq.exists (ItemsAreEffectivelyEqual ncenv.g item)
 
 let GetVisibleNamespacesAndModulesAtPoint (ncenv: NameResolver) (nenv: NameResolutionEnv) m ad =
+  protectAssemblyExploration [] <| fun () -> 
     let ilTyconNames =
         nenv.TyconsByAccessNames(FullyQualifiedFlag.OpenQualified).Values
         |> List.choose (fun tyconRef -> if tyconRef.IsILTycon then Some tyconRef.DisplayName else None)

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -127,13 +127,6 @@ type ErrorScope()  =
             | Some text -> err text
             | None -> err ""
 
-    static member ProtectWithDefault m f dflt = 
-        ErrorScope.Protect m f (fun _ -> dflt)
-
-    static member ProtectAndDiscard m f = 
-        ErrorScope.Protect m f (fun _ -> ())
-      
-
 /// An error logger that capture errors, filtering them according to warning levels etc.
 type internal CompilationErrorLogger (debugName:string, tcConfig:TcConfig) = 
     inherit ErrorLogger("CompilationErrorLogger("+debugName+")")

--- a/src/fsharp/symbols/SymbolHelpers.fsi
+++ b/src/fsharp/symbols/SymbolHelpers.fsi
@@ -229,8 +229,6 @@ type internal ErrorScope =
     new : unit -> ErrorScope
     member Diagnostics : FSharpErrorInfo list
     static member Protect<'a> : range -> (unit->'a) -> (string->'a) -> 'a
-    static member ProtectWithDefault<'a> : range -> (unit -> 'a) -> 'a -> 'a
-    static member ProtectAndDiscard : range -> (unit -> unit) -> unit
 
 /// An error logger that capture errors, filtering them according to warning levels etc.
 type internal CompilationErrorLogger = 

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -10,6 +10,7 @@ namespace Microsoft.FSharp.Compiler.SourceCodeServices
 open System
 open System.IO
 open System.Collections.Generic
+open System.Diagnostics
  
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library  
 open Microsoft.FSharp.Compiler 
@@ -108,7 +109,9 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
                     NavigationImpl.empty
                 | _ -> 
                     NavigationImpl.empty )
-            (fun _ -> NavigationImpl.empty)   
+            (fun err -> 
+                Trace.TraceInformation(sprintf "FCS: recovering from error in GetNavigationItemsImpl: '%s'" err)
+                NavigationImpl.empty)   
             
     member private scope.ValidateBreakpointLocationImpl(pos) =
         let isMatchRange m = rangeContainsPos m pos || m.StartLine = pos.Line
@@ -373,7 +376,9 @@ type FSharpParseFileResults(errors : FSharpErrorInfo[], input : Ast.ParsedInput 
                         | [] -> Seq.tryHead locations
                         | locationsAfterPos -> Seq.tryHead locationsAfterPos
                     | coveringLocations -> Seq.tryLast coveringLocations)
-            (fun _msg -> None)
+            (fun msg -> 
+                Trace.TraceInformation(sprintf "FCS: recovering from error in ValidateBreakpointLocationImpl: '%s'" msg)
+                None)
             
     /// When these files appear or disappear the configuration for the current project is invalidated.
     member scope.DependencyFiles = dependencyFiles

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -589,7 +589,7 @@ type TypeCheckInfo
     let getItem (x: ItemWithInst) = x.Item
     let GetDeclaredItems (parseResultsOpt: FSharpParseFileResults option, lineStr: string, origLongIdentOpt, colAtEndOfNamesAndResidue, residueOpt, line, loc, 
                           filterCtors, resolveOverloads, hasTextChangedSinceLastTypecheck, isInRangeOperator, allSymbols: unit -> AssemblySymbol list) =
- 
+
             // Are the last two chars (except whitespaces) = ".."
             let isLikeRangeOp = 
                 match FindFirstNonWhitespacePosition lineStr (colAtEndOfNamesAndResidue - 1) with
@@ -893,7 +893,9 @@ type TypeCheckInfo
                 /// Find items in the best naming environment.
                 let (nenv, ad), m = GetBestEnvForPos cursorPos
                 NameResolution.IsItemResolvable ncenv nenv m ad plid item)
-            (fun _ -> false)
+            (fun msg -> 
+                Trace.TraceInformation(sprintf "FCS: recovering from error in IsRelativeNameResolvable: '%s'" msg)
+                false)
         
     /// Get the auto-complete items at a location
     member __.GetDeclarations (ctok, parseResultsOpt, line, lineStr, colAtEndOfNamesAndResidue, qualifyingNames, partialName, getAllSymbols, hasTextChangedSinceLastTypecheck) =
@@ -911,7 +913,9 @@ type TypeCheckInfo
                         |> Option.map (fun parsedInput -> UntypedParseImpl.GetFullNameOfSmallestModuleOrNamespaceAtPoint(parsedInput, mkPos line 0))
                     let isAttributeApplication = ctx = Some CompletionContext.AttributeApplication
                     FSharpDeclarationListInfo.Create(infoReader,m,denv,getAccessibility,items,reactorOps,currentNamespaceOrModule,isAttributeApplication,checkAlive))
-            (fun msg -> FSharpDeclarationListInfo.Error msg)
+            (fun msg -> 
+                Trace.TraceInformation(sprintf "FCS: recovering from error in GetDeclarations: '%s'" msg)
+                FSharpDeclarationListInfo.Error msg)
 
     /// Get the symbols for auto-complete items at a location
     member __.GetDeclarationListSymbols (ctok, parseResultsOpt, line, lineStr, colAtEndOfNamesAndResidue, qualifyingNames, partialName, hasTextChangedSinceLastTypecheck) =
@@ -975,7 +979,9 @@ type TypeCheckInfo
 
                     //end filtering
                     items)
-            (fun _msg -> [])
+            (fun msg -> 
+                Trace.TraceInformation(sprintf "FCS: recovering from error in GetDeclarationListSymbols: '%s'" msg)
+                [])
             
     /// Get the "reference resolution" tooltip for at a location
     member __.GetReferenceResolutionStructuredToolTipText(ctok, line,col) = 
@@ -1009,7 +1015,9 @@ type TypeCheckInfo
                                     
         ErrorScope.Protect Range.range0 
             dataTipOfReferences
-            (fun err -> FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError err])
+            (fun err -> 
+                Trace.TraceInformation(sprintf "FCS: recovering from error in GetReferenceResolutionStructuredToolTipText: '%s'" err)
+                FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError err])
 
     // GetToolTipText: return the "pop up" (or "Quick Info") text given a certain context.
     member __.GetStructuredToolTipText(ctok, line, lineStr, colAtEndOfNames, names) = 
@@ -1020,7 +1028,9 @@ type TypeCheckInfo
                     | None -> FSharpToolTipText []
                     | Some(items, denv, _, m) ->
                          FSharpToolTipText(items |> List.map (fun x -> FormatStructuredDescriptionOfItem false infoReader m denv x.ItemWithInst)))
-                (fun err -> FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError err])
+                (fun err -> 
+                    Trace.TraceInformation(sprintf "FCS: recovering from error in GetStructuredToolTipText: '%s'" err)
+                    FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError err])
                
         // See devdiv bug 646520 for rationale behind truncating and caching these quick infos (they can be big!)
         let key = line,colAtEndOfNames,lineStr
@@ -1059,7 +1069,9 @@ type TypeCheckInfo
                                 -> GetF1Keyword g typ
                         |   _ -> None
             )    
-            (fun _ -> None)
+            (fun msg -> 
+                Trace.TraceInformation(sprintf "FCS: recovering from error in GetF1Keyword: '%s'" msg)
+                None)
 
     member __.GetMethods (ctok, line, lineStr, colAtEndOfNames, namesOpt) =
         ErrorScope.Protect Range.range0 
@@ -1068,17 +1080,26 @@ type TypeCheckInfo
                 | None -> FSharpMethodGroup("",[| |])
                 | Some (items, denv, _, m) -> FSharpMethodGroup.Create(infoReader, m, denv, items |> List.map (fun x -> x.ItemWithInst)))
             (fun msg -> 
+                Trace.TraceInformation(sprintf "FCS: recovering from error in GetMethods: '%s'" msg)
                 FSharpMethodGroup(msg,[| |]))
 
     member __.GetMethodsAsSymbols (ctok, line, lineStr, colAtEndOfNames, names) =
+      ErrorScope.Protect Range.range0 
+       (fun () -> 
         match GetDeclItemsForNamesAtPosition (ctok, None,Some(names), None, line, lineStr, colAtEndOfNames, ResolveTypeNamesToCtors, ResolveOverloads.No,(fun() -> []),fun _ -> false) with
         | None | Some ([],_,_,_) -> None
         | Some (items, denv, _, m) ->
             let allItems = items |> List.collect (fun item -> SymbolHelpers.FlattenItems g m item.Item)
             let symbols = allItems |> List.map (fun item -> FSharpSymbol.Create(g, thisCcu, tcImports, item))
             Some (symbols, denv, m)
+       )
+       (fun msg -> 
+           Trace.TraceInformation(sprintf "FCS: recovering from error in GetMethodsAsSymbols: '%s'" msg)
+           None)
 
     member scope.GetDeclarationLocation (ctok, line, lineStr, colAtEndOfNames, names, preferFlag) =
+      ErrorScope.Protect Range.range0 
+       (fun () -> 
           match GetDeclItemsForNamesAtPosition (ctok, None,Some(names), None, line, lineStr, colAtEndOfNames, ResolveTypeNamesToCtors,ResolveOverloads.Yes,(fun() -> []), fun _ -> false) with
           | None
           | Some ([], _, _, _) -> FSharpFindDeclResult.DeclNotFound FSharpFindDeclFailureReason.Unknown
@@ -1119,13 +1140,23 @@ type TypeCheckInfo
                       FSharpFindDeclResult.DeclFound (mkRange filename itemRange.Start itemRange.End)
                   else 
                       fail FSharpFindDeclFailureReason.NoSourceCode // provided items may have TypeProviderDefinitionLocationAttribute that binds them to some location
+       )
+       (fun msg -> 
+           Trace.TraceInformation(sprintf "FCS: recovering from error in GetDeclarationLocation: '%s'" msg)
+           FSharpFindDeclResult.DeclNotFound FSharpFindDeclFailureReason.Unknown)
 
     member scope.GetSymbolUseAtLocation (ctok, line, lineStr, colAtEndOfNames, names) =
+      ErrorScope.Protect Range.range0 
+       (fun () -> 
         match GetDeclItemsForNamesAtPosition (ctok, None,Some(names), None, line, lineStr, colAtEndOfNames, ResolveTypeNamesToCtors, ResolveOverloads.Yes,(fun() -> []), fun _ -> false) with
         | None | Some ([], _, _, _) -> None
         | Some (item :: _, denv, _, m) -> 
             let symbol = FSharpSymbol.Create(g, thisCcu, tcImports, item.Item)
             Some (symbol, denv, m)
+       ) 
+       (fun msg -> 
+           Trace.TraceInformation(sprintf "FCS: recovering from error in GetSymbolUseAtLocation: '%s'" msg)
+           None)
 
     member scope.PartialAssemblySignature() = FSharpAssemblySignature(g, thisCcu, tcImports, None, ccuSig)
 
@@ -1139,6 +1170,8 @@ type TypeCheckInfo
          sSymbolUses.GetFormatSpecifierLocationsAndArity()
 
     member __.GetSemanticClassification(range: range option) : (range * SemanticClassificationType) [] =
+      ErrorScope.Protect Range.range0 
+       (fun () -> 
         let (|LegitTypeOccurence|_|) = function
             | ItemOccurence.UseInType
             | ItemOccurence.UseInAttribute
@@ -1243,6 +1276,10 @@ type TypeCheckInfo
             | _ -> None)
         |> Seq.toArray
         |> Array.append (sSymbolUses.GetFormatSpecifierLocationsAndArity() |> Array.map (fun m -> fst m, SemanticClassificationType.Printf))
+       ) 
+       (fun msg -> 
+           Trace.TraceInformation(sprintf "FCS: recovering from error in GetSemanticClassification: '%s'" msg)
+           Array.empty)
 
     /// The resolutions in the file
     member __.ScopeResolutions = sResolutions
@@ -1291,7 +1328,7 @@ module internal Parser =
                 if not(exn.IsPhaseInCompile()) then
                     // Reaching this point means that the error would be sticky if we let it prop up to the language service.
                     // Assert and recover by replacing phase with one known to the language service.
-                    System.Diagnostics.Debug.Assert(false, sprintf "The subcategory '%s' seen in an error should not be seen by the language service" (exn.Subcategory()))
+                    Trace.TraceInformation(sprintf "The subcategory '%s' seen in an error should not be seen by the language service" (exn.Subcategory()))
                     {exn with Phase=BuildPhase.TypeCheck}
                 else exn
             if reportErrors then 


### PR DESCRIPTION
Some watson dump error reports reported automatically to Microsoft are showing failures where exceptions are escaping the language service.  This fix adds error protection to more language service entry points, and adds error recovery for incomplete assembly reference sets in some extra cases.

