### PR TITLE
Fix version numbers for buildfrom source

### DIFF
--- a/src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.BuildFromSource.fsproj
+++ b/src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.BuildFromSource.fsproj
@@ -9,7 +9,7 @@
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <FX_NO_LOADER>true</FX_NO_LOADER>
-    <DefineConstants>EXTENSIONTYPING;$(DefineConstants)</DefineConstants>
+    <DefineConstants>EXTENSIONTYPING;$(DefineConstants);BUILD_FROM_SOURCE</DefineConstants>
     <OtherFlags>$(OtherFlags) --warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
   </PropertyGroup>
 

--- a/src/fsharp/FSharp.Core/FSharp.Core.BuildFromSource.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.BuildFromSource.fsproj
@@ -9,7 +9,7 @@
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <FX_NO_LOADER>true</FX_NO_LOADER>
-    <DefineConstants>$(DefineConstants);FSHARP_CORE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FSHARP_CORE;BUILD_FROM_SOURCE</DefineConstants>
     <OtherFlags>$(OtherFlags) --warnon:1182 --compiling-fslib --compiling-fslib-40 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
   </PropertyGroup>
 


### PR DESCRIPTION
Build from source for fsharp.core and FSharp.Compiler.Interactive.Settings dll was missing version numbers.

