### PR TITLE
Preserve XML docs for in-memory project references

### DIFF
--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -31,7 +31,7 @@ open Microsoft.FSharp.Compiler.ExtensionTyping
 #if DEBUG
 
 module internal CompilerService =
-    val showAssertForUnexpectedException : bool ref
+    val showAssertForUnexpectedException: bool ref
 #endif
 
 //----------------------------------------------------------------------------
@@ -39,82 +39,82 @@ module internal CompilerService =
 //--------------------------------------------------------------------------
 
 /// Signature file suffixes
-val FSharpSigFileSuffixes : string list
+val FSharpSigFileSuffixes: string list
 
 /// Implementation file suffixes
-val FSharpImplFileSuffixes : string list
+val FSharpImplFileSuffixes: string list
 
 /// Script file suffixes
-val FSharpScriptFileSuffixes : string list
+val FSharpScriptFileSuffixes: string list
 
-val IsScript : string -> bool
+val IsScript: string -> bool
 
 /// File suffixes where #light is the default
-val FSharpLightSyntaxFileSuffixes : string list
+val FSharpLightSyntaxFileSuffixes: string list
 
 
 /// Get the name used for FSharp.Core
-val GetFSharpCoreLibraryName : unit -> string
+val GetFSharpCoreLibraryName: unit -> string
 
 //----------------------------------------------------------------------------
 // Parsing inputs
 //--------------------------------------------------------------------------
   
-val ComputeQualifiedNameOfFileFromUniquePath : range * string list -> Ast.QualifiedNameOfFile
+val ComputeQualifiedNameOfFileFromUniquePath: range * string list -> Ast.QualifiedNameOfFile
 
-val PrependPathToInput : Ast.Ident list -> Ast.ParsedInput -> Ast.ParsedInput
+val PrependPathToInput: Ast.Ident list -> Ast.ParsedInput -> Ast.ParsedInput
 
 /// Checks if a module name is already given and deduplicates the name if needed.
-val DeduplicateModuleName : Dictionary<string,Set<string>> -> Set<string> -> string -> Ast.QualifiedNameOfFile -> Ast.QualifiedNameOfFile
+val DeduplicateModuleName: Dictionary<string,Set<string>> -> Set<string> -> string -> Ast.QualifiedNameOfFile -> Ast.QualifiedNameOfFile
 
 /// Checks if a ParsedInput is using a module name that was already given and deduplicates the name if needed.
-val DeduplicateParsedInputModuleName : Dictionary<string,Set<string>> -> Ast.ParsedInput -> Ast.ParsedInput
+val DeduplicateParsedInputModuleName: Dictionary<string,Set<string>> -> Ast.ParsedInput -> Ast.ParsedInput
 
-val ParseInput : (UnicodeLexing.Lexbuf -> Parser.token) * ErrorLogger * UnicodeLexing.Lexbuf * string option * string * isLastCompiland:(bool * bool) -> Ast.ParsedInput
+val ParseInput: (UnicodeLexing.Lexbuf -> Parser.token) * ErrorLogger * UnicodeLexing.Lexbuf * string option * string * isLastCompiland:(bool * bool) -> Ast.ParsedInput
 
 //----------------------------------------------------------------------------
 // Error and warnings
 //--------------------------------------------------------------------------
 
 /// Get the location associated with an error
-val GetRangeOfDiagnostic : PhasedDiagnostic -> range option
+val GetRangeOfDiagnostic: PhasedDiagnostic -> range option
 
 /// Get the number associated with an error
-val GetDiagnosticNumber : PhasedDiagnostic -> int
+val GetDiagnosticNumber: PhasedDiagnostic -> int
 
 /// Split errors into a "main" error and a set of associated errors
-val SplitRelatedDiagnostics : PhasedDiagnostic -> PhasedDiagnostic * PhasedDiagnostic list
+val SplitRelatedDiagnostics: PhasedDiagnostic -> PhasedDiagnostic * PhasedDiagnostic list
 
 /// Output an error to a buffer
-val OutputPhasedDiagnostic : StringBuilder -> PhasedDiagnostic -> flattenErrors: bool -> unit
+val OutputPhasedDiagnostic: StringBuilder -> PhasedDiagnostic -> flattenErrors: bool -> unit
 
 /// Output an error or warning to a buffer
-val OutputDiagnostic : implicitIncludeDir:string * showFullPaths: bool * flattenErrors: bool * errorStyle: ErrorStyle *  isError:bool -> StringBuilder -> PhasedDiagnostic -> unit
+val OutputDiagnostic: implicitIncludeDir:string * showFullPaths: bool * flattenErrors: bool * errorStyle: ErrorStyle *  isError:bool -> StringBuilder -> PhasedDiagnostic -> unit
 
 /// Output extra context information for an error or warning to a buffer
-val OutputDiagnosticContext : prefix:string -> fileLineFunction:(string -> int -> string) -> StringBuilder -> PhasedDiagnostic -> unit
+val OutputDiagnosticContext: prefix:string -> fileLineFunction:(string -> int -> string) -> StringBuilder -> PhasedDiagnostic -> unit
 
 /// Part of LegacyHostedCompilerForTesting
 [<RequireQualifiedAccess>]
 type DiagnosticLocation =
-    { Range : range
-      File : string
-      TextRepresentation : string
-      IsEmpty : bool }
+    { Range: range
+      File: string
+      TextRepresentation: string
+      IsEmpty: bool }
 
 /// Part of LegacyHostedCompilerForTesting
 [<RequireQualifiedAccess>]
 type DiagnosticCanonicalInformation = 
-    { ErrorNumber : int
-      Subcategory : string
-      TextRepresentation : string }
+    { ErrorNumber: int
+      Subcategory: string
+      TextRepresentation: string }
 
 /// Part of LegacyHostedCompilerForTesting
 [<RequireQualifiedAccess>]
 type DiagnosticDetailedInfo = 
-    { Location : DiagnosticLocation option
-      Canonical : DiagnosticCanonicalInformation
-      Message : string }
+    { Location: DiagnosticLocation option
+      Canonical: DiagnosticCanonicalInformation
+      Message: string }
 
 /// Part of LegacyHostedCompilerForTesting
 [<RequireQualifiedAccess>]
@@ -123,7 +123,7 @@ type Diagnostic =
     | Long of bool * DiagnosticDetailedInfo
 
 /// Part of LegacyHostedCompilerForTesting
-val CollectDiagnostic : implicitIncludeDir:string * showFullPaths: bool * flattenErrors: bool * errorStyle: ErrorStyle *  warning:bool * PhasedDiagnostic -> seq<Diagnostic>
+val CollectDiagnostic: implicitIncludeDir:string * showFullPaths: bool * flattenErrors: bool * errorStyle: ErrorStyle *  warning:bool * PhasedDiagnostic -> seq<Diagnostic>
 
 //----------------------------------------------------------------------------
 // Resolve assembly references 
@@ -145,37 +145,37 @@ exception HashLoadedScriptConsideredSource of range
 /// reference in FSharp.Compiler.Service.
 type IRawFSharpAssemblyData = 
     ///  The raw list AutoOpenAttribute attributes in the assembly
-    abstract GetAutoOpenAttributes : ILGlobals -> string list
+    abstract GetAutoOpenAttributes: ILGlobals -> string list
     ///  The raw list InternalsVisibleToAttribute attributes in the assembly
-    abstract GetInternalsVisibleToAttributes : ILGlobals  -> string list
+    abstract GetInternalsVisibleToAttributes: ILGlobals  -> string list
     ///  The raw IL module definition in the assembly, if any. This is not present for cross-project references
     /// in the language service
-    abstract TryGetRawILModule : unit -> ILModuleDef option
-    abstract HasAnyFSharpSignatureDataAttribute : bool
-    abstract HasMatchingFSharpSignatureDataAttribute : ILGlobals -> bool
+    abstract TryGetRawILModule: unit -> ILModuleDef option
+    abstract HasAnyFSharpSignatureDataAttribute: bool
+    abstract HasMatchingFSharpSignatureDataAttribute: ILGlobals -> bool
     ///  The raw F# signature data in the assembly, if any
-    abstract GetRawFSharpSignatureData : range * ilShortAssemName: string * fileName: string -> (string * byte[]) list
+    abstract GetRawFSharpSignatureData: range * ilShortAssemName: string * fileName: string -> (string * byte[]) list
     ///  The raw F# optimization data in the assembly, if any
-    abstract GetRawFSharpOptimizationData : range * ilShortAssemName: string * fileName: string -> (string * (unit -> byte[])) list
+    abstract GetRawFSharpOptimizationData: range * ilShortAssemName: string * fileName: string -> (string * (unit -> byte[])) list
     ///  The table of type forwarders in the assembly
-    abstract GetRawTypeForwarders : unit -> ILExportedTypesAndForwarders
+    abstract GetRawTypeForwarders: unit -> ILExportedTypesAndForwarders
     /// The identity of the module
-    abstract ILScopeRef : ILScopeRef
-    abstract ILAssemblyRefs : ILAssemblyRef list
-    abstract ShortAssemblyName : string
+    abstract ILScopeRef: ILScopeRef
+    abstract ILAssemblyRefs: ILAssemblyRef list
+    abstract ShortAssemblyName: string
 
 type TimeStampCache = 
-    new : defaultTimeStamp: DateTime -> TimeStampCache
+    new: defaultTimeStamp: DateTime -> TimeStampCache
     member GetFileTimeStamp: string -> DateTime
     member GetProjectReferenceTimeStamp: IProjectReference * CompilationThreadToken -> DateTime
 
 and IProjectReference = 
 
     /// The name of the assembly file generated by the project
-    abstract FileName : string 
+    abstract FileName: string 
 
     /// Evaluate raw contents of the assembly file generated by the project
-    abstract EvaluateRawContents : CompilationThreadToken -> Cancellable<IRawFSharpAssemblyData option>
+    abstract EvaluateRawContents: CompilationThreadToken -> Cancellable<IRawFSharpAssemblyData option>
 
     /// Get the logical timestamp that would be the timestamp of the assembly file generated by the project.
     ///
@@ -185,25 +185,25 @@ and IProjectReference =
     ///
     /// The operation returns None only if it is not possible to create an IncrementalBuilder for the project at all, e.g. if there
     /// are fatal errors in the options for the project.
-    abstract TryGetLogicalTimeStamp : TimeStampCache * CompilationThreadToken -> System.DateTime option
+    abstract TryGetLogicalTimeStamp: TimeStampCache * CompilationThreadToken -> System.DateTime option
 
 type AssemblyReference = 
     | AssemblyReference of range * string  * IProjectReference option
