### PR TITLE
improve stack traces for watson exns

### DIFF
--- a/src/fsharp/ErrorLogger.fs
+++ b/src/fsharp/ErrorLogger.fs
@@ -360,7 +360,8 @@ module ErrorLoggerExtensions =
         | :? System.NotSupportedException  -> ()
         | :? System.IO.IOException -> () // This covers FileNotFoundException and DirectoryNotFoundException
         | :? System.UnauthorizedAccessException -> ()
-        | exn -> 
+        | Failure _ // This gives reports for compiler INTERNAL ERRORs
+        | :? System.SystemException ->
             PreserveStackTrace(exn)
             raise exn
 #endif

--- a/src/fsharp/ErrorLogger.fs
+++ b/src/fsharp/ErrorLogger.fs
@@ -22,14 +22,18 @@ open System
 /// Represents the style being used to format errors
 [<RequireQualifiedAccess>]
 type ErrorStyle = 
-| DefaultErrors 
-| EmacsErrors 
-| TestErrors 
-| VSErrors
-| GccErrors
+    | DefaultErrors 
+    | EmacsErrors 
+    | TestErrors 
+    | VSErrors
+    | GccErrors
 
 /// Thrown when we want to add some range information to a .NET exception
-exception WrappedError of exn * range
+exception WrappedError of exn * range with
+    override this.Message =
+        match this :> exn with
+        | WrappedError (exn, _) -> "WrappedError(" + exn.Message + ")"
+        | _ -> "WrappedError"
 
 /// Thrown when immediate, local error recovery is not possible. This indicates
 /// we've reported an error but need to make a non-local transfer of control.
@@ -39,10 +43,55 @@ exception WrappedError of exn * range
 /// situations (LazyWithContext) we may need to re-report the original error
 /// when a lazy thunk is re-evaluated.
 exception ReportedError of exn option with
+    override this.Message = 
+        let msg = "The exception has been reported. This internal exception should now be caught at an error recovery point on the stack."
+        match this :> exn with
+        | ReportedError (Some exn) -> msg + " Original message: " + exn.Message + ")"
+        | _ -> msg
+
+/// Thrown when we stop processing the F# Interactive entry or #load.
+exception StopProcessingExn of exn option with
+    override this.Message = "Processing of a script fragment has stopped because an exception has been raised"
+
+    override this.ToString() = 
+        match this :> exn with 
+        | StopProcessingExn(Some exn) ->  "StopProcessingExn, originally (" + exn.ToString() + ")"
+        | _ -> "StopProcessingExn"
+
+        
+let (|StopProcessing|_|) exn = match exn with StopProcessingExn _ -> Some () | _ -> None
+let StopProcessing<'T> = StopProcessingExn None
+
+exception NumberedError of (int * string) * range with   // int is e.g. 191 in FS0191
     override this.Message =
         match this :> exn with
-        | ReportedError (Some exn) -> exn.Message
-        | _ -> "ReportedError"
+        | NumberedError((_,msg),_) -> msg
+        | _ -> ""
+
+exception Error of (int * string) * range with   // int is e.g. 191 in FS0191  // eventually remove this type, it is a transitional artifact of the old unnumbered error style
+    override this.Message =
+        match this :> exn with
+        | Error((_,msg),_) -> msg
+        | _ -> "impossible"
+
+
+exception InternalError of msg: string * range with 
+    override this.Message = 
+        match this :> exn with 
+        | InternalError(msg,m) -> msg + m.ToString()
+        | _ -> "impossible"
+
+exception UserCompilerMessage of string * int * range
+exception LibraryUseOnly of range
+exception Deprecated of string * range
+exception Experimental of string * range
+exception PossibleUnverifiableCode of range
+
+exception UnresolvedReferenceNoRange of (*assemblyname*) string 
+exception UnresolvedReferenceError of (*assemblyname*) string * range
+exception UnresolvedPathReferenceNoRange of (*assemblyname*) string * (*path*) string
+exception UnresolvedPathReference of (*assemblyname*) string * (*path*) string * range
+
 
 let rec findOriginalException err = 
     match err with 
@@ -53,45 +102,13 @@ let rec findOriginalException err =
 
 type Suggestions = unit -> Set<string>
 
