### PR TITLE
UseStandardResourceNames on templates, targets and Application property page

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -41,6 +41,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
     <WarningLevel Condition=" '$(WarningLevel)' == '' ">3</WarningLevel>
     <WarningsAsErrors Condition="'$(WarningsAsErrors)' == '' " />
+    <UseStandardResourceNames Condition=" '$(UseStandardResourceNames)' == '' ">true</UseStandardResourceNames>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
@@ -11,6 +11,7 @@
     <AssemblyName>$safeprojectname$</AssemblyName>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseStandardResourceNames>true</UseStandardResourceNames>
     $if$ ($targetframeworkversion$ >= 4.0)
     <TargetFSharpCoreVersion>4.4.1.0</TargetFSharpCoreVersion>
     $else$

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>$safeprojectname$</AssemblyName>
+    <UseStandardResourceNames>true</UseStandardResourceNames>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     $if$ ($targetframeworkversion$ >= 4.0)
     <TargetFSharpCoreVersion>4.4.1.0</TargetFSharpCoreVersion>

--- a/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore259Project/Template/PortableLibrary.fsproj
@@ -14,6 +14,7 @@
     <TargetProfile>netcore</TargetProfile>
     <TargetFSharpCoreVersion>3.259.41.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseStandardResourceNames>true</UseStandardResourceNames>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCore78Project/Template/PortableLibrary.fsproj
@@ -14,6 +14,7 @@
     <TargetProfile>netcore</TargetProfile>
     <TargetFSharpCoreVersion>3.78.41.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseStandardResourceNames>true</UseStandardResourceNames>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/NetCoreProject/Template/PortableLibrary.fsproj
@@ -14,6 +14,7 @@
     <TargetProfile>netcore</TargetProfile>
     <TargetFSharpCoreVersion>3.7.41.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseStandardResourceNames>true</UseStandardResourceNames>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
+++ b/vsintegration/ProjectTemplates/PortableLibraryProject/Template/PortableLibrary.fsproj
@@ -13,6 +13,7 @@
     <TargetFrameworkProfile>Profile47</TargetFrameworkProfile>
     <TargetFSharpCoreVersion>3.47.41.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseStandardResourceNames>true</UseStandardResourceNames>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
@@ -11,6 +11,7 @@
     <AssemblyName>$safeprojectname$</AssemblyName>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseStandardResourceNames>true</UseStandardResourceNames>
     $if$ ($targetframeworkversion$ >= 4.0)
     <TargetFSharpCoreVersion>4.4.1.0</TargetFSharpCoreVersion>
     $else$

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectConfig.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectConfig.cs
@@ -426,6 +426,18 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             }
         }
 