-    member Range : range
-    member Text : string
-    member ProjectReference : IProjectReference option
+    member Range: range
+    member Text: string
+    member ProjectReference: IProjectReference option
 
 type AssemblyResolution = 
       {/// The original reference to the assembly.
-       originalReference : AssemblyReference
+       originalReference: AssemblyReference
        /// Path to the resolvedFile
-       resolvedPath : string    
+       resolvedPath: string    
        /// Create the tooltip text for the assembly reference
-       prepareToolTip : unit -> string
+       prepareToolTip: unit -> string
        /// Whether or not this is an installed system assembly (for example, System.dll)
-       sysdir : bool
+       sysdir: bool
        // Lazily populated ilAssemblyRef for this reference. 
-       ilAssemblyRef : ILAssemblyRef option ref  }
+       ilAssemblyRef: ILAssemblyRef option ref  }
 
 type UnresolvedAssemblyReference = UnresolvedAssemblyReference of string * AssemblyReference list
 
@@ -216,7 +216,7 @@ type CompilerTarget =
     | ConsoleExe 
     | Dll 
     | Module
-    member IsExe : bool
+    member IsExe: bool
     
 type ResolveAssemblyReferenceMode = 
     | Speculative 
@@ -231,11 +231,11 @@ type VersionFlag =
     | VersionString of string
     | VersionFile of string
     | VersionNone
-    member GetVersionInfo : implicitIncludeDir:string -> ILVersionInfo
-    member GetVersionString : implicitIncludeDir:string -> string
+    member GetVersionInfo: implicitIncludeDir:string -> ILVersionInfo
+    member GetVersionString: implicitIncludeDir:string -> string
 
 type TcConfigBuilder =
