### PR TITLE
Fix 3022 - Generate correct names for delegate and object expression arguments

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -3428,18 +3428,20 @@ and GenFormalSlotsig m cenv eenv (TSlotSig(_,typ,ctps,mtps,paraml,returnTy)) =
     let eenvForSlotSig = EnvForTypars (ctps @ mtps) eenv
     let ilParams = paraml |> List.map (GenSlotParam m cenv eenvForSlotSig) 
     let ilRetTy = GenReturnType cenv.amap m eenvForSlotSig.tyenv returnTy
-    let ilReturn = mkILReturn  ilRetTy
-    ilTy, ilParams,ilReturn
+    let ilRet = mkILReturn  ilRetTy
+    ilTy, ilParams, ilRet
 
 and instSlotParam inst (TSlotParam(nm,ty,inFlag,fl2,fl3,attrs)) = TSlotParam(nm,instType inst ty,inFlag,fl2,fl3,attrs) 
 
-and GenActualSlotsig m cenv eenv (TSlotSig(_,typ,ctps,mtps,paraml,returnTy)) methTyparsOfOverridingMethod = 
-    let paraml = List.concat paraml
+and GenActualSlotsig m cenv eenv (TSlotSig(_,typ,ctps,mtps,ilSlotParams,ilSlotRetTy)) methTyparsOfOverridingMethod (methodParams: Val list) = 
+    let ilSlotParams = List.concat ilSlotParams
     let instForSlotSig = mkTyparInst (ctps@mtps) (argsOfAppTy cenv.g typ @ generalizeTypars methTyparsOfOverridingMethod)
-    let ilParams = paraml |> List.map (instSlotParam instForSlotSig >> GenSlotParam m cenv eenv) 
-    let ilRetTy = GenReturnType cenv.amap m eenv.tyenv (Option.map (instType instForSlotSig) returnTy)
-    let ilReturn = mkILReturn ilRetTy
-    ilParams,ilReturn
+    let ilParams = ilSlotParams |> List.map (instSlotParam instForSlotSig >> GenSlotParam m cenv eenv) 
+    // Use the better names if available
+    let ilParams = if ilParams.Length = methodParams.Length then (ilParams, methodParams) ||> List.map2 (fun p pv -> { p with Name = Some (nameOfVal pv) }) else ilParams
+    let ilRetTy = GenReturnType cenv.amap m eenv.tyenv (Option.map (instType instForSlotSig) ilSlotRetTy)
+    let iLRet = mkILReturn ilRetTy
+    ilParams,iLRet
 
 and GenNameOfOverridingMethod cenv (useMethodImpl,(TSlotSig(nameOfOverridenMethod,enclTypOfOverridenMethod,_,_,_,_))) =
     if useMethodImpl then qualifiedMangledNameOfTyconRef (tcrefOfAppTy cenv.g enclTypOfOverridenMethod) nameOfOverridenMethod else nameOfOverridenMethod
