### PR TITLE
[Experiment/Discussion] Erase List.iter

### DIFF
--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -592,6 +592,9 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
   let v_seq_map_info               = makeIntrinsicValRef(fslib_MFSeqModule_nleref,                             "map"                                  , None                 , Some "Map"    , [vara;varb], ([[varaTy --> varbTy]; [mkSeqTy varaTy]], mkSeqTy varbTy))
   let v_seq_singleton_info         = makeIntrinsicValRef(fslib_MFSeqModule_nleref,                             "singleton"                            , None                 , Some "Singleton"              , [vara],     ([[varaTy]], mkSeqTy varaTy))
   let v_seq_empty_info             = makeIntrinsicValRef(fslib_MFSeqModule_nleref,                             "empty"                                , None                 , Some "Empty"                  , [vara],     ([], mkSeqTy varaTy))
+  let v_seq_iter_info              = makeIntrinsicValRef(fslib_MFSeqModule_nleref,                             "iter"                                 , None                 , Some "Iterate"                , [varb],     ([[mkSeqTy varbTy]], v_unit_ty))
+  let v_list_iter_info             = makeIntrinsicValRef(fslib_MFListModule_nleref,                            "iter"                                 , None                 , Some "Iterate"                , [varb],     ([[mkListTy varbTy]], v_unit_ty))
+  let v_array_iter_info            = makeIntrinsicValRef(fslib_MFArrayModule_nleref,                           "iter"                                 , None                 , Some "Iterate"                , [varb],     ([[mkArrayType 1 varbTy]], v_unit_ty))
   let v_new_format_info            = makeIntrinsicValRef(fslib_MFCore_nleref,                                  ".ctor"                                , Some "PrintfFormat`5", None                          , [vara;varb;varc;vard;vare], ([[v_string_ty]], mkPrintfFormatTy varaTy varbTy varcTy vardTy vareTy))  
   let v_sprintf_info               = makeIntrinsicValRef(fslib_MFExtraTopLevelOperators_nleref,                "sprintf"                              , None                 , Some "PrintFormatToStringThen", [vara],     ([[mk_format4_ty varaTy v_unit_ty v_string_ty v_string_ty]], varaTy))  
   let v_lazy_force_info            = 
@@ -1149,6 +1152,11 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
   member val seq_of_functions_vref      = ValRefForIntrinsic  v_seq_of_functions_info
   member val seq_map_vref               = ValRefForIntrinsic  v_seq_map_info
   member val seq_empty_vref             = ValRefForIntrinsic  v_seq_empty_info
+  //--
+  member val seq_iter_vref              = ValRefForIntrinsic  v_seq_iter_info
+  member val list_iter_vref             = ValRefForIntrinsic  v_list_iter_info
+  member val array_iter_vref            = ValRefForIntrinsic  v_array_iter_info
+  //--
   member val new_format_vref            = ValRefForIntrinsic v_new_format_info
   member val sprintf_vref               = ValRefForIntrinsic v_sprintf_info
   member val unbox_vref                 = ValRefForIntrinsic v_unbox_info


### PR DESCRIPTION
### EDIT: similar behavior can be gained by just marking *.iter as ``inline``, I will create a second pr with performance / binary size comparisons in the evening.

---------------

I propose we erase all instances of [Seq/Array/List].iter into a boring foreach loop.

#### Why?

1) debuggability
``s |> List.iter (fun i -> ...)`` versus ``for i in s do ...`` have equal semantics, but vastly different debuggability.  
In the first case, you can only see the loop-local variables in the debugger (``i`` in this case), in the second, you can debug like normal.
For a slightly more complicated example compare [for loop](https://user-images.githubusercontent.com/4236651/30987039-e1b5e8c0-a495-11e7-9595-ac798cdd309d.png) vs [List.iter](https://user-images.githubusercontent.com/4236651/30987064-f69ab69e-a495-11e7-9810-0438ad976566.png)


2) performance
I doubt it would make _much_ of a difference, but eliminating the repeated callback invokes, and possibly removing closures _could_ slightly improve performance. Hoisting the callback into the outer function may (or may not) enable other optimizations to take hold.

#### Precedent:

My first thought was that this would surely not be accepted. But there is actually already something similar done: All calls to ``Array.map`` are hoisted into the calling function and converted to a for-loop, which iterates over the source array and writes into the copy. In the compiled code, the lambda is erased, similar to the goal of this pr.


#### State of this PR:

This PR rewrites only List.iter into a for-loop. It seems to work well, for what it is.
I actually don't think implementing this cleanly would take too much work, but please don't look too hard at the current code. For example, at the moment I simply ignore all sequence points, where as they would need to be properly converted.

#### Future

Should you agree with me that such transformations are beneficial, then I am sure we can come up with some more. I would also ask to to reconsider accepting [forkis PR](https://github.com/Microsoft/visualfsharp/pull/3233).


-------

I did not create a lang-suggestion / rfc, because this does not change the semantics of the code. It is purely a ergonomic and performance optimization.

#### EDIT: clarification:

Not _all_ instances of ``List.iter`` are rewritten, but only the ones where you directly pass a lambda into it.

So

``s |> List.iter (fun i -> ...)`` => rewritten to ``for i in s do ...``

``List.iter (fun i -> ...) s`` => rewritten to ``for i in s do ...``

```F#
let f s cb =
     s |> List.iter cb
```

=> _should_ __not__ be rewritten, instead kept-as-is.

The current code matches on ``Apply(List.iter, Lambda)``, so it should __not__ match if you pass it a function variable instead of a lambda.