-    { mutable primaryAssembly : PrimaryAssembly
+    { mutable primaryAssembly: PrimaryAssembly
       mutable autoResolveOpenDirectivesToDlls: bool
       mutable noFeedback: bool
       mutable stackReserveSize: int32 option
@@ -252,8 +252,8 @@ type TcConfigBuilder =
       mutable implicitOpens: string list
       mutable useFsiAuxLib: bool
       mutable framework: bool
-      mutable resolutionEnvironment : ReferenceResolver.ResolutionEnvironment
-      mutable implicitlyResolveAssemblies : bool
+      mutable resolutionEnvironment: ReferenceResolver.ResolutionEnvironment
+      mutable implicitlyResolveAssemblies: bool
       /// Set if the user has explicitly turned indentation-aware syntax on/off
       mutable light: bool option
       mutable conditionalCompilationDefines: string list
@@ -261,114 +261,114 @@ type TcConfigBuilder =
       mutable loadedSources: (range * string) list
       
       mutable referencedDLLs: AssemblyReference  list
-      mutable projectReferences : IProjectReference list
-      mutable knownUnresolvedReferences : UnresolvedAssemblyReference list
+      mutable projectReferences: IProjectReference list
+      mutable knownUnresolvedReferences: UnresolvedAssemblyReference list
       optimizeForMemory: bool
-      mutable subsystemVersion : int * int
-      mutable useHighEntropyVA : bool
+      mutable subsystemVersion: int * int
+      mutable useHighEntropyVA: bool
       mutable inputCodePage: int option
-      mutable embedResources : string list
+      mutable embedResources: string list
       mutable errorSeverityOptions: FSharpErrorSeverityOptions
       mutable mlCompatibility:bool
       mutable checkOverflow:bool
       mutable showReferenceResolutions:bool
-      mutable outputFile : string option
-      mutable platform : ILPlatform option
-      mutable prefer32Bit : bool
-      mutable useSimpleResolution : bool
-      mutable target : CompilerTarget
-      mutable debuginfo : bool
-      mutable testFlagEmitFeeFeeAs100001 : bool
-      mutable dumpDebugInfo : bool
-      mutable debugSymbolFile : string option
-      mutable typeCheckOnly : bool
-      mutable parseOnly : bool
-      mutable importAllReferencesOnly : bool
-      mutable simulateException : string option
-      mutable printAst : bool
-      mutable tokenizeOnly : bool
-      mutable testInteractionParser : bool
-      mutable reportNumDecls : bool
-      mutable printSignature : bool
-      mutable printSignatureFile : string
-      mutable xmlDocOutputFile : string option
-      mutable stats : bool
-      mutable generateFilterBlocks : bool 
-      mutable signer : string option
-      mutable container : string option
-      mutable delaysign : bool
-      mutable publicsign : bool
-      mutable version : VersionFlag 
-      mutable metadataVersion : string option
-      mutable standalone : bool
-      mutable extraStaticLinkRoots : string list 
-      mutable noSignatureData : bool
-      mutable onlyEssentialOptimizationData : bool
-      mutable useOptimizationDataFile : bool
-      mutable jitTracking : bool
-      mutable portablePDB : bool
-      mutable embeddedPDB : bool
-      mutable embedAllSource : bool
-      mutable embedSourceList : string list
-      mutable sourceLink : string
-      mutable ignoreSymbolStoreSequencePoints : bool
-      mutable internConstantStrings : bool
-      mutable extraOptimizationIterations : int
-      mutable win32res : string 
-      mutable win32manifest : string
-      mutable includewin32manifest : bool
-      mutable linkResources : string list
+      mutable outputFile: string option
+      mutable platform: ILPlatform option
+      mutable prefer32Bit: bool
+      mutable useSimpleResolution: bool
+      mutable target: CompilerTarget
+      mutable debuginfo: bool
+      mutable testFlagEmitFeeFeeAs100001: bool
+      mutable dumpDebugInfo: bool
+      mutable debugSymbolFile: string option
+      mutable typeCheckOnly: bool
+      mutable parseOnly: bool
+      mutable importAllReferencesOnly: bool
+      mutable simulateException: string option
+      mutable printAst: bool
+      mutable tokenizeOnly: bool
+      mutable testInteractionParser: bool
+      mutable reportNumDecls: bool
+      mutable printSignature: bool
+      mutable printSignatureFile: string
+      mutable xmlDocOutputFile: string option
+      mutable stats: bool
+      mutable generateFilterBlocks: bool 
+      mutable signer: string option
+      mutable container: string option
+      mutable delaysign: bool
+      mutable publicsign: bool
+      mutable version: VersionFlag 
+      mutable metadataVersion: string option
+      mutable standalone: bool
+      mutable extraStaticLinkRoots: string list 
+      mutable noSignatureData: bool
+      mutable onlyEssentialOptimizationData: bool
+      mutable useOptimizationDataFile: bool
+      mutable jitTracking: bool
+      mutable portablePDB: bool
+      mutable embeddedPDB: bool
+      mutable embedAllSource: bool
+      mutable embedSourceList: string list
+      mutable sourceLink: string
+      mutable ignoreSymbolStoreSequencePoints: bool
+      mutable internConstantStrings: bool
+      mutable extraOptimizationIterations: int
+      mutable win32res: string 
+      mutable win32manifest: string
+      mutable includewin32manifest: bool
+      mutable linkResources: string list
       mutable legacyReferenceResolver: ReferenceResolver.Resolver 
-      mutable showFullPaths : bool
-      mutable errorStyle : ErrorStyle
-      mutable utf8output : bool
-      mutable flatErrors : bool
-      mutable maxErrors : int
-      mutable abortOnError : bool
-      mutable baseAddress : int32 option
+      mutable showFullPaths: bool
+      mutable errorStyle: ErrorStyle
+      mutable utf8output: bool
+      mutable flatErrors: bool
+      mutable maxErrors: int
+      mutable abortOnError: bool
+      mutable baseAddress: int32 option
  #if DEBUG
-      mutable showOptimizationData : bool
+      mutable showOptimizationData: bool
 #endif
-      mutable showTerms     : bool 
-      mutable writeTermsToFiles : bool 
-      mutable doDetuple     : bool 
-      mutable doTLR         : bool 
-      mutable doFinalSimplify : bool
-      mutable optsOn        : bool 
-      mutable optSettings   : Optimizer.OptimizationSettings 
-      mutable emitTailcalls : bool
-      mutable deterministic : bool
+      mutable showTerms    : bool 
+      mutable writeTermsToFiles: bool 
+      mutable doDetuple    : bool 
+      mutable doTLR        : bool 
+      mutable doFinalSimplify: bool
+      mutable optsOn       : bool 
+      mutable optSettings  : Optimizer.OptimizationSettings 
+      mutable emitTailcalls: bool
+      mutable deterministic: bool
 #if PREFERRED_UI_LANG
       mutable preferredUiLang: string option
 #endif
-      mutable lcid         : int option
-      mutable productNameForBannerText : string
-      mutable showBanner  : bool
-      mutable showTimes : bool
-      mutable showLoadedAssemblies : bool
-      mutable continueAfterParseFailure : bool
+      mutable lcid        : int option
+      mutable productNameForBannerText: string
+      mutable showBanner : bool
+      mutable showTimes: bool
+      mutable showLoadedAssemblies: bool
+      mutable continueAfterParseFailure: bool
 #if EXTENSIONTYPING
-      mutable showExtensionTypeMessages : bool
+      mutable showExtensionTypeMessages: bool
 #endif
-      mutable pause : bool 
-      mutable alwaysCallVirt : bool
-      mutable noDebugData : bool
+      mutable pause: bool 
+      mutable alwaysCallVirt: bool
+      mutable noDebugData: bool
 
       /// If true, indicates all type checking and code generation is in the context of fsi.exe
-      isInteractive : bool 
-      isInvalidationSupported : bool 
-      mutable sqmSessionGuid : System.Guid option
-      mutable sqmNumOfSourceFiles : int
-      sqmSessionStartedTime : int64
-      mutable emitDebugInfoInQuotations : bool
-      mutable exename : string option 
-      mutable copyFSharpCore : bool
-      mutable shadowCopyReferences : bool
+      isInteractive: bool 
+      isInvalidationSupported: bool 
+      mutable sqmSessionGuid: System.Guid option
+      mutable sqmNumOfSourceFiles: int
+      sqmSessionStartedTime: int64
+      mutable emitDebugInfoInQuotations: bool
+      mutable exename: string option 
+      mutable copyFSharpCore: bool
+      mutable shadowCopyReferences: bool
     }
 
     static member Initial: TcConfigBuilder
 
-    static member CreateNew : 
+    static member CreateNew: 
         legacyReferenceResolver: ReferenceResolver.Resolver *
         defaultFSharpBinariesDir: string * 
         optimizeForMemory: bool * 
@@ -377,16 +377,16 @@ type TcConfigBuilder =
         isInvalidationSupported: bool *
         defaultCopyFSharpCore: bool -> TcConfigBuilder
 
-    member DecideNames : string list -> outfile: string * pdbfile: string option * assemblyName: string 
-    member TurnWarningOff : range * string -> unit
-    member TurnWarningOn : range * string -> unit
-    member AddIncludePath : range * string * string -> unit
-    member AddReferencedAssemblyByPath : range * string -> unit
-    member RemoveReferencedAssemblyByPath : range * string -> unit
-    member AddEmbeddedSourceFile : string -> unit
-    member AddEmbeddedResource : string -> unit
+    member DecideNames: string list -> outfile: string * pdbfile: string option * assemblyName: string 
+    member TurnWarningOff: range * string -> unit
+    member TurnWarningOn: range * string -> unit
+    member AddIncludePath: range * string * string -> unit
+    member AddReferencedAssemblyByPath: range * string -> unit
+    member RemoveReferencedAssemblyByPath: range * string -> unit
+    member AddEmbeddedSourceFile: string -> unit
+    member AddEmbeddedResource: string -> unit
     
-    static member SplitCommandLineResourceInfo : string -> string * string * ILResourceAccess
+    static member SplitCommandLineResourceInfo: string -> string * string * ILResourceAccess
 
 
     
@@ -410,141 +410,141 @@ type TcConfig =
     member implicitOpens: string list
     member useFsiAuxLib: bool
     member framework: bool
-    member implicitlyResolveAssemblies : bool
+    member implicitlyResolveAssemblies: bool
     /// Set if the user has explicitly turned indentation-aware syntax on/off
     member light: bool option
     member conditionalCompilationDefines: string list
-    member subsystemVersion : int * int
-    member useHighEntropyVA : bool
+    member subsystemVersion: int * int
+    member useHighEntropyVA: bool
     member referencedDLLs: AssemblyReference list
     member optimizeForMemory: bool
     member inputCodePage: int option
-    member embedResources : string list
+    member embedResources: string list
     member errorSeverityOptions: FSharpErrorSeverityOptions
     member mlCompatibility:bool
     member checkOverflow:bool
     member showReferenceResolutions:bool
-    member outputFile : string option
-    member platform : ILPlatform option
-    member prefer32Bit : bool
-    member useSimpleResolution : bool
-    member target : CompilerTarget
-    member debuginfo : bool
-    member testFlagEmitFeeFeeAs100001 : bool
-    member dumpDebugInfo : bool
-    member debugSymbolFile : string option
-    member typeCheckOnly : bool
-    member parseOnly : bool
-    member importAllReferencesOnly : bool
-    member simulateException : string option
-    member printAst : bool
-    member tokenizeOnly : bool
-    member testInteractionParser : bool
-    member reportNumDecls : bool
-    member printSignature : bool
-    member printSignatureFile : string
-    member xmlDocOutputFile : string option
-    member stats : bool
-    member generateFilterBlocks : bool 
-    member signer : string option
-    member container : string option
-    member delaysign : bool
-    member publicsign : bool
-    member version : VersionFlag 
-    member metadataVersion : string option
-    member standalone : bool
-    member extraStaticLinkRoots : string list 
-    member noSignatureData : bool
-    member onlyEssentialOptimizationData : bool
-    member useOptimizationDataFile : bool
-    member jitTracking : bool
-    member portablePDB : bool
-    member embeddedPDB : bool
-    member embedAllSource : bool
-    member embedSourceList : string list
-    member sourceLink : string
-    member ignoreSymbolStoreSequencePoints : bool
-    member internConstantStrings : bool
-    member extraOptimizationIterations : int
-    member win32res : string 
-    member win32manifest : string
-    member includewin32manifest : bool
-    member linkResources : string list
-    member showFullPaths : bool
-    member errorStyle : ErrorStyle
-    member utf8output : bool
-    member flatErrors : bool
+    member outputFile: string option
+    member platform: ILPlatform option
+    member prefer32Bit: bool
+    member useSimpleResolution: bool
+    member target: CompilerTarget
+    member debuginfo: bool
+    member testFlagEmitFeeFeeAs100001: bool
+    member dumpDebugInfo: bool
+    member debugSymbolFile: string option
+    member typeCheckOnly: bool
+    member parseOnly: bool
+    member importAllReferencesOnly: bool
+    member simulateException: string option
+    member printAst: bool
+    member tokenizeOnly: bool
+    member testInteractionParser: bool
+    member reportNumDecls: bool
+    member printSignature: bool
+    member printSignatureFile: string
+    member xmlDocOutputFile: string option
+    member stats: bool
+    member generateFilterBlocks: bool 
+    member signer: string option
+    member container: string option
+    member delaysign: bool
+    member publicsign: bool
+    member version: VersionFlag 
+    member metadataVersion: string option
+    member standalone: bool
+    member extraStaticLinkRoots: string list 
+    member noSignatureData: bool
+    member onlyEssentialOptimizationData: bool
+    member useOptimizationDataFile: bool
+    member jitTracking: bool
+    member portablePDB: bool
+    member embeddedPDB: bool
+    member embedAllSource: bool
+    member embedSourceList: string list
+    member sourceLink: string
+    member ignoreSymbolStoreSequencePoints: bool
+    member internConstantStrings: bool
+    member extraOptimizationIterations: int
+    member win32res: string 
+    member win32manifest: string
+    member includewin32manifest: bool
+    member linkResources: string list
+    member showFullPaths: bool
+    member errorStyle: ErrorStyle
+    member utf8output: bool
+    member flatErrors: bool
 
-    member maxErrors : int
-    member baseAddress : int32 option
+    member maxErrors: int
+    member baseAddress: int32 option
 #if DEBUG
-    member showOptimizationData : bool
+    member showOptimizationData: bool
 #endif
-    member showTerms     : bool 
-    member writeTermsToFiles : bool 
-    member doDetuple     : bool 
-    member doTLR         : bool 
-    member doFinalSimplify : bool
-    member optSettings   : Optimizer.OptimizationSettings 
-    member emitTailcalls : bool
-    member deterministic : bool
+    member showTerms    : bool 
+    member writeTermsToFiles: bool 
+    member doDetuple    : bool 
+    member doTLR        : bool 
+    member doFinalSimplify: bool
+    member optSettings  : Optimizer.OptimizationSettings 
+    member emitTailcalls: bool
+    member deterministic: bool
 #if PREFERRED_UI_LANG
     member preferredUiLang: string option
 #else
-    member lcid         : int option
+    member lcid        : int option
 #endif
-    member optsOn        : bool 
-    member productNameForBannerText : string
-    member showBanner  : bool
-    member showTimes : bool
-    member showLoadedAssemblies : bool
-    member continueAfterParseFailure : bool
+    member optsOn       : bool 
+    member productNameForBannerText: string
+    member showBanner : bool
+    member showTimes: bool
+    member showLoadedAssemblies: bool
+    member continueAfterParseFailure: bool
 #if EXTENSIONTYPING
-    member showExtensionTypeMessages : bool
+    member showExtensionTypeMessages: bool
 #endif
-    member pause : bool 
-    member alwaysCallVirt : bool
-    member noDebugData : bool
+    member pause: bool 
+    member alwaysCallVirt: bool
+    member noDebugData: bool
 
     /// If true, indicates all type checking and code generation is in the context of fsi.exe
-    member isInteractive : bool
-    member isInvalidationSupported : bool 
+    member isInteractive: bool
+    member isInvalidationSupported: bool 
 
 
-    member ComputeLightSyntaxInitialStatus : string -> bool
-    member GetTargetFrameworkDirectories : unit -> string list
+    member ComputeLightSyntaxInitialStatus: string -> bool
+    member GetTargetFrameworkDirectories: unit -> string list
     
     /// Get the loaded sources that exist and issue a warning for the ones that don't
-    member GetAvailableLoadedSources : unit -> (range*string) list
+    member GetAvailableLoadedSources: unit -> (range*string) list
     
-    member ComputeCanContainEntryPoint : sourceFiles:string list -> bool list *bool 
+    member ComputeCanContainEntryPoint: sourceFiles:string list -> bool list *bool 
 
     /// File system query based on TcConfig settings
-    member ResolveSourceFile : range * filename: string * pathLoadedFrom: string -> string
+    member ResolveSourceFile: range * filename: string * pathLoadedFrom: string -> string
 
     /// File system query based on TcConfig settings
-    member MakePathAbsolute : string -> string
+    member MakePathAbsolute: string -> string
 
-    member sqmSessionGuid : System.Guid option
-    member sqmNumOfSourceFiles : int
-    member sqmSessionStartedTime : int64
-    member copyFSharpCore : bool
-    member shadowCopyReferences : bool
-    static member Create : TcConfigBuilder * validate: bool -> TcConfig
+    member sqmSessionGuid: System.Guid option
+    member sqmNumOfSourceFiles: int
+    member sqmSessionStartedTime: int64
+    member copyFSharpCore: bool
+    member shadowCopyReferences: bool
+    static member Create: TcConfigBuilder * validate: bool -> TcConfig
 
 /// Represents a computation to return a TcConfig. Normally this is just a constant immutable TcConfig,
 /// but for F# Interactive it may be based on an underlying mutable TcConfigBuilder.
 [<Sealed>]
 type TcConfigProvider = 
 
-    member Get : CompilationThreadToken -> TcConfig
+    member Get: CompilationThreadToken -> TcConfig
 
     /// Get a TcConfigProvider which will return only the exact TcConfig.
-    static member Constant : TcConfig -> TcConfigProvider
+    static member Constant: TcConfig -> TcConfigProvider
 
     /// Get a TcConfigProvider which will continue to respect changes in the underlying
     /// TcConfigBuilder rather than delivering snapshots.
-    static member BasedOnMutableBuilder : TcConfigBuilder -> TcConfigProvider
+    static member BasedOnMutableBuilder: TcConfigBuilder -> TcConfigProvider
 
 //----------------------------------------------------------------------------
 // Tables of referenced DLLs 
@@ -558,9 +558,9 @@ type ImportedBinary =
 #if EXTENSIONTYPING
       ProviderGeneratedAssembly: System.Reflection.Assembly option
       IsProviderGenerated: bool
-      ProviderGeneratedStaticLinkMap : ProvidedAssemblyStaticLinkingMap  option
+      ProviderGeneratedStaticLinkMap: ProvidedAssemblyStaticLinkingMap  option
 #endif
-      ILAssemblyRefs : ILAssemblyRef list
+      ILAssemblyRefs: ILAssemblyRef list
       ILScopeRef: ILScopeRef}
 
 /// Represents a resolved imported assembly
@@ -574,15 +574,15 @@ type ImportedAssembly =
       IsProviderGenerated: bool
       mutable TypeProviders: Tainted<Microsoft.FSharp.Core.CompilerServices.ITypeProvider> list
 #endif
-      FSharpOptimizationData : Lazy<Option<Optimizer.LazyModuleInfo>> }
+      FSharpOptimizationData: Lazy<Option<Optimizer.LazyModuleInfo>> }
 
 
 [<Sealed>] 
 type TcAssemblyResolutions = 