@@ -3453,7 +3455,7 @@ and GenMethodImpl cenv eenv (useMethodImpl,(TSlotSig(nameOfOverridenMethod,_,_,_
         let ilOverrideTyRef = ilOverrideTy.TypeRef
         let ilOverrideMethRef = mkILMethRef(ilOverrideTyRef, ILCallingConv.Instance, nameOfOverridenMethod, List.length (DropErasedTypars methTyparsOfOverridingMethod), (typesOfILParams ilOverrideParams), ilOverrideRet.Type)
         let eenvForOverrideBy = AddTyparsToEnv methTyparsOfOverridingMethod eenv 
-        let ilParamsOfOverridingMethod,ilReturnOfOverridingMethod = GenActualSlotsig m cenv eenvForOverrideBy slotsig methTyparsOfOverridingMethod
+        let ilParamsOfOverridingMethod,ilReturnOfOverridingMethod = GenActualSlotsig m cenv eenvForOverrideBy slotsig methTyparsOfOverridingMethod []
         let ilOverrideMethGenericParams = GenGenericParams cenv eenvForOverrideBy methTyparsOfOverridingMethod 
         let ilOverrideMethGenericArgs = mkILFormalGenericArgs 0 ilOverrideMethGenericParams
         let ilOverrideBy = mkILInstanceMethSpecInTy(ilTyForOverriding, nameOfOverridingMethod, typesOfILParams ilParamsOfOverridingMethod, ilReturnOfOverridingMethod.Type, ilOverrideMethGenericArgs)
@@ -3500,11 +3502,12 @@ and GenObjectMethod cenv eenvinner (cgbuf:CodeGenBuffer) useMethodImpl tmethod =
         []
     else
         let eenvUnderTypars = AddTyparsToEnv methTyparsOfOverridingMethod eenvinner
-        let ilParamsOfOverridingMethod,ilReturnOfOverridingMethod = GenActualSlotsig m cenv eenvUnderTypars slotsig methTyparsOfOverridingMethod
+        let methodParams = List.concat methodParams
+        let methodParamsNonSelf = match methodParams with [] -> [] | _::t -> t // drop the 'this' arg when computing better argument names for IL parameters
+        let ilParamsOfOverridingMethod,ilReturnOfOverridingMethod = GenActualSlotsig m cenv eenvUnderTypars slotsig methTyparsOfOverridingMethod methodParamsNonSelf 
         let ilAttribs = GenAttrs cenv eenvinner attribs
 
         // Args are stored starting at #1
-        let methodParams = List.concat methodParams
         let eenvForMeth = AddStorageForLocalVals cenv.g (methodParams  |> List.mapi (fun i v -> (v,Arg i)))  eenvUnderTypars
         let ilMethodBody = CodeGenMethodForExpr cenv cgbuf.mgbuf (SPAlways,[],nameOfOverridenMethod,eenvForMeth,0,0,methodBodyExpr,(if slotSigHasVoidReturnTy slotsig then discardAndReturnVoid else Return))
 
@@ -4081,12 +4084,13 @@ and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod((TSlotSig(_,delega
 
     let envForDelegeeUnderTypars = AddTyparsToEnv methTyparsOfOverridingMethod eenvinner
 
-    // The slot sig contains a formal instantiation.  When creating delegates we're only 
-    // interested in the actual instantiation since we don't have to emit a method impl. 
-    let ilDelegeeParams,ilDelegeeRet = GenActualSlotsig m cenv envForDelegeeUnderTypars slotsig methTyparsOfOverridingMethod
-
     let numthis = 1
     let tmvs, body = BindUnitVars cenv.g (tmvs, List.replicate (List.concat slotsig.FormalParams).Length ValReprInfo.unnamedTopArg1, body)
+
+    // The slot sig contains a formal instantiation.  When creating delegates we're only 
+    // interested in the actual instantiation since we don't have to emit a method impl. 
+    let ilDelegeeParams,ilDelegeeRet = GenActualSlotsig m cenv envForDelegeeUnderTypars slotsig methTyparsOfOverridingMethod tmvs
+
     let envForDelegeeMeth = AddStorageForLocalVals cenv.g (List.mapi (fun i v -> (v,Arg (i+numthis))) tmvs)  envForDelegeeUnderTypars
     let ilMethodBody = CodeGenMethodForExpr cenv cgbuf.mgbuf (SPAlways,[],delegeeMethName,envForDelegeeMeth,1,0,body,(if slotSigHasVoidReturnTy slotsig then discardAndReturnVoid else Return))
     let delegeeInvokeMeth =
@@ -6482,7 +6486,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                              match paraml with
                              | [[tsp]] when isUnitTy cenv.g tsp.Type -> [] (* suppress unit arg *)
                              | paraml -> paraml
-                         GenActualSlotsig m cenv eenvinner (TSlotSig(nm,typ,ctps,mtps,paraml,returnTy)) []
+                         GenActualSlotsig m cenv eenvinner (TSlotSig(nm,typ,ctps,mtps,paraml,returnTy)) [] []
                      for ilMethodDef in mkILDelegateMethods cenv.g.ilg (cenv.g.iltyp_AsyncCallback, cenv.g.iltyp_IAsyncResult) (p,r) do
                         yield { ilMethodDef with Access=reprAccess }
                  | _ -> 

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/CompiledNameAttribute/CompiledNameAttribute04.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/CompiledNameAttribute/CompiledNameAttribute04.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.17376
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:3:0:0
+  .ver 4:4:1:0
 }
 .assembly CompiledNameAttribute04
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.CompiledNameAttribute04
 {
-  // Offset: 0x00000000 Length: 0x00000D0E
+  // Offset: 0x00000000 Length: 0x00000CE9
 }
 .mresource public FSharpOptimizationData.CompiledNameAttribute04
 {
-  // Offset: 0x00000D18 Length: 0x000002CB
+  // Offset: 0x00000CF0 Length: 0x000002CB
 }
 .module CompiledNameAttribute04.exe
-// MVID: {4F20DC6A-34DF-584F-A745-03836ADC204F}
+// MVID: {59A6D79B-34DF-584F-A745-03839BD7A659}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000000B84EEF0000
+// Image base: 0x02D50000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -74,7 +74,7 @@
       // Code size       10 (0xa)
       .maxstack  8
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 20,20 : 6,7 
+      .line 20,20 : 6,7 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\CompiledNameAttribute\\CompiledNameAttribute04.fs'
       IL_0000:  ldarg.0
       IL_0001:  callvirt   instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
@@ -88,7 +88,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 21,21 : 19,20 
+      .line 21,21 : 19,20 ''
       IL_0000:  nop
       IL_0001:  ldc.i4.1
       IL_0002:  ret
@@ -101,7 +101,7 @@
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
       // Code size       5 (0x5)
       .maxstack  8
-      .line 22,22 : 24,29 
+      .line 22,22 : 24,29 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldarg.2
@@ -114,7 +114,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 24,24 : 22,23 
+      .line 24,24 : 22,23 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -154,7 +154,7 @@
       // Code size       6 (0x6)
       .maxstack  3
       .locals init ([0] valuetype CompiledNameAttribute04/S& V_0)
-      .line 37,37 : 6,7 
+      .line 37,37 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarga.s   obj
       IL_0003:  stloc.0
@@ -168,7 +168,7 @@
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       14 (0xe)
       .maxstack  8
-      .line 37,37 : 6,7 
+      .line 37,37 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  ldarg.1
@@ -186,7 +186,7 @@
       .maxstack  3
       .locals init ([0] valuetype CompiledNameAttribute04/S V_0,
                [1] valuetype CompiledNameAttribute04/S& V_1)
-      .line 37,37 : 6,7 
+      .line 37,37 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  unbox.any  CompiledNameAttribute04/S
@@ -203,7 +203,7 @@
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       3 (0x3)
       .maxstack  8
-      .line 37,37 : 6,7 
+      .line 37,37 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldc.i4.0
       IL_0002:  ret
@@ -215,7 +215,7 @@
       .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       // Code size       13 (0xd)
       .maxstack  8
-      .line 37,37 : 6,7 
+      .line 37,37 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarg.0
       IL_0002:  call       class [mscorlib]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
@@ -256,7 +256,7 @@
     {
       // Code size       3 (0x3)
       .maxstack  8
-      .line 40,40 : 24,25 
+      .line 40,40 : 24,25 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ret
@@ -269,7 +269,7 @@
       // Code size       6 (0x6)
       .maxstack  3
       .locals init ([0] valuetype CompiledNameAttribute04/S& V_0)
-      .line 37,37 : 6,7 
+      .line 37,37 : 6,7 ''
       IL_0000:  nop
       IL_0001:  ldarga.s   obj
       IL_0003:  stloc.0
@@ -334,13 +334,13 @@
     } // end of method a@49::.ctor
 
     .method private hidebysig newslot virtual final 
-            instance int32  'CompiledNameAttribute04-ITestInterface-M'(int32 A_1) cil managed
+            instance int32  'CompiledNameAttribute04-ITestInterface-M'(int32 x) cil managed
     {
       .custom instance void [mscorlib]System.Runtime.InteropServices.PreserveSigAttribute::.ctor() = ( 01 00 00 00 ) 
       .override CompiledNameAttribute04/ITestInterface::M
       // Code size       5 (0x5)
       .maxstack  8
-      .line 51,51 : 33,38 
+      .line 51,51 : 33,38 ''
       IL_0000:  nop
       IL_0001:  ldarg.1
       IL_0002:  ldc.i4.1
@@ -356,7 +356,7 @@
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
     // Code size       5 (0x5)
     .maxstack  8
-    .line 16,16 : 14,19 
+    .line 16,16 : 14,19 ''
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  ldarg.1
@@ -368,7 +368,7 @@
   {
     // Code size       3 (0x3)
     .maxstack  8
-    .line 17,17 : 12,13 
+    .line 17,17 : 12,13 ''
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  ret

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.17376
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:3:0:0
+  .ver 4:4:1:0
 }
 .assembly DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x000002B5
+  // Offset: 0x00000000 Length: 0x00000291
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x000002C0 Length: 0x000000BA
+  // Offset: 0x00000298 Length: 0x000000BA
 }
 .module DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.exe
-// MVID: {4F20DD34-1475-D984-A745-038334DD204F}
+// MVID: {59A6D79B-1475-D984-A745-03839BD7A659}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00000031611D0000
+// Image base: 0x005A0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -66,14 +66,14 @@
     } // end of method F@6::.ctor
 
     .method assembly hidebysig instance void 
-            Invoke(object sender,
-                   int32 args) cil managed
+            Invoke(object x,
+                   int32 _arg1) cil managed
     {
       // Code size       4 (0x4)
       .maxstack  5
       .locals init ([0] int32 V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 6,6 : 80,82 
+      .line 6,6 : 80,82 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_ArrayOfArray_FSInterface_NoExtMeth.fs'
       IL_0000:  ldarg.2
       IL_0001:  stloc.0
       IL_0002:  nop
@@ -86,7 +86,7 @@
   {
     // Code size       45 (0x2d)
     .maxstack  8
-    .line 6,6 : 48,83 
+    .line 6,6 : 48,83 ''
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  ldc.i4.0

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_Array_FSInterface_NoExtMeth.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_Array_FSInterface_NoExtMeth.il.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.17376
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:3:0:0
+  .ver 4:4:1:0
 }
 .assembly DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x0000029C
+  // Offset: 0x00000000 Length: 0x00000278
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_Array_FSInterface_NoExtMeth
 {
-  // Offset: 0x000002A0 Length: 0x000000AC
+  // Offset: 0x00000280 Length: 0x000000AC
 }
 .module DoNotBoxStruct_Array_FSInterface_NoExtMeth.exe
-// MVID: {4F20DD37-8127-3EE3-A745-038337DD204F}
+// MVID: {59A6D79B-8127-3EE3-A745-03839BD7A659}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000007D4C710000
+// Image base: 0x00E10000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -51,7 +51,7 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname F@6
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'F@6-1'
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
@@ -63,38 +63,38 @@
       IL_0000:  ldarg.0
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ret
-    } // end of method F@6::.ctor
+    } // end of method 'F@6-1'::.ctor
 
     .method assembly hidebysig instance void 
-            Invoke(object sender,
-                   int32 args) cil managed
+            Invoke(object x,
+                   int32 _arg1) cil managed
     {
       // Code size       4 (0x4)
       .maxstack  5
       .locals init ([0] int32 V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 6,6 : 74,76 
+      .line 6,6 : 74,76 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_Array_FSInterface_NoExtMeth.fs'
       IL_0000:  ldarg.2
       IL_0001:  stloc.0
       IL_0002:  nop
       IL_0003:  ret
-    } // end of method F@6::Invoke
+    } // end of method 'F@6-1'::Invoke
 
-  } // end of class F@6
+  } // end of class 'F@6-1'
 
   .method public static void  F<(class [FSharp.Core]Microsoft.FSharp.Control.IEvent`2<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>,int32>) T>(!!T[] x) cil managed
   {
     // Code size       39 (0x27)
     .maxstack  8
-    .line 6,6 : 46,77 
+    .line 6,6 : 46,77 ''
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  ldc.i4.0
     IL_0003:  readonly.
     IL_0005:  ldelema    !!T
-    IL_000a:  newobj     instance void DoNotBoxStruct_Array_FSInterface_NoExtMeth/F@6::.ctor()
-    IL_000f:  ldftn      instance void DoNotBoxStruct_Array_FSInterface_NoExtMeth/F@6::Invoke(object,
-                                                                                              int32)
+    IL_000a:  newobj     instance void DoNotBoxStruct_Array_FSInterface_NoExtMeth/'F@6-1'::.ctor()
+    IL_000f:  ldftn      instance void DoNotBoxStruct_Array_FSInterface_NoExtMeth/'F@6-1'::Invoke(object,
+                                                                                                  int32)
     IL_0015:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
                                                                                                                  native int)
     IL_001a:  constrained. !!T

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.17376
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:3:0:0
+  .ver 4:4:1:0
 }
 .assembly DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x000002A3
+  // Offset: 0x00000000 Length: 0x0000027F
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_MDArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x000002A8 Length: 0x000000B0
+  // Offset: 0x00000288 Length: 0x000000B0
 }
 .module DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.exe
-// MVID: {4F20DD3B-A67D-867A-A745-03833BDD204F}
+// MVID: {59A6D79B-A67D-867A-A745-03839BD7A659}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x000000518AC20000
+// Image base: 0x002E0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -51,7 +51,7 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname F@6
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'F@6-2'
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
@@ -63,30 +63,30 @@
       IL_0000:  ldarg.0
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ret
-    } // end of method F@6::.ctor
+    } // end of method 'F@6-2'::.ctor
 
     .method assembly hidebysig instance void 
-            Invoke(object sender,
-                   int32 args) cil managed
+            Invoke(object x,
+                   int32 _arg1) cil managed
     {
       // Code size       4 (0x4)
       .maxstack  5
       .locals init ([0] int32 V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 6,6 : 77,79 
+      .line 6,6 : 77,79 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_MDArray_FSInterface_NoExtMeth.fs'
       IL_0000:  ldarg.2
       IL_0001:  stloc.0
       IL_0002:  nop
       IL_0003:  ret
-    } // end of method F@6::Invoke
+    } // end of method 'F@6-2'::Invoke
 
-  } // end of class F@6
+  } // end of class 'F@6-2'
 
   .method public static void  F<(class [FSharp.Core]Microsoft.FSharp.Control.IEvent`2<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>,int32>) T>(!!T[0...,0...] x) cil managed
   {
     // Code size       40 (0x28)
     .maxstack  8
-    .line 6,6 : 47,80 
+    .line 6,6 : 47,80 ''
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  ldc.i4.0
@@ -94,9 +94,9 @@
     IL_0004:  readonly.
     IL_0006:  call       instance !!T& !!T[0...,0...]::Address(int32,
                                                                int32)
-    IL_000b:  newobj     instance void DoNotBoxStruct_MDArray_FSInterface_NoExtMeth/F@6::.ctor()
-    IL_0010:  ldftn      instance void DoNotBoxStruct_MDArray_FSInterface_NoExtMeth/F@6::Invoke(object,
-                                                                                                int32)
+    IL_000b:  newobj     instance void DoNotBoxStruct_MDArray_FSInterface_NoExtMeth/'F@6-2'::.ctor()
+    IL_0010:  ldftn      instance void DoNotBoxStruct_MDArray_FSInterface_NoExtMeth/'F@6-2'::Invoke(object,
+                                                                                                    int32)
     IL_0016:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
                                                                                                                  native int)
     IL_001b:  constrained. !!T

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/DoNotBoxStruct/DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.il.netfx4.bsl
@@ -1,5 +1,5 @@
 
-//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.0.30319.17376
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 
 
@@ -13,7 +13,7 @@
 .assembly extern FSharp.Core
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:3:0:0
+  .ver 4:4:1:0
 }
 .assembly DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
@@ -29,20 +29,20 @@
 }
 .mresource public FSharpSignatureData.DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000000 Length: 0x00000293
