### PR TITLE
Fix resource code generation

### DIFF
--- a/fcs/samples/EditorService/EditorService.fsproj
+++ b/fcs/samples/EditorService/EditorService.fsproj
@@ -61,5 +61,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\..\packages\FSharp.Compiler.Tools.4.1.23\tools\Microsoft.FSharp.Targets" />
-  <Import Project="$(SolutionDir).paket\paket.targets" />
 </Project>

--- a/fcs/samples/FscExe/FscExe.fsproj
+++ b/fcs/samples/FscExe/FscExe.fsproj
@@ -74,5 +74,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\..\packages\FSharp.Compiler.Tools.4.1.23\tools\Microsoft.FSharp.Targets" />
-  <Import Project="$(SolutionDir).paket\paket.targets" />
 </Project>

--- a/src/fsharp/FSharp.Build/FSharpEmbedResXSource.fs
+++ b/src/fsharp/FSharp.Build/FSharpEmbedResXSource.fs
@@ -77,9 +77,7 @@ module internal {1} =
                             | (true, true) -> sprintf "    [<Literal>]\n    let %s = \"%s\"" identifier name
                             | (true, false) -> sprintf "    let %s = \"%s\"" identifier name // the [<Literal>] attribute can't be used for FSharp.Core
                             | (false, _) ->
-                                let isStringResource = match node.Attribute(xname "type") with
-                                                       | null -> true
-                                                       | _ -> false
+                                let isStringResource = node.Attribute(xname "type") |> isNull
                                 match (isStringResource, generateGetObject) with
                                 | (true, _) -> sprintf "    let %s() = GetString(\"%s\")" identifier name
                                 | (false, true) -> sprintf "    let %s() = GetObject(\"%s\")" identifier name
@@ -134,7 +132,7 @@ module internal {1} =
                     if getBooleanMetadata "GenerateSource" false item then
                         let moduleName =
                             match item.GetMetadata("GeneratedModuleName") with
-                            | null -> Path.GetFileNameWithoutExtension(item.ItemSpec)
+                            | null | "" -> Path.GetFileNameWithoutExtension(item.ItemSpec)
                             | value -> value
                         let generateLegacy = getBooleanMetadata "GenerateLegacyCode" false item
                         let generateLiteral = getBooleanMetadata "GenerateLiterals" true item

--- a/tests/projects/Sample_VS2012_FSharp_ConsoleApp_net45_with_resource/Sample_VS2012_FSharp_ConsoleApp_net45/Sample_VS2012_FSharp_ConsoleApp_net45.fsproj
+++ b/tests/projects/Sample_VS2012_FSharp_ConsoleApp_net45_with_resource/Sample_VS2012_FSharp_ConsoleApp_net45/Sample_VS2012_FSharp_ConsoleApp_net45.fsproj
@@ -1,73 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>b5b8c6fd-d77d-46e6-a9c5-5d78200668cc</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <RootNamespace>Sample_VS2012_FSharp_ConsoleApp_net45</RootNamespace>
-    <AssemblyName>Sample_VS2012_FSharp_ConsoleApp_net45</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <Name>Sample_VS2012_FSharp_ConsoleApp_net45</Name>
-    <ProductVersion>10.0.0</ProductVersion>
-    <UsePartialTypes>False</UsePartialTypes>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
-    <Tailcalls>False</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>bin\Debug\Sample_VS2012_FSharp_ConsoleApp_net45.xml</DocumentationFile>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>True</Optimize>
-    <Tailcalls>True</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>bin\Release\Sample_VS2012_FSharp_ConsoleApp_net45.xml</DocumentationFile>
-    <Prefer32Bit>true</Prefer32Bit>
-    <DebugSymbols>False</DebugSymbols>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="FSharp.Core" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.fs" />
-    <None Include="App.config" />
-  </ItemGroup>
-  <PropertyGroup>
-    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <ItemGroup>
-    <EmbeddedResource Include="resource.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="content.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
 	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -173,6 +105,5 @@
 		<Reference Include="System.Core" />
 		<Reference Include="System.Numerics" />
 	</ItemGroup>
-	<Import Project="tools\FSharp.SRGen.targets" />
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/Microsoft/visualfsharp/issues/3689

@brettfo You had to check for an empty string, not just a null.  

This bug was found by running some of the extra "Mono" tests we've historically run in http://github.com/fsharp/fsharp. Note we should activate these tests in this repository, particularly the ones building all the projects under ``tests\projects``