+        public bool UseStandardResourceNames
+        {
+            get
+            {
+                return getNullableBool(ProjectFileConstants.UseStandardResourceNames) ?? true;
+            }
+            set
+            {
+                setBool(ProjectFileConstants.UseStandardResourceNames, value);
+            }
+        }
+
         public bool Prefer32Bit
         {
             get

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectFileConstants.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectFileConstants.cs
@@ -122,6 +122,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         public const string DebugType = "DebugType";
         public const string Optimize = "Optimize";
         public const string Tailcalls = "Tailcalls";
+        public const string UseStandardResourceNames = "UseStandardResourceNames";
         public const string Prefer32Bit = "Prefer32Bit";
         public const string OutputPath = "OutputPath";
         public const string DefineConstants = "DefineConstants";

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -1982,7 +1982,12 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     | OutputType.Library -> "Library"
                     | _ -> raise <| ArgumentException(FSharpSR.GetString(FSharpSR.InvalidOutputType), "value")
                 this.Node.ProjectMgr.SetProjectProperty(ProjectFileConstants.OutputType, outputTypeInteger)
-        
+
+        [<Browsable(false)>]
+        member this.UseStandardResourceNames 
+            with get() = this.Node.ProjectMgr.GetProjectProperty(ProjectFileConstants.UseStandardResourceNames)
+            and set(value) = this.Node.ProjectMgr.SetProjectProperty(ProjectFileConstants.UseStandardResourceNames, value)
+
         // Build Events Page Properties
         [<Browsable(false)>]
         member this.PreBuildEvent

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectPrelude.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectPrelude.fs
@@ -198,6 +198,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         [<Literal>]
         let   TailcallsDescription = "TailcallsDescription"
         [<Literal>]
+        let   UseStandardResourceNames = "UseStandardResourceNames"
+        [<Literal>]
+        let   UseStandardResourceNamesDescription = "UseStandardResourceNamesDescription"
+        [<Literal>]
         let   TemplateNotFound = "TemplateNotFound"
         [<Literal>]
         let   NeedReloadToChangeTargetFx = "NeedReloadToChangeTargetFx" 

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.resx
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
- <root>
+<root>
   <!-- 
     Microsoft ResX Schema 
     
@@ -113,16 +112,16 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="TopHalfLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="TopHalfLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
@@ -135,15 +134,15 @@
   <data name="AssemblyNameLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="AssemblyNameLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
   <data name="AssemblyNameLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 3, 0</value>
+    <value>0, 0, 6, 0</value>
   </data>
   <data name="AssemblyNameLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 13</value>
+    <value>172, 27</value>
   </data>
   <data name="AssemblyNameLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -155,7 +154,7 @@
     <value>AssemblyNameLabel</value>
   </data>
   <data name="&gt;&gt;AssemblyNameLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AssemblyNameLabel.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -172,17 +171,53 @@
   <data name="ResourcesGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
+  <data name="Win32ResourceFileBrowse.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Win32ResourceFileBrowse.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="Win32ResourceFileBrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Win32ResourceFileBrowse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>838, 177</value>
+  </data>
+  <data name="Win32ResourceFileBrowse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 6, 0</value>
+  </data>
+  <data name="Win32ResourceFileBrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>43, 37</value>
+  </data>
+  <data name="Win32ResourceFileBrowse.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="Win32ResourceFileBrowse.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;Win32ResourceFileBrowse.Name" xml:space="preserve">
+    <value>Win32ResourceFileBrowse</value>
+  </data>
+  <data name="&gt;&gt;Win32ResourceFileBrowse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Win32ResourceFileBrowse.Parent" xml:space="preserve">
+    <value>ResourcesGroupBox</value>
+  </data>
+  <data name="&gt;&gt;Win32ResourceFileBrowse.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="ResourcesLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="ResourcesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 18</value>
+    <value>30, 45</value>
   </data>
   <data name="ResourcesLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 0, 0, 0</value>
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="ResourcesLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>390, 12</value>
+    <value>780, 25</value>
   </data>
   <data name="ResourcesLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -194,97 +229,25 @@
     <value>ResourcesLabel</value>
   </data>
   <data name="&gt;&gt;ResourcesLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ResourcesLabel.Parent" xml:space="preserve">
     <value>ResourcesGroupBox</value>
   </data>
   <data name="&gt;&gt;ResourcesLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="iconTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="iconTableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="iconTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Win32ResourceFileBrowse.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Win32ResourceFileBrowse.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="Win32ResourceFileBrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Win32ResourceFileBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>313, 15</value>
-  </data>
-  <data name="Win32ResourceFileBrowse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 0, 3, 0</value>
-  </data>
-  <data name="Win32ResourceFileBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 23</value>
-  </data>
-  <data name="Win32ResourceFileBrowse.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="Win32ResourceFileBrowse.Text" xml:space="preserve">
-    <value>...</value>
-  </data>
-  <data name="&gt;&gt;Win32ResourceFileBrowse.Name" xml:space="preserve">
-    <value>Win32ResourceFileBrowse</value>
-  </data>
-  <data name="&gt;&gt;Win32ResourceFileBrowse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Win32ResourceFileBrowse.Parent" xml:space="preserve">
-    <value>iconTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;Win32ResourceFileBrowse.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="Win32ResourceFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="Win32ResourceFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 15</value>
-  </data>
-  <data name="Win32ResourceFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 3, 3</value>
-  </data>
-  <data name="Win32ResourceFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>400, 21</value>
-  </data>
-  <data name="Win32ResourceFile.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;Win32ResourceFile.Name" xml:space="preserve">
-    <value>Win32ResourceFile</value>
-  </data>
-  <data name="&gt;&gt;Win32ResourceFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Win32ResourceFile.Parent" xml:space="preserve">
-    <value>iconTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;Win32ResourceFile.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="ResourceLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="ResourceLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>30, 132</value>
   </data>
   <data name="ResourceLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 2</value>
+    <value>0, 0, 0, 4</value>
   </data>
   <data name="ResourceLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 12</value>
+    <value>845, 33</value>
   </data>
   <data name="ResourceLabel.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -296,25 +259,94 @@
     <value>ResourceLabel</value>
   </data>
   <data name="&gt;&gt;ResourceLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ResourceLabel.Parent" xml:space="preserve">
-    <value>iconTableLayoutPanel</value>
+    <value>ResourcesGroupBox</value>
   </data>
   <data name="&gt;&gt;ResourceLabel.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="Win32ResourceFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="Win32ResourceFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 175</value>
+  </data>
+  <data name="Win32ResourceFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 6, 6</value>
+  </data>
+  <data name="Win32ResourceFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>796, 34</value>
+  </data>
+  <data name="Win32ResourceFile.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;Win32ResourceFile.Name" xml:space="preserve">
+    <value>Win32ResourceFile</value>
+  </data>
+  <data name="&gt;&gt;Win32ResourceFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Win32ResourceFile.Parent" xml:space="preserve">
+    <value>ResourcesGroupBox</value>
+  </data>
+  <data name="&gt;&gt;Win32ResourceFile.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="UseStandardResourceNames.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="UseStandardResourceNames.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="UseStandardResourceNames.Location" type="System.Drawing.Point, System.Drawing">
+    <value>36, 89</value>
+  </data>
+  <data name="UseStandardResourceNames.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>46, 6, 6, 23</value>
+  </data>
+  <data name="UseStandardResourceNames.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 31</value>
+  </data>
+  <data name="UseStandardResourceNames.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="UseStandardResourceNames.Text" xml:space="preserve">
+    <value>U&amp;se standard resource names</value>
+  </data>
+  <data name="&gt;&gt;UseStandardResourceNames.Name" xml:space="preserve">
+    <value>UseStandardResourceNames</value>
+  </data>
+  <data name="&gt;&gt;UseStandardResourceNames.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;UseStandardResourceNames.Parent" xml:space="preserve">
+    <value>ResourcesGroupBox</value>
+  </data>
+  <data name="&gt;&gt;UseStandardResourceNames.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="iconTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="iconTableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="iconTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
   <data name="iconTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 40</value>
+    <value>24, 83</value>
   </data>
   <data name="iconTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>9, 9, 9, 9</value>
+    <value>18, 19, 18, 19</value>
   </data>
   <data name="iconTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
   <data name="iconTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>345, 39</value>
+    <value>0, 0</value>
   </data>
   <data name="iconTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -323,28 +355,28 @@
     <value>iconTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;iconTableLayoutPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;iconTableLayoutPanel.Parent" xml:space="preserve">
     <value>ResourcesGroupBox</value>
   </data>
   <data name="&gt;&gt;iconTableLayoutPanel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>5</value>
   </data>
   <data name="iconTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="Win32ResourceFileBrowse" Row="8" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="Win32ResourceFile" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ResourceLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls /&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="ResourcesGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 101</value>
+    <value>0, 192</value>
   </data>
   <data name="ResourcesGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 12, 0, 0</value>
+    <value>0, 25, 0, 0</value>
   </data>
   <data name="ResourcesGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="ResourcesGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>366, 102</value>
+    <value>897, 242</value>
   </data>
   <data name="ResourcesGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -356,7 +388,7 @@
     <value>ResourcesGroupBox</value>
   </data>
   <data name="&gt;&gt;ResourcesGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ResourcesGroupBox.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -365,13 +397,13 @@
     <value>1</value>
   </data>
   <data name="AssemblyName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 16</value>
+    <value>0, 33</value>
   </data>
   <data name="AssemblyName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 3, 3</value>
+    <value>0, 6, 6, 6</value>
   </data>
   <data name="AssemblyName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 21</value>
+    <value>502, 34</value>
   </data>
   <data name="AssemblyName.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -380,7 +412,7 @@
     <value>AssemblyName</value>
   </data>
   <data name="&gt;&gt;AssemblyName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AssemblyName.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -395,13 +427,13 @@
     <value>NoControl</value>
   </data>
   <data name="OutputTypeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 49</value>
+    <value>526, 93</value>
   </data>
   <data name="OutputTypeLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>9, 9, 0, 0</value>
+    <value>18, 19, 0, 0</value>
   </data>
   <data name="OutputTypeLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 13</value>
+    <value>135, 27</value>
   </data>
   <data name="OutputTypeLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -413,7 +445,7 @@
     <value>OutputTypeLabel</value>
   </data>
   <data name="&gt;&gt;OutputTypeLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;OutputTypeLabel.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -422,16 +454,16 @@
     <value>3</value>
   </data>
   <data name="OutputType.ItemHeight" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>27</value>
   </data>
   <data name="OutputType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 65</value>
+    <value>526, 126</value>
   </data>
   <data name="OutputType.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>9, 3, 0, 3</value>
+    <value>18, 6, 0, 6</value>
   </data>
   <data name="OutputType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 21</value>
+    <value>502, 35</value>
   </data>
   <data name="OutputType.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -440,7 +472,7 @@
     <value>OutputType</value>
   </data>
   <data name="&gt;&gt;OutputType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;OutputType.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -455,13 +487,13 @@
     <value>NoControl</value>
   </data>
   <data name="TargetFrameworkLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 49</value>
+    <value>0, 93</value>
   </data>
   <data name="TargetFrameworkLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 9, 3, 0</value>
+    <value>0, 19, 6, 0</value>
   </data>
   <data name="TargetFrameworkLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 13</value>
+    <value>199, 27</value>
   </data>
   <data name="TargetFrameworkLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -473,7 +505,7 @@
     <value>TargetFrameworkLabel</value>
   </data>
   <data name="&gt;&gt;TargetFrameworkLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TargetFrameworkLabel.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -482,16 +514,16 @@
     <value>5</value>
   </data>
   <data name="TargetFramework.ItemHeight" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>27</value>
   </data>
   <data name="TargetFramework.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 65</value>
+    <value>0, 126</value>
   </data>
   <data name="TargetFramework.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 3, 0</value>
+    <value>0, 6, 6, 0</value>
   </data>
   <data name="TargetFramework.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 21</value>
+    <value>502, 35</value>
   </data>
   <data name="TargetFramework.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -500,7 +532,7 @@
     <value>TargetFramework</value>
   </data>
   <data name="&gt;&gt;TargetFramework.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TargetFramework.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -509,10 +541,13 @@
     <value>6</value>
   </data>
   <data name="TargetFSharpCoreVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 16</value>
+    <value>526, 33</value>
+  </data>
+  <data name="TargetFSharpCoreVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>18, 6, 0, 6</value>
   </data>
   <data name="TargetFSharpCoreVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 21</value>
+    <value>502, 35</value>
   </data>
   <data name="TargetFSharpCoreVersion.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -521,7 +556,7 @@
     <value>TargetFSharpCoreVersion</value>
   </data>
   <data name="&gt;&gt;TargetFSharpCoreVersion.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TargetFSharpCoreVersion.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -529,25 +564,21 @@
   <data name="&gt;&gt;TargetFSharpCoreVersion.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="TargetFSharpCoreVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>9, 3, 0, 3</value>
-  </data>  
   <data name="TargetFSharpCoreVersionLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="TargetFSharpCoreVersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>9, 0, 0, 0</value>
-  </data>  
   <data name="TargetFSharpCoreVersionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 0</value>
+    <value>526, 0</value>
+  </data>
+  <data name="TargetFSharpCoreVersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>18, 0, 0, 0</value>
   </data>
   <data name="TargetFSharpCoreVersionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 13</value>
+    <value>199, 27</value>
   </data>
   <data name="TargetFSharpCoreVersionLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  
   <data name="TargetFSharpCoreVersionLabel.Text" xml:space="preserve">
     <value>Target F# runtime:</value>
   </data>
@@ -555,7 +586,7 @@
     <value>TargetFSharpCoreVersionLabel</value>
   </data>
   <data name="&gt;&gt;TargetFSharpCoreVersionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TargetFSharpCoreVersionLabel.Parent" xml:space="preserve">
     <value>TopHalfLayoutPanel</value>
@@ -573,7 +604,7 @@
     <value>11</value>
   </data>
   <data name="TopHalfLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>518, 203</value>
+    <value>1028, 434</value>
   </data>
   <data name="TopHalfLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -582,7 +613,7 @@
     <value>TopHalfLayoutPanel</value>
   </data>
   <data name="&gt;&gt;TopHalfLayoutPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TopHalfLayoutPanel.Parent" xml:space="preserve">
     <value>$this</value>
@@ -591,13 +622,13 @@
     <value>0</value>
   </data>
   <data name="TopHalfLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AssemblyNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ResourcesGroupBox" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="OutputTypeLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="OutputType" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TargetFrameworkLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFramework" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFSharpCoreVersion" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TargetFSharpCoreVersionLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AssemblyNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ResourcesGroupBox" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="AssemblyName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="OutputTypeLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="OutputType" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TargetFrameworkLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFramework" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFSharpCoreVersion" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TargetFSharpCoreVersionLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>12, 27</value>
   </data>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -614,13 +645,16 @@
   <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>518, 203</value>
+    <value>1028, 434</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ApplicationPropPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>Microsoft.VisualStudio.Editors.PropertyPages.ApplicationPropPageBase, Microsoft.VisualStudio.Editors, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.ApplicationPropPageBase, FSharp.ProjectSystem.PropertyPages, Version=15.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
@@ -56,6 +56,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents TargetFrameworkLabel As System.Windows.Forms.Label
         Friend WithEvents AssemblyNameLabel As System.Windows.Forms.Label
         Friend WithEvents ResourceLabel As System.Windows.Forms.Label
+        Friend WithEvents UseStandardResourceNames As System.Windows.Forms.CheckBox
         Friend WithEvents TargetFSharpCoreVersion As System.Windows.Forms.ComboBox
         Friend WithEvents TargetFSharpCoreVersionLabel As System.Windows.Forms.Label
 
@@ -117,16 +118,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents Win32ResourceFileBrowse As System.Windows.Forms.Button
         Friend WithEvents Win32ResourceFile As System.Windows.Forms.TextBox
         Friend WithEvents TopHalfLayoutPanel As System.Windows.Forms.TableLayoutPanel
+
         <System.Diagnostics.DebuggerStepThrough()> Private Sub InitializeComponent()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(ApplicationPropPage))
             Me.TopHalfLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.AssemblyNameLabel = New System.Windows.Forms.Label()
             Me.ResourcesGroupBox = New System.Windows.Forms.GroupBox()