+  // Offset: 0x00000000 Length: 0x0000026F
 }
 .mresource public FSharpOptimizationData.DoNotBoxStruct_NoArray_FSInterface_NoExtMeth
 {
-  // Offset: 0x00000298 Length: 0x000000B0
+  // Offset: 0x00000278 Length: 0x000000B0
 }
 .module DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.exe
-// MVID: {4F20DD3E-CD0A-F713-A745-03833EDD204F}
+// MVID: {59A6D79B-CD0A-F713-A745-03839BD7A659}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x0000008057540000
+// Image base: 0x01500000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -51,7 +51,7 @@
        extends [mscorlib]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
-  .class auto autochar serializable sealed nested assembly beforefieldinit specialname F@6
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'F@6-3'
          extends [mscorlib]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
@@ -63,38 +63,38 @@
       IL_0000:  ldarg.0
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ret
-    } // end of method F@6::.ctor
+    } // end of method 'F@6-3'::.ctor
 
     .method assembly hidebysig instance void 
-            Invoke(object sender,
-                   int32 args) cil managed
+            Invoke(object x,
+                   int32 _arg1) cil managed
     {
       // Code size       4 (0x4)
       .maxstack  5
       .locals init ([0] int32 V_0)
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 6,6 : 68,70 
+      .line 6,6 : 68,70 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\DoNotBoxStruct\\DoNotBoxStruct_NoArray_FSInterface_NoExtMeth.fs'
       IL_0000:  ldarg.2
       IL_0001:  stloc.0
       IL_0002:  nop
       IL_0003:  ret
-    } // end of method F@6::Invoke
+    } // end of method 'F@6-3'::Invoke
 
