### PR TITLE
Make SimplifyNameEachItemDelay zero

### DIFF
--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -13,7 +13,7 @@ module DefaultTuning =
     let UnusedDeclarationsAnalyzerInitialDelay = 0 (* 1000 *) (* milliseconds *)
     let UnusedOpensAnalyzerInitialDelay = 0 (* 2000 *) (* milliseconds *)
     let SimplifyNameInitialDelay = 2000 (* milliseconds *)
-    let SimplifyNameEachItemDelay = 5 (* milliseconds *)
+    let SimplifyNameEachItemDelay = 0 (* milliseconds *)
 
 // CLIMutable to make the record work also as a view model
 [<CLIMutable>]


### PR DESCRIPTION
This reduces errors highlighting delay from 12 seconds to 6:

![1](https://user-images.githubusercontent.com/873919/31310855-498a599a-aba8-11e7-8433-8ade4f501544.gif)
