### PR TITLE
Fix the CopyAndSubstituteTextFiles task

### DIFF
--- a/src/FSharpSource.BuildFromSource.targets
+++ b/src/FSharpSource.BuildFromSource.targets
@@ -40,16 +40,18 @@
           Inputs="@(CopyAndSubstituteText)"
           Outputs="@(CopyAndSubstituteText->'$(OutDir)%(TargetFilename)')" >
 
-    <PropertyGroup>
-      <FileText>
-        $([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText("%(CopyAndSubstituteText.FullPath)")), "%(CopyAndSubstituteText.Pattern1)", "%(CopyAndSubstituteText.Replacement1)"))
-      </FileText>
-
-      <FileText Condition = "'%(CopyAndSubstituteText.Pattern2)' != ''">
-        $([System.Text.RegularExpressions.Regex]::Replace($(FileText), "%(CopyAndSubstituteText.Pattern2)", "%(CopyAndSubstituteText.Replacement2)"))
-      </FileText>
-    </PropertyGroup>
-    <WriteLinesToFile File="$(OutDir)%(CopyAndSubstituteText.TargetFilename)" Lines="$(FileText)" Overwrite="true" />
+    <ItemGroup>
+        <Results Include="@(CopyAndSubstituteText->'$(OutDir)%(TargetFilename)')">
+            <Lines>
+                $([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText("%(CopyAndSubstituteText.FullPath)")), "%(CopyAndSubstituteText.Pattern1)", "%(CopyAndSubstituteText.Replacement1)"))
+            </Lines>
+            <Lines  Condition = "'%(CopyAndSubstituteText.Pattern2)' != ''">
+                $([System.Text.RegularExpressions.Regex]::Replace($(FileText), "%(CopyAndSubstituteText.Pattern2)", "%(CopyAndSubstituteText.Replacement2)"))
+            </Lines>
+        </Results>
+    </ItemGroup>
+    
+    <WriteLinesToFile File="$(OutDir)%(Results.Filename)%(Results.Extension)" Lines="%(Results.Lines)" Overwrite="true" />
   </Target>
 
   <!--


### PR DESCRIPTION
The CopyAndSubstituteTextFiles  in the BuildFromSource script overwrote the output file with the text from the last file read.

This corrects that behavior by correctly using an item group rather than a propertygroup for the text lines.