-  } // end of class F@6
+  } // end of class 'F@6-3'
 
   .method public static void  F<(class [FSharp.Core]Microsoft.FSharp.Control.IEvent`2<class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>,int32>) T>(!!T x) cil managed
   {
     // Code size       34 (0x22)
     .maxstack  5
     .locals init ([0] !!T V_0)
-    .line 6,6 : 44,71 
+    .line 6,6 : 44,71 ''
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  stloc.0
     IL_0003:  ldloca.s   V_0
-    IL_0005:  newobj     instance void DoNotBoxStruct_NoArray_FSInterface_NoExtMeth/F@6::.ctor()
-    IL_000a:  ldftn      instance void DoNotBoxStruct_NoArray_FSInterface_NoExtMeth/F@6::Invoke(object,
-                                                                                                int32)
+    IL_0005:  newobj     instance void DoNotBoxStruct_NoArray_FSInterface_NoExtMeth/'F@6-3'::.ctor()
+    IL_000a:  ldftn      instance void DoNotBoxStruct_NoArray_FSInterface_NoExtMeth/'F@6-3'::Invoke(object,
+                                                                                                    int32)
     IL_0010:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Control.FSharpHandler`1<int32>::.ctor(object,
                                                                                                                  native int)
     IL_0015:  constrained. !!T

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Aggregates01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Aggregates01.il.netfx4.bsl
@@ -45,13 +45,13 @@
   // Offset: 0x00000610 Length: 0x00000211
 }
 .module Linq101Aggregates01.exe
