### PR TITLE
Silverlight is not a thing

### DIFF
--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -12,26 +12,6 @@
 "{7651a701-06e5-11d1-8ebd-00a0c90f26ea}"=""
 "{7651a703-06e5-11d1-8ebd-00a0c90f26ea}"=""
 
-[$RootKey$\Projects\{A1591282-1198-4647-A2B1-27E5FF5F6F3B}\LanguageTemplates]
-"{F2A71F9B-5D33-465A-A702-920D77279786}"="{76B279E8-36ED-494E-B145-5344F8DEFCB6}"
-
-[$RootKey$\Projects\{349C5851-65DF-11DA-9384-00065B846F21}\LanguageTemplates]
-"{F2A71F9B-5D33-465A-A702-920D77279786}"="{76B279E8-36ED-494E-B145-5344F8DEFCB6}"
-
-[$RootKey$\Projects\{76B279E8-36ED-494E-B145-5344F8DEFCB6}]
-"Language(VsTemplate)"="FSharp"
-"Package"="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}"
-"ShowOnlySpecifiedTemplates(VsTemplate)"="00000000"
-"TemplateGroupIDs(VsTemplate)"="Silverlight"
-@="F# Silverlight Project Templates"
-
-[$RootKey$\Projects\{76B279E8-36ED-494E-B145-5344F8DEFCB6}\SilverlightProperties]
-"CodeFileExtension"=".fs"
-"TemplateFolder"="FSharp"
-"DefaultProjectTemplate"="SilverlightLibrary\SilverlightLibrary.vstemplate"
-"LanguageDisplayString"="Visual F#"
-"PropertyPagesToRemove"="{6D2D9B56-2691-4624-A1BF-D07A14594748};{9CFBEB2A-6824-43e2-BD3B-B112FEBC3772}"
-
 [$RootKey$\InstalledProducts\Microsoft Visual F#]
 "Package"="{91a04a73-4f2c-4e7c-ad38-c1a68e7da05c}"
 "ProductDetails"="#9002"


### PR DESCRIPTION
Because F# no longer supports Silverlight, there is not a good reason to have the registration entries in the vsix pkgdef.