### PR TITLE
Add providerkey to msi

### DIFF
--- a/setup/Swix/Microsoft.FSharp.SDK.Core/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Core/Files.swr
@@ -3,7 +3,7 @@ use vs
 package name=Microsoft.FSharp.SDK.Core
         version=$(FSharpPackageVersion)
         vs.package.type=msi
-        vs.package.providerkey=Microsoft.FSharp.SDK.Core,V4.1
+        vs.package.providerkey=Microsoft.FSharp.SDK.Core,v4.1
 
 vs.installSize
   SystemDrive=194670592

--- a/setup/Swix/Microsoft.FSharp.SDK.Core/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Core/Files.swr
@@ -3,6 +3,7 @@ use vs
 package name=Microsoft.FSharp.SDK.Core
         version=$(FSharpPackageVersion)
         vs.package.type=msi
+        vs.package.providerkey=Microsoft.FSharp.SDK.Core,V4.1
 
 vs.installSize
   SystemDrive=194670592

--- a/setup/Swix/Microsoft.FSharp.SDK.Core/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Core/Files.swr
@@ -3,7 +3,7 @@ use vs
 package name=Microsoft.FSharp.SDK.Core
         version=$(FSharpPackageVersion)
         vs.package.type=msi
-        vs.package.providerkey=Microsoft.FSharp.SDK.Core,v4.1
+        vs.package.providerKey=Microsoft.FSharp.SDK.Core,v4.1
 
 vs.installSize
   SystemDrive=194670592

--- a/setup/Swix/Microsoft.FSharp.SDK.Resources/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Resources/Files.swr
@@ -4,7 +4,7 @@ package name=Microsoft.FSharp.SDK.Resources
         version=$(FSharpPackageVersion)
         vs.package.type=msi
         vs.package.language=$(LocaleSpecificCulture)
-        vs.package.providerkey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),v4.1
+        vs.package.providerKey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),v4.1
 
 vs.installSize
   SystemDrive=12681438

--- a/setup/Swix/Microsoft.FSharp.SDK.Resources/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Resources/Files.swr
@@ -4,7 +4,7 @@ package name=Microsoft.FSharp.SDK.Resources
         version=$(FSharpPackageVersion)
         vs.package.type=msi
         vs.package.language=$(LocaleSpecificCulture)
-        vs.package.providerkey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),V4.1
+        vs.package.providerkey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),v4.1
 
 vs.installSize
   SystemDrive=12681438

--- a/setup/Swix/Microsoft.FSharp.SDK.Resources/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Resources/Files.swr
@@ -4,6 +4,7 @@ package name=Microsoft.FSharp.SDK.Resources
         version=$(FSharpPackageVersion)
         vs.package.type=msi
         vs.package.language=$(LocaleSpecificCulture)
+        vs.package.providerkey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),V4.1
 
 vs.installSize
   SystemDrive=12681438


### PR DESCRIPTION
Part of improving the VS setup requires us to add this additional metadata to the installer msi file.


