### PR TITLE
Fix attribute references

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -838,7 +838,8 @@ type ILAttribElem =
 type ILAttributeNamedArg =  (string * ILType * bool * ILAttribElem)
 type ILAttribute = 
     { Method: ILMethodSpec;
-      Data: byte[] }
+      Data: byte[] 
+      Elements: ILAttribElem list}
 
 [<NoEquality; NoComparison; Sealed>]
 type ILAttributes(f: unit -> ILAttribute[]) = 
@@ -3088,12 +3089,12 @@ let rec decodeCustomAttrElemType (ilg: ILGlobals) bytes sigptr x =
 let rec encodeCustomAttrPrimValue ilg c = 
     match c with 
     | ILAttribElem.Bool b -> [| (if b then 0x01uy else 0x00uy) |]
-    | ILAttribElem.String None 
-    | ILAttribElem.Type None 
+    | ILAttribElem.String None
+    | ILAttribElem.Type None
     | ILAttribElem.TypeRef None
     | ILAttribElem.Null -> [| 0xFFuy |]
     | ILAttribElem.String (Some s) -> encodeCustomAttrString s
-    | ILAttribElem.Char x -> u16AsBytes (uint16 x)
+    | ILAttribElem.Char x ->  u16AsBytes (uint16 x)
     | ILAttribElem.SByte x -> i8AsBytes x
     | ILAttribElem.Int16 x -> i16AsBytes x
     | ILAttribElem.Int32 x -> i32AsBytes x
@@ -3135,9 +3136,9 @@ let mkILCustomAttribMethRef (ilg: ILGlobals) (mspec:ILMethodSpec, fixedArgs: lis
          yield! u16AsBytes (uint16 namedArgs.Length) 
          for namedArg in namedArgs do 
              yield! encodeCustomAttrNamedArg ilg namedArg |]
-
     { Method = mspec;
-      Data = args }
+      Data = args;
+      Elements = fixedArgs @ (namedArgs |> List.map(fun (_,_,_,e) -> e)) }
 
 let mkILCustomAttribute ilg (tref,argtys,argvs,propvs) = 
     mkILCustomAttribMethRef ilg (mkILNonGenericCtorMethSpec (tref,argtys),argvs,propvs)

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -852,7 +852,8 @@ type ILAttributeNamedArg = string * ILType * bool * ILAttribElem
 /// to ILAttribElem's as best as possible.  
 type ILAttribute =
     { Method: ILMethodSpec;  
-      Data: byte[] }
+      Data: byte[] 
+      Elements: ILAttribElem list}
 
 [<NoEquality; NoComparison; Sealed>]
 type ILAttributes =

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2532,7 +2532,8 @@ and seekReadCustomAttrUncached ctxtH (CustomAttrIdx (cat,idx,valIdx)) =
       Data=
         match readBlobHeapOption ctxt valIdx with
         | Some bytes -> bytes
-        | None -> Bytes.ofInt32Array [| |] }
+        | None -> Bytes.ofInt32Array [| |] 
+      Elements = [] }
 
 and seekReadSecurityDecls ctxt idx = 
    mkILLazySecurityDecls

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -1415,7 +1415,7 @@ and GetCustomAttrRow cenv hca attr =
     let cat = GetMethodRefAsCustomAttribType cenv attr.Method.MethodRef
     for element in attr.Elements do
         match element with
-        | ILAttribElem.Type (Some ty) -> GetTypeRefAsTypeRefIdx cenv ty.TypeRef |> ignore
+        | ILAttribElem.Type (Some ty) when ty.IsNominal -> GetTypeRefAsTypeRefIdx cenv ty.TypeRef |> ignore
         | ILAttribElem.TypeRef (Some tref) -> GetTypeRefAsTypeRefIdx cenv tref  |> ignore
         | _ -> ()
 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -1413,10 +1413,17 @@ let rec GetCustomAttrDataAsBlobIdx cenv (data:byte[]) =
 
 and GetCustomAttrRow cenv hca attr = 
     let cat = GetMethodRefAsCustomAttribType cenv attr.Method.MethodRef
-    UnsharedRow 
-        [| HasCustomAttribute (fst hca, snd hca)
-           CustomAttributeType (fst cat, snd cat) 
-           Blob (GetCustomAttrDataAsBlobIdx cenv attr.Data) |]  
+    for element in attr.Elements do
+        match element with
+        | ILAttribElem.Type (Some ty) -> GetTypeRefAsTypeRefIdx cenv ty.TypeRef |> ignore
+        | ILAttribElem.TypeRef (Some tref) -> GetTypeRefAsTypeRefIdx cenv tref  |> ignore
+        | _ -> ()
+
+    UnsharedRow
+            [| HasCustomAttribute (fst hca, snd hca);
+               CustomAttributeType (fst cat, snd cat);
+               Blob (GetCustomAttrDataAsBlobIdx cenv attr.Data)
+            |]
 
 and GenCustomAttrPass3Or4 cenv hca attr = 
     AddUnsharedRow cenv TableNames.CustomAttribute (GetCustomAttrRow cenv hca attr) |> ignore
@@ -4323,4 +4330,3 @@ let WriteILBinary (outfile, (args: options), modul) =
                                   args.ilg, args.pdbfile, args.signer, args.portablePDB, args.embeddedPDB, args.embedAllSource, 
                                   args.embedSourceList, args.sourceLink, args.emitTailcalls, args.deterministic, args.showTimes, args.dumpDebugInfo) modul
     |> ignore
-


### PR DESCRIPTION
@auduchinok, @dsyme, Fixes: #3522
The approach is:
* When we are serializing the attribute, accumulate all of the arguments ILAttributeElements for it.
* When we are emiting the blob to the PE add a typeref for each type of it' arguments where the argument is a type or typeref.

If you would like to test this: 

* build coreclr
* make a copy of the %programfiles%\dotnet\sdk\2.0.1-servicing-006924\FSharp directory
* copy fsc.exe, fsharp.core.*, fsharp.*.dll into %programfiles%\dotnet\sdk\2.0.1-servicing-006924\FSharp 


* make the repro
````
namespace AttrRef

type AttrAttribute(t: System.Type) = class end

[<Attr(typeof<System.IO.File>)>]
type Class() = class end
````

* dotnet restore
* dotnet build
* use ildasm, reflector or ilspy to checkout the reference

![image](https://user-images.githubusercontent.com/5175830/29923399-42ae1d9e-8e0e-11e7-8cda-8d52c6704450.png)




