### PR TITLE
[Discussion] mark Seq.iter inline

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -482,7 +482,7 @@ namespace Microsoft.FSharp.Collections
             mkSeq (fun () -> IEnumerator.upto (Some (count-1)) initializer)
 
         [<CompiledName("Iterate")>]
-        let iter action (source : seq<'T>) =
+        let inline iter action (source : seq<'T>) =
             checkNonNull "source" source
             use e = source.GetEnumerator()
             while e.MoveNext() do

--- a/src/fsharp/FSharp.Core/seq.fsi
+++ b/src/fsharp/FSharp.Core/seq.fsi
@@ -625,7 +625,7 @@ namespace Microsoft.FSharp.Collections
         ///
         /// <exception cref="System.ArgumentNullException">Thrown when the input sequence is null.</exception>
         [<CompiledName("Iterate")>]
-        val iter: action:('T -> unit) -> source:seq<'T> -> unit
+        val inline iter: action:('T -> unit) -> source:seq<'T> -> unit
 
         /// <summary>Applies the given function to each element of the collection. The integer passed to the
         /// function indicates the index of element.</summary>


### PR DESCRIPTION

Program Code: https://gist.github.com/0x53A/9da43cb0f7c42f1b629b888fe7a68224
(for the inline version I inlined ``let iter action (source : seq<'T>) =``)

This code was compiled into a release console exe.
TargetFW: net461
TargetRuntime: I have Win10CU with net47

__Size:__

|            | AnyCpu (32bit) | x64  |
|------------|----------------|------|
| inline     | 45kB           | 45kB |
| not inline | 55kB           | 55kB |

__Speed:__

"Benchmark" Program:

```F#
open System.Diagnostics
open System.IO

let dir = @"C:\Users\lr\Source\Repos\IterInlineTest\IterInlineTest\bin\Release"

let files = [
    "IterInlineTest-AnyCpu-Inline.exe"
    "IterInlineTest-AnyCpu-NotInline.exe"
    "IterInlineTest-x64-inline.exe"
    "IterInlineTest-x64-NotInline.exe"
]

for i in 1..10 do
    for f in files do
        printfn "%i - %s" i f
        let fullPath = Path.Combine(dir, f)
        let proc = Process.Start(ProcessStartInfo(fullPath, UseShellExecute=false))
        proc.WaitForExit()
```

```
1 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.0717219 seconds
1 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.103574 seconds
1 - IterInlineTest-x64-inline.exe
Time: 6.3089797 seconds
1 - IterInlineTest-x64-NotInline.exe
Time: 6.4022095 seconds
2 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.1084784 seconds
2 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.1381134 seconds
2 - IterInlineTest-x64-inline.exe
Time: 6.2733213 seconds
2 - IterInlineTest-x64-NotInline.exe
Time: 6.2912988 seconds
3 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.201093 seconds
3 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.1094063 seconds
3 - IterInlineTest-x64-inline.exe
Time: 6.2986958 seconds
3 - IterInlineTest-x64-NotInline.exe
Time: 6.3382166 seconds
4 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.1207324 seconds
4 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.1065901 seconds
4 - IterInlineTest-x64-inline.exe
Time: 6.3112234 seconds
4 - IterInlineTest-x64-NotInline.exe
Time: 6.3317693 seconds
5 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.0858645 seconds
5 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.1014179 seconds
5 - IterInlineTest-x64-inline.exe
Time: 6.4862915 seconds
5 - IterInlineTest-x64-NotInline.exe
Time: 6.3200616 seconds
6 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.0870462 seconds
6 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.1001479 seconds
6 - IterInlineTest-x64-inline.exe
Time: 6.290876 seconds
6 - IterInlineTest-x64-NotInline.exe
Time: 6.2454101 seconds
7 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.1010845 seconds
7 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.1180521 seconds
7 - IterInlineTest-x64-inline.exe
Time: 6.3788174 seconds
7 - IterInlineTest-x64-NotInline.exe
Time: 6.3946524 seconds
8 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.0704105 seconds
8 - IterInlineTest-AnyCpu-NotInline.exe
Time: 9.3288509 seconds
8 - IterInlineTest-x64-inline.exe
Time: 6.3131007 seconds
8 - IterInlineTest-x64-NotInline.exe
Time: 6.3239749 seconds
9 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.0876243 seconds
9 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.1352227 seconds
9 - IterInlineTest-x64-inline.exe
Time: 6.4821192 seconds
9 - IterInlineTest-x64-NotInline.exe
Time: 6.3198395 seconds
10 - IterInlineTest-AnyCpu-Inline.exe
Time: 8.0812481 seconds
10 - IterInlineTest-AnyCpu-NotInline.exe
Time: 8.1302496 seconds
10 - IterInlineTest-x64-inline.exe
Time: 6.3678513 seconds
10 - IterInlineTest-x64-NotInline.exe
Time: 6.3046622 seconds
```

As you can see, the x64 is always faster than the 32bit. The results have a lot of jitter, but the inline version is most of the time faster.

------------------


I also created a "real" benchmark using BenchmarkDotNet: https://gist.github.com/0x53A/320abe9890af709c510f02abdabd410a

``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i7-6700K CPU 4.00GHz (Skylake), ProcessorCount=8
Frequency=3914059 Hz, Resolution=255.4893 ns, Timer=TSC
  [Host]     : .NET Framework 4.7 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2110.0
  DefaultJob : .NET Framework 4.7 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2110.0


```
 |     Method |     Mean |     Error |    StdDev |
 |----------- |---------:|----------:|----------:|
 |    Inlined | 264.2 us | 0.9388 us | 0.8323 us |
 | NonInlined | 271.3 us | 3.3525 us | 3.1359 us |

``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i7-6700K CPU 4.00GHz (Skylake), ProcessorCount=8
Frequency=3914059 Hz, Resolution=255.4893 ns, Timer=TSC
  [Host]     : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2110.0
  DefaultJob : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2110.0


```
 |     Method |     Mean |     Error |    StdDev |
 |----------- |---------:|----------:|----------:|
 |    Inlined | 204.2 us | 0.4885 us | 0.4331 us |
 | NonInlined | 207.5 us | 1.5505 us | 1.3745 us |


-------------

__Debuggability:__

This one was a bit disappointing:

```F#
[<EntryPoint>]
let main argv = 

    let thisIsAnOutsideVar = "hello"
    
    let s = Seq.init 2000 (id >> int64)
    let mutable counter = 0L

    s |> MySeq.iter (fun i ->
        counter <- counter + i)

    s |> MySeq.iterInline (fun i ->
        counter <- counter + i)

        
    printfn "%s" thisIsAnOutsideVar
    printfn "%A" argv

    0 // return an integer exit code
```

__Debug:__

Well, ``i`` and the closure are visible, as expected:
![image](https://user-images.githubusercontent.com/4236651/31038557-ced696d6-a577-11e7-9a04-7e92b2fc3476.png)

This is a bit disappointing, the call to ``iter`` was inlined, but the lambda was __not__ erased, so I am still inside the ``Invoke`` and the outside variables are not visible:
![image](https://user-images.githubusercontent.com/4236651/31038574-eed9c8ea-a577-11e7-9df6-1c21bca8da3c.png)


__Release:__

![image](https://user-images.githubusercontent.com/4236651/31038537-b4e52314-a577-11e7-8537-5a3d0d826820.png)


I couldn't even set a breakpoint into the callback for ``iterInline``...

------------

#### Conclusion:

Inlining improves performance, but __does not__ improve debugability. I would still prefer to explicitly erase *.iter to a for loop, because that one also erases the lambda into the outer scope.

-----------

Now my question is: __Which functions should all be inlined?__

I strongly assume that any benchmarks for List.iter and Array.iter would give similar results. What about iteri? What about Option.[map/iter/forall]?

It is my strong guess that all functions with a __small body__ that __accept a callback__ would benefit a lot from this. For small functions that don't accept a callback, it is probably not so clear-cut.