### PR TITLE
Fix In IDE Build logging.

### DIFF
--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -158,7 +158,7 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
     let mutable subsystemVersion : string = null
     let mutable tailcalls : bool = true
     let mutable targetProfile : string = null
-    let mutable targetType : string = null 
+    let mutable targetType : string = null
     let mutable toolExe : string = "fsc.exe"
     let mutable toolPath : string = 
         let locationOfThisDll = 
@@ -277,7 +277,7 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
                 | "WINEXE" -> "winexe" 
                 | "MODULE" -> "module"
                 | _ -> null)
-        
+
         // NoWarn
         match disabledWarnings with
         | null -> ()
@@ -418,7 +418,7 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
     // --noframework
     member fsc.NoFramework
         with get() = noFramework 
-        and set(b) = noFramework <- b        
+        and set(b) = noFramework <- b
 
     // --optimize
     member fsc.Optimize
@@ -543,7 +543,7 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
     member fsc.Win32ManifestFile
         with get() = win32manifest
         and set(m) = win32manifest <- m
-        
+
     // For specifying the warning level (0-4)    
     member fsc.WarningLevel
         with get() = warningLevel
@@ -552,7 +552,7 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
     member fsc.WarningsAsErrors 
         with get() = warningsAsErrors
         and set(s) = warningsAsErrors <- s
-    
+
     member fsc.VisualStudioStyleErrors
         with get() = vserrors
         and set(p) = vserrors <- p
@@ -581,6 +581,9 @@ type [<Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:Iden
     override fsc.GenerateFullPathToTool() = 
         if toolPath = "" then raise (new System.InvalidOperationException(FSBuild.SR.toolpathUnknown()))
         System.IO.Path.Combine(toolPath, fsc.ToolExe)
+    override fsc.LogToolCommand (message:string) =
+        fsc.Log.LogMessageFromText(message, MessageImportance.Normal) |>ignore
+
     member internal fsc.InternalGenerateFullPathToTool() = fsc.GenerateFullPathToTool()             // expose for unit testing
     member internal fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands) =    // F# does not allow protected members to be captured by lambdas, this is the standard workaround
         base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands)

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/IDEBuildLogger.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/IDEBuildLogger.cs
@@ -358,7 +358,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             try
             {
                 this.haveCachedRegistry = false;
-                if (LogAtImportance(MessageImportance.Low))
+                if (LogAtImportance(MessageImportance.Normal))
                 {
                     LogEvent(sender, buildEvent);
                 }
@@ -385,7 +385,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 		{
             try
             {
-                if (LogAtImportance(buildEvent.Succeeded ? MessageImportance.Low :
+                if (LogAtImportance(buildEvent.Succeeded ? MessageImportance.Normal :
                                                            MessageImportance.High))
                 {
                     if (this.outputWindowPane != null)
@@ -408,7 +408,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 		{
             try
             {
-                if (LogAtImportance(MessageImportance.Low))
+                if (LogAtImportance(MessageImportance.Normal))
                 {
                     LogEvent(sender, buildEvent);
                 }
@@ -427,7 +427,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 		{
             try
             {
-                if (LogAtImportance(buildEvent.Succeeded ? MessageImportance.Low
+                if (LogAtImportance(buildEvent.Succeeded ? MessageImportance.Normal
                                                          : MessageImportance.High))
                 {
                     LogEvent(sender, buildEvent);
@@ -473,7 +473,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             {
                 --this.currentIndent;
                 if ((isLogTaskDone) &&
-                    LogAtImportance(buildEvent.Succeeded ? MessageImportance.Low
+                    LogAtImportance(buildEvent.Succeeded ? MessageImportance.Normal
                                                          : MessageImportance.High))
                 {
                     LogEvent(sender, buildEvent);
@@ -572,9 +572,10 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 					logIt = (importance == MessageImportance.High);
 					break;
 				case LoggerVerbosity.Normal:
-				// Falling through...
-				case LoggerVerbosity.Detailed:
-					logIt = (importance != MessageImportance.Low);
+                    logIt = (importance == MessageImportance.Normal) || (importance == MessageImportance.High);
+                    break;
+                case LoggerVerbosity.Detailed:
+					logIt = (importance == MessageImportance.Low) || (importance == MessageImportance.Normal) || (importance == MessageImportance.High);
 					break;
 				case LoggerVerbosity.Diagnostic:
 					logIt = true;

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/IDEBuildLogger.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/IDEBuildLogger.cs
@@ -556,37 +556,37 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 		/// This method takes a MessageImportance and returns true if messages
 		/// at importance i should be loggeed.  Otherwise return false.
 		/// </summary>
-		private bool LogAtImportance(MessageImportance importance)
-		{
-			// If importance is too low for current settings, ignore the event
-			bool logIt = false;
+        private bool LogAtImportance(MessageImportance importance)
+        {
+            // If importance is too low for current settings, ignore the event
+            bool logIt = false;
 
-			this.SetVerbosity();
+            this.SetVerbosity();
 
-			switch (this.Verbosity)
-			{
-				case LoggerVerbosity.Quiet:
-					logIt = false;
-					break;
-				case LoggerVerbosity.Minimal:
-					logIt = (importance == MessageImportance.High);
-					break;
-				case LoggerVerbosity.Normal:
+            switch (this.Verbosity)
+            {
+                case LoggerVerbosity.Quiet:
+                    logIt = false;
+                    break;
+                case LoggerVerbosity.Minimal:
+                    logIt = (importance == MessageImportance.High);
+                    break;
+                case LoggerVerbosity.Normal:
                     logIt = (importance == MessageImportance.Normal) || (importance == MessageImportance.High);
                     break;
                 case LoggerVerbosity.Detailed:
-					logIt = (importance == MessageImportance.Low) || (importance == MessageImportance.Normal) || (importance == MessageImportance.High);
-					break;
-				case LoggerVerbosity.Diagnostic:
-					logIt = true;
-					break;
-				default:
-					Debug.Fail("Unknown Verbosity level. Ignoring will cause everything to be logged");
-					break;
-			}
+                    logIt = (importance == MessageImportance.Low) || (importance == MessageImportance.Normal) || (importance == MessageImportance.High);
+                    break;
+                case LoggerVerbosity.Diagnostic:
+                    logIt = true;
+                    break;
+                default:
+                    Debug.Fail("Unknown Verbosity level. Ignoring will cause everything to be logged");
+                    break;
+            }
 
-			return logIt;
-		}
+            return logIt;
+        }
 
 		/// <summary>
 		/// This is the method that does the main work of logging an event


### PR DESCRIPTION
The Build logging displayed in the output window for an F# build was to say the least idiosyncratic.

This PR addresses that by producing in IDE logging that more closely aligns with the definitions of:

- Minimal
- Normal
- Detailed
- Diagnostic.

