### PR TITLE
Fix for: 3596 --- [.NET Framework Projects] IDE is confused about the last file to compile

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -273,9 +273,13 @@ type internal FSharpProjectOptionsManager
         }
 
     member this.UpdateProjectInfoWithProjectId(projectId:ProjectId, userOpName) =
-        let project = workspace.CurrentSolution.GetProject(projectId)
-        let siteProvider = this.ProvideProjectSiteProvider(project)
-        this.UpdateProjectInfo(tryGetOrCreateProjectId, projectId, siteProvider.GetProjectSite(), userOpName)
+        let hier = workspace.GetHierarchy(projectId)
+        match hier with
+        | h when (h.IsCapabilityMatch("CPS")) ->
+            let project = workspace.CurrentSolution.GetProject(projectId)
+            let siteProvider = this.ProvideProjectSiteProvider(project)
+            this.UpdateProjectInfo(tryGetOrCreateProjectId, projectId, siteProvider.GetProjectSite(), userOpName)
+        | _ -> ()
 
     member this.UpdateProjectInfoWithPath(path, userOpName) =
         let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(path, projectDisplayNameOf path)


### PR DESCRIPTION
Okay the fix here is to check to see if the project supports CPS before invoking from Workstation events.

I don't think this is the long term solution ... but right now setupproject is needed to eagerly fetch everything needed to compile the project.  I expect that we should evolve to the circumstance where we rely on the events.

Anyway this should solve the problem.


