### PR TITLE
Fix 3376 - delegate quotation for System.Func with no parameters

### DIFF
--- a/src/fsharp/FSharp.Core/quotations.fs
+++ b/src/fsharp/FSharp.Core/quotations.fs
@@ -285,10 +285,16 @@ and [<CompiledName("FSharpExpr")>]
         | CombTerm(TryWithOp,[e1;Lambda(v1,e2);Lambda(v2,e3)])         -> combL "TryWith" [expr e1; varL v1; expr e2; varL v2; expr e3]
         | CombTerm(SequentialOp,args)        -> combL "Sequential" (exprs args)
         | CombTerm(NewDelegateOp(ty),[e])   -> 
-            let n = (getDelegateInvoke ty).GetParameters().Length
-            match e with 
-            | NLambdas n (vs,e) -> combL "NewDelegate" ([typeL ty] @ (vs |> List.map varL) @ [expr e])
-            | _ -> combL "NewDelegate" [typeL ty; expr e]
+            let nargs = (getDelegateInvoke ty).GetParameters().Length
+            if nargs = 0 then 
+                match e with 
+                | NLambdas 1 ([_],e) -> combL "NewDelegate" ([typeL ty] @ [expr e])
+                | NLambdas 0 ([],e) -> combL "NewDelegate" ([typeL ty] @ [expr e])
+                | _ -> combL "NewDelegate" [typeL ty; expr e]
+            else
+                match e with 
+                | NLambdas nargs (vs,e) -> combL "NewDelegate" ([typeL ty] @ (vs |> List.map varL) @ [expr e])
+                | _ -> combL "NewDelegate" [typeL ty; expr e]
         //| CombTerm(_,args)   -> combL "??" (exprs args)
         | VarTerm(v)   -> wordL (tagLocal v.Name)
         | LambdaTerm(v,b)   -> combL "Lambda" [varL v; expr b]
@@ -503,10 +509,16 @@ module Patterns =
     let (|NewDelegate|_|) e  = 
         match e with 
         | Comb1(NewDelegateOp(ty),e) -> 
-            let n = (getDelegateInvoke ty).GetParameters().Length
-            match e with 
-            | NLambdas n (vs,e) -> Some(ty,vs,e) 
-            | _ -> None
+            let nargs = (getDelegateInvoke ty).GetParameters().Length
+            if nargs = 0 then 
+                match e with 
+                | NLambdas 1 ([_],e) -> Some(ty,[],e) // try to strip the unit parameter if there is one 
+                | NLambdas 0 ([],e) -> Some(ty,[],e) 
+                | _ -> None
+            else
+                match e with 
+                | NLambdas nargs (vs,e) -> Some(ty,vs,e) 
+                | _ -> None
         | _ -> None
 
     [<CompiledName("LetRecursivePattern")>]

--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -3106,6 +3106,32 @@ module TestStaticCtor =
     testStaticCtor()
 
 
+module TestFuncNoArgs = 
+    type SomeType() = class end
+    type Test =
+        static member ParseThis (f : System.Linq.Expressions.Expression<System.Func<SomeType>>) = f
+
+    
+    type D = delegate of unit -> int
+    type D2<'T> = delegate of unit -> 'T
+
+    let testFunc() = 
+        check "cvwenklwevpo1" (match <@ new System.Func<int>(fun () -> 3) @> with Quotations.Patterns.NewDelegate(_,[],Value _) -> true | _ -> false) true
+        check "cvwenklwevpo2" (match <@ new System.Func<int,int>(fun n -> 3) @> with Quotations.Patterns.NewDelegate(_,[_],Value _) -> true | _ -> false) true
+        check "cvwenklwevpo1d" (match <@ new D(fun () -> 3) @> with Quotations.Patterns.NewDelegate(_,[],Value _) -> true | _ -> false) true
+        check "cvwenklwevpo2d" (match <@ new D2<int>(fun () -> 3) @> with Quotations.Patterns.NewDelegate(_,[],Value _) -> true | _ -> false) true
+
+    testFunc()
+
+
+    let testFunc2() = 
+        // was raising exception
+        let foo = Test.ParseThis (fun () -> SomeType())
+        check "clew0mmlvew" (foo.ToString()) "() => new SomeType()"
+
+    testFunc2()
+    
+
 #if !FX_RESHAPED_REFLECTION
 module TestAssemblyAttributes = 
     let attributes = System.Reflection.Assembly.GetExecutingAssembly().GetCustomAttributes(false)


### PR DESCRIPTION
Fixes #3376.  The fix is a conservative one in FSharp.Core.dll.  

An alternative to fixing this might have been to change the quotation data we generate for these cases.  However, I'm concerned that that would either cause failures of newly generated code with  previous FSharp.Core, or failures of previously generated code with new FSharp.Core.  

The current fix clearly continues to process previous quotation data for NewDelegateOp in the same way, and processes the unit-variable case of NewDelegateOp correctly as well. 
