### PR TITLE
add WPF path to fsi.exe and cleanup resolution flags

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2213,7 +2213,7 @@ type TcConfigBuilder =
           useFsiAuxLib=false
           implicitOpens=[]
           includes=[]
-          resolutionEnvironment=ReferenceResolver.CompileTimeLike
+          resolutionEnvironment=ResolutionEnvironment.EditingAndCompilation false
           framework=true
           implicitlyResolveAssemblies=true
           referencedDLLs = []
@@ -2801,46 +2801,52 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
     // This call can fail if no CLR is found (this is the path to mscorlib)
     member tcConfig.GetTargetFrameworkDirectories() = 
         use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parameter
-        match tcConfig.clrRoot with 
-        | Some x -> 
-            [tcConfig.MakePathAbsolute x]
-        | None -> 
-#if ENABLE_MONO_SUPPORT
-            if runningOnMono then 
-                [ let runtimeRoot = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
-                  let runtimeRootWithoutSlash = runtimeRoot.TrimEnd('/', '\\')
-                  let api = runtimeRootWithoutSlash + "-api"
-                  let rootFacades = Path.Combine(runtimeRootWithoutSlash, "Facades")
-                  let apiFacades = Path.Combine(api, "Facades")
-                  match tcConfig.resolutionEnvironment with
-#if !FSI_TODO_NETCORE
-                  // For F# Interactive code we must inly reference impementation assemblies
-                  | ReferenceResolver.RuntimeLike ->
-                      yield runtimeRoot
-                      if Directory.Exists(rootFacades) then
-                          yield rootFacades // System.Runtime.dll is in /usr/lib/mono/4.5/Facades
-#endif
-                  | _ ->
-                      // The default FSharp.Core is found in lib/mono/4.5
-                      yield runtimeRoot  
-                      if Directory.Exists(rootFacades) then
-                          yield rootFacades // System.Runtime.dll is in /usr/lib/mono/4.5/Facades
-                      // It's not clear why we would need to reference the 4.5-api directory.  
-                      if Directory.Exists(api) then
-                          yield api
-                      if Directory.Exists(apiFacades) then
-                          yield apiFacades
-                ]
-            else                                
-#endif
-                try 
-                  [ 
-                    match tcConfig.resolutionEnvironment with
-#if !FSI_TODO_NETCORE
-                    | ReferenceResolver.RuntimeLike ->
-                        yield System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory() 
-#endif
-                    | _ -> 
+        try 
+          [ 
+            // Check if we are given an explicit framework root - if so, use that
+            match tcConfig.clrRoot with 
+            | Some x -> 
+                yield tcConfig.MakePathAbsolute x
+
+            | None -> 
+                let runtimeRoot = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
+                let runtimeRootWithoutSlash = runtimeRoot.TrimEnd('/', '\\')
+                let runtimeRootFacades = Path.Combine(runtimeRootWithoutSlash, "Facades")
+                let runtimeRootWPF = Path.Combine(runtimeRootWithoutSlash, "WPF")
+
+                match tcConfig.resolutionEnvironment with
+                | ResolutionEnvironment.CompilationAndEvaluation ->
+                    // Default compilation-and-execution-time references on .NET Framework and Mono, e.g. for F# Interactive
+                    //
+                    // In the current way of doing things, F# Interactive refers to implementation assemblies.
+                    yield runtimeRoot
+                    if Directory.Exists(runtimeRootFacades) then
+                        yield runtimeRootFacades // System.Runtime.dll is in /usr/lib/mono/4.5/Facades
+                    if Directory.Exists(runtimeRootWPF) then
+                        yield runtimeRootWPF // PresentationCore.dll is in C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF
+
+                | ResolutionEnvironment.EditingAndCompilation _ ->
+                    if runningOnMono then 
+                        // Default compilation-time references on Mono
+                        //
+                        // On Mono, the default references come from the implementation assemblies.
+                        // This is because we have had trouble reliably using MSBuild APIs to compute DotNetFrameworkReferenceAssembliesRootDirectory on Mono.
+                        yield runtimeRoot
+                        if Directory.Exists(runtimeRootFacades) then
+                            yield runtimeRootFacades // System.Runtime.dll is in /usr/lib/mono/4.5/Facades
+                        if Directory.Exists(runtimeRootWPF) then
+                            yield runtimeRootWPF // PresentationCore.dll is in C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF
+                        // On Mono we also add a default reference to the 4.5-api and 4.5-api/Facades directories.  
+                        let runtimeRootApi = runtimeRootWithoutSlash + "-api"
+                        let runtimeRootApiFacades = Path.Combine(runtimeRootApi, "Facades")
+                        if Directory.Exists(runtimeRootApi) then
+                            yield runtimeRootApi
+                        if Directory.Exists(runtimeRootApiFacades) then
+                             yield runtimeRootApiFacades
+                    else                                
+                        // Default compilation-time references on .NET Framework
+                        //
+                        // This is the normal case for "fsc.exe a.fs". We refer to the reference assemblies folder.
                         let frameworkRoot = tcConfig.legacyReferenceResolver.DotNetFrameworkReferenceAssembliesRootDirectory
                         let frameworkRootVersion = Path.Combine(frameworkRoot,tcConfig.targetFrameworkVersion)
                         yield frameworkRootVersion
@@ -2848,8 +2854,8 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                         if Directory.Exists(facades) then
                             yield facades
                   ]                    
-                with e -> 
-                    errorRecovery e range0; [] 
+        with e -> 
+            errorRecovery e range0; [] 
 
     member tcConfig.ComputeLightSyntaxInitialStatus(filename) = 
         use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parameter
@@ -4854,7 +4860,7 @@ type LoadClosure =
 
 [<RequireQualifiedAccess>]
 type CodeContext =
-    | Evaluation // in fsi.exe
+    | CompilationAndEvaluation // in fsi.exe
     | Compilation  // in fsc.exe
     | Editing // in VS
     
@@ -4887,7 +4893,7 @@ module private ScriptPreprocessClosure =
         //     .fsx -- EDITING + !COMPILED\INTERACTIVE    
         let defines =
             match codeContext with 
-            | CodeContext.Evaluation -> ["INTERACTIVE"]
+            | CodeContext.CompilationAndEvaluation -> ["INTERACTIVE"]
             | CodeContext.Compilation -> ["COMPILED"]
             | CodeContext.Editing -> "EDITING" :: (if IsScript filename then ["INTERACTIVE"] else ["COMPILED"])
         let lexbuf = UnicodeLexing.StringAsLexbuf source 
@@ -4898,7 +4904,7 @@ module private ScriptPreprocessClosure =
     /// Create a TcConfig for load closure starting from a single .fsx file
     let CreateScriptSourceTcConfig (legacyReferenceResolver, defaultFSharpBinariesDir, filename:string, codeContext, useSimpleResolution, useFsiAuxLib, basicReferences, applyCommandLineArgs, assumeDotNetFramework) =  
         let projectDir = Path.GetDirectoryName(filename)
-        let isInteractive = (codeContext = CodeContext.Evaluation)
+        let isInteractive = (codeContext = CodeContext.CompilationAndEvaluation)
         let isInvalidationSupported = (codeContext = CodeContext.Editing)
         let tcConfigB = TcConfigBuilder.CreateNew(legacyReferenceResolver, defaultFSharpBinariesDir, true (* optimize for memory *), projectDir, isInteractive, isInvalidationSupported, defaultCopyFSharpCore=false) 
         applyCommandLineArgs tcConfigB
@@ -4908,12 +4914,14 @@ module private ScriptPreprocessClosure =
 
         tcConfigB.resolutionEnvironment <-
             match codeContext with 
-            | CodeContext.Editing -> ReferenceResolver.DesignTimeLike
+            | CodeContext.Editing -> ResolutionEnvironment.EditingAndCompilation true
+            | CodeContext.Compilation -> ResolutionEnvironment.EditingAndCompilation false
+            | CodeContext.CompilationAndEvaluation -> 
 #if FSI_TODO_NETCORE
-            // "RuntimeLike" assembly resolution for F# Interactive is not yet properly figured out on .NET Core
-            | CodeContext.Compilation | CodeContext.Evaluation -> ReferenceResolver.CompileTimeLike
+                // "CompilationAndEvaluation" assembly resolution for F# Interactive is not yet properly figured out on .NET Core
+                ResolutionEnvironment.EditingAndCompilation false
 #else
-            | CodeContext.Compilation | CodeContext.Evaluation -> ReferenceResolver.RuntimeLike
+                ResolutionEnvironment.CompilationAndEvaluation
 #endif
         tcConfigB.framework <- false 
         tcConfigB.useSimpleResolution <- useSimpleResolution

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2213,7 +2213,7 @@ type TcConfigBuilder =
           useFsiAuxLib=false
           implicitOpens=[]
           includes=[]
-          resolutionEnvironment=ResolutionEnvironment.EditingAndCompilation false
+          resolutionEnvironment=ResolutionEnvironment.EditingOrCompilation false
           framework=true
           implicitlyResolveAssemblies=true
           referencedDLLs = []
@@ -2825,7 +2825,7 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                     if Directory.Exists(runtimeRootWPF) then
                         yield runtimeRootWPF // PresentationCore.dll is in C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF
 
-                | ResolutionEnvironment.EditingAndCompilation _ ->
+                | ResolutionEnvironment.EditingOrCompilation _ ->
                     if runningOnMono then 
                         // Default compilation-time references on Mono
                         //
@@ -4914,12 +4914,12 @@ module private ScriptPreprocessClosure =
 
         tcConfigB.resolutionEnvironment <-
             match codeContext with 
-            | CodeContext.Editing -> ResolutionEnvironment.EditingAndCompilation true
-            | CodeContext.Compilation -> ResolutionEnvironment.EditingAndCompilation false
+            | CodeContext.Editing -> ResolutionEnvironment.EditingOrCompilation true
+            | CodeContext.Compilation -> ResolutionEnvironment.EditingOrCompilation false
             | CodeContext.CompilationAndEvaluation -> 
 #if FSI_TODO_NETCORE
                 // "CompilationAndEvaluation" assembly resolution for F# Interactive is not yet properly figured out on .NET Core
-                ResolutionEnvironment.EditingAndCompilation false
+                ResolutionEnvironment.EditingOrCompilation false
 #else
                 ResolutionEnvironment.CompilationAndEvaluation
 #endif

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2809,7 +2809,11 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                 yield tcConfig.MakePathAbsolute x
 
             | None -> 
+#if FSI_TODO_NETCORE // there is no really good notion of runtime directory on .NETCore
+                let runtimeRoot = Path.GetDirectoryName(typeof<System.Object>.Assembly.Location)
+#else
                 let runtimeRoot = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
+#endif
                 let runtimeRootWithoutSlash = runtimeRoot.TrimEnd('/', '\\')
                 let runtimeRootFacades = Path.Combine(runtimeRootWithoutSlash, "Facades")
                 let runtimeRootWPF = Path.Combine(runtimeRootWithoutSlash, "WPF")
@@ -2826,6 +2830,7 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                         yield runtimeRootWPF // PresentationCore.dll is in C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF
 
                 | ResolutionEnvironment.EditingOrCompilation _ ->
+#if ENABLE_MONO_SUPPORT
                     if runningOnMono then 
                         // Default compilation-time references on Mono
                         //
@@ -2844,6 +2849,7 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                         if Directory.Exists(runtimeRootApiFacades) then
                              yield runtimeRootApiFacades
                     else                                
+#endif
                         // Default compilation-time references on .NET Framework
                         //
                         // This is the normal case for "fsc.exe a.fs". We refer to the reference assemblies folder.

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -761,7 +761,7 @@ val ReportWarningAsError : globalWarnLevel: int * specificWarnOff: int list * sp
 
 [<RequireQualifiedAccess>]
 type CodeContext =
-    | Evaluation
+    | CompilationAndEvaluation
     | Compilation
     | Editing
 

--- a/src/fsharp/MSBuildReferenceResolver.fs
+++ b/src/fsharp/MSBuildReferenceResolver.fs
@@ -287,11 +287,12 @@ module internal Microsoft.FSharp.Compiler.MSBuildReferenceResolver
 
             let registry = sprintf "{Registry:%s,%s,%s%s}" frameworkRegistryBase targetFrameworkVersion assemblyFoldersSuffix assemblyFoldersConditions
 
-            [|  // When compiling scripts, for some reason we have always historically put TargetFrameworkDirectory first
-                // It is unclear why.
+            [|  // When compiling scripts using fsc.exe, for some reason we have always historically put TargetFrameworkDirectory first
+                // It is unclear why.  This is the only place we look at the 'isdifference between ResolutionEnvironment.EditingAndCompilation and ResolutionEnvironment.EditingTime.
                 match resolutionEnvironment with
-                | CompileTimeLike -> yield "{TargetFrameworkDirectory}"
-                | DesignTimeLike | RuntimeLike -> ()
+                | ResolutionEnvironment.EditingAndCompilation false -> yield "{TargetFrameworkDirectory}"
+                | ResolutionEnvironment.EditingAndCompilation true
+                | ResolutionEnvironment.CompilationAndEvaluation -> ()
 
                 // Quick-resolve straight to filename first 
                 if allowRawFileName then 
@@ -301,8 +302,9 @@ module internal Microsoft.FSharp.Compiler.MSBuildReferenceResolver
                 yield implicitIncludeDir   // Usually the project directory
 
                 match resolutionEnvironment with
-                | DesignTimeLike | RuntimeLike -> yield "{TargetFrameworkDirectory}"
-                | CompileTimeLike -> ()
+                | ResolutionEnvironment.EditingAndCompilation true
+                | ResolutionEnvironment.CompilationAndEvaluation -> yield "{TargetFrameworkDirectory}"
+                | ResolutionEnvironment.EditingAndCompilation false -> ()
 
                 yield registry
                 yield "{AssemblyFolders}"

--- a/src/fsharp/MSBuildReferenceResolver.fs
+++ b/src/fsharp/MSBuildReferenceResolver.fs
@@ -288,10 +288,10 @@ module internal Microsoft.FSharp.Compiler.MSBuildReferenceResolver
             let registry = sprintf "{Registry:%s,%s,%s%s}" frameworkRegistryBase targetFrameworkVersion assemblyFoldersSuffix assemblyFoldersConditions
 
             [|  // When compiling scripts using fsc.exe, for some reason we have always historically put TargetFrameworkDirectory first
-                // It is unclear why.  This is the only place we look at the 'isdifference between ResolutionEnvironment.EditingAndCompilation and ResolutionEnvironment.EditingTime.
+                // It is unclear why.  This is the only place we look at the 'isdifference between ResolutionEnvironment.EditingOrCompilation and ResolutionEnvironment.EditingTime.
                 match resolutionEnvironment with
-                | ResolutionEnvironment.EditingAndCompilation false -> yield "{TargetFrameworkDirectory}"
-                | ResolutionEnvironment.EditingAndCompilation true
+                | ResolutionEnvironment.EditingOrCompilation false -> yield "{TargetFrameworkDirectory}"
+                | ResolutionEnvironment.EditingOrCompilation true
                 | ResolutionEnvironment.CompilationAndEvaluation -> ()
 
                 // Quick-resolve straight to filename first 
@@ -302,9 +302,9 @@ module internal Microsoft.FSharp.Compiler.MSBuildReferenceResolver
                 yield implicitIncludeDir   // Usually the project directory
 
                 match resolutionEnvironment with
-                | ResolutionEnvironment.EditingAndCompilation true
+                | ResolutionEnvironment.EditingOrCompilation true
                 | ResolutionEnvironment.CompilationAndEvaluation -> yield "{TargetFrameworkDirectory}"
-                | ResolutionEnvironment.EditingAndCompilation false -> ()
+                | ResolutionEnvironment.EditingOrCompilation false -> ()
 
                 yield registry
                 yield "{AssemblyFolders}"

--- a/src/fsharp/ReferenceResolver.fs
+++ b/src/fsharp/ReferenceResolver.fs
@@ -12,8 +12,8 @@ module internal ReferenceResolver =
 
     [<RequireQualifiedAccess>]
     type ResolutionEnvironment = 
-        /// Indicates a script or source being compiled. Uses reference assemblies (not implementation assemblies).
-        | EditingAndCompilation of isEditing: bool
+        /// Indicates a script or source being edited or compiled. Uses reference assemblies (not implementation assemblies).
+        | EditingOrCompilation of isEditing: bool
         /// Indicates a script or source being dynamically compiled and executed. Uses implementation assemblies.
         | CompilationAndEvaluation 
 

--- a/src/fsharp/ReferenceResolver.fs
+++ b/src/fsharp/ReferenceResolver.fs
@@ -10,13 +10,12 @@ module internal ReferenceResolver =
 
     exception internal ResolutionFailure
 
+    [<RequireQualifiedAccess>]
     type ResolutionEnvironment = 
-        /// Indicates a script or source being compiled
-        | CompileTimeLike 
-        /// Indicates a script or source being interpreted
-        | RuntimeLike 
-        /// Indicates a script or source being edited
-        | DesignTimeLike
+        /// Indicates a script or source being compiled. Uses reference assemblies (not implementation assemblies).
+        | EditingAndCompilation of isEditing: bool
+        /// Indicates a script or source being dynamically compiled and executed. Uses implementation assemblies.
+        | CompilationAndEvaluation 
 
     type ResolvedFile = 
         { /// Item specification.

--- a/src/fsharp/SimulatedMSBuildReferenceResolver.fs
+++ b/src/fsharp/SimulatedMSBuildReferenceResolver.fs
@@ -208,7 +208,7 @@ let fscoreDir =
         System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
 
 let resolve s = 
-    SimulatedMSBuildResolver.Resolve(ResolutionEnvironment.EditingAndCompilation,[| for a in s -> (a, "") |],"v4.5.1", [SimulatedMSBuildResolver.DotNetFrameworkReferenceAssembliesRootDirectory + @"\v4.5.1" ],"", "", fscoreDir,[],__SOURCE_DIRECTORY__,ignore, (fun _ _ -> ()), (fun _ _-> ()))
+    SimulatedMSBuildResolver.Resolve(ResolutionEnvironment.EditingOrCompilation,[| for a in s -> (a, "") |],"v4.5.1", [SimulatedMSBuildResolver.DotNetFrameworkReferenceAssembliesRootDirectory + @"\v4.5.1" ],"", "", fscoreDir,[],__SOURCE_DIRECTORY__,ignore, (fun _ _ -> ()), (fun _ _-> ()))
 
 // Resolve partial name to something on search path
 resolve ["FSharp.Core" ]

--- a/src/fsharp/SimulatedMSBuildReferenceResolver.fs
+++ b/src/fsharp/SimulatedMSBuildReferenceResolver.fs
@@ -208,7 +208,7 @@ let fscoreDir =
         System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
 
 let resolve s = 
-    SimulatedMSBuildResolver.Resolve(ResolutionEnvironment.CompileTimeLike,[| for a in s -> (a, "") |],"v4.5.1", [SimulatedMSBuildResolver.DotNetFrameworkReferenceAssembliesRootDirectory + @"\v4.5.1" ],"", "", fscoreDir,[],__SOURCE_DIRECTORY__,ignore, (fun _ _ -> ()), (fun _ _-> ()))
+    SimulatedMSBuildResolver.Resolve(ResolutionEnvironment.EditingAndCompilation,[| for a in s -> (a, "") |],"v4.5.1", [SimulatedMSBuildResolver.DotNetFrameworkReferenceAssembliesRootDirectory + @"\v4.5.1" ],"", "", fscoreDir,[],__SOURCE_DIRECTORY__,ignore, (fun _ _ -> ()), (fun _ _-> ()))
 
 // Resolve partial name to something on search path
 resolve ["FSharp.Core" ]

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1291,7 +1291,7 @@ type internal FsiDynamicCompiler
           let sourceFiles = sourceFiles |> List.map (fun nm -> tcConfig.ResolveSourceFile(m, nm, tcConfig.implicitIncludeDir),m) 
          
           // Close the #load graph on each file and gather the inputs from the scripts.
-          let closure = LoadClosure.ComputeClosureOfSourceFiles(ctok, TcConfig.Create(tcConfigB,validate=false), sourceFiles, CodeContext.Evaluation,lexResourceManager=lexResourceManager)
+          let closure = LoadClosure.ComputeClosureOfSourceFiles(ctok, TcConfig.Create(tcConfigB,validate=false), sourceFiles, CodeContext.CompilationAndEvaluation, lexResourceManager=lexResourceManager)
           
           // Intent "[Loading %s]\n" (String.concat "\n     and " sourceFiles)
           fsiConsoleOutput.uprintf "[%s " (FSIstrings.SR.fsiLoadingFilesPrefixText())
@@ -2459,12 +2459,12 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let tcConfigB = TcConfigBuilder.CreateNew(legacyReferenceResolver, defaultFSharpBinariesDir=defaultFSharpBinariesDir, optimizeForMemory=true, implicitIncludeDir=currentDirectory, isInteractive=true, isInvalidationSupported=false, defaultCopyFSharpCore=false)
     let tcConfigP = TcConfigProvider.BasedOnMutableBuilder(tcConfigB)
-    do tcConfigB.resolutionEnvironment <- ReferenceResolver.RuntimeLike // See Bug 3608
+    do tcConfigB.resolutionEnvironment <- ReferenceResolver.ResolutionEnvironment.CompilationAndEvaluation // See Bug 3608
     do tcConfigB.useFsiAuxLib <- fsi.UseFsiAuxLib
 
 #if FSI_TODO_NETCORE
-    // "RuntimeLike" assembly resolution for F# Interactive is not yet properly figured out on .NET Core
-    do tcConfigB.resolutionEnvironment <- ReferenceResolver.DesignTimeLike
+    // "CompilationAndEvaluation" assembly resolution for F# Interactive is not yet properly figured out on .NET Core
+    do tcConfigB.resolutionEnvironment <- ResolutionEnvironment.EditingAndCompilation false
     do tcConfigB.useSimpleResolution <- true
     do SetTargetProfile tcConfigB "netcore" // always assume System.Runtime codegen
     //do SetTargetProfile tcConfigB "privatecorelib" // always assume System.Private.CoreLib codegen

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2464,7 +2464,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
 #if FSI_TODO_NETCORE
     // "CompilationAndEvaluation" assembly resolution for F# Interactive is not yet properly figured out on .NET Core
-    do tcConfigB.resolutionEnvironment <- ResolutionEnvironment.EditingAndCompilation false
+    do tcConfigB.resolutionEnvironment <- ResolutionEnvironment.EditingOrCompilation false
     do tcConfigB.useSimpleResolution <- true
     do SetTargetProfile tcConfigB "netcore" // always assume System.Runtime codegen
     //do SetTargetProfile tcConfigB "privatecorelib" // always assume System.Private.CoreLib codegen

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -48,6 +48,7 @@ open Microsoft.FSharp.Compiler.Tast
 open Microsoft.FSharp.Compiler.Tastops
 open Microsoft.FSharp.Compiler.TcGlobals
 open Microsoft.FSharp.Compiler.SourceCodeServices
+open Microsoft.FSharp.Compiler.ReferenceResolver
 
 open Internal.Utilities
 open Internal.Utilities.Collections
@@ -2459,7 +2460,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let tcConfigB = TcConfigBuilder.CreateNew(legacyReferenceResolver, defaultFSharpBinariesDir=defaultFSharpBinariesDir, optimizeForMemory=true, implicitIncludeDir=currentDirectory, isInteractive=true, isInvalidationSupported=false, defaultCopyFSharpCore=false)
     let tcConfigP = TcConfigProvider.BasedOnMutableBuilder(tcConfigB)
-    do tcConfigB.resolutionEnvironment <- ReferenceResolver.ResolutionEnvironment.CompilationAndEvaluation // See Bug 3608
+    do tcConfigB.resolutionEnvironment <- ResolutionEnvironment.CompilationAndEvaluation // See Bug 3608
     do tcConfigB.useFsiAuxLib <- fsi.UseFsiAuxLib
 
 #if FSI_TODO_NETCORE

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1701,7 +1701,8 @@ type IncrementalBuilder(tcGlobals,frameworkTcImports, nonFrameworkAssemblyInputs
                 // The following uses more memory but means we don't take read-exclusions on the DLLs we reference 
                 // Could detect well-known assemblies--ie System.dll--and open them with read-locks 
                 tcConfigB.openBinariesInMemory <- true
-                tcConfigB.resolutionEnvironment <- (if useScriptResolutionRules then ReferenceResolver.DesignTimeLike else ReferenceResolver.CompileTimeLike)
+
+                tcConfigB.resolutionEnvironment <- (ReferenceResolver.ResolutionEnvironment.EditingAndCompilation true)
                 
                 tcConfigB.conditionalCompilationDefines <- 
                     let define = if useScriptResolutionRules then "INTERACTIVE" else "COMPILED"

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1702,7 +1702,7 @@ type IncrementalBuilder(tcGlobals,frameworkTcImports, nonFrameworkAssemblyInputs
                 // Could detect well-known assemblies--ie System.dll--and open them with read-locks 
                 tcConfigB.openBinariesInMemory <- true
 
-                tcConfigB.resolutionEnvironment <- (ReferenceResolver.ResolutionEnvironment.EditingAndCompilation true)
+                tcConfigB.resolutionEnvironment <- (ReferenceResolver.ResolutionEnvironment.EditingOrCompilation true)
                 
                 tcConfigB.conditionalCompilationDefines <- 
                     let define = if useScriptResolutionRules then "INTERACTIVE" else "COMPILED"

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/GlobalSuppressions.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/GlobalSuppressions.cs
@@ -160,7 +160,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Scope = "member", Target = "Microsoft.VisualStudio.Package.ProjectOptions.#BugReportFileName", MessageId = "")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Scope = "member", Target = "Microsoft.VisualStudio.Package.ProjectOptions.#CheckedArithmetic", MessageId = "")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Scope = "member", Target = "Microsoft.VisualStudio.Package.ProjectOptions.#CodePage", MessageId = "")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Scope = "member", Target = "Microsoft.VisualStudio.Package.ProjectOptions.#CompileAndExecute", MessageId = "")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Scope = "member", Target = "Microsoft.VisualStudio.Package.ProjectOptions.#CompilationAndEvaluation", MessageId = "")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Scope = "member", Target = "Microsoft.VisualStudio.Package.ProjectOptions.#DefinedPreProcessorSymbols", MessageId = "")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Scope = "member", Target = "Microsoft.VisualStudio.Package.ProjectOptions.#DisplayCommandLineHelp", MessageId = "")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Scope = "member", Target = "Microsoft.VisualStudio.Package.ProjectOptions.#EmitManifest", MessageId = "")]

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectOptions.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectOptions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
         public string RootNamespace;
 
-        public bool CompileAndExecute;
+        public bool CompilationAndEvaluation;
 
         /// <devdoc>must be an int if not null.</devdoc>
         public object UserLocaleId;

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectOptions.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectOptions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
         public string RootNamespace;
 
-        public bool CompilationAndEvaluation;
+        public bool CompileAndExecute;
 
         /// <devdoc>must be an int if not null.</devdoc>
         public object UserLocaleId;


### PR DESCRIPTION
This is my proposed interim fix for https://github.com/Microsoft/visualfsharp/issues/3444

For better or worse, F# Interactive compiles against implementation assemblies at the moment, and has done for a long time. In F# 4.1, we stopped making the reference assemblies available to F# Interactive because we were getting cases where it was dynamically loading reference assemblies and trying to execute them.

For this reason, the safest fix to the linked issue is to make the WPF implementation assemblies available to F# Interactive during compilation.  These are the only .NET Framework assemblies not already addressable.

We have talked about rigorously separating reference and implementation assemblies as part of .NET Core work, but as things stand today it is just risky to have F# Interactive on .NET Framework compile against reference assemblies, as it may try to dynamically load and execute them

ALso includes a considerable amount of "flag cleanup" to give the existing internal flags clearer names