-    member GetAssemblyResolutions : unit -> AssemblyResolution list
+    member GetAssemblyResolutions: unit -> AssemblyResolution list
 
-    static member SplitNonFoundationalResolutions  : CompilationThreadToken * TcConfig -> AssemblyResolution list * AssemblyResolution list * UnresolvedAssemblyReference list
-    static member BuildFromPriorResolutions     : CompilationThreadToken * TcConfig * AssemblyResolution list * UnresolvedAssemblyReference list -> TcAssemblyResolutions 
+    static member SplitNonFoundationalResolutions : CompilationThreadToken * TcConfig -> AssemblyResolution list * AssemblyResolution list * UnresolvedAssemblyReference list
+    static member BuildFromPriorResolutions    : CompilationThreadToken * TcConfig * AssemblyResolution list * UnresolvedAssemblyReference list -> TcAssemblyResolutions 
     
 
 
@@ -590,64 +590,64 @@ type TcAssemblyResolutions =
 [<Sealed>] 
 type TcImports =
     interface System.IDisposable
-    //new : TcImports option -> TcImports
-    member DllTable : NameMap<ImportedBinary> with get
-    member GetImportedAssemblies : unit -> ImportedAssembly list
-    member GetCcusInDeclOrder : unit -> CcuThunk list
+    //new: TcImports option -> TcImports
+    member DllTable: NameMap<ImportedBinary> with get
+    member GetImportedAssemblies: unit -> ImportedAssembly list
+    member GetCcusInDeclOrder: unit -> CcuThunk list
     /// This excludes any framework imports (which may be shared between multiple builds)
-    member GetCcusExcludingBase : unit -> CcuThunk list 
-    member FindDllInfo : CompilationThreadToken * range * string -> ImportedBinary
-    member TryFindDllInfo : CompilationThreadToken * range * string * lookupOnly: bool -> option<ImportedBinary>
-    member FindCcuFromAssemblyRef : CompilationThreadToken * range * ILAssemblyRef -> CcuResolutionResult
+    member GetCcusExcludingBase: unit -> CcuThunk list 
+    member FindDllInfo: CompilationThreadToken * range * string -> ImportedBinary
+    member TryFindDllInfo: CompilationThreadToken * range * string * lookupOnly: bool -> option<ImportedBinary>
+    member FindCcuFromAssemblyRef: CompilationThreadToken * range * ILAssemblyRef -> CcuResolutionResult
 #if EXTENSIONTYPING
-    member ProviderGeneratedTypeRoots : ProviderGeneratedType list
+    member ProviderGeneratedTypeRoots: ProviderGeneratedType list
 #endif
-    member GetImportMap : unit -> Import.ImportMap
+    member GetImportMap: unit -> Import.ImportMap
 
     /// Try to resolve a referenced assembly based on TcConfig settings.
-    member TryResolveAssemblyReference : CompilationThreadToken * AssemblyReference * ResolveAssemblyReferenceMode -> OperationResult<AssemblyResolution list>
+    member TryResolveAssemblyReference: CompilationThreadToken * AssemblyReference * ResolveAssemblyReferenceMode -> OperationResult<AssemblyResolution list>
 
     /// Resolve a referenced assembly and report an error if the resolution fails.
-    member ResolveAssemblyReference : CompilationThreadToken * AssemblyReference * ResolveAssemblyReferenceMode -> AssemblyResolution list
+    member ResolveAssemblyReference: CompilationThreadToken * AssemblyReference * ResolveAssemblyReferenceMode -> AssemblyResolution list
 
     /// Try to find the given assembly reference by simple name.  Used in magic assembly resolution.  Effectively does implicit
     /// unification of assemblies by simple assembly name.
-    member TryFindExistingFullyQualifiedPathBySimpleAssemblyName : CompilationThreadToken * string -> string option
+    member TryFindExistingFullyQualifiedPathBySimpleAssemblyName: CompilationThreadToken * string -> string option
 
     /// Try to find the given assembly reference.
-    member TryFindExistingFullyQualifiedPathByExactAssemblyRef : CompilationThreadToken * ILAssemblyRef -> string option
+    member TryFindExistingFullyQualifiedPathByExactAssemblyRef: CompilationThreadToken * ILAssemblyRef -> string option
 
 #if EXTENSIONTYPING
     /// Try to find a provider-generated assembly
-    member TryFindProviderGeneratedAssemblyByName : CompilationThreadToken * assemblyName:string -> System.Reflection.Assembly option
+    member TryFindProviderGeneratedAssemblyByName: CompilationThreadToken * assemblyName:string -> System.Reflection.Assembly option
 #endif
     /// Report unresolved references that also weren't consumed by any type providers.
-    member ReportUnresolvedAssemblyReferences : UnresolvedAssemblyReference list -> unit
-    member SystemRuntimeContainsType : string -> bool
+    member ReportUnresolvedAssemblyReferences: UnresolvedAssemblyReference list -> unit
+    member SystemRuntimeContainsType: string -> bool
 
-    static member BuildFrameworkTcImports      : CompilationThreadToken * TcConfigProvider * AssemblyResolution list * AssemblyResolution list -> Cancellable<TcGlobals * TcImports>
-    static member BuildNonFrameworkTcImports   : CompilationThreadToken * TcConfigProvider * TcGlobals * TcImports * AssemblyResolution list * UnresolvedAssemblyReference list -> Cancellable<TcImports>
-    static member BuildTcImports               : CompilationThreadToken * TcConfigProvider -> Cancellable<TcGlobals * TcImports>
+    static member BuildFrameworkTcImports     : CompilationThreadToken * TcConfigProvider * AssemblyResolution list * AssemblyResolution list -> Cancellable<TcGlobals * TcImports>
+    static member BuildNonFrameworkTcImports  : CompilationThreadToken * TcConfigProvider * TcGlobals * TcImports * AssemblyResolution list * UnresolvedAssemblyReference list -> Cancellable<TcImports>
+    static member BuildTcImports              : CompilationThreadToken * TcConfigProvider -> Cancellable<TcGlobals * TcImports>
 
 //----------------------------------------------------------------------------
 // Special resources in DLLs
 //--------------------------------------------------------------------------
 
 /// Determine if an IL resource attached to an F# assembly is an F# signature data resource
-val IsSignatureDataResource : ILResource -> bool
+val IsSignatureDataResource: ILResource -> bool
 
 /// Determine if an IL resource attached to an F# assembly is an F# optimization data resource
-val IsOptimizationDataResource : ILResource -> bool
+val IsOptimizationDataResource: ILResource -> bool
 
 /// Determine if an IL resource attached to an F# assembly is an F# quotation data resource for reflected definitions
-val IsReflectedDefinitionsResource : ILResource -> bool
-val GetSignatureDataResourceName : ILResource -> string
+val IsReflectedDefinitionsResource: ILResource -> bool
+val GetSignatureDataResourceName: ILResource -> string
 
 /// Write F# signature data as an IL resource
-val WriteSignatureData : TcConfig * TcGlobals * Tastops.Remap * CcuThunk * string -> ILResource
+val WriteSignatureData: TcConfig * TcGlobals * Tastops.Remap * CcuThunk * filename: string * inMem: bool -> ILResource
 
 /// Write F# optimization data as an IL resource
-val WriteOptimizationData :  TcGlobals * string * CcuThunk * Optimizer.LazyModuleInfo -> ILResource
+val WriteOptimizationData: TcGlobals * filename: string * inMem: bool * CcuThunk * Optimizer.LazyModuleInfo -> ILResource
 
 
 //----------------------------------------------------------------------------
@@ -656,39 +656,39 @@ val WriteOptimizationData :  TcGlobals * string * CcuThunk * Optimizer.LazyModul
 
 /// Process #r in F# Interactive.
 /// Adds the reference to the tcImports and add the ccu to the type checking environment.
-val RequireDLL : CompilationThreadToken * TcImports * TcEnv * thisAssemblyName: string * referenceRange: range * file: string -> TcEnv * (ImportedBinary list * ImportedAssembly list)
+val RequireDLL: CompilationThreadToken * TcImports * TcEnv * thisAssemblyName: string * referenceRange: range * file: string -> TcEnv * (ImportedBinary list * ImportedAssembly list)
 
 /// Processing # commands
