### PR TITLE
Fix 3509 - compiler should give error not crash

### DIFF
--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -3539,14 +3539,14 @@ and
     member x.GetAssemblyName() =
         match x with
         | TType_forall (_tps, ty)        -> ty.GetAssemblyName()
-        | TType_app (tcref, _tinst)      -> tcref.CompilationPath.ILScopeRef.AssemblyRef.QualifiedName
+        | TType_app (tcref, _tinst)      -> tcref.CompilationPath.ILScopeRef.QualifiedName
         | TType_tuple (_tupInfo, _tinst) -> ""
         | TType_fun (_d,_r)              -> ""
         | TType_measure _ms              -> ""
         | TType_var tp                   -> tp.Solution |> function Some sln -> sln.GetAssemblyName() | None -> ""
         | TType_ucase (_uc,_tinst)       ->
             let (TILObjectReprData(scope,_nesting,_definition)) = _uc.Tycon.ILTyconInfo
-            scope.AssemblyRef.QualifiedName
+            scope.QualifiedName
 
 and TypeInst = TType list 
 and TTypes = TType list 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2138,6 +2138,9 @@ module TypecheckTests =
     let ``type check neg98`` () = singleNegTest (testConfig "typecheck/sigs") "neg98"
 
     [<Test>] 
+    let ``type check neg99`` () = singleNegTest (testConfig "typecheck/sigs") "neg99"
+
+    [<Test>] 
     let ``type check neg_byref_1`` () = singleNegTest (testConfig "typecheck/sigs") "neg_byref_1"
 
     [<Test>] 

--- a/tests/fsharp/typecheck/sigs/neg99.bsl
+++ b/tests/fsharp/typecheck/sigs/neg99.bsl
@@ -1,0 +1,6 @@
+
+neg99.fs(19,16,19,64): typecheck error FS0077: Member constraints with the name 'op_Explicit' are given special status by the F# compiler as certain .NET types are implicitly augmented with this member. This may result in runtime failures if you attempt to invoke the member constraint from your own code.
+
+neg99.fs(22,18,22,64): typecheck error FS0077: Member constraints with the name 'op_Explicit' are given special status by the F# compiler as certain .NET types are implicitly augmented with this member. This may result in runtime failures if you attempt to invoke the member constraint from your own code.
+
+neg99.fs(25,39,25,43): typecheck error FS0043: The type 'CrashFSC.OhOh.MyByte' does not support a conversion to the type 'CrashFSC.OhOh.MyByte'

--- a/tests/fsharp/typecheck/sigs/neg99.fs
+++ b/tests/fsharp/typecheck/sigs/neg99.fs
@@ -1,0 +1,26 @@
+namespace CrashFSC
+
+open System
+
+// debatable code, but it was the minimalist example I could come up 
+// with after analysis in the original project
+module OhOh =
+
+    type MyByte = MyByte of byte with
+        static member inline op_Explicit (MyByte x): int64 = int64 x
+        static member inline op_Explicit (MyByte x): double = double x
+
+        static member inline op_Explicit (x: int64): MyByte = MyByte (byte x)
+        static member inline op_Explicit (x: float): MyByte = MyByte (byte x)        
+        static member inline op_Explicit (MyByte x): 'a = failwith "cannot convert"
+        
+    /// testing testing
+    let inline ( !>>> ) (a: ^a) min: ^b option =
+        if a < (^b : (static member op_Explicit: ^b -> ^a) min)  
+            then None
+        else    
+            Some (^b : (static member op_Explicit: ^a -> ^b) a)
+
+    let inline crashMe (a: ^a) min =
+        let (result: MyByte option) = !>>> a min
+        result


### PR DESCRIPTION
Fix the compiler crash https://github.com/Microsoft/visualfsharp/issues/3509 - it was caused by relatively new code