-// MVID: {594BFA7F-D281-4783-A745-03837FFA4B59}
+// MVID: {59A6D79A-D281-4783-A745-03839AD7A659}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x002F0000
+// Image base: 0x001E0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -3399,7 +3399,7 @@
     } // end of method 'min@68-2'::.ctor
 
     .method assembly hidebysig instance valuetype [mscorlib]System.Decimal 
-            Invoke(class [Utils]Utils/Product arg) cil managed
+            Invoke(class [Utils]Utils/Product p) cil managed
     {
       // Code size       10 (0xa)
       .maxstack  8

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Quantifiers01.il.netfx4.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/QueryExpressionStepping/Linq101Quantifiers01.il.netfx4.bsl
@@ -38,20 +38,20 @@
 }
 .mresource public FSharpSignatureData.Linq101Quantifiers01
 {
-  // Offset: 0x00000000 Length: 0x0000039B
+  // Offset: 0x00000000 Length: 0x00000397
 }
 .mresource public FSharpOptimizationData.Linq101Quantifiers01
 {
   // Offset: 0x000003A0 Length: 0x000000FF
 }
 .module Linq101Quantifiers01.exe
-// MVID: {590846DB-76DD-E373-A745-0383DB460859}
+// MVID: {59A6D79A-76DD-E373-A745-03839AD7A659}
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x01290000
+// Image base: 0x00D00000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -116,7 +116,7 @@
       // Code size       191 (0xbf)
       .maxstack  6
       .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