-            Me.ResourcesLabel = New System.Windows.Forms.Label()
-            Me.iconTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.Win32ResourceFileBrowse = New System.Windows.Forms.Button()
-            Me.Win32ResourceFile = New System.Windows.Forms.TextBox()
+            Me.ResourcesLabel = New System.Windows.Forms.Label()
             Me.ResourceLabel = New System.Windows.Forms.Label()
+            Me.Win32ResourceFile = New System.Windows.Forms.TextBox()
+            Me.UseStandardResourceNames = New System.Windows.Forms.CheckBox()
+            Me.iconTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.AssemblyName = New System.Windows.Forms.TextBox()
             Me.OutputTypeLabel = New System.Windows.Forms.Label()
             Me.OutputType = New System.Windows.Forms.ComboBox()
@@ -136,7 +139,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.TargetFSharpCoreVersionLabel = New System.Windows.Forms.Label()
             Me.TopHalfLayoutPanel.SuspendLayout()
             Me.ResourcesGroupBox.SuspendLayout()
-            Me.iconTableLayoutPanel.SuspendLayout()
             Me.SuspendLayout()
             '
             'TopHalfLayoutPanel
@@ -162,38 +164,44 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             resources.ApplyResources(Me.ResourcesGroupBox, "ResourcesGroupBox")
             Me.TopHalfLayoutPanel.SetColumnSpan(Me.ResourcesGroupBox, 2)
+            Me.ResourcesGroupBox.Controls.Add(Me.Win32ResourceFileBrowse)
             Me.ResourcesGroupBox.Controls.Add(Me.ResourcesLabel)
+            Me.ResourcesGroupBox.Controls.Add(Me.ResourceLabel)
+            Me.ResourcesGroupBox.Controls.Add(Me.Win32ResourceFile)
+            Me.ResourcesGroupBox.Controls.Add(Me.UseStandardResourceNames)
             Me.ResourcesGroupBox.Controls.Add(Me.iconTableLayoutPanel)
             Me.ResourcesGroupBox.Name = "ResourcesGroupBox"
             Me.ResourcesGroupBox.TabStop = False
-            '
-            'ResourcesLabel
-            '
-            resources.ApplyResources(Me.ResourcesLabel, "ResourcesLabel")
-            Me.ResourcesLabel.Name = "ResourcesLabel"
-            '
-            'iconTableLayoutPanel
-            '
-            resources.ApplyResources(Me.iconTableLayoutPanel, "iconTableLayoutPanel")
-            Me.iconTableLayoutPanel.Controls.Add(Me.Win32ResourceFileBrowse, 1, 8)
-            Me.iconTableLayoutPanel.Controls.Add(Me.Win32ResourceFile, 0, 8)
-            Me.iconTableLayoutPanel.Controls.Add(Me.ResourceLabel, 0, 6)
-            Me.iconTableLayoutPanel.Name = "iconTableLayoutPanel"
             '
             'Win32ResourceFileBrowse
             '
             resources.ApplyResources(Me.Win32ResourceFileBrowse, "Win32ResourceFileBrowse")
             Me.Win32ResourceFileBrowse.Name = "Win32ResourceFileBrowse"
             '
-            'Win32ResourceFile
+            'ResourcesLabel
             '
-            resources.ApplyResources(Me.Win32ResourceFile, "Win32ResourceFile")
-            Me.Win32ResourceFile.Name = "Win32ResourceFile"
+            resources.ApplyResources(Me.ResourcesLabel, "ResourcesLabel")
+            Me.ResourcesLabel.Name = "ResourcesLabel"
             '
             'ResourceLabel
             '
             resources.ApplyResources(Me.ResourceLabel, "ResourceLabel")
             Me.ResourceLabel.Name = "ResourceLabel"
+            '
+            'Win32ResourceFile
+            '
+            resources.ApplyResources(Me.Win32ResourceFile, "Win32ResourceFile")
+            Me.Win32ResourceFile.Name = "Win32ResourceFile"
+            '
+            'UseStandardResourceNames
+            '
+            resources.ApplyResources(Me.UseStandardResourceNames, "UseStandardResourceNames")
+            Me.UseStandardResourceNames.Name = "UseStandardResourceNames"
+            '
+            'iconTableLayoutPanel
+            '
+            resources.ApplyResources(Me.iconTableLayoutPanel, "iconTableLayoutPanel")
+            Me.iconTableLayoutPanel.Name = "iconTableLayoutPanel"
             '
             'AssemblyName
             '
@@ -229,9 +237,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             Me.TargetFSharpCoreVersion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
             Me.TargetFSharpCoreVersion.FormattingEnabled = True
-            Me.TargetFSharpCoreVersion.Sorted = True
             resources.ApplyResources(Me.TargetFSharpCoreVersion, "TargetFSharpCoreVersion")
             Me.TargetFSharpCoreVersion.Name = "TargetFSharpCoreVersion"
