### PR TITLE
Correct compiler nuspecs

### DIFF
--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -15,7 +15,6 @@
         <tags>$tags$</tags>
         <dependencies>
             <group targetFramework=".NETStandard1.6">
-                <dependency id="Microsoft.NETCore.Platforms" version="1.0.1" />
                 <dependency id="NETStandard.Library" version="1.6.0" />
                 <dependency id="System.Collections.Immutable" version="1.2.0" />
                 <dependency id="System.Console" version="4.0.0" />

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
@@ -14,7 +14,6 @@
         <tags>$tags$</tags>
         <dependencies>
             <group targetFramework=".NETStandard1.6">
-                <dependency id="Microsoft.NETCore.Platforms" version="1.0.1" />
                 <dependency id="NETStandard.Library" version="1.6.0" />
                 <dependency id="System.Collections.Immutable" version="1.2.0" />
                 <dependency id="System.Console" version="4.0.0" />


### PR DESCRIPTION
The Microsoft FSharp Compiler package incorrectly references : Microsoft.NETCore.Platforms

This PR: fixes that.  fixes issue https://github.com/Microsoft/visualfsharp/issues/3504

@nguerrera 
