### PR TITLE
Ignore XML Doc comment lines if they are separated by new lines

### DIFF
--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -79,10 +79,17 @@ type XmlDocCollector() =
                 let prevGrabPointPos = grabPoints.[grabPointIndex-1]
                 Array.findFirstIndexWhereTrue lines (fun (_,pos) -> posGeq pos prevGrabPointPos)
         //printfn "#lines = %d, firstLineIndexAfterPrevGrabPoint = %d, firstLineIndexAfterGrabPoint = %d" lines.Length firstLineIndexAfterPrevGrabPoint  firstLineIndexAfterGrabPoint
-        lines.[firstLineIndexAfterPrevGrabPoint..firstLineIndexAfterGrabPoint-1] |> Array.map fst
+
+        let lines = lines.[firstLineIndexAfterPrevGrabPoint..firstLineIndexAfterGrabPoint-1] |> Array.rev
+        let firstLineNumber = (snd lines.[0]).Line
+        lines 
+        |> Array.mapi (fun i x -> firstLineNumber - i, x)
+        |> Array.takeWhile (fun (sequencedLineNumber, (_, pos)) -> sequencedLineNumber = pos.Line)
+        |> Array.map (fun (_, (lineStr, _)) -> lineStr)
+        |> Array.rev
       with e -> 
-          //printfn "unexpected error in LinesBefore:\n%s" (e.ToString())
-          [| |]
+        //printfn "unexpected error in LinesBefore:\n%s" (e.ToString())
+        [| |]
 
 type XmlDoc =
     | XmlDoc of string[]


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/3457

![image](https://user-images.githubusercontent.com/873919/29978959-233024c8-8f4c-11e7-94c4-96e4d8412527.png)

![image](https://user-images.githubusercontent.com/873919/29978966-2e5ed1dc-8f4c-11e7-8475-240908fab6d6.png)

![image](https://user-images.githubusercontent.com/873919/29980742-bdabf7b4-8f53-11e7-88da-e49659ce74f7.png)
