### PR TITLE
do not generalize top-level values that uses a mutable top-level binding

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -2120,9 +2120,11 @@ module GeneralizationHelpers =
             && List.forall (IsGeneralizableValue g) args
 
         | Expr.LetRec(binds,body,_,_)  ->
+            binds |> List.forall (fun b -> not b.Var.IsMutable) &&
             binds |> List.forall (fun b -> IsGeneralizableValue g b.Expr) &&
             IsGeneralizableValue g body
         | Expr.Let(bind,body,_,_) -> 
+            not bind.Var.IsMutable &&
             IsGeneralizableValue g bind.Expr &&
             IsGeneralizableValue g body
 

--- a/tests/fsharp/core/letrec/test.fsx
+++ b/tests/fsharp/core/letrec/test.fsx
@@ -625,6 +625,23 @@ module BasicPermutations =
           // to the base implementations of overridden members <file> <line>
           override x.Foo a = base.Foo(a)
 
+module Test2 = 
+    let tag = 
+        let mutable i = 0
+        fun _ -> i <- i+1; i // this should _not_ generalize, see https://github.com/Microsoft/visualfsharp/issues/3358
+
+    test "vwekjwve91" (tag()) 1
+    test "vwekjwve92" (tag()) 2
+    test "vwekjwve93" (tag()) 3
+
+module Test3 = 
+    let rec tag = 
+        let mutable i = 0
+        fun _ -> i <- i+1; i // this should _not_ generalize, see https://github.com/Microsoft/visualfsharp/issues/3358
+
+    test "vwekjwve94" (tag()) 1
+    test "vwekjwve95" (tag()) 2
+    test "vwekjwve96" (tag()) 3
 
 #if TESTS_AS_APP
 let RUN() = !failures


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/3358
