### PR TITLE
Fix for #3267  --- Arrow keys and backspace stopped working

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -308,6 +308,8 @@ and
 
     let optionsAssociation = ConditionalWeakTable<IWorkspaceProjectContext, string[]>()
 
+    let lockObj = new Object()
+
     override this.Initialize() =
         base.Initialize()
 
@@ -416,18 +418,19 @@ and
             let projectGuid = Guid(site.ProjectGuid)
             let projectFileName = site.ProjectFileName()
             let projectDisplayName = projectDisplayNameOf projectFileName
+
             let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName)
 
             if isNull (workspace.ProjectTracker.GetProject projectId) then
                 projectInfoManager.UpdateProjectInfo(tryGetOrCreateProjectId workspace, projectId, site, workspace, userOpName)
                 let projectContextFactory = package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
                 let errorReporter = ProjectExternalErrorReporter(projectId, "FS", this.SystemServiceProvider)
-                
+
                 let hierarchy =
                     site.ProjectProvider
                     |> Option.map (fun p -> p :?> IVsHierarchy)
                     |> Option.toObj
-                
+
                 // Roslyn is expecting site to be an IVsHierarchy.
                 // It just so happens that the object that implements IProvideProjectSite is also
                 // an IVsHierarchy. This assertion is to ensure that the assumption holds true.
@@ -450,7 +453,12 @@ and
                 for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites (site, this.SystemServiceProvider) do
                     let referencedProjectId = setup referencedSite                    
                     project.AddProjectReference(ProjectReference referencedProjectId)
-                workspace.ProjectTracker.AddProject(project)
+
+                lock lockObj (fun () -> 
+                    if not (workspace.ProjectTracker.ContainsProject(project)) then 
+                        workspace.ProjectTracker.AddProject(project) |> ignore
+                )
+
             projectId
         setup (siteProvider.GetProjectSite()) |> ignore
 


### PR DESCRIPTION
This is for vs2017-rtm branch and is a fix of the arrow keys bug.: https://github.com/Microsoft/visualfsharp/issues/3267

Don has a similar fix in master, although in master, it still repros although less frequently.  I believe there it is a threading issue.

/cc @cartermp, @dsyme, @pichie, @brettfo