### PR TITLE
Update package version numbers

### DIFF
--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -44,10 +44,10 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(TargetDotnetProfile)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PortableProfileBeingReferenced)' != ''">obj\$(Configuration)\$(TargetDotnetProfile)\$(PortableProfileBeingReferenced)\</IntermediateOutputPath>
 
-    <FSharpCore41TargetVersion>4.1.18</FSharpCore41TargetVersion>
+    <FSharpCore41TargetVersion>4.1.19</FSharpCore41TargetVersion>
     <FSharpCore41FrozenPortableVersion>4.1.20</FSharpCore41FrozenPortableVersion>
     <FSharpCore41FrozenPortableTargetVersion>4.1.21</FSharpCore41FrozenPortableTargetVersion>
-    <FSharpCore42TargetVersion>4.2.3</FSharpCore42TargetVersion>
+    <FSharpCore42TargetVersion>4.2.4</FSharpCore42TargetVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoPackaging)' != 'true' AND '$(OS)' != 'Unix'">

--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.proj
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.proj
@@ -13,7 +13,7 @@
     <PackageAuthors    Condition="'$(PackageAuthors)' == ''"   >Microsoft and F# Software Foundation</PackageAuthors> 
     <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags> 
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\coreclr\bin</OutputPath>
-    <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rc-$(BuildRevision.Trim())-0</PreReleaseSuffix>
+    <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rtm-$(BuildRevision.Trim())-0</PreReleaseSuffix>
     <PackageVersion>4.2.0$(PreReleaseSuffix)</PackageVersion>
     <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
   </PropertyGroup>


### PR DESCRIPTION
I have released new nuget packages to match the compiler to be shipped with VS2017.4 preview 2.

This updates the package version numbers.
Also updates the Microsoft.FSharp.Compiler package to -rtm- 