-let NoSuggestions : Suggestions = fun () -> Set.empty
-
-/// Thrown when we stop processing the F# Interactive entry or #load.
-exception StopProcessingExn of exn option
-let (|StopProcessing|_|) exn = match exn with StopProcessingExn _ -> Some () | _ -> None
-let StopProcessing<'T> = StopProcessingExn None
-
-(* common error kinds *)
-exception NumberedError of (int * string) * range with   // int is e.g. 191 in FS0191
-    override this.Message =
-        match this :> exn with
-        | NumberedError((_,msg),_) -> msg
-        | _ -> "impossible"
-
-exception Error of (int * string) * range with   // int is e.g. 191 in FS0191  // eventually remove this type, it is a transitional artifact of the old unnumbered error style
-    override this.Message =
-        match this :> exn with
-        | Error((_,msg),_) -> msg
-        | _ -> "impossible"
-
-
 exception ErrorWithSuggestions of (int * string) * range * string * Suggestions with   // int is e.g. 191 in FS0191 
     override this.Message =
         match this :> exn with
         | ErrorWithSuggestions((_,msg),_,_,_) -> msg
         | _ -> "impossible"
 
-exception InternalError of string * range
-exception UserCompilerMessage of string * int * range
-exception LibraryUseOnly of range
-exception Deprecated of string * range
-exception Experimental of string * range
-exception PossibleUnverifiableCode of range
-
-// Range/NoRange Duals
-exception UnresolvedReferenceNoRange of (*assemblyname*) string 
-exception UnresolvedReferenceError of (*assemblyname*) string * range
-exception UnresolvedPathReferenceNoRange of (*assemblyname*) string * (*path*) string
-exception UnresolvedPathReference of (*assemblyname*) string * (*path*) string * range
+let NoSuggestions : Suggestions = fun () -> Set.empty
 
 
 let inline protectAssemblyExploration dflt f = 
@@ -149,9 +166,9 @@ let QuitProcessExiter =
 type BuildPhase =
     | DefaultPhase 
     | Compile 
-    |  Parameter | Parse | TypeCheck 
+    | Parameter | Parse | TypeCheck 
     | CodeGen 
-    |  Optimize |  IlxGen |  IlGen |  Output 
+    | Optimize |  IlxGen |  IlGen |  Output 
     | Interactive // An error seen during interactive execution
     
 /// Literal build phase subcategory strings.
@@ -320,9 +337,7 @@ type internal CompileThreadStatic =
 module ErrorLoggerExtensions = 
     open System.Reflection
 
-    // Instruct the exception not to reset itself when thrown again.
-    // Design Note: This enables the compiler to prompt the user to send mail to fsbugs@microsoft.com, 
-    // by catching the exception, prompting and then propagating the exception with reraise. 
+    /// Instruct the exception not to reset itself when thrown again.
     let PreserveStackTrace(exn) =
         try 
             let preserveStackTrace = typeof<System.Exception>.GetMethod("InternalPreserveStackTrace", BindingFlags.Instance ||| BindingFlags.NonPublic)
@@ -333,7 +348,7 @@ module ErrorLoggerExtensions =
            ()
 
 
-    // Reraise an exception if it is one we want to report to Watson.
+    /// Reraise an exception if it is one we want to report to Watson.
     let ReraiseIfWatsonable(exn:exn) =
 #if FX_REDUCED_EXCEPTIONS
         ignore exn
@@ -345,11 +360,9 @@ module ErrorLoggerExtensions =
         | :? System.NotSupportedException  -> ()
         | :? System.IO.IOException -> () // This covers FileNotFoundException and DirectoryNotFoundException
         | :? System.UnauthorizedAccessException -> ()
-        | Failure _ // This gives reports for compiler INTERNAL ERRORs
-        | :? System.SystemException -> 
+        | exn -> 
             PreserveStackTrace(exn)
             raise exn
-        | _ -> ()
 #endif
 
     type ErrorLogger with  
@@ -362,13 +375,17 @@ module ErrorLoggerExtensions =
 
             match exn with 
             | StopProcessing 
-            | ReportedError _ -> raise exn 
+            | ReportedError _ -> 
+                PreserveStackTrace(exn)
+                raise exn 
             | _ -> x.DiagnosticSink(PhasedDiagnostic.Create(exn,CompileThreadStatic.BuildPhase), true)
 
         member x.Warning exn = 
             match exn with 
             | StopProcessing 
