### PR TITLE
Simplify key and value access in zmap

### DIFF
--- a/src/absil/zmap.fs
+++ b/src/absil/zmap.fs
@@ -43,7 +43,7 @@ module internal Zmap =
         
     let ofList m xs = List.fold (fun m (k,v) -> add k v m) (empty m) xs
 
-    let keys   m = chooseL (fun k _ -> Some k) m 
-    let values m = chooseL (fun _ v -> Some v) m
+    let keys   (m:Zmap<_,_>) = m.Fold (fun k _ s -> k::s) []
+    let values (m:Zmap<_,_>) = m.Fold (fun _ v s -> v::s) []
 
     let memberOf m k = mem k m

--- a/src/absil/zmap.fs
+++ b/src/absil/zmap.fs
@@ -36,6 +36,9 @@ module internal Zmap =
 
     let choose f  (m:Zmap<_,_>) = m.First(f)
 
+    let chooseL f  (m:Zmap<_,_>) =
+      m.Fold (fun k v s -> match f k v with None -> s | Some x -> x::s) []
+
     let ofList ord xs = Internal.Utilities.Collections.Tagged.Map<_,_>.FromList(ord,xs)
 
     let keys   (m:Zmap<_,_>) = m.Fold (fun k _ s -> k::s) []

--- a/src/absil/zmap.fs
+++ b/src/absil/zmap.fs
@@ -2,9 +2,7 @@
 
 namespace Microsoft.FSharp.Compiler.AbstractIL.Internal
 
-open Internal.Utilities
 open Internal.Utilities.Collections.Tagged
-open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library 
 open System.Collections.Generic
 
 /// Maps with a specific comparison function
@@ -37,10 +35,7 @@ module internal Zmap =
       z,m
 
     let choose f  (m:Zmap<_,_>) = m.First(f)
-      
-    let chooseL f  (m:Zmap<_,_>) =
-      m.Fold (fun k v s -> match f k v with None -> s | Some x -> x::s) []
-        
+
     let ofList m xs = List.fold (fun m (k,v) -> add k v m) (empty m) xs
 
     let keys   (m:Zmap<_,_>) = m.Fold (fun k _ s -> k::s) []

--- a/src/absil/zmap.fs
+++ b/src/absil/zmap.fs
@@ -36,7 +36,7 @@ module internal Zmap =
 
     let choose f  (m:Zmap<_,_>) = m.First(f)
 
-    let ofList m xs = List.fold (fun m (k,v) -> add k v m) (empty m) xs
+    let ofList ord xs = Internal.Utilities.Collections.Tagged.Map<_,_>.FromList(ord,xs)
 
     let keys   (m:Zmap<_,_>) = m.Fold (fun k _ s -> k::s) []
     let values (m:Zmap<_,_>) = m.Fold (fun _ v s -> v::s) []

--- a/src/absil/zmap.fsi
+++ b/src/absil/zmap.fsi
@@ -36,6 +36,7 @@ module internal Zmap =
     val forall   : ('Key -> 'T -> bool) -> Zmap<'Key,'T> -> bool
 
     val choose   : ('Key -> 'T -> 'U option) -> Zmap<'Key,'T> -> 'U option
+    val chooseL  : ('Key -> 'T -> 'U option) -> Zmap<'Key,'T> -> 'U list
 
     val toList   : Zmap<'Key,'T> -> ('Key * 'T) list
     val ofList   : IComparer<'Key> -> ('Key * 'T) list -> Zmap<'Key,'T>

--- a/src/absil/zmap.fsi
+++ b/src/absil/zmap.fsi
@@ -36,7 +36,6 @@ module internal Zmap =
     val forall   : ('Key -> 'T -> bool) -> Zmap<'Key,'T> -> bool
 
     val choose   : ('Key -> 'T -> 'U option) -> Zmap<'Key,'T> -> 'U option
-    val chooseL  : ('Key -> 'T -> 'U option) -> Zmap<'Key,'T> -> 'U list
 
     val toList   : Zmap<'Key,'T> -> ('Key * 'T) list
     val ofList   : IComparer<'Key> -> ('Key * 'T) list -> Zmap<'Key,'T>


### PR DESCRIPTION
Keys and values can be accessed without intermediate some + pattern matching. 
OfList should not use add but lower level add. This reduces the number of map ctor calls since we only operate on maptree 