### PR TITLE
Fix:  Portable PDB MethodDebugInformation table size differs from MethodDef #3514

### DIFF
--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2903,7 +2903,6 @@ and seekReadMethodRVA ctxt (idx,nm,_internalcall,noinline,aggressiveinline,numty
                try 
 
                  let pdbm = pdbReaderGetMethod pdbr (uncodedToken TableNames.Method idx)
-                 //let rootScope = pdbMethodGetRootScope pdbm 
                  let sps = pdbMethodGetSequencePoints pdbm
                  (*dprintf "#sps for 0x%x = %d\n" (uncodedToken TableNames.Method idx) (Array.length sps)  *)
                  (* let roota,rootb = pdbScopeGetOffsets rootScope in  *)

--- a/src/absil/ilsupp.fs
+++ b/src/absil/ilsupp.fs
@@ -1230,9 +1230,6 @@ let pdbMethodGetToken (meth:PdbMethod) : int32 =
     let token = meth.symMethod.Token
     token.GetToken()
   
-let pdbMethodGetRootScope (meth:PdbMethod) : PdbMethodScope = 
-    { symScope = meth.symMethod.RootScope }
-
 let pdbMethodGetSequencePoints (meth:PdbMethod) : PdbSequencePoint array =
     let  pSize = meth.symMethod.SequencePointCount
     let offsets = Array.zeroCreate pSize

--- a/src/absil/ilsupp.fsi
+++ b/src/absil/ilsupp.fsi
@@ -73,7 +73,6 @@ val pdbDocumentGetLanguageVendor: PdbDocument -> byte[] (* guid *)
 val pdbDocumentFindClosestLine: PdbDocument -> int -> int
 
 val pdbMethodGetToken: PdbMethod -> int32
-val pdbMethodGetRootScope: PdbMethod ->  PdbMethodScope
 val pdbMethodGetSequencePoints: PdbMethod -> PdbSequencePoint array
 
 val pdbScopeGetChildren: PdbMethodScope -> PdbMethodScope array

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2577,7 +2577,7 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
                 MethName=md.Name
                 LocalSignatureToken=localToken
                 Params= [| |] (* REVIEW *)
-                RootScope = rootScope
+                RootScope = Some rootScope
                 Range=  
                   match ilmbody.SourceMarker with 
                   | Some m  when cenv.generatePdb -> 
@@ -2592,9 +2592,20 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
                               Column=m.EndColumn })
                   | _ -> None
                 SequencePoints=seqpoints }
-         
           cenv.AddCode code
-          addr 
+          addr
+      | MethodBody.Abstract ->
+          // Now record the PDB record for this method - we write this out later. 
+          if cenv.generatePdb then 
+            cenv.pdbinfo.Add  
+              { MethToken = getUncodedToken TableNames.Method midx
+                MethName = md.Name
+                LocalSignatureToken = 0x0                   // No locals it's abstract
+                Params = [| |]
+                RootScope = None
+                Range = None
+                SequencePoints = [| |] }
+          0x0000
       | MethodBody.Native -> 
           failwith "cannot write body of native method - Abstract IL cannot roundtrip mixed native/managed binaries"
       | _  -> 0x0000)

--- a/src/absil/ilwritepdb.fsi
+++ b/src/absil/ilwritepdb.fsi
@@ -44,7 +44,7 @@ type PdbMethodData =
       MethName:string
       LocalSignatureToken: int32
       Params: PdbLocalVar array
-      RootScope: PdbMethodScope
+      RootScope: PdbMethodScope option
       Range: (PdbSourceLoc * PdbSourceLoc) option
       SequencePoints: PdbSequencePoint array }
 


### PR DESCRIPTION
Fixes: Portable PDB MethodDebugInformation table size differs from MethodDef #3514 

When generating a portable PDB file, we failed to generate a MethodDebugInformation record for methods with no sequence points.

This PR addresses that by writing out for methods with empty sequence points a MethodDebugInformation record with
- Document = 0
- SequencePoint Blob heap index of 0 