-val ProcessMetaCommandsFromInput : 
+val ProcessMetaCommandsFromInput: 
     (('T -> range * string -> 'T) * ('T -> range * string -> 'T) * ('T -> range * string -> unit)) 
     -> TcConfigBuilder * Ast.ParsedInput * string * 'T 
     -> 'T
 
 /// Process all the #r, #I etc. in an input
-val ApplyMetaCommandsFromInputToTcConfig : TcConfig * Ast.ParsedInput * string -> TcConfig
+val ApplyMetaCommandsFromInputToTcConfig: TcConfig * Ast.ParsedInput * string -> TcConfig
 
 /// Process the #nowarn in an input
-val ApplyNoWarnsToTcConfig : TcConfig * Ast.ParsedInput * string -> TcConfig
+val ApplyNoWarnsToTcConfig: TcConfig * Ast.ParsedInput * string -> TcConfig
 
 //----------------------------------------------------------------------------
 // Scoped pragmas
 //--------------------------------------------------------------------------
 
 /// Find the scoped #nowarn pragmas with their range information
-val GetScopedPragmasForInput : Ast.ParsedInput -> ScopedPragma list
+val GetScopedPragmasForInput: Ast.ParsedInput -> ScopedPragma list
 
 /// Get an error logger that filters the reporting of warnings based on scoped pragma information
-val GetErrorLoggerFilteringByScopedPragmas : checkFile:bool * ScopedPragma list * ErrorLogger  -> ErrorLogger
+val GetErrorLoggerFilteringByScopedPragmas: checkFile:bool * ScopedPragma list * ErrorLogger  -> ErrorLogger
 
 /// This list is the default set of references for "non-project" files. 
-val DefaultReferencesForScriptsAndOutOfProjectSources : bool -> string list
+val DefaultReferencesForScriptsAndOutOfProjectSources: bool -> string list
 
 //----------------------------------------------------------------------------
 // Parsing
 //--------------------------------------------------------------------------
 
 /// Parse one input file
-val ParseOneInputFile : TcConfig * Lexhelp.LexResourceManager * string list * string * isLastCompiland: (bool * bool) * ErrorLogger * (*retryLocked*) bool -> ParsedInput option
+val ParseOneInputFile: TcConfig * Lexhelp.LexResourceManager * string list * string * isLastCompiland: (bool * bool) * ErrorLogger * (*retryLocked*) bool -> ParsedInput option
 
 //----------------------------------------------------------------------------
 // Type checking and querying the type checking state
@@ -696,30 +696,30 @@ val ParseOneInputFile : TcConfig * Lexhelp.LexResourceManager * string list * st
 
 /// Get the initial type checking environment including the loading of mscorlib/System.Core, FSharp.Core
 /// applying the InternalsVisibleTo in referenced assemblies and opening 'Checked' if requested.
-val GetInitialTcEnv : assemblyName: string * range * TcConfig * TcImports * TcGlobals -> TcEnv
+val GetInitialTcEnv: assemblyName: string * range * TcConfig * TcImports * TcGlobals -> TcEnv
                 
 [<Sealed>]
 /// Represents the incremental type checking state for a set of inputs
 type TcState =
-    member NiceNameGenerator : Ast.NiceNameGenerator
+    member NiceNameGenerator: Ast.NiceNameGenerator
 
     /// The CcuThunk for the current assembly being checked
-    member Ccu : CcuThunk
+    member Ccu: CcuThunk
     
     /// Get the typing environment implied by the set of signature files and/or inferred signatures of implementation files checked so far
-    member TcEnvFromSignatures : TcEnv
+    member TcEnvFromSignatures: TcEnv
 
     /// Get the typing environment implied by the set of implementation files checked so far
-    member TcEnvFromImpls : TcEnv
+    member TcEnvFromImpls: TcEnv
     /// The inferred contents of the assembly, containing the signatures of all implemented files.
-    member PartialAssemblySignature : ModuleOrNamespaceType
+    member PartialAssemblySignature: ModuleOrNamespaceType
 
-    member NextStateAfterIncrementalFragment : TcEnv -> TcState
+    member NextStateAfterIncrementalFragment: TcEnv -> TcState
 
-    member CreatesGeneratedProvidedTypes : bool
+    member CreatesGeneratedProvidedTypes: bool
 
 /// Get the initial type checking state for a set of inputs
-val GetInitialTcState : 
+val GetInitialTcState: 
     range * string * TcConfig * TcGlobals * TcImports * Ast.NiceNameGenerator * TcEnv -> TcState
 
 /// Check one input, returned as an Eventually computation
@@ -728,13 +728,13 @@ val TypeCheckOneInputEventually :
            -> Eventually<(TcEnv * TopAttribs * TypedImplFile list) * TcState>
 
 /// Finish the checking of multiple inputs 
-val TypeCheckMultipleInputsFinish : (TcEnv * TopAttribs * 'T list) list * TcState -> (TcEnv * TopAttribs * 'T list) * TcState
+val TypeCheckMultipleInputsFinish: (TcEnv * TopAttribs * 'T list) list * TcState -> (TcEnv * TopAttribs * 'T list) * TcState
     
 /// Finish the checking of a closed set of inputs 
-val TypeCheckClosedInputSetFinish : TypedImplFile list * TcState -> TcState * TypedImplFile list
+val TypeCheckClosedInputSetFinish: TypedImplFile list * TcState -> TcState * TypedImplFile list
 
 /// Check a closed set of inputs 
-val TypeCheckClosedInputSet : CompilationThreadToken * checkForErrors: (unit -> bool) * TcConfig * TcImports * TcGlobals * Ast.LongIdent option * TcState * Ast.ParsedInput  list  -> TcState * TopAttribs * TypedImplFile list * TcEnv
+val TypeCheckClosedInputSet: CompilationThreadToken * checkForErrors: (unit -> bool) * TcConfig * TcImports * TcGlobals * Ast.LongIdent option * TcState * Ast.ParsedInput  list  -> TcState * TopAttribs * TypedImplFile list * TcEnv
 
 /// Check a single input and finish the checking
 val TypeCheckOneInputAndFinishEventually :
@@ -774,7 +774,7 @@ type LoadClosure =
       References: (string * AssemblyResolution list) list
 
       /// The list of references that were not resolved during load closure.
-      UnresolvedReferences : UnresolvedAssemblyReference list
+      UnresolvedReferences: UnresolvedAssemblyReference list
 
       /// The list of all sources in the closure with inputs when available, with associated parse errors and warnings
       Inputs: LoadClosureInput list
@@ -786,16 +786,16 @@ type LoadClosure =
       NoWarns: (string * range list) list
 
       /// Diagnostics seen while processing resolutions
-      ResolutionDiagnostics : (PhasedDiagnostic * bool)  list
+      ResolutionDiagnostics: (PhasedDiagnostic * bool)  list
 
       /// Diagnostics to show for root of closure (used by fsc.fs)
-      AllRootFileDiagnostics : (PhasedDiagnostic * bool) list
+      AllRootFileDiagnostics: (PhasedDiagnostic * bool) list
 
       /// Diagnostics seen while processing the compiler options implied root of closure
-      LoadClosureRootFileDiagnostics : (PhasedDiagnostic * bool) list }   
+      LoadClosureRootFileDiagnostics: (PhasedDiagnostic * bool) list }   
 
     // Used from service.fs, when editing a script file
-    static member ComputeClosureOfSourceText : CompilationThreadToken * legacyReferenceResolver: ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * filename: string * source: string * implicitDefines:CodeContext * useSimpleResolution: bool * useFsiAuxLib: bool * lexResourceManager: Lexhelp.LexResourceManager * applyCompilerOptions: (TcConfigBuilder -> unit) * assumeDotNetFramework : bool -> LoadClosure
+    static member ComputeClosureOfSourceText: CompilationThreadToken * legacyReferenceResolver: ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * filename: string * source: string * implicitDefines:CodeContext * useSimpleResolution: bool * useFsiAuxLib: bool * lexResourceManager: Lexhelp.LexResourceManager * applyCompilerOptions: (TcConfigBuilder -> unit) * assumeDotNetFramework: bool -> LoadClosure
 
     /// Used from fsi.fs and fsc.fs, for #load and command line. The resulting references are then added to a TcConfig.
-    static member ComputeClosureOfSourceFiles : CompilationThreadToken * tcConfig:TcConfig * (string * range) list * implicitDefines:CodeContext * lexResourceManager : Lexhelp.LexResourceManager -> LoadClosure
+    static member ComputeClosureOfSourceFiles: CompilationThreadToken * tcConfig:TcConfig * (string * range) list * implicitDefines:CodeContext * lexResourceManager: Lexhelp.LexResourceManager -> LoadClosure

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1421,3 +1421,4 @@ notAFunctionButMaybeIndexer,"This expression is not a function and cannot be app
 3217,notAFunctionButMaybeIndexerErrorCode,""
 notAFunctionButMaybeDeclaration,"This value is not a function and cannot be applied. Did you forget to terminate a declaration?"
 3218,ArgumentsInSigAndImplMismatch,"The argument names in the signature '%s' and implementation '%s' do not match. The argument name from the signature file will be used. This may cause problems when debugging or profiling."
+3219,pickleUnexpectedNonZero,"An error occurred while reading the F# metadata of assembly '%s'. A reserved construct was utilized. You may need to upgrade your F# compiler or use an earlier version of the assembly that doesn't make use of a specific construct."

--- a/src/fsharp/TastPickle.fs
+++ b/src/fsharp/TastPickle.fs
@@ -122,6 +122,8 @@ type WriterState =
     osimpletyps: Table<int>
     oglobals : TcGlobals
     ofile : string
+    /// Indicates if we are using in-memory format, where we store XML docs as well
+    oInMem : bool
   }
 let pfailwith st str = ffailwith st.ofile str
     
@@ -185,6 +187,12 @@ let space = ()
 let p_space n () st = 
     for i = 0 to n - 1 do 
         p_byte 0 st
+
+let p_used_space1 f st = 
+    p_byte 1 st
+    f st
+    // leave more space
+    p_space 1 space st
 
 let p_bytes (s:byte[]) st = 
     let len = s.Length
@@ -290,8 +298,19 @@ let u_ieee64 st = float_of_bits (u_int64 st)
 let u_char st = char (int32 (u_uint16 st))
 let u_space n st = 
     for i = 0 to n - 1 do 
-        u_byte st |> ignore
+        let b = u_byte st
+        if b <> 0 then 
+            warning(Error(FSComp.SR.pickleUnexpectedNonZero st.ifile, range0))
         
+let u_used_space1 f st = 
+    let b = u_byte st
+    match b with 
+    | 0 -> None
+    | 1 -> let x = f st 
+           // read additional space
+           u_space 1 st
+           Some x
+    | _ -> warning(Error(FSComp.SR.pickleUnexpectedNonZero st.ifile, range0)); None
 
 
 let inline  u_tup2 p1 p2 (st:ReaderState) = let a = p1 st in let b = p2 st in (a,b)
@@ -411,8 +430,20 @@ let p_array f (x: 'T[]) st =
     for i = 0 to x.Length-1 do
         f x.[i] st
 
+let p_array_ext extraf f (x: 'T[]) st =
+    let n = x.Length
+    // The XmlDoc are only written for the extended in-memory format. We encode their presence using a marker bit here
+    let n = if Option.isSome extraf then n ||| 0x80000000 else n
+    p_int n st
+    match extraf with 
+    | None -> ()
+    | Some f -> f st
+    for i = 0 to x.Length-1 do
+        f x.[i] st
+
  
 let p_list f x st = p_array f (Array.ofList x) st
+let p_list_ext extraf f x st = p_array_ext extraf f (Array.ofList x) st
 
 let p_List f (x: 'T list) st = p_list f x st 
 
@@ -478,7 +509,21 @@ let u_array f st =
         res.[i] <- f st
     res
 
+let u_array_ext extra f st =
+    let n = u_int st
+    let v = 
+        if n &&& 0x80000000 = 0x80000000 then 
+            Some (extra st)
+        else
+            None
+    let n = n &&& 0x7FFFFFFF 
+    let res = Array.zeroCreate n
+    for i = 0 to n-1 do
+        res.[i] <- f st
+    v, res
+
 let u_list f st = Array.toList (u_array f st)
+let u_list_ext extra f st = let v, res = u_array_ext extra f st in v, Array.toList res
 
 #if FLAT_LIST_AS_LIST
 #else
@@ -641,7 +686,7 @@ let p_encoded_simpletyp x st = p_int x st
 let p_simpletyp x st = p_int (encode_simpletyp st.occus st.ostrings st.onlerefs st.osimpletyps st.oscope x) st
 
 type sizes = int * int * int 
-let pickleObjWithDanglingCcus file g scope p x =
+let pickleObjWithDanglingCcus inMem file g scope p x =
   let ccuNameTab,(sizes: sizes),stringTab,pubpathTab,nlerefTab,simpletypTab,phase1bytes =
     let st1 = 
       { os = ByteBuffer.Create 100000 
@@ -656,7 +701,7 @@ let pickleObjWithDanglingCcus file g scope p x =
         osimpletyps=Table<_>.Create "osimpletyps"  
         oglobals=g
         ofile=file
-        (* REINSTATE: odecomps=NodeOutTable.Create stamp_of_decomp name_of_decomp "odecomps" *) }
+        oInMem=inMem }
     p x st1
     let sizes = 
       st1.otycons.Size,
@@ -677,7 +722,8 @@ let pickleObjWithDanglingCcus file g scope p x =
        onlerefs=Table<_>.Create "onlerefs (fake)"
        osimpletyps=Table<_>.Create "osimpletyps (fake)"
        oglobals=g
-       ofile=file }
+       ofile=file
+       oInMem=inMem }
     p_tup7
       (p_array p_encoded_ccuref) 
       (p_tup3 p_int p_int p_int) 
