### PR TITLE
WIP:   Map workspace to iprojectsite

### DIFF
--- a/vsintegration/packages.config
+++ b/vsintegration/packages.config
@@ -62,6 +62,9 @@
   <package id="Microsoft.VisualStudio.Language.StandardClassification" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Language.Intellisense" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" />
+  <package id="Microsoft.VisualStudio.ProjectSystem" version="15.0.751" />
+  <package id="Microsoft.VisualStudio.ProjectSystem.Managed" version="2.0.6142705" />
+  <package id="Microsoft.VisualStudio.Composition" version="15.3.38" />
 
   <!--<package id="Roslyn.Microsoft.VisualStudio.ComponentModelHost" version="15.0.26201-alpha" targetFramework="net46" />-->
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="15.0.26201-alpha" targetFramework="net46" />

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -147,6 +147,15 @@
       <HintPath>$(FSharpSourcesRoot)\..\packages\EnvDTE80.8.0.1\lib\net10\EnvDTE80.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Composition">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Composition.15.3.38\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.ProjectSystem.Managed">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.ProjectSystem.Managed.2.0.6142705\lib\net46\Microsoft.VisualStudio.ProjectSystem.Managed.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.ProjectSystem">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.ProjectSystem.15.0.751\lib\net46\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Threading.$(MicrosoftVisualStudioThreadingVersion)\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -326,7 +326,6 @@ and
             | WorkspaceChangeKind.DocumentRemoved
             | WorkspaceChangeKind.AdditionalDocumentAdded
             | WorkspaceChangeKind.AdditionalDocumentRemoved
-            | WorkspaceChangeKind.DocumentInfoChanged
             | WorkspaceChangeKind.SolutionCleared ->
                 for projectId in this.Workspace.CurrentSolution.ProjectIds do
                     let project = this.Workspace.CurrentSolution.GetProject(projectId)


### PR DESCRIPTION
Use the Roslyn workspace as a datasource for source files and referenced projects for the F# Editor language service.

Note:  as of right now the source files are not in project file order. 