### PR TITLE
[FS-1044] Add NativePtr.toByRef

### DIFF
--- a/src/fsharp/FSharp.Core/nativeptr.fs
+++ b/src/fsharp/FSharp.Core/nativeptr.fs
@@ -49,3 +49,6 @@ module NativePtr =
     [<CompiledName("StackAllocate")>]
     let inline stackalloc (count:int) : nativeptr<'T> = (# "localloc" (count * sizeof<'T>) : nativeptr<'T> #)
 
+    [<NoDynamicInvocation>]
+    [<CompiledName("ToByrefInlined")>]
+    let inline toByref (address: nativeptr<'T>) : byref<'T> = (# "" address : 'T byref  #)

--- a/src/fsharp/FSharp.Core/nativeptr.fs
+++ b/src/fsharp/FSharp.Core/nativeptr.fs
@@ -50,5 +50,5 @@ module NativePtr =
     let inline stackalloc (count:int) : nativeptr<'T> = (# "localloc" (count * sizeof<'T>) : nativeptr<'T> #)
 
     [<NoDynamicInvocation>]
-    [<CompiledName("ToByrefInlined")>]
-    let inline toByref (address: nativeptr<'T>) : byref<'T> = (# "" address : 'T byref  #)
+    [<CompiledName("ToByRefInlined")>]
+    let inline toByRef (address: nativeptr<'T>) : byref<'T> = (# "" address : 'T byref  #)

--- a/src/fsharp/FSharp.Core/nativeptr.fsi
+++ b/src/fsharp/FSharp.Core/nativeptr.fsi
@@ -87,5 +87,5 @@ namespace Microsoft.FSharp.NativeInterop
         /// <returns>The managed pointer.</returns>
         [<Unverifiable>]
         [<NoDynamicInvocation>]
-        [<CompiledName("ToByrefInlined")>]
-        val inline toByref : nativeptr<'T> -> byref<'T>        
+        [<CompiledName("ToByRefInlined")>]
+        val inline toByRef : nativeptr<'T> -> byref<'T>        

--- a/src/fsharp/FSharp.Core/nativeptr.fsi
+++ b/src/fsharp/FSharp.Core/nativeptr.fsi
@@ -81,3 +81,11 @@ namespace Microsoft.FSharp.NativeInterop
         [<NoDynamicInvocation>]
         [<CompiledName("StackAllocate")>]
         val inline stackalloc : count:int -> nativeptr<'T>
+
+        /// <summary>Converts a given typed native pointer to a managed pointer.</summary>
+        /// <param name="address">The input pointer.</param>
+        /// <returns>The managed pointer.</returns>
+        [<Unverifiable>]
+        [<NoDynamicInvocation>]
+        [<CompiledName("ToByrefInlined")>]
+        val inline toByref : nativeptr<'T> -> byref<'T>        

--- a/tests/fsharpqa/Source/Libraries/Core/NativeInterop/stackalloc/ofDateTime01.fs
+++ b/tests/fsharpqa/Source/Libraries/Core/NativeInterop/stackalloc/ofDateTime01.fs
@@ -15,4 +15,13 @@ module M3 =
         if not (NativeInterop.NativePtr.get data i = now) then 
             noerr <- false
             
+   let later = now.AddDays 1.
+   for i = 0 to 99 do
+        let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
+        datai <- later
+   for i = 0 to 99 do
+        let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
+        if not (datai = later) then 
+            noerr <- false
+
    (if noerr then 0 else 1) |> exit

--- a/tests/fsharpqa/Source/Libraries/Core/NativeInterop/stackalloc/ofenum01.fs
+++ b/tests/fsharpqa/Source/Libraries/Core/NativeInterop/stackalloc/ofenum01.fs
@@ -19,4 +19,13 @@ module M6 =
          if not (NativeInterop.NativePtr.get data i = (if (i % 2)=0 then E.A else E.B)) then 
              noerr <- false
 
+    for i = 0 to 9 do
+        let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
+        datai <- (if (i % 2)=1 then E.A else E.B)
+    
+    for i = 0 to 9 do
+         let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
+         if not (datai = (if (i % 2)=1 then E.A else E.B)) then 
+             noerr <- false
+
     (if noerr then 0 else 1) |> exit

--- a/tests/fsharpqa/Source/Libraries/Core/NativeInterop/stackalloc/ofint01.fs
+++ b/tests/fsharpqa/Source/Libraries/Core/NativeInterop/stackalloc/ofint01.fs
@@ -16,5 +16,14 @@ module M1 =
         if not (NativeInterop.NativePtr.get data i = (i*i)) then 
             noerr <- false
 
+   for i = 0 to 99 do
+        let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
+        datai <- 1-i
+    
+   for i = 0 to 99 do
+        let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
+        if not (datai = 1-i) then 
+            noerr <- false
+
    (if noerr then 0 else 1) |> exit
 

--- a/tests/fsharpqa/Source/Libraries/Core/NativeInterop/stackalloc/ofint6401.fs
+++ b/tests/fsharpqa/Source/Libraries/Core/NativeInterop/stackalloc/ofint6401.fs
@@ -14,5 +14,14 @@ module M2 =
         if not (NativeInterop.NativePtr.get data i = (int64 (i*i))) then 
             noerr <- false
 
+   for i = 0 to 99 do
+        let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
+        datai <- int64 (1-i)
+    
+   for i = 0 to 99 do
+        let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
+        if not (datai = int64 (1-i)) then 
+            noerr <- false
+
    (if noerr then 0 else 1) |> exit
 


### PR DESCRIPTION
The `toByref` method fills a gap in the `NativePtr` module - converting typed native pointers to byref pointers.  This is necessary, e.g., to call methods such as `Thread.VolatileRead` or `Thread.VolatileWrite`.  This method was originally proposed here https://github.com/Microsoft/visualfsharp/issues/409 but wasn't incorporated into the `NativePtr` module.

RFC https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1044-add-nativeptr-tobyref.md