@@ -1159,12 +1205,10 @@ let u_ILInstr st =
 // Pickle/unpickle for F# types and module signatures
 //---------------------------------------------------------------------------
 
-// TODO: remove all pickling of maps
 let p_Map pk pv = p_wrap Map.toList (p_list (p_tup2 pk pv))
 let p_qlist pv = p_wrap QueueList.toList (p_list pv)
 let p_namemap p = p_Map p_string p
 
-// TODO: remove all pickling of maps
 let u_Map uk uv = u_wrap Map.ofList (u_list (u_tup2 uk uv))
 let u_qlist uv = u_wrap QueueList.ofList (u_list uv)
 let u_namemap u = u_Map u_string u
@@ -1610,10 +1654,17 @@ and p_tycon_objmodel_data x st =
   p_tup3 p_tycon_objmodel_kind (p_vrefs "vslots") p_rfield_table 
     (x.fsobjmodel_kind, x.fsobjmodel_vslots, x.fsobjmodel_rfields) st
 
+and p_attribs_ext f x st = p_list_ext f p_attrib x st
+
 and p_unioncase_spec x st =                     
-    p_tup7 
-        p_rfield_table p_typ p_string p_ident p_attribs p_string p_access
-        (x.FieldTable,x.ReturnType,x.CompiledName,x.Id,x.Attribs,x.XmlDocSig,x.Accessibility) st
+    p_rfield_table x.FieldTable st
+    p_typ x.ReturnType st
+    p_string x.CompiledName st
+    p_ident x.Id st
+    // The XmlDoc are only written for the extended in-memory format. We encode their presence using a marker bit here
+    p_attribs_ext (if st.oInMem then Some (p_used_space1 (p_xmldoc x.XmlDoc)) else None)  x.Attribs st
+    p_string x.XmlDocSig st
+    p_access x.Accessibility st
 
 and p_exnc_spec_data x st = p_entity_spec_data x st
 
@@ -1629,32 +1680,44 @@ and p_exnc_spec x st = p_tycon_spec x st
 and p_access (TAccess n) st = p_list p_cpath n st
 
 and p_recdfield_spec x st = 
-    p_tup11
-      p_bool p_bool p_typ p_bool p_bool (p_option p_const) p_ident p_attribs p_attribs p_string p_access 
-      (x.rfield_mutable,x.rfield_volatile,x.rfield_type,x.rfield_static,x.rfield_secret,x.rfield_const,x.rfield_id,x.rfield_pattribs,x.rfield_fattribs,x.rfield_xmldocsig,x.rfield_access) st
+    p_bool x.rfield_mutable st
+    p_bool x.rfield_volatile st
+    p_typ x.rfield_type st
+    p_bool x.rfield_static st
+    p_bool x.rfield_secret st
+    p_option p_const x.rfield_const st
+    p_ident x.rfield_id st 
+    p_attribs_ext (if st.oInMem then Some (p_used_space1 (p_xmldoc x.XmlDoc)) else None) x.rfield_pattribs st
+    p_attribs x.rfield_fattribs st
+    p_string x.rfield_xmldocsig st
+    p_access x.rfield_access st
 
 and p_rfield_table x st = 
     p_list p_recdfield_spec (Array.toList x.FieldsByIndex) st
 
 and p_entity_spec_data (x:Entity) st = 
-      p_typar_specs (x.entity_typars.Force(x.entity_range)) st 
-      p_string x.entity_logical_name st
-      p_option p_string x.entity_compiled_name st
-      p_range  x.entity_range st
-      p_option p_pubpath x.entity_pubpath st
-      p_access x.entity_accessiblity st
-      p_access  x.entity_tycon_repr_accessibility st
-      p_attribs x.entity_attribs st
-      let flagBit = p_tycon_repr x.entity_tycon_repr st
-      p_option p_typ x.entity_tycon_abbrev st
-      p_tcaug x.entity_tycon_tcaug st
-      p_string x.entity_xmldocsig st
-      p_kind x.entity_kind st
-      p_int64 (x.entity_flags.PickledBits ||| (if flagBit then EntityFlags.ReservedBitForPickleFormatTyconReprFlag else 0L)) st
-      p_option p_cpath x.entity_cpath st
-      p_maybe_lazy p_modul_typ x.entity_modul_contents st
-      p_exnc_repr x.entity_exn_info st
-      p_space 1 space st
+    p_typar_specs (x.entity_typars.Force(x.entity_range)) st 
+    p_string x.entity_logical_name st
+    p_option p_string x.entity_compiled_name st
+    p_range  x.entity_range st
+    p_option p_pubpath x.entity_pubpath st
+    p_access x.entity_accessiblity st
+    p_access  x.entity_tycon_repr_accessibility st
+    p_attribs x.entity_attribs st
+    let flagBit = p_tycon_repr x.entity_tycon_repr st
+    p_option p_typ x.entity_tycon_abbrev st
+    p_tcaug x.entity_tycon_tcaug st
+    p_string x.entity_xmldocsig st
+    p_kind x.entity_kind st
+    p_int64 (x.entity_flags.PickledBits ||| (if flagBit then EntityFlags.ReservedBitForPickleFormatTyconReprFlag else 0L)) st
+    p_option p_cpath x.entity_cpath st
+    p_maybe_lazy p_modul_typ x.entity_modul_contents st
+    p_exnc_repr x.entity_exn_info st
+    if st.oInMem then
+        p_used_space1 (p_xmldoc x.entity_xmldoc) st
+    else
+        p_space 1 () st
+
 
 and p_tcaug p st = 
     p_tup9
@@ -1740,35 +1803,23 @@ and p_vrefFlags x st =
     | VSlotDirectCall -> p_byte 4 st
 
 and p_ValData x st =
-    //if verbose then dprintf "p_ValData, nm = %s, stamp #%d, ty = %s\n" x.val_name x.val_stamp (DebugPrint.showType x.val_type);
-    p_tup13
-      p_string
-      (p_option p_string)
-      p_ranges
-      p_typ 
-      p_int64 
-      (p_option p_member_info) 
-      p_attribs 
-      (p_option p_ValReprInfo)
-      p_string
-      p_access
-      p_parentref
-      (p_option p_const)
-      (p_space 1)
-      ( x.val_logical_name,
-        x.val_compiled_name,
-        // only keep range information on published values, not on optimization data
-        (if x.val_repr_info.IsSome then Some(x.val_range, x.DefinitionRange) else None),
-        x.val_type,
-        x.val_flags.PickledBits,
-        x.val_member_info,
-        x.val_attribs,
-        x.val_repr_info,
-        x.val_xmldocsig,
-        x.val_access,
-        x.val_actual_parent,
-        x.val_const,
-        space) st
+    p_string x.val_logical_name st
+    p_option p_string x.val_compiled_name st
+    // only keep range information on published values, not on optimization data
+    p_ranges (if x.val_repr_info.IsSome then Some(x.val_range, x.DefinitionRange) else None) st
+    p_typ x.val_type st
+    p_int64 x.val_flags.PickledBits st
+    p_option p_member_info x.val_member_info st
+    p_attribs x.val_attribs st
+    p_option p_ValReprInfo x.val_repr_info st
+    p_string x.val_xmldocsig st
+    p_access x.val_access st
+    p_parentref x.val_actual_parent st
+    p_option p_const x.val_const st
+    if st.oInMem then
+        p_used_space1 (p_xmldoc x.val_xmldoc) st
+    else
+        p_space 1 () st
       
 and p_Val x st = 
     p_osgn_decl st.ovals p_ValData x st
@@ -1831,16 +1882,25 @@ and u_tycon_objmodel_data st =
     let x1,x2,x3 = u_tup3 u_tycon_objmodel_kind u_vrefs u_rfield_table st
     {fsobjmodel_kind=x1; fsobjmodel_vslots=x2; fsobjmodel_rfields=x3 }
   
+and u_attribs_ext extraf st = u_list_ext extraf u_attrib st
 and u_unioncase_spec st = 
-    let a,b,c,d,e,f,i = u_tup7 u_rfield_table u_typ u_string u_ident u_attribs u_string u_access st
-    {FieldTable=a 
-     ReturnType=b 
-     CompiledName=c 
-     Id=d 
-     Attribs=e
-     XmlDoc=XmlDoc.Empty
-     XmlDocSig=f;Accessibility=i 
-     OtherRangeOpt=None }
+    let a = u_rfield_table  st
+    let b = u_typ st
+    let c = u_string st
+    let d = u_ident  st
+    // The XmlDoc is only present in the extended in-memory format. We detect its presence using a marker bit here
+    let xmldoc, e = u_attribs_ext u_xmldoc st
+    let f = u_string st
+    let i = u_access st
+    { FieldTable=a 
+      ReturnType=b 
+      CompiledName=c 
+      Id=d 
+      Attribs=e
+      XmlDoc= defaultArg xmldoc XmlDoc.Empty
+      XmlDocSig=f
+      Accessibility=i 
+      OtherRangeOpt=None }
     
 and u_exnc_spec_data st = u_entity_spec_data st 
 
@@ -1861,20 +1921,18 @@ and u_access st =
     | res -> TAccess res
 
 and u_recdfield_spec st = 
-    let a,b,c1,c2,c2b,c3,d,e1,e2,f,g = 
-        u_tup11 
-            u_bool 
-            u_bool 
-            u_typ 
-            u_bool 
-            u_bool 
-            (u_option u_const) 
-            u_ident 
-            u_attribs 
-            u_attribs 
-            u_string
-            u_access 
-            st
+    let a = u_bool st
+    let b = u_bool st
+    let c1 = u_typ st
+    let c2 = u_bool st
+    let c2b = u_bool st
+    let c3 = u_option u_const st
+    let d = u_ident st
+    // The XmlDoc is only present in the extended in-memory format. We detect its presence using a marker bit here
+    let xmldoc, e1 = u_attribs_ext u_xmldoc st
+    let e2 = u_attribs st
+    let f = u_string st
+    let g = u_access st
     { rfield_mutable=a  
       rfield_volatile=b  
       rfield_type=c1 
@@ -1884,7 +1942,7 @@ and u_recdfield_spec st =
       rfield_id=d 
       rfield_pattribs=e1
       rfield_fattribs=e2
-      rfield_xmldoc=XmlDoc.Empty
+      rfield_xmldoc= defaultArg xmldoc XmlDoc.Empty
       rfield_xmldocsig=f 
       rfield_access=g
       rfield_other_range = None }
