### PR TITLE
Correctly fetch the IVsBuildMacroInfo to use for the build events page

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildEventsPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildEventsPropPage.vb
@@ -335,8 +335,16 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Function GetTokenValue(ByVal MacroName As String) As String
             Dim MacroEval As IVsBuildMacroInfo
             Dim MacroValue As String = Nothing
+            Dim Hier As IVsHierarchy = Nothing
+            Dim ItemId As UInteger
+            Dim ThisObj As Object = m_Objects(0)
 
-            MacroEval = CType(m_Objects(0), IVsBuildMacroInfo)
+            If TypeOf ThisObj Is IVsBrowseObject Then
+                VSErrorHandler.ThrowOnFailure(CType(ThisObj, IVsBrowseObject).GetProjectItem(Hier, ItemId))
+            ElseIf TypeOf ThisObj Is IVsCfgBrowseObject Then
+                VSErrorHandler.ThrowOnFailure(CType(ThisObj, IVsCfgBrowseObject).GetProjectItem(Hier, ItemId))
+            End If
+            MacroEval = CType(Hier, IVsBuildMacroInfo)
             VSErrorHandler.ThrowOnFailure(MacroEval.GetBuildMacroValue(MacroName, MacroValue))
 
             Return MacroValue


### PR DESCRIPTION
This code is blindly copied and pasted from [here](https://github.com/dotnet/project-system/blob/88606ba869a29aa24979e0d14a199b2430f31f43/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb#L162-L176). Without it, if you're on the CPS-based project system trying to open the pre/post event editing dialogs just crashes when you click the button.

![image](https://user-images.githubusercontent.com/201340/28597846-029ab08a-7155-11e7-976e-187d8cb60383.png)

@srivatsn has recently poked around here, so might be able to confirm this is now expected. It looks like whatever object it previously assumed implemented IVsBuildMacroInfo no longer does, and an extra jump is required.