-            | ReportedError _ -> raise exn 
+            | ReportedError _ -> 
+                PreserveStackTrace(exn)
+                raise exn 
             | _ -> x.DiagnosticSink(PhasedDiagnostic.Create(exn,CompileThreadStatic.BuildPhase), false)
 
         member x.Error   exn = 
@@ -389,13 +406,16 @@ module ErrorLoggerExtensions =
             | :? System.Threading.ThreadAbortException | WrappedError((:? System.Threading.ThreadAbortException),_) ->  ()
 #endif
             | ReportedError _  | WrappedError(ReportedError _,_)  -> ()
-            | StopProcessing | WrappedError(StopProcessing,_) -> raise exn
+            | StopProcessing | WrappedError(StopProcessing,_) -> 
+                PreserveStackTrace(exn)
+                raise exn
             | _ ->
                 try  
                     x.ErrorR (AttachRange m exn) // may raise exceptions, e.g. an fsi error sink raises StopProcessing.
                     ReraiseIfWatsonable(exn)
                 with
                   | ReportedError _ | WrappedError(ReportedError _,_)  -> ()
+
         member x.StopProcessingRecovery (exn:exn) (m:range) =
             // Do standard error recovery.
             // Additionally ignore/catch StopProcessing. [This is the only catch handler for StopProcessing].
@@ -408,6 +428,7 @@ module ErrorLoggerExtensions =
                 with
                   | StopProcessing | WrappedError(StopProcessing,_) -> () // catch, e.g. raised by DiagnosticSink.
                   | ReportedError _ | WrappedError(ReportedError _,_)  -> () // catch, but not expected unless ErrorRecovery is changed.
+
         member x.ErrorRecoveryNoRange (exn:exn) =
             x.ErrorRecovery exn range0
 

--- a/src/fsharp/ErrorLogger.fs
+++ b/src/fsharp/ErrorLogger.fs
@@ -364,6 +364,7 @@ module ErrorLoggerExtensions =
         | :? System.SystemException ->
             PreserveStackTrace(exn)
             raise exn
+        | _ -> ()
 #endif
 
     type ErrorLogger with  

--- a/src/fsharp/InnerLambdasToTopLevelFuncs.fs
+++ b/src/fsharp/InnerLambdasToTopLevelFuncs.fs
@@ -42,7 +42,12 @@ let liftTLR    = ref false
 let internalError str = dprintf "Error: %s\n" str;raise (Failure str)  
 
 module Zmap = 
-    let force k   mp (str,soK) = try Zmap.find k mp with e -> dprintf "Zmap.force: %s %s\n" str (soK k); raise e
+    let force k   mp (str,soK) = 
+        try Zmap.find k mp 
+        with e -> 
+            dprintf "Zmap.force: %s %s\n" str (soK k); 
+            PreserveStackTrace(e)
+            raise e
 
 //-------------------------------------------------------------------------
 // misc

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -3329,7 +3329,9 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
         if (AddCxTypeMustSubsumeTypeUndoIfFailed env.DisplayEnv cenv.css m ty exprty) then 
             match tryType (mkCoerceExpr(expr,ty,expr.Range,exprty),ty) with 
             | Result res  -> Some res
-            | Exception e -> raise e
+            | Exception e -> 
+                PreserveStackTrace(e)
+                raise e
         else None
 
     // Next try to typecheck the thing as a sequence
@@ -3343,6 +3345,7 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
     match probe ienumerable with
     | Some res -> res
     | None ->
+    PreserveStackTrace(e)
     raise e
 
 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2043,7 +2043,9 @@ module CompileHelpers =
             for exec in execs do 
                 match exec() with 
                 | None -> ()
-                | Some exn -> raise exn
+                | Some exn -> 
+                    PreserveStackTrace(exn)
+                    raise exn
 
         // Register the reflected definitions for the dynamically generated assembly
         for resource in ilxMainModule.Resources.AsList do 


### PR DESCRIPTION

Some Watson-reported exceptions were not preserving stack traces. This fixes that, and makes a few other improvements to messages for exceptions (used when debugging the compiler itself, not visible externally)