@@ -1892,7 +1950,7 @@ and u_recdfield_spec st =
 and u_rfield_table st = MakeRecdFieldsTable (u_list u_recdfield_spec st)
 
 and u_entity_spec_data st : Entity = 
-    let x1,x2a,x2b,x2c,x3,(x4a,x4b),x6,x7f,x8,x9,x10,x10b,x11,x12,x13,x14,_space = 
+    let x1,x2a,x2b,x2c,x3,(x4a,x4b),x6,x7f,x8,x9,x10,x10b,x11,x12,x13,x14,x15 = 
        u_tup17
           u_typar_specs
           u_string
@@ -1910,7 +1968,7 @@ and u_entity_spec_data st : Entity =
           (u_option u_cpath )
           (u_lazy u_modul_typ) 
           u_exnc_repr 
-          (u_space 1)
+          (u_used_space1 u_xmldoc)
           st
     // We use a bit that was unused in the F# 2.0 format to indicate two possible representations in the F# 3.0 tycon_repr format
     let x7 = x7f (x11 &&& EntityFlags.ReservedBitForPickleFormatTyconReprFlag <> 0L)
@@ -1929,7 +1987,7 @@ and u_entity_spec_data st : Entity =
       entity_tycon_repr=x7
       entity_tycon_abbrev=x8
       entity_tycon_tcaug=x9
-      entity_xmldoc=XmlDoc.Empty
+      entity_xmldoc= defaultArg x15 XmlDoc.Empty
       entity_xmldocsig=x10
       entity_kind=x10b
       entity_flags=EntityFlags(x11)
@@ -2038,7 +2096,7 @@ and u_vrefFlags st =
     | _ -> ufailwith st "u_vrefFlags"
 
 and u_ValData st =
-    let x1,x1z,x1a,x2,x4,x8,x9,x10,x12,x13,x13b,x14,_space = 
+    let x1,x1z,x1a,x2,x4,x8,x9,x10,x12,x13,x13b,x14,x15 = 
       u_tup13
         u_string
         (u_option u_string)
@@ -2052,7 +2110,8 @@ and u_ValData st =
         u_access
         u_parentref
         (u_option u_const) 
