### PR TITLE
Don't suggest variables explicitly marked unused

### DIFF
--- a/src/fsharp/ErrorResolutionHints.fs
+++ b/src/fsharp/ErrorResolutionHints.fs
@@ -43,7 +43,11 @@ let FilterPredictions (idText:string) (suggestionF:ErrorLogger.Suggestions) =
     if allSuggestions.Contains idText then [] else // some other parsing error occurred
     allSuggestions
     |> Seq.choose (fun suggestion ->
-        if IsOperatorName suggestion then None else
+        // Because beginning a name with _ is used both to indicate an unused
+        // value as well as to formally squelch the associated compiler
+        // error/warning (FS1182), we remove such names from the suggestions,
+        // both to prevent accidental usages as well as to encourage good taste
+        if IsOperatorName suggestion || suggestion.StartsWith "_" then None else
         let suggestion:string = demangle suggestion
         let suggestedText = suggestion.ToUpperInvariant()
         let similarity = EditDistance.JaroWinklerDistance uppercaseText suggestedText

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/dumpAllCommandLineOptions/dummy.fsx
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/dumpAllCommandLineOptions/dummy.fsx
@@ -95,6 +95,7 @@
 //<Expects status="success">section='- ADVANCED -             ' ! option=readline                       kind=OptionSwitch</Expects>
 //<Expects status="success">section='- ADVANCED -             ' ! option=quotations-debug               kind=OptionSwitch</Expects>
 //<Expects status="success">section='- ADVANCED -             ' ! option=shadowcopyreferences           kind=OptionSwitch</Expects>
+//<Expects status="success">section='- ADVANCED -             ' ! option=simpleresolution               kind=OptionUnit</Expects>
 
 // These are for FSC.EXE ONLY:
 
@@ -121,7 +122,6 @@
 //<Expects status="notin">section='- ADVANCED -             ' ! option=standalone                     kind=OptionUnit</Expects>
 //<Expects status="notin">section='- ADVANCED -             ' ! option=staticlink                     kind=OptionString</Expects>
 //<Expects status="notin">section='- ADVANCED -             ' ! option=pdb                            kind=OptionString</Expects>
-//<Expects status="notin">section='- ADVANCED -             ' ! option=simpleresolution               kind=OptionUnit</Expects>
 //<Expects status="notin">section='NoSection                ' ! option=generatehtml                   kind=OptionUnit</Expects>
 //<Expects status="notin">section='NoSection                ' ! option=htmloutputdir                  kind=OptionString</Expects>
 //<Expects status="notin">section='NoSection                ' ! option=htmlcss                        kind=OptionString</Expects>

--- a/tests/fsharpqa/Source/Warnings/DontSuggestIntentionallyUnusedVariables.fs
+++ b/tests/fsharpqa/Source/Warnings/DontSuggestIntentionallyUnusedVariables.fs
@@ -1,0 +1,8 @@
+//<Expects status="Error" id="FS0039">The value or constructor 'xyz' is not defined.</Expects>
+//<Expects>Maybe you want one of the following:</Expects>
+//<Expects>\s+xy</Expects>
+//<Expects status="notin">\s+_xyz</Expects>
+
+let hober xy _xyz = xyz
+
+exit 0

--- a/tests/fsharpqa/Source/Warnings/env.lst
+++ b/tests/fsharpqa/Source/Warnings/env.lst
@@ -78,3 +78,4 @@
 	SOURCE=WarnIfPossiblePropertySetter.fs
 	SOURCE=DoCannotHaveVisibilityDeclarations.fs
 	SOURCE=ModuleAbbreviationsArePrivate.fs
+	SOURCE=DontSuggestIntentionallyUnusedVariables.fs SCFLAGS="--vserrors" # DontSuggestIntentionallyUnusedVariables.fs

--- a/tests/fsharpqa/Source/run.pl
+++ b/tests/fsharpqa/Source/run.pl
@@ -646,7 +646,7 @@ sub GetExpectedResults(){
       push @dontmatch, $2 if $2;
     }
     # test full xml form
-    elsif (m@//\s*<Expect\w*\s*Status\s*=\s*(notin)\s*>\s*(.*?)\s*<(/Expect|/)\w*>@i) {
+    elsif (m@//\s*<Expect\w*\s*Status\s*=\s*\"?(notin)\"?\s*>\s*(.*?)\s*<(/Expect|/)\w*>@i) {
       push @dontmatch, $2 if $2;
     } else {
       next;


### PR DESCRIPTION
This is the first half of fixing #3705. The next half is to fix the scope leak itself.