### PR TITLE
Fixing JaroWinkler tests with InvariantCulture and fixing async tests by removing Debugger.Break()

### DIFF
--- a/src/fsharp/FSharp.Compiler.Unittests/EditDistance.fs
+++ b/src/fsharp/FSharp.Compiler.Unittests/EditDistance.fs
@@ -2,6 +2,7 @@
 namespace FSharp.Compiler.Unittests
 
 open System
+open System.Globalization
 open System.Text
 open NUnit.Framework
 open Microsoft.FSharp.Compiler
@@ -16,7 +17,7 @@ module EditDistance =
     [<TestCase("DWAYNE", "DUANE", ExpectedResult = "0.840")>]
     [<TestCase("DIXON", "DICKSONX", ExpectedResult = "0.813")>]
     let JaroWinklerTest (str1 : string, str2 : string) : string =
-        String.Format("{0:0.000}", JaroWinklerDistance str1 str2)
+        String.Format(CultureInfo.InvariantCulture, "{0:0.000}", JaroWinklerDistance str1 str2)
 
     [<Test>]
     [<TestCase("RICK", "RICK", ExpectedResult = 0)>]

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -177,7 +177,6 @@ type AsyncType() =
             match a.InnerException with
             | :? TaskCanceledException as t -> ()
             | _ -> reraise()
-        System.Diagnostics.Debugger.Break() |> ignore
         Assert.IsTrue (t.IsCompleted, "Task is not completed")
 
     [<Test>]


### PR DESCRIPTION
This fixes #3583, a few tests that fail on different locales than en-US, and fixes #3605, which crashes some test runners or causes awkward popups to attach a debugger.