### PR TITLE
add build task to generate *.resx and *.fs from *.txt resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ obj
 extras
 ossreadme*.txt
 *.csproj.user
+*.fsproj.user
 *.sln.DotSettings.user
 *.ide
 *.log

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -262,7 +262,7 @@
       <Output TaskParameter="Include" ItemName="FileWrites"/>
     </CreateItem>
   </Target>
-  <Import Project="scripts\fssrgen.targets" />
+  <Import Project="$(FSharpSourcesRoot)\scripts\fssrgen.targets" Condition="'$(Configuration)' == 'Proto'" />
   <Import Project="Microbuild.Settings.targets" Condition="'$(UseMicroBuild)' == 'true'"/>
 
   <Target Name="dotnetrestore" BeforeTargets="Build" Condition=" '$(TargetDotnetProfile)' == 'coreclr' ">
@@ -355,6 +355,30 @@
       <OldBuildVersionFiles Include="$(BuildVersionFilePath)BuildVersions-*.props" Exclude="$(BuildVersionFilePath)%(BuildVersionFileItem.Filename).props" />
     </ItemGroup>
     <Delete Files="@(OldBuildVersionFiles)" TreatErrorsAsWarnings="true"/>
+  </Target>
+
+  <UsingTask TaskName="FSharpEmbedResourceText"
+             AssemblyFile="$(FSharpSourcesRoot)\..\Proto\net40\bin\FSharp.Build-proto.dll"
+             Condition="'$(Configuration)' != 'Proto'" />
+
+  <Target Name="GenerateFSharpTextResources"
+          BeforeTargets="CoreResGen;PrepareForBuild"
+          Condition="'$(Configuration)' != 'Proto'">
+
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+
+    <FSharpEmbedResourceText EmbeddedText="@(EmbeddedText)" IntermediateOutputPath="$(IntermediateOutputPath)">
+      <Output TaskParameter="GeneratedSource" ItemName="_FsGeneratedSource" />
+      <Output TaskParameter="GeneratedResx" ItemName="_FsGeneratedResx" />
+    </FSharpEmbedResourceText>
+
+    <ItemGroup>
+      <CompileBefore Include="@(_FsGeneratedSource)" />
+      <EmbeddedResource Include="@(_FsGeneratedResx)" />
+      <FileWrites Include="@(_FsGeneratedSource)" />
+      <FileWrites Include="@(_FsGeneratedResx)" />
+    </ItemGroup>
+
   </Target>
 
   <UsingTask TaskName="ReplaceFileText" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">

--- a/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
+++ b/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
@@ -34,6 +34,9 @@
     <Compile Include="..\FSharp.Build\Fsc.fs">
       <Link>Fsc.fs</Link>
     </Compile>
+    <Compile Include="..\FSharp.Build\FSharpEmbedResourceText.fs">
+      <Link>FSharpEmbedResourceText.fs</Link>
+    </Compile>
     <CopyAndSubstituteText Include="..\FSharp.Build\Microsoft.FSharp.Targets">
       <Link>Microsoft.FSharp-proto.targets</Link>
       <TargetFilename>Microsoft.FSharp-proto.targets</TargetFilename>
@@ -63,6 +66,7 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetDotnetProfile)' != 'coreclr' AND '$(MonoPackaging)' != 'true' ">
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/fsharp/FSharp.Build/FSharp.Build.BuildFromSource.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.BuildFromSource.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="..\..\utils\reshapedreflection.fs" />
     <Compile Include="Fsc.fsi" />
     <Compile Include="Fsc.fs" />
+    <Compile Include="FSharpEmbedResourceText.fs" />
     <Compile Include="CreateFSharpManifestResourceName.fsi" />
     <Compile Include="CreateFSharpManifestResourceName.fs" />
     <CopyAndSubstituteText Include="Microsoft.FSharp.Targets">

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -23,13 +23,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FsSrGen Include="FSBuild.txt" />
+    <EmbeddedText Include="FSBuild.txt" />
     <Compile Include="InternalsVisibleTo.fs" />
     <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Build.dll.fs" />
     <Compile Include="..\..\utils\CompilerLocationUtils.fs" />
     <Compile Include="..\..\utils\reshapedreflection.fs" />
     <Compile Include="Fsc.fsi" />
     <Compile Include="Fsc.fs" />
+    <Compile Include="FSharpEmbedResourceText.fs" />
     <Compile Include="CreateFSharpManifestResourceName.fsi" />
     <Compile Include="CreateFSharpManifestResourceName.fs" />
     <CopyAndSubstituteText Include="Microsoft.FSharp.Targets">