-        (u_space 1) st
+        (u_used_space1 u_xmldoc)
+        st
     { val_logical_name=x1
       val_compiled_name=x1z
       val_range=(match x1a with None -> range0 | Some(a,_) -> a)
@@ -2064,7 +2123,7 @@ and u_ValData st =
       val_member_info=x8
       val_attribs=x9
       val_repr_info=x10
-      val_xmldoc=XmlDoc.Empty
+      val_xmldoc= defaultArg x15 XmlDoc.Empty
       val_xmldocsig=x12
       val_access=x13
       val_actual_parent=x13b

--- a/src/fsharp/TastPickle.fsi
+++ b/src/fsharp/TastPickle.fsi
@@ -16,7 +16,7 @@ open Microsoft.FSharp.Compiler.TcGlobals
 [<NoEquality; NoComparison>]
 type PickledDataWithReferences<'RawData> = 
     { /// The data that uses a collection of CcuThunks internally
-      RawData: 'RawData; 
+      RawData: 'RawData 
       /// The assumptions that need to be fixed up
       FixupThunks: list<CcuThunk> } 
 
@@ -82,7 +82,7 @@ val internal p_typ : pickler<TType>
 val internal pickleCcuInfo : pickler<PickledCcuInfo>
 
 /// Serialize an arbitrary object using the given pickler
-val pickleObjWithDanglingCcus : string -> TcGlobals -> scope:CcuThunk -> pickler<'T> -> 'T -> byte[]
+val pickleObjWithDanglingCcus : inMem: bool -> file: string -> TcGlobals -> scope:CcuThunk -> pickler<'T> -> 'T -> byte[]
 
 /// The type of state unpicklers read from
 type ReaderState 
@@ -142,7 +142,7 @@ val internal u_typ : unpickler<TType>
 val internal unpickleCcuInfo : ReaderState -> PickledCcuInfo
 
 /// Deserialize an arbitrary object which may have holes referring to other compilation units
-val internal unpickleObjWithDanglingCcus : string -> viewedScope:ILScopeRef -> ilModule:ILModuleDef option -> ('T  unpickler) -> byte[] ->  PickledDataWithReferences<'T>
+val internal unpickleObjWithDanglingCcus : file:string -> viewedScope:ILScopeRef -> ilModule:ILModuleDef option -> ('T  unpickler) -> byte[] ->  PickledDataWithReferences<'T>
 
 
 

--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -97,6 +97,7 @@ type XmlDocCollector() =
 type XmlDoc =
     | XmlDoc of string[]
     static member Empty = XmlDocStatics.Empty
+    member x.NonEmpty = (let (XmlDoc lines) = x in lines.Length <> 0)
     static member Merge (XmlDoc lines) (XmlDoc lines') = XmlDoc (Array.append lines lines')
     static member Process (XmlDoc lines) =
         // This code runs for .XML generation and thus influences cross-project xmldoc tooltips; for within-project tooltips, see XmlDocumentation.fs in the language service

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -435,7 +435,7 @@ let GenerateInterfaceData(tcConfig:TcConfig) =
 
 let EncodeInterfaceData(tcConfig: TcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, isIncrementalBuild) = 
     if GenerateInterfaceData(tcConfig) then 
-        let resource = WriteSignatureData (tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile)
+        let resource = WriteSignatureData (tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, isIncrementalBuild)
         // The resource gets written to a file for FSharp.Core
         let useDataFiles = (tcConfig.useOptimizationDataFile || tcGlobals.compilingFslib) && not isIncrementalBuild
         if useDataFiles then 
@@ -463,7 +463,7 @@ let EncodeOptimizationData(tcGlobals, tcConfig: TcConfig, outfile, exportRemappi
         let useDataFiles = (tcConfig.useOptimizationDataFile || tcGlobals.compilingFslib) && not isIncrementalBuild
         if useDataFiles then 
             let ccu, modulInfo = data
-            let bytes = TastPickle.pickleObjWithDanglingCcus outfile tcGlobals ccu Optimizer.p_CcuOptimizationInfo modulInfo
+            let bytes = TastPickle.pickleObjWithDanglingCcus isIncrementalBuild outfile tcGlobals ccu Optimizer.p_CcuOptimizationInfo modulInfo
             let optDataFileName = (Filename.chopExtension outfile)+".optdata"
             File.WriteAllBytes(optDataFileName, bytes)
         let (ccu, optData) = 
@@ -471,7 +471,7 @@ let EncodeOptimizationData(tcGlobals, tcConfig: TcConfig, outfile, exportRemappi
                 map2Of2 Optimizer.AbstractOptimizationInfoToEssentials data 
             else 
                 data
-        [ WriteOptimizationData (tcGlobals, outfile, ccu, optData) ]
+        [ WriteOptimizationData (tcGlobals, outfile, isIncrementalBuild, ccu, optData) ]
     else
         [ ]
 

--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -661,7 +661,7 @@ module internal SymbolHelpers =
     let mutable ToolTipFault  = None
     
     let GetXmlCommentForMethInfoItem infoReader m d (minfo: MethInfo) = 
-        GetXmlCommentForItemAux (if minfo.HasDirectXmlComment then Some minfo.XmlDoc else None) infoReader m d 
+        GetXmlCommentForItemAux (if minfo.HasDirectXmlComment || minfo.XmlDoc.NonEmpty then Some minfo.XmlDoc else None) infoReader m d 
 
     let FormatTyparMapping denv (prettyTyparInst: TyparInst) = 
         [ for (tp, ty) in prettyTyparInst -> 
@@ -918,26 +918,26 @@ module internal SymbolHelpers =
             GetXmlCommentForItem infoReader m (Item.Value vref)
 
         | Item.Value vref | Item.CustomBuilder (_, vref) ->            
-            GetXmlCommentForItemAux (if valRefInThisAssembly g.compilingFslib vref then Some vref.XmlDoc else None) infoReader m item 
+            GetXmlCommentForItemAux (if valRefInThisAssembly g.compilingFslib vref || vref.XmlDoc.NonEmpty then Some vref.XmlDoc else None) infoReader m item 
 
         | Item.UnionCase(ucinfo, _) -> 
-            GetXmlCommentForItemAux (if tyconRefUsesLocalXmlDoc g.compilingFslib ucinfo.TyconRef then Some ucinfo.UnionCase .XmlDoc else None) infoReader m item 
+            GetXmlCommentForItemAux (if tyconRefUsesLocalXmlDoc g.compilingFslib ucinfo.TyconRef || ucinfo.UnionCase.XmlDoc.NonEmpty then Some ucinfo.UnionCase.XmlDoc else None) infoReader m item 
 
         | Item.ActivePatternCase apref -> 
             GetXmlCommentForItemAux (Some apref.ActivePatternVal.XmlDoc) infoReader m item 
 
         | Item.ExnCase ecref -> 
-            GetXmlCommentForItemAux (if tyconRefUsesLocalXmlDoc g.compilingFslib ecref then Some ecref.XmlDoc else None) infoReader m item 
+            GetXmlCommentForItemAux (if tyconRefUsesLocalXmlDoc g.compilingFslib ecref || ecref.XmlDoc.NonEmpty then Some ecref.XmlDoc else None) infoReader m item 
 
         | Item.RecdField rfinfo ->
-            GetXmlCommentForItemAux (if tyconRefUsesLocalXmlDoc g.compilingFslib rfinfo.TyconRef then Some rfinfo.RecdField.XmlDoc else None) infoReader m item 
+            GetXmlCommentForItemAux (if tyconRefUsesLocalXmlDoc g.compilingFslib rfinfo.TyconRef || rfinfo.TyconRef.XmlDoc.NonEmpty then Some rfinfo.RecdField.XmlDoc else None) infoReader m item 
 
         | Item.Event einfo ->
-            GetXmlCommentForItemAux (if einfo.HasDirectXmlComment  then Some einfo.XmlDoc else None) infoReader m item 
+            GetXmlCommentForItemAux (if einfo.HasDirectXmlComment || einfo.XmlDoc.NonEmpty then Some einfo.XmlDoc else None) infoReader m item 
 
         | Item.Property(_, pinfos) -> 
             let pinfo = pinfos.Head
-            GetXmlCommentForItemAux (if pinfo.HasDirectXmlComment then Some pinfo.XmlDoc else None) infoReader m item 
+            GetXmlCommentForItemAux (if pinfo.HasDirectXmlComment || pinfo.XmlDoc.NonEmpty then Some pinfo.XmlDoc else None) infoReader m item 
 
         | Item.CustomOperation (_, _, Some minfo) 
         | Item.CtorGroup(_, minfo :: _) 
@@ -945,12 +945,12 @@ module internal SymbolHelpers =
             GetXmlCommentForMethInfoItem infoReader m item minfo
 
         | Item.Types(_, ((TType_app(tcref, _)):: _)) -> 
-            GetXmlCommentForItemAux (if tyconRefUsesLocalXmlDoc g.compilingFslib tcref then Some tcref.XmlDoc else None) infoReader m item 
+            GetXmlCommentForItemAux (if tyconRefUsesLocalXmlDoc g.compilingFslib tcref  || tcref.XmlDoc.NonEmpty then Some tcref.XmlDoc else None) infoReader m item 
 
         | Item.ModuleOrNamespaces((modref :: _) as modrefs) -> 
             let definiteNamespace = modrefs |> List.forall (fun modref -> modref.IsNamespace)
             if not definiteNamespace then
-                GetXmlCommentForItemAux (if entityRefInThisAssembly g.compilingFslib modref then Some modref.XmlDoc else None) infoReader m item 
+                GetXmlCommentForItemAux (if entityRefInThisAssembly g.compilingFslib modref || modref.XmlDoc.NonEmpty  then Some modref.XmlDoc else None) infoReader m item 
             else
                 GetXmlCommentForItemAux None infoReader m item
 
@@ -958,11 +958,11 @@ module internal SymbolHelpers =
             let xmldoc = 
                 match argContainer with
                 | Some(ArgumentContainer.Method (minfo)) ->
-                    if minfo.HasDirectXmlComment then Some minfo.XmlDoc else None 
+                    if minfo.HasDirectXmlComment || minfo.XmlDoc.NonEmpty  then Some minfo.XmlDoc else None 
                 | Some(ArgumentContainer.Type(tcref)) ->
-                    if (tyconRefUsesLocalXmlDoc g.compilingFslib tcref) then Some tcref.XmlDoc else None
+                    if tyconRefUsesLocalXmlDoc g.compilingFslib tcref || tcref.XmlDoc.NonEmpty  then Some tcref.XmlDoc else None
                 | Some(ArgumentContainer.UnionCase(ucinfo)) ->
-                    if (tyconRefUsesLocalXmlDoc g.compilingFslib ucinfo.TyconRef) then Some ucinfo.UnionCase.XmlDoc else None
+                    if tyconRefUsesLocalXmlDoc g.compilingFslib ucinfo.TyconRef || ucinfo.UnionCase.XmlDoc.NonEmpty then Some ucinfo.UnionCase.XmlDoc else None
                 | _ -> None
             GetXmlCommentForItemAux xmldoc infoReader m item
 

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1133,7 +1133,7 @@ type RawFSharpAssemblyDataBackedByLanguageService (tcConfig,tcGlobals,tcState:Tc
     let exportRemapping = MakeExportRemapping generatedCcu generatedCcu.Contents
                       
     let sigData = 
-        let _sigDataAttributes,sigDataResources = Driver.EncodeInterfaceData(tcConfig,tcGlobals,exportRemapping,generatedCcu,outfile,true)
+        let _sigDataAttributes,sigDataResources = Driver.EncodeInterfaceData(tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, true)
         [ for r in sigDataResources  do
             let ccuName = GetSignatureDataResourceName r
             let bytes = 

--- a/tests/service/CSharpProjectAnalysis.fs
+++ b/tests/service/CSharpProjectAnalysis.fs
@@ -1,6 +1,6 @@
 ﻿
 #if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../bin/v4.5/CSharp_Analysis.dll"
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -19,7 +19,7 @@
 //    Use F# Interactive.  This only works for FSHarp.Compiler.Service.dll which has a public API
 
 #if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -1,6 +1,6 @@
 ﻿
 #if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../Debug/net40/bin/FSharp.Compiler.Service.ProjectCracker.dll"
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -1,5 +1,5 @@
 ﻿#if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -1,6 +1,6 @@
 
 #if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"

--- a/tests/service/FsiTests.fs
+++ b/tests/service/FsiTests.fs
@@ -1,6 +1,6 @@
 ﻿
 #if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"

--- a/tests/service/InteractiveCheckerTests.fs
+++ b/tests/service/InteractiveCheckerTests.fs
@@ -1,6 +1,6 @@
 ﻿
 #if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -1,6 +1,6 @@
 ﻿
 #if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
@@ -38,13 +38,24 @@ module internal Project1A =
     let fileSource1 = """
 module Project1A
 
+/// This is type C
 type C() = 
     static member M(arg1: int, arg2: int, ?arg3 : int) = arg1 + arg2 + defaultArg arg3 4
 
+/// This is x1
 let x1 = C.M(arg1 = 3, arg2 = 4, arg3 = 5)
 
+/// This is x2
 let x2 = C.M(arg1 = 3, arg2 = 4, ?arg3 = Some 5)
 
+/// This is type U
+type U = 
+
+   /// This is Case1
+   | Case1 of int
+
+   /// This is Case2
+   | Case2 of string
     """
     File.WriteAllText(fileName1, fileSource1)
 
@@ -100,7 +111,8 @@ open Project1A
 open Project1B
 
 let p = (Project1A.x1, Project1B.b)
-
+let c = C()
+let u = Case1 3
     """
     File.WriteAllText(fileName1, fileSource1)
 
@@ -179,6 +191,54 @@ let ``Test multi project 1 all symbols`` () =
             |> Array.map (fun s -> s.Symbol.DisplayName, MultiProject1.cleanFileName  s.FileName, tups s.Symbol.DeclarationLocation.Value) 
 
     usesOfx1FromProject1AInMultiProject1 |> shouldEqual usesOfx1FromMultiProject1InMultiProject1
+
+[<Test>]
+let ``Test multi project 1 xmldoc`` () = 
+
+    let p1A = checker.ParseAndCheckProject(Project1A.options) |> Async.RunSynchronously
+    let p1B = checker.ParseAndCheckProject(Project1B.options) |> Async.RunSynchronously
+    let mp = checker.ParseAndCheckProject(MultiProject1.options) |> Async.RunSynchronously
+
+    let x1FromProject1A = 
+        [ for s in p1A.GetAllUsesOfAllSymbols() |> Async.RunSynchronously do
+             if  s.Symbol.DisplayName = "x1" then 
+                 yield s.Symbol ]   |> List.head
+
+    let x1FromProjectMultiProject = 
+        [ for s in mp.GetAllUsesOfAllSymbols() |> Async.RunSynchronously do
+             if  s.Symbol.DisplayName = "x1" then 
+                 yield s.Symbol ]   |> List.head
+
+    let ctorFromProjectMultiProject = 
+        [ for s in mp.GetAllUsesOfAllSymbols() |> Async.RunSynchronously do
+             if  s.Symbol.DisplayName = "C" then 
+                 yield s.Symbol ]   |> List.head
+
+    let case1FromProjectMultiProject = 
+        [ for s in mp.GetAllUsesOfAllSymbols() |> Async.RunSynchronously do
+             if  s.Symbol.DisplayName = "Case1" then 
+                 yield s.Symbol ]   |> List.head
+
+
+    match x1FromProject1A with 
+    | :? FSharpMemberOrFunctionOrValue as v -> v.XmlDoc.Count |> shouldEqual 1
+    | _ -> failwith "odd symbol!"
+
+    match x1FromProjectMultiProject with 
+    | :? FSharpMemberOrFunctionOrValue as v -> v.XmlDoc.Count |> shouldEqual 1
+    | _ -> failwith "odd symbol!"
+
+    match ctorFromProjectMultiProject with 
+    | :? FSharpMemberOrFunctionOrValue as c -> c.XmlDoc.Count |> shouldEqual 0
+    | _ -> failwith "odd symbol!"
+
+    match ctorFromProjectMultiProject with 
+    | :? FSharpMemberOrFunctionOrValue as c -> c.EnclosingEntity.Value.XmlDoc.Count |> shouldEqual 1
+    | _ -> failwith "odd symbol!"
+
+    match case1FromProjectMultiProject with 
+    | :? FSharpUnionCase as c -> c.XmlDoc.Count |> shouldEqual 1
+    | _ -> failwith "odd symbol!"
 
 //------------------------------------------------------------------------------------
 

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -150,7 +150,7 @@ let ``Test multi project 1 basic`` () =
 
 
     [ for x in wholeProjectResults.AssemblySignature.Entities.[0].MembersFunctionsAndValues -> x.DisplayName ] 
-        |> shouldEqual ["p"]
+        |> shouldEqual ["p"; "c"; "u"]
 
 [<Test>]
 let ``Test multi project 1 all symbols`` () = 
@@ -802,7 +802,7 @@ let ``Test active patterns' XmlDocSig declared in referenced projects`` () =
     divisibleBySymbol.ToString() |> shouldEqual "symbol DivisibleBy"
 
     let divisibleByActivePatternCase = divisibleBySymbol :?> FSharpActivePatternCase
-    divisibleByActivePatternCase.XmlDoc |> Seq.toList |> shouldEqual []
+    divisibleByActivePatternCase.XmlDoc |> Seq.toList |> shouldEqual [ "A parameterized active pattern of divisibility" ]
     divisibleByActivePatternCase.XmlDocSig |> shouldEqual "M:Project3A.|DivisibleBy|_|(System.Int32,System.Int32)"
     let divisibleByGroup = divisibleByActivePatternCase.Group
     divisibleByGroup.IsTotal |> shouldEqual false

--- a/tests/service/PerfTests.fs
+++ b/tests/service/PerfTests.fs
@@ -1,5 +1,5 @@
 ﻿#if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -1,5 +1,5 @@
 ﻿#if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"

--- a/tests/service/ProjectOptionsTests.fs
+++ b/tests/service/ProjectOptionsTests.fs
@@ -1,5 +1,5 @@
 ﻿#if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../Debug/net40/bin/FSharp.Compiler.Service.ProjectCracker.dll"
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"

--- a/tests/service/TokenizerTests.fs
+++ b/tests/service/TokenizerTests.fs
@@ -1,6 +1,6 @@
 ﻿
 #if INTERACTIVE
-#r "../../Debug/net40/bin/FSharp.Compiler.Service.dll" // note, run 'build fcs' to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../Debug/fcs/net45/FSharp.Compiler.Service.dll" // note, run 'build fcs debug' to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../packages/NUnit.3.5.0/lib/net45/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"


### PR DESCRIPTION
Fixes https://github.com/Microsoft/visualfsharp/issues/3374

The XML docs weren't actually being stored in the F# metadata for in-memory project references. Only the XML doc signature was stored.  This PR adjusts so that for in-memory builds we always save the XML doc into the in-memory data