-      .line 100001,100001 : 0,0 'C:\\src\\manofstick\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Quantifiers01.fs'
+      .line 100001,100001 : 0,0 'C:\\GitHub\\dsyme\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\QueryExpressionStepping\\Linq101Quantifiers01.fs'
       IL_0000:  ldarg.0
       IL_0001:  ldfld      int32 Linq101Quantifiers01/iAfterE@12::pc
       IL_0006:  ldc.i4.1
@@ -609,7 +609,7 @@
     } // end of method 'productGroups@23-5'::.ctor
 
     .method assembly hidebysig instance bool 
-            Invoke(class [Utils]Utils/Product arg) cil managed
+            Invoke(class [Utils]Utils/Product x) cil managed
     {
       // Code size       11 (0xb)
       .maxstack  8
@@ -1240,7 +1240,7 @@
     } // end of method 'productGroups2@41-5'::.ctor
 
     .method assembly hidebysig instance bool 
-            Invoke(class [Utils]Utils/Product arg) cil managed
+            Invoke(class [Utils]Utils/Product x) cil managed
     {
       // Code size       11 (0xb)
       .maxstack  8


### PR DESCRIPTION
Fixes the relatively old issue #3022 - but it's a fairly significant issue since we generate the wrong names for arguments in delegate and object expression implementations

    https://github.com/Microsoft/visualfsharp/issues/3022

This affects debugging and is one of the cases of "values not appearing" when debugging some code.

I've tested this manually - we probably have codegen tests for these cases already which need to be updated - if not I will add tests