@@ -57,6 +58,7 @@
   <ItemGroup Condition=" '$(TargetDotnetProfile)' != 'coreclr' ">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetDotnetProfile)' != 'coreclr' AND '$(MonoPackaging)' != 'true' ">
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/fsharp/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/fsharp/FSharp.Build/FSharpEmbedResourceText.fs
@@ -1,0 +1,498 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.FSharp.Build
+
+open System.Collections
+open System.IO
+open Microsoft.Build.Framework
+open Microsoft.Build.Utilities
+
+type FSharpEmbedResourceText() =
+    let mutable _buildEngine : IBuildEngine = null
+    let mutable _hostObject : ITaskHost = null
+    let mutable _embeddedText : ITaskItem[] = [||]
+    let mutable _generatedSource : ITaskItem[] = [||]
+    let mutable _generatedResx : ITaskItem[] = [||]
+    let mutable _outputPath : string = ""
+
+    let PrintErr(filename, line, msg) =
+        printfn "%s(%d): error : %s" filename line msg
+
+    let Err(filename, line, msg) =
+        PrintErr(filename, line, msg)
+        printfn "Note that the syntax of each line is one of these three alternatives:"
+        printfn "# comment"
+        printfn "ident,\"string\""
+        printfn "errNum,ident,\"string\""
+        failwith (sprintf "there were errors in the file '%s'" filename)
+
+    let xmlBoilerPlateString = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<root>
+    <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name=""resmimetype"">text/microsoft-resx</resheader>
+    <resheader name=""version"">2.0</resheader>
+    <resheader name=""reader"">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name=""writer"">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name=""Name1""><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name=""Color1"" type=""System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name=""Bitmap1"" mimetype=""application/x-microsoft.net.object.binary.base64"">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name=""Icon1"" type=""System.Drawing.Icon, System.Drawing"" mimetype=""application/x-microsoft.net.object.bytearray.base64"">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of ""resheader"" rows that contain simple 
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+    <xsd:schema id=""root"" xmlns="""" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata"">
+    <xsd:import namespace=""http://www.w3.org/XML/1998/namespace"" />
+    <xsd:element name=""root"" msdata:IsDataSet=""true"">
+        <xsd:complexType>
+        <xsd:choice maxOccurs=""unbounded"">
+            <xsd:element name=""metadata"">
+            <xsd:complexType>
+                <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" />
+                </xsd:sequence>
+                <xsd:attribute name=""name"" use=""required"" type=""xsd:string"" />
+                <xsd:attribute name=""type"" type=""xsd:string"" />
+                <xsd:attribute name=""mimetype"" type=""xsd:string"" />
+                <xsd:attribute ref=""xml:space"" />
+            </xsd:complexType>
+            </xsd:element>
+            <xsd:element name=""assembly"">
+            <xsd:complexType>
+                <xsd:attribute name=""alias"" type=""xsd:string"" />
+                <xsd:attribute name=""name"" type=""xsd:string"" />
+            </xsd:complexType>
+            </xsd:element>
+            <xsd:element name=""data"">
+            <xsd:complexType>
+                <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
+                <xsd:element name=""comment"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""2"" />
+                </xsd:sequence>
+                <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" msdata:Ordinal=""1"" />
+                <xsd:attribute name=""type"" type=""xsd:string"" msdata:Ordinal=""3"" />
+                <xsd:attribute name=""mimetype"" type=""xsd:string"" msdata:Ordinal=""4"" />
+                <xsd:attribute ref=""xml:space"" />
+            </xsd:complexType>
+            </xsd:element>
+            <xsd:element name=""resheader"">
+            <xsd:complexType>
+                <xsd:sequence>
+                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
+                </xsd:sequence>
+                <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" />
+            </xsd:complexType>
+            </xsd:element>
+        </xsd:choice>
+        </xsd:complexType>
+    </xsd:element>
+    </xsd:schema>
+    <resheader name=""resmimetype"">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name=""version"">
+        <value>2.0</value>
+    </resheader>
+    <resheader name=""reader"">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name=""writer"">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+</root>"
+
+    // The kinds of 'holes' we can do
+    let ComputeHoles filename lineNum (txt:string) : ResizeArray<string> * string =
+        // takes in a %d%s kind of string, returns array of string and {0}{1} kind of string
+        let mutable i = 0
+        let mutable holeNumber = 0
+        let mutable holes = ResizeArray()  //  order
+        let sb = new System.Text.StringBuilder()
+        let AddHole holeType =
+            sb.Append(sprintf "{%d}" holeNumber) |> ignore
+            holeNumber <- holeNumber + 1
+            holes.Add(holeType)
+        while i < txt.Length do
+            if txt.[i] = '%' then
+                if i+1 = txt.Length then
+                    Err(filename, lineNum, "(at end of string) % must be followed by d, f, s, or %")
+                else
+                    match txt.[i+1] with
+                    | 'd' -> AddHole "System.Int32"
+                    | 'f' -> AddHole "System.Double"
+                    | 's' -> AddHole "System.String"
+                    | '%' -> sb.Append('%') |> ignore
+                    | c -> Err(filename, lineNum, sprintf "'%%%c' is not a valid sequence, only %%d %%f %%s or %%%%" c)
+                i <- i + 2
+            else
+                match txt.[i] with
+                | '{' -> sb.Append "{{" |> ignore
+                | '}' -> sb.Append "}}" |> ignore
+                | c -> sb.Append c |> ignore
+                i <- i + 1
+        //printfn "holes.Length = %d, lineNum = %d" holes.Length //lineNum txt
+        (holes, sb.ToString())
+
+    let Unquote (s : string) =
+        if s.StartsWith "\"" && s.EndsWith "\"" then s.Substring(1, s.Length - 2)
+        else failwith "error message string should be quoted"
+
+    let ParseLine filename lineNum (txt:string) =
+        let mutable errNum = None
+        let identB = new System.Text.StringBuilder()
+        let mutable i = 0
+        // parse optional error number
+        if i < txt.Length && System.Char.IsDigit txt.[i] then
+            let numB = new System.Text.StringBuilder()
+            while i < txt.Length && System.Char.IsDigit txt.[i] do
+                numB.Append txt.[i] |> ignore
+                i <- i + 1
+            errNum <- Some(int (numB.ToString()))
+            if i = txt.Length || txt.[i] <> ',' then
+                Err(filename, lineNum, sprintf "After the error number '%d' there should be a comma" errNum.Value)
+            // Skip the comma
+            i <- i + 1
+        // parse short identifier
+        if i < txt.Length && not(System.Char.IsLetter(txt.[i])) then
+            Err(filename, lineNum, sprintf "The first character in the short identifier should be a letter, but found '%c'" txt.[i])
+        while i < txt.Length && System.Char.IsLetterOrDigit txt.[i] do
+            identB.Append txt.[i] |> ignore
+            i <- i + 1
+        let ident = identB.ToString()
+        if ident.Length = 0 then
+            Err(filename, lineNum, "Did not find the short identifier")
+        else
+            if i = txt.Length || txt.[i] <> ',' then
+                Err(filename, lineNum, sprintf "After the identifier '%s' there should be a comma" ident)
+            else
+                // Skip the comma
+                i <- i + 1
+                if i = txt.Length then
+                    Err(filename, lineNum, sprintf "After the identifier '%s' and comma, there should be the quoted string resource" ident)
+                else
+                    let str = 
+                        try
+                            System.String.Format(Unquote(txt.Substring i))  // Format turns e.g '\n' into that char, but also requires that we 'escape' curlies in the original .txt file, e.g. "{{"
+                        with 
+                            e -> Err(filename, lineNum, sprintf "Error calling System.String.Format (note that curly braces must be escaped, and there cannot be trailing space on the line): >>>%s<<< -- %s" (txt.Substring i) e.Message)
+                    let holes, netFormatString = ComputeHoles filename lineNum str
+                    (lineNum, (errNum,ident), str, holes.ToArray(), netFormatString)
+
+    let stringBoilerPlatePrefix = @"
+open Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicOperators
+open Microsoft.FSharp.Reflection
+open System.Reflection
+// (namespaces below for specific case of using the tool to compile FSharp.Core itself)
+open Microsoft.FSharp.Core
+open Microsoft.FSharp.Core.Operators
+open Microsoft.FSharp.Text
+open Microsoft.FSharp.Collections
+open Printf
+"
+    let StringBoilerPlate filename = @"
+    // BEGIN BOILERPLATE
+
+    static let getCurrentAssembly () =
+    #if DNXCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6 || NETCOREAPP1_0
+        typeof<SR>.GetTypeInfo().Assembly
+    #else
+        System.Reflection.Assembly.GetExecutingAssembly()
+    #endif
+
+    static let getTypeInfo (t: System.Type) =
+    #if DNXCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6 || NETCOREAPP1_0
+        t.GetTypeInfo()
+    #else
+        t
+    #endif
+
+    static let resources = lazy (new System.Resources.ResourceManager(""" + filename + @""", getCurrentAssembly()))
+
+    static let GetString(name:string) =
+        let s = resources.Value.GetString(name, System.Globalization.CultureInfo.CurrentUICulture)
+    #if DEBUG
+        if null = s then
+            System.Diagnostics.Debug.Assert(false, sprintf ""**RESOURCE ERROR**: Resource token %s does not exist!"" name)
+    #endif
+        s
+
+    static let mkFunctionValue (tys: System.Type[]) (impl:obj->obj) = 
+        FSharpValue.MakeFunction(FSharpType.MakeFunctionType(tys.[0],tys.[1]), impl)
+
+    static let funTyC = typeof<(obj -> obj)>.GetGenericTypeDefinition()  
+
+    static let isNamedType(ty:System.Type) = not (ty.IsArray ||  ty.IsByRef ||  ty.IsPointer)
+    static let isFunctionType (ty1:System.Type)  =
+        isNamedType(ty1) && getTypeInfo(ty1).IsGenericType && (ty1.GetGenericTypeDefinition()).Equals(funTyC)
+
+    static let rec destFunTy (ty:System.Type) =
+        if isFunctionType ty then
+            ty, ty.GetGenericArguments() 
+        else
+            match getTypeInfo(ty).BaseType with 
+            | null -> failwith ""destFunTy: not a function type""
+            | b -> destFunTy b 
+
+    static let buildFunctionForOneArgPat (ty: System.Type) impl =
+        let _,tys = destFunTy ty
+        let rty = tys.[1]
+        // PERF: this technique is a bit slow (e.g. in simple cases, like 'sprintf ""%x""')
+        mkFunctionValue tys (fun inp -> impl rty inp)
+
+    static let capture1 (fmt:string) i args ty (go : obj list -> System.Type -> int -> obj) : obj =
+        match fmt.[i] with
+        | '%' -> go args ty (i+1)
+        | 'd'
+        | 'f'
+        | 's' -> buildFunctionForOneArgPat ty (fun rty n -> go (n::args) rty (i+1))
+        | _ -> failwith ""bad format specifier""
+
+    // newlines and tabs get converted to strings when read from a resource file
+    // this will preserve their original intention
+    static let postProcessString (s : string) =
+        s.Replace(""\\n"",""\n"").Replace(""\\t"",""\t"").Replace(""\\r"",""\r"").Replace(""\\\"""", ""\"""")
+
+    static let createMessageString (messageString : string) (fmt : Printf.StringFormat<'T>) : 'T =
+        let fmt = fmt.Value // here, we use the actual error string, as opposed to the one stored as fmt
+        let len = fmt.Length 
+
+        /// Function to capture the arguments and then run.
+        let rec capture args ty i =
+            if i >= len ||  (fmt.[i] = '%' && i+1 >= len) then
+                let b = new System.Text.StringBuilder()
+                b.AppendFormat(messageString, [| for x in List.rev args -> x |]) |> ignore
+                box(b.ToString())
+            // REVIEW: For these purposes, this should be a nop, but I'm leaving it
+            // in incase we ever decide to support labels for the error format string
+            // E.g., ""<name>%s<foo>%d""
+            elif System.Char.IsSurrogatePair(fmt,i) then
+                capture args ty (i+2)
+            else
+                match fmt.[i] with
+                | '%' ->
+                    let i = i+1
+                    capture1 fmt i args ty capture
+                | _ ->
+                    capture args ty (i+1)
+
+        (unbox (capture [] (typeof<'T>) 0) : 'T)
+
+    static let mutable swallowResourceText = false
+
+    static let GetStringFunc((messageID : string),(fmt : Printf.StringFormat<'T>)) : 'T =
+        if swallowResourceText then
+            sprintf fmt
+        else
+            let mutable messageString = GetString(messageID)
+            messageString <- postProcessString messageString
+            createMessageString messageString fmt
+
+    /// If set to true, then all error messages will just return the filled 'holes' delimited by ',,,'s - this is for language-neutral testing (e.g. localization-invariant baselines).
+    static member SwallowResourceText with get () = swallowResourceText
+                                        and set (b) = swallowResourceText <- b
+    // END BOILERPLATE
+"
+
+    let generateResxAndSource (filename:string) =
+        try
+            let printMessage message = printfn "FSharpEmbedResourceText: %s" message
+            let justfilename = Path.GetFileNameWithoutExtension(filename) // .txt
+            if justfilename |> Seq.exists (System.Char.IsLetterOrDigit >> not) then
+                Err(filename, 0, sprintf "The filename '%s' is not allowed; only letters and digits can be used, as the filename also becomes the namespace for the SR class" justfilename)
+            let outFilename = Path.Combine(_outputPath, justfilename + ".fs")
+            let outXmlFilename = Path.Combine(_outputPath, justfilename + ".resx")
+
+            printMessage (sprintf "Reading %s" filename)
+            let lines = File.ReadAllLines(filename) 
+                        |> Array.mapi (fun i s -> i,s) // keep line numbers
+                        |> Array.filter (fun (i,s) -> not(s.StartsWith "#"))  // filter out comments
+
+            printMessage (sprintf "Parsing %s" filename)
+            let stringInfos = lines |> Array.map (fun (i,s) -> ParseLine filename i s)
+            // now we have array of (lineNum, ident, str, holes, netFormatString)  // str has %d, netFormatString has {0}
+            
+            printMessage (sprintf "Validating %s" filename)
+            // validate that all the idents are unique
+            let allIdents = new System.Collections.Generic.Dictionary<string,int>()
+            for (line,(_,ident),_,_,_) in stringInfos do
+                if allIdents.ContainsKey(ident) then
+                    Err(filename,line,sprintf "Identifier '%s' is already used previously on line %d - each identifier must be unique" ident allIdents.[ident])
+                allIdents.Add(ident,line)
+            
+            printMessage (sprintf "Validating uniqueness of %s" filename)
+            // validate that all the strings themselves are unique
+            let allStrs = new System.Collections.Generic.Dictionary<string,(int*string)>()
+            for (line,(_,ident),str,_,_) in stringInfos do
+                if allStrs.ContainsKey(str) then
+                    let prevLine,prevIdent = allStrs.[str]
+                    Err(filename,line,sprintf "String '%s' already appears on line %d with identifier '%s' - each string must be unique" str prevLine prevIdent)
+                allStrs.Add(str,(line,ident))
+            
+            printMessage (sprintf "Generating %s" outFilename)
+            use outStream = File.Create outFilename
+            use out = new StreamWriter(outStream)
+            fprintfn out "// This is a generated file; the original input is '%s'" filename
+            fprintfn out "namespace %s" justfilename
+            fprintfn out "%s" stringBoilerPlatePrefix
+            fprintfn out "type internal SR private() ="
+            let theResourceName = justfilename
+            fprintfn out "%s" (StringBoilerPlate theResourceName)
+
+            printMessage (sprintf "Generating resource methods for %s" outFilename)
+            // gen each resource method
+            stringInfos |> Seq.iter (fun (lineNum, (optErrNum,ident), str, holes, netFormatString) ->
+                let formalArgs = new System.Text.StringBuilder()
+                let actualArgs = new System.Text.StringBuilder()
+                let firstTime = ref true
+                let n = ref 0
+                formalArgs.Append "(" |> ignore
+                for hole in holes do
+                    if !firstTime then
+                        firstTime := false
+                    else
+                        formalArgs.Append ", " |> ignore
+                        actualArgs.Append " " |> ignore
+                    formalArgs.Append(sprintf "a%d : %s" !n hole) |> ignore
+                    actualArgs.Append(sprintf "a%d" !n) |> ignore
+                    n := !n + 1
+                formalArgs.Append ")" |> ignore
+                fprintfn out "    /// %s" str
+                fprintfn out "    /// (Originally from %s:%d)" filename (lineNum+1)
+                let justPercentsFromFormatString = 
+                    (holes |> Array.fold (fun acc holeType -> 
+                        acc + match holeType with 
+                                | "System.Int32" -> ",,,%d" 
+                                | "System.Double" -> ",,,%f" 
+                                | "System.String" -> ",,,%s"
+                                | _ -> failwith "unreachable") "") + ",,,"
+                let errPrefix = match optErrNum with
+                                | None -> ""
+                                | Some n -> sprintf "%d, " n
+                fprintfn out "    static member %s%s = (%sGetStringFunc(\"%s\",\"%s\") %s)" ident (formalArgs.ToString()) errPrefix ident justPercentsFromFormatString (actualArgs.ToString())
+                )
+
+            printMessage (sprintf "Generating .resx for %s" outFilename)
+            fprintfn out ""
+            // gen validation method
+            fprintfn out "    /// Call this method once to validate that all known resources are valid; throws if not"
+            fprintfn out "    static member RunStartupValidation() ="
+            stringInfos |> Seq.iter (fun (lineNum, (optErrNum,ident), str, holes, netFormatString) ->
+                fprintfn out "        ignore(GetString(\"%s\"))" ident
+            )
+            fprintfn out "        ()"  // in case there are 0 strings, we need the generated code to parse
+            // gen to resx
+            let xd = new System.Xml.XmlDocument()
+            xd.LoadXml(xmlBoilerPlateString)
+            stringInfos |> Seq.iter (fun (lineNum, (optErrNum,ident), str, holes, netFormatString) ->
+                let xn = xd.CreateElement("data")
+                xn.SetAttribute("name",ident) |> ignore
+                xn.SetAttribute("xml:space","preserve") |> ignore
+                let xnc = xd.CreateElement "value"
+                xn.AppendChild xnc |> ignore
+                xnc.AppendChild(xd.CreateTextNode netFormatString) |> ignore
+                xd.LastChild.AppendChild xn |> ignore
+            )
+            use outXmlStream = File.Create outXmlFilename
+            xd.Save outXmlStream
+            printMessage (sprintf "Done %s" outFilename)
+            Some (outFilename, outXmlFilename)
+        with e -> 
+            PrintErr(filename, 0, sprintf "An exception occurred when processing '%s'\n%s" filename (e.ToString()))
+            None
+
+    [<Required>]
+    member this.EmbeddedText
+        with get() = _embeddedText
+         and set(value) = _embeddedText <- value
+
+    [<Required>]
+    member this.IntermediateOutputPath
+        with get() = _outputPath
+         and set(value) = _outputPath <- value
+
+    [<Output>]
+    member this.GeneratedSource
+        with get() = _generatedSource
+
+    [<Output>]
+    member this.GeneratedResx
+        with get() = _generatedResx
+
+    interface ITask with
+        member this.BuildEngine
+            with get() = _buildEngine
+             and set(value) = _buildEngine <- value
+        member this.HostObject
+            with get() = _hostObject
+             and set(value) = _hostObject <- value
+        member this.Execute() =
+            let sourceItem (source:string) (originalItem:string) =
+                let item = TaskItem(source)
+                item.SetMetadata("AutoGen", "true")
+                item.SetMetadata("DesignTime", "true")
+                item.SetMetadata("DependentUpon", originalItem)
+                item :> ITaskItem
+            let resxItem (resx:string) =
+                let item = TaskItem(resx)
+                item.SetMetadata("ManifestResourceName", Path.GetFileNameWithoutExtension(resx))
+                item :> ITaskItem
+            let generatedFiles, generatedResult =
+                this.EmbeddedText
+                |> Array.fold (fun (resultList, aggregateResult) item ->
+                    match generateResxAndSource item.ItemSpec with
+                    | Some (source, resx) -> (((source, resx) :: resultList), aggregateResult)
+                    | None -> (resultList, false)
+                ) ([], true)
+            let generatedSource, generatedResx =
+                generatedFiles
+                |> List.map (fun (source, resx) -> (sourceItem source resx, resxItem resx))
+                |> List.fold (fun (sources, resxs) (source, resx) -> (source :: sources, resx:: resxs)) ([], [])
+            _generatedSource <- generatedSource |> List.rev |> List.toArray
+            _generatedResx <- generatedResx |> List.rev |> List.toArray
+            generatedResult

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -22,6 +22,7 @@ this file.
     </PropertyGroup>
 
     <UsingTask TaskName="Fsc" AssemblyFile="FSharp.Build{BuildSuffix}.dll"/>
+    <UsingTask TaskName="FSharpEmbedResourceText" AssemblyFile="FSharp.Build{BuildSuffix}.dll"/>
     <UsingTask TaskName="CreateFSharpManifestResourceName" AssemblyFile="FSharp.Build{BuildSuffix}.dll"/>
 
     <PropertyGroup>
@@ -169,11 +170,30 @@ this file.
         <CoreCompileDependsOn>_ComputeNonExistentFileProperty</CoreCompileDependsOn>
     </PropertyGroup>
 
+    <Target Name="GenerateFSharpTextResources"
+            BeforeTargets="CoreResGen;PrepareForBuild">
+
+        <MakeDir Directories="$(IntermediateOutputPath)" />
+
+        <FSharpEmbedResourceText EmbeddedText="@(EmbeddedText)" IntermediateOutputPath="$(IntermediateOutputPath)">
+            <Output TaskParameter="GeneratedSource" ItemName="_FsGeneratedSource" />
+            <Output TaskParameter="GeneratedResx" ItemName="_FsGeneratedResx" />
+        </FSharpEmbedResourceText>
+
+        <ItemGroup>
+            <CompileBefore Include="@(_FsGeneratedSource)" />
+            <EmbeddedResource Include="@(_FsGeneratedResx)" />
+            <FileWrites Include="@(_FsGeneratedSource)" />
+            <FileWrites Include="@(_FsGeneratedResx)" />
+        </ItemGroup>
+
+    </Target>
+
     <Target
         Name="CoreCompile"
         Inputs="$(MSBuildAllProjects);
                 @(CompileBefore);
-                @(Compile);                               
+                @(Compile);
                 @(CompileAfter);
                 @(_CoreCompileResourceInputs);
                 @(ManifestNonResxWithNoCultureOnDisk);
@@ -189,7 +209,7 @@ this file.
                 $(KeyOriginatorFile)"
         Outputs="@(DocFileItem);
                  @(IntermediateAssembly);
-                 @(_DebugSymbolsIntermediatePath);                 
+                 @(_DebugSymbolsIntermediatePath);
                  $(NonExistentFile);
                  @(CustomAdditionalCompileOutputs)"
         Returns=""

--- a/src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
+++ b/src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FsSrGen Include="..\FSInteractiveSettings.txt" />
+    <EmbeddedText Include="..\FSInteractiveSettings.txt" />
     <Compile Include="InternalsVisibleTo.fs" />
     <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Compiler.Interactive.Settings.dll.fs" />
     <Compile Include="..\..\utils\reshapedreflection.fs" />

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -58,9 +58,9 @@
     <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Compiler.Private.dll.fs">
       <Link>assemblyinfo.FSharp.Compiler.Private.dll.fs</Link>
     </Compile>
-    <FsSrGen Include="..\FSComp.txt">
+    <EmbeddedText Include="..\FSComp.txt">
       <Link>FSComp.txt</Link>
-    </FsSrGen>
+    </EmbeddedText>
     <EmbeddedResource Include="..\FSStrings.resx">
       <Link>FSStrings.resx</Link>
     </EmbeddedResource>
@@ -620,9 +620,9 @@
     </Compile>
 
     <!-- the core of the F# Interactive fsi.exe implementation -->
-    <FsSrGen Include="..\fsi\FSIstrings.txt">
+    <EmbeddedText Include="..\fsi\FSIstrings.txt">
       <Link>FSIstrings.txt</Link>
-    </FsSrGen>
+    </EmbeddedText>
     <Compile Include="..\fsi\fsi.fsi">
       <Link>InteractiveSession\fsi.fsi</Link>
     </Compile>

--- a/tests/projects/Sample_VS2012_FSharp_ConsoleApp_net45_with_resource/Sample_VS2012_FSharp_ConsoleApp_net45/Sample_VS2012_FSharp_ConsoleApp_net45.fsproj
+++ b/tests/projects/Sample_VS2012_FSharp_ConsoleApp_net45_with_resource/Sample_VS2012_FSharp_ConsoleApp_net45/Sample_VS2012_FSharp_ConsoleApp_net45.fsproj
@@ -125,16 +125,16 @@
 	<Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
 	<ItemGroup>
 		<Compile Include="Program.fs" />
-		<FsSrGen Include="FSComp.txt" />
-		<FsSrGen Include="..\FSCompLinkedInSuperDir.txt">
+		<EmbeddedText Include="FSComp.txt" />
+		<EmbeddedText Include="..\FSCompLinkedInSuperDir.txt">
 			<Link>FSCompLinkedInSuperDir.txt</Link>
-		</FsSrGen>
-		<FsSrGen Include="FSCompLinkedInSameDir.txt">
+		</EmbeddedText>
+		<EmbeddedText Include="FSCompLinkedInSameDir.txt">
 			<Link>FSCompLinkedInSameDir.txt</Link>
-		</FsSrGen>
-		<FsSrGen Include="SubDir\FSCompLinkedInSubDir.txt">
+		</EmbeddedText>
+		<EmbeddedText Include="SubDir\FSCompLinkedInSubDir.txt">
 			<Link>FSCompLinkedInSubDir.txt</Link>
-		</FsSrGen>
+		</EmbeddedText>
 		<None Include="App.config" />
 		<EmbeddedResource Include="ExplicitCompiledResource.resources" />
 		<EmbeddedResource Include="ResxResource.resx" />
@@ -167,9 +167,6 @@
 		<Reference Include="System.Core" />
 		<Reference Include="System.Numerics" />
 	</ItemGroup>
-	<PropertyGroup>
-		<FsSrGenToolPath>$(MSBuildProjectDirectory)\tools</FsSrGenToolPath>
-	</PropertyGroup>
 	<Import Project="tools\FSharp.SRGen.targets" />
 
 </Project>

--- a/tests/projects/Sample_VS2012_FSharp_ConsoleApp_net45_with_resource_using_bootstrap/Sample_VS2012_FSharp_ConsoleApp_net45/Sample_VS2012_FSharp_ConsoleApp_net45.fsproj
+++ b/tests/projects/Sample_VS2012_FSharp_ConsoleApp_net45_with_resource_using_bootstrap/Sample_VS2012_FSharp_ConsoleApp_net45/Sample_VS2012_FSharp_ConsoleApp_net45.fsproj
@@ -47,16 +47,16 @@
 	<Import Project="$(LkgPath)\Microsoft.FSharp.Targets" />
 	<ItemGroup>
 		<Compile Include="Program.fs" />
-		<FsSrGen Include="FSComp.txt" />
-		<FsSrGen Include="..\FSCompLinkedInSuperDir.txt">
+		<EmbeddedText Include="FSComp.txt" />
+		<EmbeddedText Include="..\FSCompLinkedInSuperDir.txt">
 			<Link>FSCompLinkedInSuperDir.txt</Link>
-		</FsSrGen>
-		<FsSrGen Include="FSCompLinkedInSameDir.txt">
+		</EmbeddedText>
+		<EmbeddedText Include="FSCompLinkedInSameDir.txt">
 			<Link>FSCompLinkedInSameDir.txt</Link>
-		</FsSrGen>
-		<FsSrGen Include="SubDir\FSCompLinkedInSubDir.txt">
+		</EmbeddedText>
+		<EmbeddedText Include="SubDir\FSCompLinkedInSubDir.txt">
 			<Link>FSCompLinkedInSubDir.txt</Link>
-		</FsSrGen>
+		</EmbeddedText>
 		<None Include="App.config" />
 		<EmbeddedResource Include="ExplicitCompiledResource.resources" />
 		<EmbeddedResource Include="ResxResource.resx" />
@@ -89,9 +89,6 @@
 		<Reference Include="System.Core" />
 		<Reference Include="System.Numerics" />
 	</ItemGroup>
-	<PropertyGroup>
-		<FsSrGenToolPath>$(MSBuildProjectDirectory)\tools</FsSrGenToolPath>
-	</PropertyGroup>
 	<Import Project="tools\FSharp.SRGen.targets" />
 
 </Project>

--- a/vsintegration/src/FSharp.VS.FSI/FSHarp.VS.FSI.fsproj
+++ b/vsintegration/src/FSharp.VS.FSI/FSHarp.VS.FSI.fsproj
@@ -46,7 +46,7 @@
       <HasLceComments>false</HasLceComments>
       <InProject>false</InProject>
     </FilesToLocalize>
-    <FsSrGen Include="VFSIstrings.txt" />
+    <EmbeddedText Include="VFSIstrings.txt" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="srProperties.fs" />
     <Compile Include="$(FSharpSourcesRoot)\utils\CompilerLocationUtils.fs">

--- a/vsintegration/tests/unittests/MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fsproj
+++ b/vsintegration/tests/unittests/MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fsproj
@@ -16,7 +16,6 @@
     <TargetType>LIBRARY</TargetType>
     <NoWarn>58;75</NoWarn>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <EnsureThereAreNoUnusedFsSrGenResources>False</EnsureThereAreNoUnusedFsSrGenResources>
     <DefineConstants>DEBUG;TRACE;$(DefineConstants)</DefineConstants>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <CustomOutputPath>true</CustomOutputPath>
@@ -32,7 +31,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-	<FsSrGen Include="FSData.txt" />
+    <EmbeddedText Include="FSData.txt" />
     <Compile Include="ProvidedTypes.fsi" />
     <Compile Include="ProvidedTypes.fs" />
     <Compile Include="DummyProviderForLanguageServiceTesting.fs" />


### PR DESCRIPTION
The build task `FSharpEmbedResourceText` added to `FSharp.Build.dll` is basically the contents of [`fssrgen.fsx`](https://github.com/Microsoft/visualfsharp/blob/f745fe5a7aed0fa418890dd50b5444d5bc27669b/src/buildtools/fssrgen/fssrgen.fsx), just re-worked with the appropriate entry point.

Projects using the old `<FsSrGen />` task have been updated to `<EmbeddedText />` as appropriate **except** for the following:

- Proto builds.
- Build from source.
- Fcs

These can't be (easily) moved forward until our LKG contains this new build task, so for now the old method has to stick around for a bit longer.