### PR TITLE
[WIP] Adds optimized emit for int64 constants

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2073,6 +2073,7 @@ and GenConstant cenv cgbuf eenv (c,m,ty) sequel =
           | Const.Int16 i -> CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (mkLdcInt32 (int32 i))
           | Const.Int32 i -> CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (mkLdcInt32 i)
           | Const.Int64 i -> 
+            // see https://github.com/Microsoft/visualfsharp/pull/3620 
             if i >= int64 System.Int32.MinValue && i <= int64 System.Int32.MaxValue then
                 CG.EmitInstrs cgbuf (pop 0) (Push [ilTy]) [ mkLdcInt32 (int32 i); AI_conv DT_I8 ]
             elif i >= int64 System.UInt32.MinValue && i <= int64 System.UInt32.MaxValue then

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -2072,7 +2072,13 @@ and GenConstant cenv cgbuf eenv (c,m,ty) sequel =
           | Const.SByte i -> CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (mkLdcInt32 (int32 i))
           | Const.Int16 i -> CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (mkLdcInt32 (int32 i))
           | Const.Int32 i -> CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (mkLdcInt32 i)
-          | Const.Int64 i -> CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (iLdcInt64 i)
+          | Const.Int64 i -> 
+            if i >= int64 System.Int32.MinValue && i <= int64 System.Int32.MaxValue then
+                CG.EmitInstrs cgbuf (pop 0) (Push [ilTy]) [ mkLdcInt32 (int32 i); AI_conv DT_I8 ]
+            elif i >= int64 System.UInt32.MinValue && i <= int64 System.UInt32.MaxValue then
+                CG.EmitInstrs cgbuf (pop 0) (Push [ilTy]) [ mkLdcInt32 (int32 i); AI_conv DT_U8 ]
+            else
+                CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (iLdcInt64 i)
           | Const.IntPtr i -> CG.EmitInstrs cgbuf (pop 0) (Push [ilTy]) [iLdcInt64 i; AI_conv DT_I ]
           | Const.Byte i -> CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (mkLdcInt32 (int32 i))
           | Const.UInt16 i -> CG.EmitInstr cgbuf (pop 0) (Push [ilTy]) (mkLdcInt32 (int32 i))


### PR DESCRIPTION
This PR changes the emitted IL for Int64 constants and aligns it with what Roslyn is doing for C#.

## Why?
The new emitted IL is smaller in code size.

Currently if you create a Int64 value, the compiler emits an [`ldc.i8 <value>`](https://docs.microsoft.com/de-de/dotnet/api/system.reflection.emit.opcodes.ldc_i8?view=netframework-4.7), that is an 9 byte instruction (one byte encoding the instruction (0x21) and 8 bytes the actual value). This is quite a lot. Roslyn takes a shortcut there (see here: http://source.roslyn.io/#Microsoft.CodeAnalysis/CodeGen/ILBuilderEmit.cs,642). It creates an Int32 and converts it to an Int64. As Int32 even has special instructions for values 0 to 8, this produces methods of less code size.
![capture](https://user-images.githubusercontent.com/9868229/30686411-7d7c8784-9eb8-11e7-994c-2d3b4a3fb489.PNG)

## Done so far

- Changing the emitted IL

## Still missing

- Tests
- Document performance impact (there should be none)
- Consensus that this should be done for F# as well

---
I remember seeing a blog post somewhere ranting about F#'s emitted IL for Int64, but unfortunately cannot find it anymore. Alas, I picked the same logic that Roslyn applies where. Can't be this wrong then, can it? ;)

Let me know of anything that is missing and how to proceed on this.