+            Me.TargetFSharpCoreVersion.Sorted = True
             '
             'TargetFSharpCoreVersionLabel
             '
@@ -248,8 +256,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.TopHalfLayoutPanel.PerformLayout()
             Me.ResourcesGroupBox.ResumeLayout(False)
             Me.ResourcesGroupBox.PerformLayout()
-            Me.iconTableLayoutPanel.ResumeLayout(False)
-            Me.iconTableLayoutPanel.PerformLayout()
             Me.ResumeLayout(False)
             Me.PerformLayout()
 
@@ -265,33 +271,55 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
-                    m_ControlData = New PropertyControlData() { _
-                        New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", Me.AssemblyName, New Control() {Me.AssemblyNameLabel}), _
-                        New PropertyControlData(VsProjPropId.VBPROJPROPID_OutputType, Const_OutputType, Me.OutputType, AddressOf Me.OutputTypeSet, AddressOf Me.OutputTypeGet, ControlDataFlags.UserHandledEvents, New Control() {Me.OutputTypeLabel}), _
-                        New PropertyControlData(VsProjPropId80.VBPROJPROPID_Win32ResourceFile, "Win32ResourceFile", Me.Win32ResourceFile, AddressOf Me.Win32ResourceSet, AddressOf Me.Win32ResourceGet, ControlDataFlags.None, New Control() {Me.Win32ResourceFileBrowse}), _
-                        New PropertyControlData( _
-                            VsProjPropId100.VBPROJPROPID_TargetFrameworkMoniker, Const_TargetFrameworkMoniker, _
-                            TargetFramework, _
-                            AddressOf SetTargetFramework, AddressOf GetTargetFramework, _
-                            ControlDataFlags.ProjectMayBeReloadedDuringPropertySet Or ControlDataFlags.NoOptimisticFileCheckout, _
-                            New Control() {Me.TargetFrameworkLabel}), _
-                        New PropertyControlData( _
-                            VsProjPropId100.VBPROJPROPID_TargetFrameworkMoniker + 100, ProjectFileConstants.TargetFSharpCoreVersion, _
-                            Me.TargetFSharpCoreVersion, _
-                            AddressOf SetTargetFSharpCore, AddressOf GetTargetFSharpCore, _
-                            ControlDataFlags.ProjectMayBeReloadedDuringPropertySet Or ControlDataFlags.NoOptimisticFileCheckout, _
-                            New Control() {Me.TargetFSharpCoreVersionLabel}) _
+                    m_ControlData = New PropertyControlData() {
+                        New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", Me.AssemblyName, New Control() {Me.AssemblyNameLabel}),
+                        New PropertyControlData(VsProjPropId.VBPROJPROPID_OutputType, Const_OutputType, Me.OutputType, AddressOf Me.OutputTypeSet, AddressOf Me.OutputTypeGet, ControlDataFlags.UserHandledEvents, New Control() {Me.OutputTypeLabel}),
+                        New PropertyControlData(VsProjPropId80.VBPROJPROPID_Win32ResourceFile, "Win32ResourceFile", Me.Win32ResourceFile, AddressOf Me.Win32ResourceSet, AddressOf Me.Win32ResourceGet, ControlDataFlags.None, New Control() {Me.Win32ResourceFileBrowse}),
+                        New PropertyControlData(&H10000000, "UseStandardResourceNames", Me.UseStandardResourceNames, AddressOf CheckBoxSet, AddressOf CheckBoxGet),
+                        New PropertyControlData(
+                            VsProjPropId100.VBPROJPROPID_TargetFrameworkMoniker, Const_TargetFrameworkMoniker,
+                            TargetFramework,
+                            AddressOf SetTargetFramework, AddressOf GetTargetFramework,
+                            ControlDataFlags.ProjectMayBeReloadedDuringPropertySet Or ControlDataFlags.NoOptimisticFileCheckout,
+                            New Control() {Me.TargetFrameworkLabel}),
+                        New PropertyControlData(
+                            VsProjPropId100.VBPROJPROPID_TargetFrameworkMoniker + 100, ProjectFileConstants.TargetFSharpCoreVersion,
+                            Me.TargetFSharpCoreVersion,
+                            AddressOf SetTargetFSharpCore, AddressOf GetTargetFSharpCore,
+                            ControlDataFlags.ProjectMayBeReloadedDuringPropertySet Or ControlDataFlags.NoOptimisticFileCheckout,
+                            New Control() {Me.TargetFSharpCoreVersionLabel})
                         }
                 End If
                 Return m_ControlData
             End Get
         End Property
 
+        Protected Function CheckBoxSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
+            'If PropertyControlData.IsSpecialValue(value) Then
+            '    ' Don't do anything if the value is missing or indeterminate
+            '    Return False
+            'End If
+
+            If Not TypeOf value Is Boolean Then
+                ' Don't do anything if the value isn't of the expected type
+                Return False
+            End If
+
+            CType(control, CheckBox).Checked = CBool(value)
+            Return True
+        End Function
+
+        Protected Function CheckBoxGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
+            Dim checkBox As CheckBox = CType(control, CheckBox)
+            value = checkBox.Checked.ToString()
+            Return True
+        End Function
+
         Protected Overrides ReadOnly Property ValidationControlGroups() As Control()()
             Get
                 If m_controlGroup Is Nothing Then
-                    m_controlGroup = New Control()() { _
-                        New Control() {Win32ResourceFile, Win32ResourceFileBrowse} _
+                    m_controlGroup = New Control()() {
+                        New Control() {Win32ResourceFile, Win32ResourceFileBrowse}
                         }
                 End If
                 Return m_controlGroup
@@ -463,6 +491,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MyBase.PostInitPage()
 
             EnableControlSet(CType(GetControlValueNative(Const_OutputType), VSLangProj.prjOutputType))
+            Me.UseStandardResourceNames.Enabled = True
         End Sub
 
 
@@ -478,11 +507,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
 
             Dim OutputType As VSLangProj.prjOutputType
-
             OutputType = CType(GetControlValueNative(Const_OutputType), VSLangProj.prjOutputType)
-
             Me.EnableControlSet(OutputType)
-
 
             SetDirty(VsProjPropId.VBPROJPROPID_OutputType, False)
             SetDirty(True) 'True forces Apply
@@ -522,11 +548,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 sInitialDirectory = System.IO.Path.GetDirectoryName(sInitialDirectory)
             End If
 
-            Dim fileNames As ArrayList = Common.Utils.GetFilesViaBrowse(ServiceProvider, Me.Handle, sInitialDirectory, SR.GetString(SR.PPG_AddWin32ResourceTitle), _
-                    Common.CombineDialogFilters( _
-                        Common.CreateDialogFilter(SR.GetString(SR.PPG_AddWin32ResourceFilter), "res"), _
-                        Common.Utils.GetAllFilesDialogFilter() _
-                        ), _
+            Dim fileNames As ArrayList = Common.Utils.GetFilesViaBrowse(ServiceProvider, Me.Handle, sInitialDirectory, SR.GetString(SR.PPG_AddWin32ResourceTitle),
+                    Common.CombineDialogFilters(
+                        Common.CreateDialogFilter(SR.GetString(SR.PPG_AddWin32ResourceFilter), "res"),
+                        Common.Utils.GetAllFilesDialogFilter()
+                        ),
                         0, False, sFileName)
             If fileNames IsNot Nothing AndAlso fileNames.Count = 1 Then
                 sFileName = CStr(fileNames(0))
@@ -762,6 +788,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Debug.Fail("The combobox should not have still been unselected yet be dirty")
             Return False
         End Function
+
+        Private Sub Win32ResourceFile_TextChanged(sender As Object, e As EventArgs) Handles Win32ResourceFile.TextChanged
+
+        End Sub
 
 
 #End Region

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildPropPage.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildPropPage.resx
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -128,13 +127,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblConditionalCompilationSymbols.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 27</value>
+    <value>23, 39</value>
   </data>
   <data name="lblConditionalCompilationSymbols.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 11, 3, 3</value>
   </data>
   <data name="lblConditionalCompilationSymbols.Size" type="System.Drawing.Size, System.Drawing">
-    <value>158, 13</value>
+    <value>326, 25</value>
   </data>
   <data name="lblConditionalCompilationSymbols.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -158,13 +157,13 @@
     <value>Left, Right</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 24</value>
+    <value>355, 36</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 3, 3</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>271, 31</value>
   </data>
   <data name="txtConditionalCompilationSymbols.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -203,13 +202,13 @@
     <value>NoControl</value>
   </data>
   <data name="chkPrefer32Bit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 149</value>
+    <value>23, 216</value>
   </data>
   <data name="chkPrefer32Bit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 0, 3, 1</value>
   </data>
   <data name="chkPrefer32Bit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 17</value>
+    <value>162, 23</value>
   </data>
   <data name="chkPrefer32Bit.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -242,13 +241,13 @@
     <value>Left, Right</value>
   </data>
   <data name="outputLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>48, 6</value>
+    <value>85, 12</value>
   </data>
   <data name="outputLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
   </data>
   <data name="outputLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>519, 1</value>
+    <value>658, 1</value>
   </data>
   <data name="outputLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -275,7 +274,7 @@
     <value>3, 0</value>
   </data>
   <data name="outputLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
+    <value>76, 25</value>
   </data>
   <data name="outputLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -296,7 +295,7 @@
     <value>1</value>
   </data>
   <data name="outputTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 407</value>
+    <value>0, 583</value>
   </data>
   <data name="outputTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -305,7 +304,7 @@
     <value>1</value>
   </data>
   <data name="outputTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>567, 13</value>
+    <value>743, 25</value>
   </data>
   <data name="outputTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -338,13 +337,13 @@
     <value>Left, Right</value>
   </data>
   <data name="generalLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>50, 6</value>
+    <value>94, 12</value>
   </data>
   <data name="generalLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
   </data>
   <data name="generalLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>517, 1</value>
+    <value>649, 1</value>
   </data>
   <data name="generalLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -374,7 +373,7 @@
     <value>0, 0, 3, 0</value>
   </data>
   <data name="generalLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
+    <value>88, 25</value>
   </data>
   <data name="generalLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -404,7 +403,7 @@
     <value>1</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>567, 13</value>
+    <value>743, 25</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -437,13 +436,13 @@
     <value>Left, Right</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 6</value>
+    <value>251, 12</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>441, 1</value>
+    <value>492, 1</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -473,7 +472,7 @@
     <value>0, 0, 3, 0</value>
   </data>
   <data name="treatWarningsAsErrorsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 13</value>
+    <value>245, 25</value>
   </data>
   <data name="treatWarningsAsErrorsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -494,7 +493,7 @@
     <value>1</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 306</value>
+    <value>0, 435</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -503,7 +502,7 @@
     <value>1</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>567, 13</value>
+    <value>743, 25</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -539,13 +538,13 @@
     <value>NoControl</value>
   </data>
   <data name="errorsAndWarningsLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>106, 6</value>
+    <value>210, 12</value>
   </data>
   <data name="errorsAndWarningsLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
   </data>
   <data name="errorsAndWarningsLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>461, 1</value>
+    <value>533, 1</value>
   </data>
   <data name="errorsAndWarningsLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -578,7 +577,7 @@
     <value>0, 0, 3, 0</value>
   </data>
   <data name="errorsAndWarningsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
+    <value>204, 25</value>
   </data>
   <data name="errorsAndWarningsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -599,7 +598,7 @@
     <value>1</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 224</value>
+    <value>0, 318</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -608,7 +607,7 @@
     <value>1</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>567, 13</value>
+    <value>743, 25</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -638,13 +637,13 @@
     <value>NoControl</value>
   </data>
   <data name="chkXMLDocumentationFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 465</value>
+    <value>23, 660</value>
   </data>
   <data name="chkXMLDocumentationFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="chkXMLDocumentationFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>140, 17</value>
+    <value>275, 10</value>
   </data>
   <data name="chkXMLDocumentationFile.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -668,10 +667,10 @@
     <value>Left, Right</value>
   </data>
   <data name="txtXMLDocumentationFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 463</value>
+    <value>355, 660</value>
   </data>
   <data name="txtXMLDocumentationFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>271, 31</value>
   </data>
   <data name="txtXMLDocumentationFile.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -698,13 +697,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnOutputPathBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>464, 431</value>
+    <value>632, 619</value>
   </data>
   <data name="btnOutputPathBrowse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 0, 3</value>
   </data>
   <data name="btnOutputPathBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 23</value>
+    <value>111, 35</value>
   </data>
   <data name="btnOutputPathBrowse.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -728,13 +727,13 @@
     <value>Left, Right</value>
   </data>
   <data name="txtOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 432</value>
+    <value>355, 621</value>
   </data>
   <data name="txtOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 3, 3</value>
   </data>
   <data name="txtOutputPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>271, 31</value>
   </data>
   <data name="txtOutputPath.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -761,13 +760,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 436</value>
+    <value>23, 624</value>
   </data>
   <data name="lblOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 11, 3, 3</value>
   </data>
   <data name="lblOutputPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 13</value>
+    <value>130, 25</value>
   </data>
   <data name="lblOutputPath.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -797,13 +796,13 @@
     <value>NoControl</value>
   </data>
   <data name="rbWarningAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 379</value>
+    <value>23, 543</value>
   </data>
   <data name="rbWarningAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 11</value>
   </data>
   <data name="rbWarningAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 17</value>
+    <value>67, 29</value>
   </data>
   <data name="rbWarningAll.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -833,13 +832,13 @@
     <value>NoControl</value>
   </data>
   <data name="rbWarningSpecific.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 354</value>
+    <value>23, 507</value>
   </data>
   <data name="rbWarningSpecific.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="rbWarningSpecific.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 17</value>
+    <value>217, 29</value>
   </data>
   <data name="rbWarningSpecific.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -863,10 +862,10 @@
     <value>Left, Right</value>
   </data>
   <data name="txtSpecificWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 353</value>
+    <value>355, 506</value>
   </data>
   <data name="txtSpecificWarnings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>271, 31</value>
   </data>
   <data name="txtSpecificWarnings.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -893,13 +892,13 @@
     <value>NoControl</value>
   </data>
   <data name="rbWarningNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 330</value>
+    <value>23, 471</value>
   </data>
   <data name="rbWarningNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 11, 3, 3</value>
   </data>
   <data name="rbWarningNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 17</value>
+    <value>94, 29</value>
   </data>
   <data name="rbWarningNone.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -923,13 +922,13 @@
     <value>Left, Right</value>
   </data>
   <data name="txtSupressWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 275</value>
+    <value>355, 393</value>
   </data>
   <data name="txtSupressWarnings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 11</value>
   </data>
   <data name="txtSupressWarnings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>271, 31</value>
   </data>
   <data name="txtSupressWarnings.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -956,13 +955,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblSupressWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 278</value>
+    <value>23, 396</value>
   </data>
   <data name="lblSupressWarnings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 11</value>
   </data>
   <data name="lblSupressWarnings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 13</value>
+    <value>201, 25</value>
   </data>
   <data name="lblSupressWarnings.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -985,14 +984,32 @@
   <data name="cboWarningLevel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
+  <data name="cboWarningLevel.Items" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cboWarningLevel.Items1" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cboWarningLevel.Items2" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="cboWarningLevel.Items3" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="cboWarningLevel.Items4" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="cboWarningLevel.Items5" xml:space="preserve">
+    <value>5</value>
+  </data>
   <data name="cboWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 248</value>
+    <value>355, 354</value>
   </data>
   <data name="cboWarningLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 3, 3</value>
   </data>
   <data name="cboWarningLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 21</value>
+    <value>125, 33</value>
   </data>
   <data name="cboWarningLevel.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -1019,13 +1036,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 252</value>
+    <value>23, 358</value>
   </data>
   <data name="lblWarningLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 11, 3, 3</value>
   </data>
   <data name="lblWarningLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 13</value>
+    <value>149, 25</value>
   </data>
   <data name="lblWarningLevel.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -1049,10 +1066,10 @@
     <value>Left</value>
   </data>
   <data name="cboPlatformTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 96</value>
+    <value>355, 143</value>
   </data>
   <data name="cboPlatformTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 21</value>
+    <value>125, 33</value>
   </data>
   <data name="cboPlatformTarget.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1079,13 +1096,13 @@
     <value>NoControl</value>
   </data>
   <data name="chkOptimizeCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 173</value>
+    <value>23, 243</value>
   </data>
   <data name="chkOptimizeCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="chkOptimizeCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+    <value>181, 29</value>
   </data>
   <data name="chkOptimizeCode.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1115,13 +1132,13 @@
     <value>NoControl</value>
   </data>
   <data name="chkTailcalls.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 196</value>
+    <value>23, 278</value>
   </data>
   <data name="chkTailcalls.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 11</value>
   </data>
   <data name="chkTailcalls.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 17</value>
+    <value>217, 29</value>
   </data>
   <data name="chkTailcalls.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1148,13 +1165,13 @@
     <value>True</value>
   </data>
   <data name="chkDefineTrace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 73</value>
+    <value>23, 108</value>
   </data>
   <data name="chkDefineTrace.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="chkDefineTrace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>140, 17</value>
+    <value>271, 29</value>
   </data>
   <data name="chkDefineTrace.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1181,13 +1198,13 @@
     <value>True</value>
   </data>
   <data name="lblPlatformTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 100</value>
+    <value>23, 147</value>
   </data>
   <data name="lblPlatformTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="lblPlatformTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 13</value>
+    <value>158, 25</value>
   </data>
   <data name="lblPlatformTarget.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1207,21 +1224,18 @@
   <data name="&gt;&gt;lblPlatformTarget.ZOrder" xml:space="preserve">
     <value>25</value>
   </data>
-  <data name="txtOtherFlags.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 123</value>
-  </data>
-  <data name="txtOtherFlags.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
-  </data>
-  <data name="txtOtherFlags.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>  
   <data name="txtOtherFlags.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
-  <data name="txtOtherFlags.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>  
+  <data name="txtOtherFlags.Location" type="System.Drawing.Point, System.Drawing">
+    <value>355, 182</value>
+  </data>
+  <data name="txtOtherFlags.Size" type="System.Drawing.Size, System.Drawing">
+    <value>271, 31</value>
+  </data>
+  <data name="txtOtherFlags.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
   <data name="&gt;&gt;txtOtherFlags.Name" xml:space="preserve">
     <value>txtOtherFlags</value>
   </data>
@@ -1241,13 +1255,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblOtherFlags.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 123</value>
+    <value>23, 182</value>
   </data>
   <data name="lblOtherFlags.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="lblOtherFlags.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
+    <value>123, 25</value>
   </data>
   <data name="lblOtherFlags.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1277,7 +1291,7 @@
     <value>20</value>
   </data>
   <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>567, 490</value>
+    <value>743, 673</value>
   </data>
   <data name="overarchingTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1298,13 +1312,13 @@
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="chkPrefer32Bit" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="outputTableLayoutPanel" Row="17" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="generalHeaderTableLayoutPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="treatWarningsAsErrorsTableLayoutPanel" Row="13" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="errorsAndWarningsTableLayoutPanel" Row="10" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkXMLDocumentationFile" Row="19" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtXMLDocumentationFile" Row="19" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnOutputPathBrowse" Row="18" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="txtOutputPath" Row="18" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblOutputPath" Row="18" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningAll" Row="16" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbWarningSpecific" Row="15" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtSpecificWarnings" Row="15" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningNone" Row="14" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtSupressWarnings" Row="12" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblSupressWarnings" Row="12" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboWarningLevel" Row="11" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblWarningLevel" Row="11" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboPlatformTarget" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="chkOptimizeCode" Row="8" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkTailcalls" Row="9" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineTrace" Row="3" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineDebug" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtConditionalCompilationSymbols" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblConditionalCompilationSymbols" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblPlatformTarget" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtOtherFlags" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblOtherFlags" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,24,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,16,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="chkDefineDebug.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 50</value>
+    <value>23, 73</value>
   </data>
   <data name="chkDefineDebug.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="chkDefineDebug.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 17</value>
+    <value>274, 29</value>
   </data>
   <data name="chkDefineDebug.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1331,12 +1345,12 @@
     <value>True</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>567, 490</value>
+    <value>743, 673</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>BuildPropPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.AppDesigner, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, FSharp.ProjectSystem.PropertyPages, Version=15.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildPropPage.vb
@@ -202,7 +202,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             resources.ApplyResources(Me.cboWarningLevel, "cboWarningLevel")
             Me.cboWarningLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
             Me.cboWarningLevel.FormattingEnabled = True
-            Me.cboWarningLevel.Items.AddRange(New Object() {"0", "1", "2", "3", "4", "5"})
+            Me.cboWarningLevel.Items.AddRange(New Object() {resources.GetString("cboWarningLevel.Items"), resources.GetString("cboWarningLevel.Items1"), resources.GetString("cboWarningLevel.Items2"), resources.GetString("cboWarningLevel.Items3"), resources.GetString("cboWarningLevel.Items4"), resources.GetString("cboWarningLevel.Items5")})
             Me.cboWarningLevel.Name = "cboWarningLevel"
             '
             'lblSupressWarnings

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/DebugPropPage.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/DebugPropPage.resx
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -113,23 +112,23 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="StartActionLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="StartActionLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="StartActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="StartActionLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
@@ -137,7 +136,7 @@
     <value>0, 0, 3, 0</value>
   </data>
   <data name="StartActionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 13</value>
+    <value>123, 25</value>
   </data>
   <data name="StartActionLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -149,7 +148,7 @@
     <value>StartActionLabel</value>
   </data>
   <data name="&gt;&gt;StartActionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;StartActionLabel.Parent" xml:space="preserve">
     <value>startActionTableLayoutPanel</value>
@@ -164,13 +163,13 @@
     <value>NoControl</value>
   </data>
   <data name="StartActionLabelLine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 6</value>
+    <value>129, 12</value>
   </data>
   <data name="StartActionLabelLine.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
   </data>
   <data name="StartActionLabelLine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>382, 1</value>
+    <value>399, 1</value>
   </data>
   <data name="StartActionLabelLine.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -179,7 +178,7 @@
     <value>StartActionLabelLine</value>
   </data>
   <data name="&gt;&gt;StartActionLabelLine.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;StartActionLabelLine.Parent" xml:space="preserve">
     <value>startActionTableLayoutPanel</value>
@@ -197,13 +196,13 @@
     <value>NoControl</value>
   </data>
   <data name="rbStartProject.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 25</value>
+    <value>23, 37</value>
   </data>
   <data name="rbStartProject.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 12, 3, 3</value>
   </data>
   <data name="rbStartProject.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 17</value>
+    <value>159, 29</value>
   </data>
   <data name="rbStartProject.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -215,7 +214,7 @@
     <value>rbStartProject</value>
   </data>
   <data name="&gt;&gt;rbStartProject.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;rbStartProject.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -233,13 +232,13 @@
     <value>NoControl</value>
   </data>
   <data name="rbStartProgram.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 51</value>
+    <value>23, 75</value>
   </data>
   <data name="rbStartProgram.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="rbStartProgram.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 17</value>
+    <value>262, 29</value>
   </data>
   <data name="rbStartProgram.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -251,7 +250,7 @@
     <value>rbStartProgram</value>
   </data>
   <data name="&gt;&gt;rbStartProgram.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;rbStartProgram.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -266,10 +265,10 @@
     <value>Left, Right</value>
   </data>
   <data name="StartProgram.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 49</value>
+    <value>291, 74</value>
   </data>
   <data name="StartProgram.Size" type="System.Drawing.Size, System.Drawing">
-    <value>258, 20</value>
+    <value>191, 31</value>
   </data>
   <data name="StartProgram.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -278,7 +277,7 @@
     <value>StartProgram</value>
   </data>
   <data name="&gt;&gt;StartProgram.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;StartProgram.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -302,13 +301,13 @@
     <value>NoControl</value>
   </data>
   <data name="StartProgramBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>424, 48</value>
+    <value>488, 72</value>
   </data>
   <data name="StartProgramBrowse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 0, 3</value>
   </data>
   <data name="StartProgramBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 23</value>
+    <value>40, 35</value>
   </data>
   <data name="StartProgramBrowse.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -320,7 +319,7 @@
     <value>StartProgramBrowse</value>
   </data>
   <data name="&gt;&gt;StartProgramBrowse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;StartProgramBrowse.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -335,13 +334,13 @@
     <value>NoControl</value>
   </data>
   <data name="StartOptionsLabelLine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>74, 6</value>
+    <value>143, 12</value>
   </data>
   <data name="StartOptionsLabelLine.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
   </data>
   <data name="StartOptionsLabelLine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>376, 1</value>
+    <value>385, 1</value>
   </data>
   <data name="StartOptionsLabelLine.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -350,7 +349,7 @@
     <value>StartOptionsLabelLine</value>
   </data>
   <data name="&gt;&gt;StartOptionsLabelLine.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;StartOptionsLabelLine.Parent" xml:space="preserve">
     <value>startOptionsTableLayoutPanel</value>
@@ -374,7 +373,7 @@
     <value>0, 0, 3, 0</value>
   </data>
   <data name="StartOptionsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>137, 25</value>
   </data>
   <data name="StartOptionsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -386,7 +385,7 @@
     <value>StartOptionsLabel</value>
   </data>
   <data name="&gt;&gt;StartOptionsLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;StartOptionsLabel.Parent" xml:space="preserve">
     <value>startOptionsTableLayoutPanel</value>
@@ -401,13 +400,13 @@
     <value>NoControl</value>
   </data>
   <data name="CommandLineArgsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 99</value>
+    <value>23, 147</value>
   </data>
   <data name="CommandLineArgsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 12, 3, 3</value>
   </data>
   <data name="CommandLineArgsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 13</value>
+    <value>262, 25</value>
   </data>
   <data name="CommandLineArgsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -419,7 +418,7 @@
     <value>CommandLineArgsLabel</value>
   </data>
   <data name="&gt;&gt;CommandLineArgsLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CommandLineArgsLabel.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -437,13 +436,13 @@
     <value>NoControl</value>
   </data>
   <data name="WorkingDirLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 130</value>
+    <value>23, 183</value>
   </data>
   <data name="WorkingDirLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 3</value>
   </data>
   <data name="WorkingDirLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 13</value>
+    <value>186, 25</value>
   </data>
   <data name="WorkingDirLabel.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -455,7 +454,7 @@
     <value>WorkingDirLabel</value>
   </data>
   <data name="&gt;&gt;WorkingDirLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WorkingDirLabel.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -473,13 +472,13 @@
     <value>NoControl</value>
   </data>
   <data name="RemoteDebugEnabled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 155</value>
+    <value>23, 220</value>
   </data>
   <data name="RemoteDebugEnabled.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 3, 12</value>
   </data>
   <data name="RemoteDebugEnabled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>123, 17</value>
+    <value>241, 29</value>
   </data>
   <data name="RemoteDebugEnabled.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -491,7 +490,7 @@
     <value>RemoteDebugEnabled</value>
   </data>
   <data name="&gt;&gt;RemoteDebugEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;RemoteDebugEnabled.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -503,7 +502,7 @@
     <value>Left, Right</value>
   </data>
   <data name="StartArguments.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 99</value>
+    <value>291, 149</value>
   </data>
   <data name="StartArguments.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 12, 3, 3</value>
@@ -515,7 +514,7 @@
     <value>Vertical</value>
   </data>
   <data name="StartArguments.Size" type="System.Drawing.Size, System.Drawing">
-    <value>258, 20</value>
+    <value>191, 20</value>
   </data>
   <data name="StartArguments.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -524,7 +523,7 @@
     <value>StartArguments</value>
   </data>
   <data name="&gt;&gt;StartArguments.Type" xml:space="preserve">
-    <value>Microsoft.VisualStudio.Editors.PropertyPages.DebugPropPage+MultilineTextBoxRejectsEnter, Microsoft.VisualStudio.Editors, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.DebugPropPage+MultilineTextBoxRejectsEnter, FSharp.ProjectSystem.PropertyPages, Version=15.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="&gt;&gt;StartArguments.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -536,10 +535,10 @@
     <value>Left, Right</value>
   </data>
   <data name="StartWorkingDirectory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 126</value>
+    <value>291, 180</value>
   </data>
   <data name="StartWorkingDirectory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>258, 20</value>
+    <value>191, 31</value>
   </data>
   <data name="StartWorkingDirectory.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -548,7 +547,7 @@
     <value>StartWorkingDirectory</value>
   </data>
   <data name="&gt;&gt;StartWorkingDirectory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;StartWorkingDirectory.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -563,13 +562,13 @@
     <value>Left, Right</value>
   </data>
   <data name="RemoteDebugMachine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 154</value>
+    <value>291, 219</value>
   </data>
   <data name="RemoteDebugMachine.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 12</value>
   </data>
   <data name="RemoteDebugMachine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>258, 20</value>
+    <value>191, 31</value>
   </data>
   <data name="RemoteDebugMachine.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -578,7 +577,7 @@
     <value>RemoteDebugMachine</value>
   </data>
   <data name="&gt;&gt;RemoteDebugMachine.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;RemoteDebugMachine.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -602,13 +601,13 @@
     <value>NoControl</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>424, 125</value>
+    <value>488, 178</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 0, 3</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 23</value>
+    <value>40, 35</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -620,7 +619,7 @@
     <value>StartWorkingDirectoryBrowse</value>
   </data>
   <data name="&gt;&gt;StartWorkingDirectoryBrowse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;StartWorkingDirectoryBrowse.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -635,13 +634,13 @@
     <value>NoControl</value>
   </data>
   <data name="EnableDebuggerLabelLine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>101, 6</value>
+    <value>196, 12</value>
   </data>
   <data name="EnableDebuggerLabelLine.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 0, 0</value>
   </data>
   <data name="EnableDebuggerLabelLine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>349, 1</value>
+    <value>332, 1</value>
   </data>
   <data name="EnableDebuggerLabelLine.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -650,7 +649,7 @@
     <value>EnableDebuggerLabelLine</value>
   </data>
   <data name="&gt;&gt;EnableDebuggerLabelLine.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;EnableDebuggerLabelLine.Parent" xml:space="preserve">
     <value>enableDebuggersTableLayoutPanel</value>
@@ -674,7 +673,7 @@
     <value>0, 0, 3, 0</value>
   </data>
   <data name="EnableDebuggerLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 13</value>
+    <value>190, 25</value>
   </data>
   <data name="EnableDebuggerLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -686,7 +685,7 @@
     <value>EnableDebuggerLabel</value>
   </data>
   <data name="&gt;&gt;EnableDebuggerLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;EnableDebuggerLabel.Parent" xml:space="preserve">
     <value>enableDebuggersTableLayoutPanel</value>
@@ -728,7 +727,7 @@
     <value>1</value>
   </data>
   <data name="startActionTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 13</value>
+    <value>528, 25</value>
   </data>
   <data name="startActionTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -737,7 +736,7 @@
     <value>startActionTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;startActionTableLayoutPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;startActionTableLayoutPanel.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -758,7 +757,7 @@
     <value>2</value>
   </data>
   <data name="startOptionsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 74</value>
+    <value>0, 110</value>
   </data>
   <data name="startOptionsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -767,7 +766,7 @@
     <value>1</value>
   </data>
   <data name="startOptionsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 13</value>
+    <value>528, 25</value>
   </data>
   <data name="startOptionsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -776,7 +775,7 @@
     <value>startOptionsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;startOptionsTableLayoutPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;startOptionsTableLayoutPanel.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -797,7 +796,7 @@
     <value>2</value>
   </data>
   <data name="enableDebuggersTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 186</value>
+    <value>0, 262</value>
   </data>
   <data name="enableDebuggersTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -806,7 +805,7 @@
     <value>1</value>
   </data>
   <data name="enableDebuggersTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 13</value>
+    <value>528, 25</value>
   </data>
   <data name="enableDebuggersTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -815,7 +814,7 @@
     <value>enableDebuggersTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;enableDebuggersTableLayoutPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;enableDebuggersTableLayoutPanel.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -833,13 +832,13 @@
     <value>NoControl</value>
   </data>
   <data name="EnableSQLServerDebugging.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 234</value>
+    <value>23, 334</value>
   </data>
   <data name="EnableSQLServerDebugging.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 0, 1</value>
   </data>
   <data name="EnableSQLServerDebugging.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 17</value>
+    <value>335, 29</value>
   </data>
   <data name="EnableSQLServerDebugging.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -851,7 +850,7 @@
     <value>EnableSQLServerDebugging</value>
   </data>
   <data name="&gt;&gt;EnableSQLServerDebugging.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;EnableSQLServerDebugging.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -866,13 +865,13 @@
     <value>NoControl</value>
   </data>
   <data name="UseVSHostingProcess.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 255</value>
+    <value>23, 367</value>
   </data>
   <data name="UseVSHostingProcess.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 3, 0, 1</value>
   </data>
   <data name="UseVSHostingProcess.Size" type="System.Drawing.Size, System.Drawing">
-    <value>218, 17</value>
+    <value>437, 29</value>
   </data>
   <data name="UseVSHostingProcess.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -884,7 +883,7 @@
     <value>UseVSHostingProcess</value>
   </data>
   <data name="&gt;&gt;UseVSHostingProcess.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UseVSHostingProcess.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -905,7 +904,7 @@
     <value>11</value>
   </data>
   <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 273</value>
+    <value>528, 397</value>
   </data>
   <data name="overarchingTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -914,7 +913,7 @@
     <value>overarchingTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;overarchingTableLayoutPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;overarchingTableLayoutPanel.Parent" xml:space="preserve">
     <value>$this</value>
@@ -929,13 +928,13 @@
     <value>NoControl</value>
   </data>
   <data name="EnableUnmanagedDebugging.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 211</value>
+    <value>23, 299</value>
   </data>
   <data name="EnableUnmanagedDebugging.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>23, 12, 0, 3</value>
   </data>
   <data name="EnableUnmanagedDebugging.Size" type="System.Drawing.Size, System.Drawing">
-    <value>198, 17</value>
+    <value>390, 29</value>
   </data>
   <data name="EnableUnmanagedDebugging.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -947,7 +946,7 @@
     <value>EnableUnmanagedDebugging</value>
   </data>
   <data name="&gt;&gt;EnableUnmanagedDebugging.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;EnableUnmanagedDebugging.Parent" xml:space="preserve">
     <value>overarchingTableLayoutPanel</value>
@@ -955,7 +954,7 @@
   <data name="&gt;&gt;EnableUnmanagedDebugging.ZOrder" xml:space="preserve">
     <value>14</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
@@ -970,16 +969,19 @@
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
+  <data name="$this.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>540, 0</value>
+  </data>
   <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 12, 0</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>462, 273</value>
+    <value>540, 397</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>DebugPropPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.Editors, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, FSharp.ProjectSystem.PropertyPages, Version=15.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/DebugPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/DebugPropPage.vb
@@ -83,30 +83,30 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         <System.Diagnostics.DebuggerStepThrough()> Private Sub InitializeComponent()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(DebugPropPage))
-            Me.StartActionLabel = New System.Windows.Forms.Label
-            Me.StartActionLabelLine = New System.Windows.Forms.Label
-            Me.rbStartProject = New System.Windows.Forms.RadioButton
-            Me.rbStartProgram = New System.Windows.Forms.RadioButton
-            Me.StartProgram = New System.Windows.Forms.TextBox
-            Me.StartProgramBrowse = New System.Windows.Forms.Button
-            Me.StartOptionsLabelLine = New System.Windows.Forms.Label
-            Me.StartOptionsLabel = New System.Windows.Forms.Label
-            Me.CommandLineArgsLabel = New System.Windows.Forms.Label
-            Me.WorkingDirLabel = New System.Windows.Forms.Label
-            Me.RemoteDebugEnabled = New System.Windows.Forms.CheckBox
-            Me.StartArguments = New Microsoft.VisualStudio.Editors.PropertyPages.DebugPropPage.MultilineTextBoxRejectsEnter
-            Me.StartWorkingDirectory = New System.Windows.Forms.TextBox
-            Me.RemoteDebugMachine = New System.Windows.Forms.TextBox
-            Me.StartWorkingDirectoryBrowse = New System.Windows.Forms.Button
-            Me.EnableDebuggerLabelLine = New System.Windows.Forms.Label
-            Me.EnableDebuggerLabel = New System.Windows.Forms.Label
-            Me.EnableUnmanagedDebugging = New System.Windows.Forms.CheckBox
-            Me.UseVSHostingProcess = New System.Windows.Forms.CheckBox
-            Me.EnableSQLServerDebugging = New System.Windows.Forms.CheckBox
-            Me.overarchingTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
-            Me.startActionTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
-            Me.startOptionsTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
-            Me.enableDebuggersTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
+            Me.StartActionLabel = New System.Windows.Forms.Label()
+            Me.StartActionLabelLine = New System.Windows.Forms.Label()
+            Me.rbStartProject = New System.Windows.Forms.RadioButton()
+            Me.rbStartProgram = New System.Windows.Forms.RadioButton()
+            Me.StartProgram = New System.Windows.Forms.TextBox()
+            Me.StartProgramBrowse = New System.Windows.Forms.Button()
+            Me.StartOptionsLabelLine = New System.Windows.Forms.Label()
+            Me.StartOptionsLabel = New System.Windows.Forms.Label()
+            Me.CommandLineArgsLabel = New System.Windows.Forms.Label()
+            Me.WorkingDirLabel = New System.Windows.Forms.Label()
+            Me.RemoteDebugEnabled = New System.Windows.Forms.CheckBox()
+            Me.StartArguments = New Microsoft.VisualStudio.Editors.PropertyPages.DebugPropPage.MultilineTextBoxRejectsEnter()
+            Me.StartWorkingDirectory = New System.Windows.Forms.TextBox()
+            Me.RemoteDebugMachine = New System.Windows.Forms.TextBox()
+            Me.StartWorkingDirectoryBrowse = New System.Windows.Forms.Button()
+            Me.EnableDebuggerLabelLine = New System.Windows.Forms.Label()
+            Me.EnableDebuggerLabel = New System.Windows.Forms.Label()
+            Me.EnableUnmanagedDebugging = New System.Windows.Forms.CheckBox()
+            Me.UseVSHostingProcess = New System.Windows.Forms.CheckBox()
+            Me.EnableSQLServerDebugging = New System.Windows.Forms.CheckBox()
+            Me.overarchingTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+            Me.startActionTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+            Me.startOptionsTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+            Me.enableDebuggersTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.overarchingTableLayoutPanel.SuspendLayout()
             Me.startActionTableLayoutPanel.SuspendLayout()
             Me.startOptionsTableLayoutPanel.SuspendLayout()
@@ -276,7 +276,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             resources.ApplyResources(Me, "$this")
             Me.Controls.Add(Me.overarchingTableLayoutPanel)
-            Me.MaximumSize = New System.Drawing.Size(540, 0)
             Me.Name = "DebugPropPage"
             Me.overarchingTableLayoutPanel.ResumeLayout(False)
             Me.overarchingTableLayoutPanel.PerformLayout()


### PR DESCRIPTION
1. Update Desktop templates to enable UseStandardResourceNames by default.
2. Update dotnet cli targets to enable UseStandardResourceNames by default.
3. Update Application Property page on project properties to add UseStandardResourceNames checkbox.



