### PR TITLE
Fix completion inside last part of long ident

### DIFF
--- a/fcs/FSharp.Compiler.Service.netstandard/FSharp.Compiler.Service.netstandard.fsproj
+++ b/fcs/FSharp.Compiler.Service.netstandard/FSharp.Compiler.Service.netstandard.fsproj
@@ -608,6 +608,12 @@
     <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\ExternalSymbol.fs">
       <Link>Service/ExternalSymbol.fs</Link>
     </Compile>
+	<Compile Include="$(FSharpSourcesRoot)\fsharp\vs\QuickParse.fsi">
+      <Link>Service/QuickParse.fsi</Link>
+    </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\QuickParse.fs">
+      <Link>Service/QuickParse.fs</Link>
+    </Compile>
     <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\service.fsi">
       <Link>Service/service.fsi</Link>
     </Compile>

--- a/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -584,6 +584,12 @@
     <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\ExternalSymbol.fs">
       <Link>Service/ExternalSymbol.fs</Link>
     </Compile>
+	<Compile Include="$(FSharpSourcesRoot)\fsharp\vs\QuickParse.fsi">
+      <Link>Service/QuickParse.fsi</Link>
+    </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\QuickParse.fs">
+      <Link>Service/QuickParse.fs</Link>
+    </Compile>
     <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\service.fsi">
       <Link>Service/service.fsi</Link>
     </Compile>

--- a/src/buildfromsource/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -565,6 +565,12 @@
     <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\ExternalSymbol.fs">
       <Link>Service/ExternalSymbol.fs</Link>
     </Compile>
+	<Compile Include="$(FSharpSourcesRoot)\fsharp\vs\QuickParse.fsi">
+      <Link>Service/QuickParse.fsi</Link>
+    </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\QuickParse.fs">
+      <Link>Service/QuickParse.fs</Link>
+    </Compile>
     <Compile Include="$(FSharpSourcesRoot)\fsharp\vs\service.fsi">
       <Link>Service/service.fsi</Link>
     </Compile>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -600,6 +600,12 @@
     <Compile Include="..\vs\ExternalSymbol.fs">
       <Link>Service/ExternalSymbol.fs</Link>
     </Compile>
+    <Compile Include="..\vs\QuickParse.fsi">
+      <Link>Service/QuickParse.fsi</Link>
+    </Compile>
+    <Compile Include="..\vs\QuickParse.fs">
+      <Link>Service/QuickParse.fs</Link>
+    </Compile>
     <Compile Include="..\vs\service.fsi">
       <Link>Service/service.fsi</Link>
     </Compile>

--- a/src/fsharp/vs/QuickParse.fs
+++ b/src/fsharp/vs/QuickParse.fs
@@ -220,7 +220,7 @@ module QuickParse =
             let rec SkipWhitespaceBeforeDotIdentifier(pos, ident, current, throwAwayNext, lastDotPos) =
                 if pos > index then PartialLongName.Default  // we're in whitespace after an identifier, if this is where the cursor is, there is no PLID here
                 elif IsWhitespace pos then SkipWhitespaceBeforeDotIdentifier(pos+1,ident,current,throwAwayNext,lastDotPos)
-                elif IsDot pos then AtStartOfIdentifier(pos+1,ident::current,throwAwayNext, match lastDotPos with Some _ -> lastDotPos | _ -> Some pos)
+                elif IsDot pos then AtStartOfIdentifier(pos+1,ident::current,throwAwayNext, Some pos)
                 elif IsStartOfComment pos then EatComment(1, pos + 1, EatCommentCallContext.SkipWhiteSpaces(ident, current, throwAwayNext), lastDotPos)
                 else AtStartOfIdentifier(pos,[],false,None) // Throw away what we have and start over.
 
@@ -257,7 +257,7 @@ module QuickParse =
                     if IsIdentifierPartCharacter pos then InUnquotedIdentifier(left,pos+1,current,throwAwayNext,lastDotPos)
                     elif IsDot pos then 
                         let ident = line.Substring(left,pos-left)
-                        AtStartOfIdentifier(pos+1,ident::current,throwAwayNext, match lastDotPos with Some _ -> lastDotPos | _ -> Some pos)
+                        AtStartOfIdentifier(pos+1,ident::current,throwAwayNext, Some pos)
                     elif IsWhitespace pos || IsStartOfComment pos then 
                         let ident = line.Substring(left,pos-left)
                         SkipWhitespaceBeforeDotIdentifier(pos, ident, current, throwAwayNext, lastDotPos)
@@ -296,7 +296,7 @@ module QuickParse =
                         elif IsDot pos then 
                             if pos = 0 then
                                 // dot on first char of line, currently treat it like empty identifier to the left
-                                AtStartOfIdentifier(pos+1,""::current,throwAwayNext, match lastDotPos with Some _ -> lastDotPos | _ -> Some pos)
+                                AtStartOfIdentifier(pos+1,""::current,throwAwayNext, Some pos)
                             elif not (pos > 0 && (IsIdentifierPartCharacter(pos-1) || IsWhitespace(pos-1))) then
                                 // it's not dots as part.of.a.long.ident, it's e.g. the range operator (..), or some other multi-char operator ending in dot
                                 if line.[pos-1] = ')' then
@@ -308,7 +308,7 @@ module QuickParse =
                                 else
                                     AtStartOfIdentifier(pos+1,[],false,None) // Throw away what we have and start over.
                             else
-                                AtStartOfIdentifier(pos+1,""::current,throwAwayNext, match lastDotPos with Some _ -> lastDotPos | _ -> Some pos)                            
+                                AtStartOfIdentifier(pos+1,""::current,throwAwayNext, Some pos)
                         else AtStartOfIdentifier(pos+1,[],throwAwayNext, lastDotPos)
             let partialLongName = AtStartOfIdentifier(0, [], false, None) 
             

--- a/src/fsharp/vs/QuickParse.fs
+++ b/src/fsharp/vs/QuickParse.fs
@@ -309,7 +309,7 @@ module QuickParse =
                                     AtStartOfIdentifier(pos+1,[],false,None) // Throw away what we have and start over.
                             else
                                 AtStartOfIdentifier(pos+1,""::current,throwAwayNext, Some pos)
-                        else AtStartOfIdentifier(pos+1,[],throwAwayNext, lastDotPos)
+                        else AtStartOfIdentifier(pos+1,[],throwAwayNext, None)
             let partialLongName = AtStartOfIdentifier(0, [], false, None) 
             
             match List.rev partialLongName.QualifyingIdents with

--- a/src/fsharp/vs/QuickParse.fsi
+++ b/src/fsharp/vs/QuickParse.fsi
@@ -5,28 +5,83 @@ namespace Microsoft.FSharp.Compiler
 open System
 open Microsoft.FSharp.Compiler.SourceCodeServices
 
+/// Qualified long name.
 #if COMPILER_PUBLIC_API
 type PartialLongName =
 #else
 type internal PartialLongName =
 #endif
-    { QualifyingIdents: string list
-      PartialIdent: string
-      LastDotPos: int option }
-    static member Default : PartialLongName
+    { /// Qualifying idents, prior to the last dot, not including the last part.
+      QualifyingIdents: string list
 
+      /// Last part of long ident.
+      PartialIdent: string
+
+      /// Position of the last dot.
+      LastDotPos: int option }
+    
+    /// Empty patial long name.
+    static member Empty: PartialLongName
+
+/// Methods for cheaply and innacurately parsing F#.
+///
+/// These methods are very old and are mostly to do with extracting "long identifier islands" 
+///     A.B.C
+/// from F# source code, an approach taken from pre-F# VS samples for implementing intelliense.
+///
+/// This code should really no longer be needed since the language service has access to 
+/// parsed F# source code ASTs.  However, the long identifiers are still passed back to GetDeclarations and friends in the 
+/// F# Compiler Service and it's annoyingly hard to remove their use completely.
+///
+/// In general it is unlikely much progress will be made by fixing this code - it will be better to 
+/// extract more information from the F# ASTs.
+///
+/// It's also surprising how hard even the job of getting long identifier islands can be. For example the code 
+/// below is inaccurate for long identifier chains involving ``...`` identifiers.  And there are special cases
+/// for active pattern names and so on.
 #if COMPILER_PUBLIC_API
 module QuickParse =
 #else
 module internal QuickParse =
 #endif
+    /// Puts us after the last character.
     val MagicalAdjustmentConstant : int
-    val CorrectIdentifierToken : s: string -> tokenTag: int -> int
-    val GetCompleteIdentifierIsland : tolerateJustAfter: bool -> s : string -> p : int -> (string * int * bool) option
+
+    // Adjusts the token tag for the given identifier
+    // - if we're inside active pattern name (at the bar), correct the token TAG to be an identifier
+    val CorrectIdentifierToken : tokenText: string -> tokenTag: int -> int
+    
+    /// Given a string and a position in that string, find an identifier as
+    /// expected by `GotoDefinition`. This will work when the cursor is
+    /// immediately before the identifier, within the identifier, or immediately
+    /// after the identifier.
+    ///
+    /// 'tolerateJustAfter' indicates that we tolerate being one character after the identifier, used
+    /// for goto-definition
+    ///
+    /// In general, only identifiers composed from upper/lower letters and '.' are supported, but there
+    /// are a couple of explicitly handled exceptions to allow some common scenarios:
+    /// - When the name contains only letters and '|' symbol, it may be an active pattern, so we 
+    ///   treat it as a valid identifier - e.g. let ( |Identitiy| ) a = a
+    ///   (but other identifiers that include '|' are not allowed - e.g. '||' operator)
+    /// - It searches for double tick (``) to see if the identifier could be something like ``a b``
+    ///
+    /// REVIEW: Also support, e.g., operators, performing the necessary mangling.
+    /// (i.e., I would like that the name returned here can be passed as-is
+    /// (post `.`-chopping) to `GetDeclarationLocation.)
+    /// 
+    /// In addition, return the position where a `.` would go if we were making
+    /// a call to `DeclItemsForNamesAtPosition` for intellisense. This will
+    /// allow us to use find the correct qualified items rather than resorting
+    /// to the more expensive and less accurate environment lookup.
+    val GetCompleteIdentifierIsland : tolerateJustAfter: bool -> tokenText: string -> index: int -> (string * int * bool) option
+    
     /// Get the partial long name of the identifier to the left of index.
-    val GetPartialLongName : line : string * index : int -> (string list * string)
+    val GetPartialLongName : lineStr: string * index: int -> (string list * string)
+    
     /// Get the partial long name of the identifier to the left of index.
     /// For example, for `System.DateTime.Now` it returns PartialLongName ([|"System"; "DateTime"|], "Now", Some 32), where "32" pos of the last dot.
-    val GetPartialLongNameEx : line : string * index : int -> PartialLongName
+    val GetPartialLongNameEx : lineStr: string * index: int -> PartialLongName
+    
     /// Tests whether the user is typing something like "member x." or "override (*comment*) x."
     val TestMemberOrOverrideDeclaration : tokens: FSharpTokenInfo[] -> bool

--- a/src/fsharp/vs/QuickParse.fsi
+++ b/src/fsharp/vs/QuickParse.fsi
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.FSharp.Compiler
+
+open System
+open Microsoft.FSharp.Compiler.SourceCodeServices
+
+#if COMPILER_PUBLIC_API
+type PartialLongName =
+#else
+type internal PartialLongName =
+#endif
+    { QualifyingIdents: string list
+      PartialIdent: string
+      LastDotPos: int option }
+    static member Default : PartialLongName
+
+#if COMPILER_PUBLIC_API
+module QuickParse =
+#else
+module internal QuickParse =
+#endif
+    val MagicalAdjustmentConstant : int
+    val CorrectIdentifierToken : s: string -> tokenTag: int -> int
+    val GetCompleteIdentifierIsland : tolerateJustAfter: bool -> s : string -> p : int -> (string * int * bool) option
+    /// Get the partial long name of the identifier to the left of index.
+    val GetPartialLongName : line : string * index : int -> (string list * string)
+    /// Get the partial long name of the identifier to the left of index.
+    /// For example, for `System.DateTime.Now` it returns PartialLongName ([|"System"; "DateTime"|], "Now", Some 32), where "32" pos of the last dot.
+    val GetPartialLongNameEx : line : string * index : int -> PartialLongName
+    /// Tests whether the user is typing something like "member x." or "override (*comment*) x."
+    val TestMemberOrOverrideDeclaration : tokens: FSharpTokenInfo[] -> bool

--- a/src/fsharp/vs/QuickParse.fsi
+++ b/src/fsharp/vs/QuickParse.fsi
@@ -17,11 +17,14 @@ type internal PartialLongName =
       /// Last part of long ident.
       PartialIdent: string
 
+      /// The column number at the end of full partial name.
+      EndColumn: int
+
       /// Position of the last dot.
       LastDotPos: int option }
     
     /// Empty patial long name.
-    static member Empty: PartialLongName
+    static member Empty: endColumn: int -> PartialLongName
 
 /// Methods for cheaply and innacurately parsing F#.
 ///

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -896,11 +896,11 @@ type TypeCheckInfo
                 false)
         
     /// Get the auto-complete items at a location
-    member __.GetDeclarations (ctok, parseResultsOpt, line, lineStr, colAtEndOfNamesAndResidue, partialName: PartialLongName, getAllSymbols, hasTextChangedSinceLastTypecheck) =
+    member __.GetDeclarations (ctok, parseResultsOpt, line, lineStr, partialName, getAllSymbols, hasTextChangedSinceLastTypecheck) =
         let isInterfaceFile = SourceFileImpl.IsInterfaceFile mainInputFileName
         ErrorScope.Protect Range.range0 
-            (fun () -> 
-                match GetDeclItemsForNamesAtPosition(ctok, parseResultsOpt, Some partialName.QualifyingIdents, Some partialName.PartialIdent, partialName.LastDotPos, line, lineStr, colAtEndOfNamesAndResidue, ResolveTypeNamesToCtors, ResolveOverloads.Yes, getAllSymbols, hasTextChangedSinceLastTypecheck) with
+            (fun () ->
+                match GetDeclItemsForNamesAtPosition(ctok, parseResultsOpt, Some partialName.QualifyingIdents, Some partialName.PartialIdent, partialName.LastDotPos, line, lineStr, partialName.EndColumn + 1, ResolveTypeNamesToCtors, ResolveOverloads.Yes, getAllSymbols, hasTextChangedSinceLastTypecheck) with
                 | None -> FSharpDeclarationListInfo.Empty  
                 | Some (items, denv, ctx, m) -> 
                     let items = if isInterfaceFile then items |> List.filter (fun x -> IsValidSignatureFileItem x.Item) else items
@@ -916,11 +916,11 @@ type TypeCheckInfo
                 FSharpDeclarationListInfo.Error msg)
 
     /// Get the symbols for auto-complete items at a location
-    member __.GetDeclarationListSymbols (ctok, parseResultsOpt, line, lineStr, colAtEndOfNamesAndResidue, partialName: PartialLongName, hasTextChangedSinceLastTypecheck) =
+    member __.GetDeclarationListSymbols (ctok, parseResultsOpt, line, lineStr, partialName, hasTextChangedSinceLastTypecheck) =
         let isInterfaceFile = SourceFileImpl.IsInterfaceFile mainInputFileName
         ErrorScope.Protect Range.range0 
             (fun () -> 
-                match GetDeclItemsForNamesAtPosition(ctok, parseResultsOpt, Some partialName.QualifyingIdents, Some partialName.PartialIdent, partialName.LastDotPos, line, lineStr, colAtEndOfNamesAndResidue, ResolveTypeNamesToCtors, ResolveOverloads.Yes, (fun () -> []), hasTextChangedSinceLastTypecheck) with
+                match GetDeclItemsForNamesAtPosition(ctok, parseResultsOpt, Some partialName.QualifyingIdents, Some partialName.PartialIdent, partialName.LastDotPos, line, lineStr, partialName.EndColumn + 1, ResolveTypeNamesToCtors, ResolveOverloads.Yes, (fun () -> []), hasTextChangedSinceLastTypecheck) with
                 | None -> List.Empty  
                 | Some (items, denv, _, m) -> 
                     let items = if isInterfaceFile then items |> List.filter (fun x -> IsValidSignatureFileItem x.Item) else items
@@ -1879,16 +1879,16 @@ type FSharpCheckFileResults(filename: string, errors: FSharpErrorInfo[], scopeOp
     member info.HasFullTypeCheckInfo = details.IsSome
     
     /// Intellisense autocompletions
-    member info.GetDeclarationListInfo(parseResultsOpt, line, colAtEndOfNamesAndResidue, lineStr, partialName: PartialLongName, getAllEntities, ?hasTextChangedSinceLastTypecheck, ?userOpName: string) = 
+    member info.GetDeclarationListInfo(parseResultsOpt, line, lineStr, partialName, getAllEntities, ?hasTextChangedSinceLastTypecheck, ?userOpName: string) = 
         let userOpName = defaultArg userOpName "Unknown"
         let hasTextChangedSinceLastTypecheck = defaultArg hasTextChangedSinceLastTypecheck (fun _ -> false)
         reactorOp userOpName "GetDeclarations" FSharpDeclarationListInfo.Empty (fun ctok scope -> 
-            scope.GetDeclarations(ctok, parseResultsOpt, line, lineStr, colAtEndOfNamesAndResidue, partialName, getAllEntities, hasTextChangedSinceLastTypecheck))
+            scope.GetDeclarations(ctok, parseResultsOpt, line, lineStr, partialName, getAllEntities, hasTextChangedSinceLastTypecheck))
 
-    member info.GetDeclarationListSymbols(parseResultsOpt, line, colAtEndOfNamesAndResidue, lineStr, partialName, ?hasTextChangedSinceLastTypecheck, ?userOpName: string) = 
+    member info.GetDeclarationListSymbols(parseResultsOpt, line, lineStr, partialName, ?hasTextChangedSinceLastTypecheck, ?userOpName: string) = 
         let userOpName = defaultArg userOpName "Unknown"
         let hasTextChangedSinceLastTypecheck = defaultArg hasTextChangedSinceLastTypecheck (fun _ -> false)
-        reactorOp userOpName "GetDeclarationListSymbols" List.empty (fun ctok scope -> scope.GetDeclarationListSymbols(ctok, parseResultsOpt, line, lineStr, colAtEndOfNamesAndResidue, partialName, hasTextChangedSinceLastTypecheck))
+        reactorOp userOpName "GetDeclarationListSymbols" List.empty (fun ctok scope -> scope.GetDeclarationListSymbols(ctok, parseResultsOpt, line, lineStr, partialName, hasTextChangedSinceLastTypecheck))
 
     /// Resolve the names at the given location to give a data tip 
     member info.GetStructuredToolTipText(line, colAtEndOfNames, lineStr, names, tokenTag, ?userOpName: string) = 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -140,13 +140,7 @@ type SemanticClassificationType =
     | TypeArgument
     | Operator
     | Disposable
-
-type PartialLongName =
-    { QualifyingIdents: string list
-      PartialIdent: string
-      LastDotPos: int option }
-    static member Default = { QualifyingIdents = []; PartialIdent = ""; LastDotPos = None }
-
+    
 /// A TypeCheckInfo represents everything we get back from the typecheck of a file.
 /// It acts like an in-memory database about the file.
 /// It is effectively immutable and not updated: when we re-typecheck we just drop the previous

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -99,16 +99,6 @@ type internal SemanticClassificationType =
     | Operator
     | Disposable
 
-#if COMPILER_PUBLIC_API
-type PartialLongName =
-#else
-type internal PartialLongName =
-#endif
-    { QualifyingIdents: string list
-      PartialIdent: string
-      LastDotPos: int option }
-    static member Default : PartialLongName
-
 /// A handle to the results of CheckFileInProject.
 [<Sealed>]
 #if COMPILER_PUBLIC_API

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -132,13 +132,15 @@ type internal FSharpCheckFileResults =
     ///    'record field' locations and r.h.s. of 'range' operator a..b
     /// </param>
     /// <param name="line">The line number where the completion is happening</param>
-    /// <param name="colAtEndOfNamesAndResidue">The column number at the end of the 'names' text </param>
-    /// <param name="qualifyingNames">The long identifier to the left of the '.'</param>
-    /// <param name="partialName">The residue of a partial long identifier to the right of the '.'</param>
-    /// <param name="lineStr">The residue of a partial long identifier to the right of the '.'</param>
+    /// <param name="partialName">
+    ///    Partial long name. QuickParse.GetPartialLongNameEx can be used to get it.
+    /// </param>
     /// <param name="lineText">
     ///    The text of the line where the completion is happening. This is only used to make a couple
     ///    of adhoc corrections to completion accuracy (e.g. checking for "..")
+    /// </param>
+    /// <param name="getAllSymbols">
+    ///    Function that returns all symbols from current and referenced assemblies.
     /// </param>
     /// <param name="hasTextChangedSinceLastTypecheck">
     ///    If text has been used from a captured name resolution from the typecheck, then 
@@ -146,7 +148,7 @@ type internal FSharpCheckFileResults =
     ///    and assume that we're going to repeat the operation later on.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * partialName: PartialLongName * getAllSymbols: (unit -> AssemblySymbol list) * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo>
+    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * lineText:string * partialName: PartialLongName * getAllSymbols: (unit -> AssemblySymbol list) * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo>
 
     /// <summary>Get the items for a declaration list in FSharpSymbol format</summary>
     ///
@@ -156,13 +158,15 @@ type internal FSharpCheckFileResults =
     ///    'record field' locations and r.h.s. of 'range' operator a..b
     /// </param>
     /// <param name="line">The line number where the completion is happening</param>
-    /// <param name="colAtEndOfNamesAndResidue">The column number at the end of the 'names' text </param>
-    /// <param name="qualifyingNames">The long identifier to the left of the '.'</param>
-    /// <param name="partialName">The residue of a partial long identifier to the right of the '.'</param>
-    /// <param name="lineStr">The residue of a partial long identifier to the right of the '.'</param>
+    /// <param name="partialName">
+    ///    Partial long name. QuickParse.GetPartialLongNameEx can be used to get it.
+    /// </param>
     /// <param name="lineText">
     ///    The text of the line where the completion is happening. This is only used to make a couple
     ///    of adhoc corrections to completion accuracy (e.g. checking for "..")
+    /// </param>
+    /// <param name="getAllSymbols">
+    ///    Function that returns all symbols from current and referenced assemblies.
     /// </param>
     /// <param name="hasTextChangedSinceLastTypecheck">
     ///    If text has been used from a captured name resolution from the typecheck, then 
@@ -170,7 +174,7 @@ type internal FSharpCheckFileResults =
     ///    and assume that we're going to repeat the operation later on.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetDeclarationListSymbols : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * partialName: PartialLongName * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpSymbolUse list list>
+    member GetDeclarationListSymbols : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * lineText:string * partialName: PartialLongName * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpSymbolUse list list>
 
 
     /// <summary>Compute a formatted tooltip for the given location</summary>
@@ -200,7 +204,7 @@ type internal FSharpCheckFileResults =
     /// <param name="lineText">The text of the line where the information is being requested.</param>
     /// <param name="names">The identifiers at the location where the information is being requested.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetF1Keyword                   : line:int * colAtEndOfNames:int * lineText:string * names:string list * ?userOpName: string -> Async<string option>
+    member GetF1Keyword : line:int * colAtEndOfNames:int * lineText:string * names:string list * ?userOpName: string -> Async<string option>
 
 
     /// <summary>Compute a set of method overloads to show in a dialog relevant to the given code location.</summary>
@@ -210,7 +214,7 @@ type internal FSharpCheckFileResults =
     /// <param name="lineText">The text of the line where the information is being requested.</param>
     /// <param name="names">The identifiers at the location where the information is being requested.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetMethods              : line:int * colAtEndOfNames:int * lineText:string * names:string list option * ?userOpName: string -> Async<FSharpMethodGroup>
+    member GetMethods : line:int * colAtEndOfNames:int * lineText:string * names:string list option * ?userOpName: string -> Async<FSharpMethodGroup>
 
     /// <summary>Compute a set of method overloads to show in a dialog relevant to the given code location.  The resulting method overloads are returned as symbols.</summary>
     /// <param name="line">The line number where the information is being requested.</param>

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -99,6 +99,16 @@ type internal SemanticClassificationType =
     | Operator
     | Disposable
 
+#if COMPILER_PUBLIC_API
+type PartialLongName =
+#else
+type internal PartialLongName =
+#endif
+    { QualifyingIdents: string list
+      PartialIdent: string
+      LastDotPos: int option }
+    static member Default : PartialLongName
+
 /// A handle to the results of CheckFileInProject.
 [<Sealed>]
 #if COMPILER_PUBLIC_API
@@ -146,7 +156,7 @@ type internal FSharpCheckFileResults =
     ///    and assume that we're going to repeat the operation later on.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * qualifyingNames: string list * partialName: string * lastDotPos: int option * getAllSymbols: (unit -> AssemblySymbol list) * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo>
+    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * partialName: PartialLongName * getAllSymbols: (unit -> AssemblySymbol list) * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo>
 
     /// <summary>Get the items for a declaration list in FSharpSymbol format</summary>
     ///
@@ -170,7 +180,7 @@ type internal FSharpCheckFileResults =
     ///    and assume that we're going to repeat the operation later on.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetDeclarationListSymbols : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * qualifyingNames: string list * partialName: string * lastDotPos: int option * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpSymbolUse list list>
+    member GetDeclarationListSymbols : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * partialName: PartialLongName * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpSymbolUse list list>
 
 
     /// <summary>Compute a formatted tooltip for the given location</summary>

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -146,7 +146,7 @@ type internal FSharpCheckFileResults =
     ///    and assume that we're going to repeat the operation later on.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * qualifyingNames: string list * partialName: string * getAllSymbols: (unit -> AssemblySymbol list) * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo>
+    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * qualifyingNames: string list * partialName: string * lastDotPos: int option * getAllSymbols: (unit -> AssemblySymbol list) * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo>
 
     /// <summary>Get the items for a declaration list in FSharpSymbol format</summary>
     ///
@@ -170,7 +170,7 @@ type internal FSharpCheckFileResults =
     ///    and assume that we're going to repeat the operation later on.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetDeclarationListSymbols : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * qualifyingNames: string list * partialName: string * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpSymbolUse list list>
+    member GetDeclarationListSymbols : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * colAtEndOfPartialName: int * lineText:string * qualifyingNames: string list * partialName: string * lastDotPos: int option * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpSymbolUse list list>
 
 
     /// <summary>Compute a formatted tooltip for the given location</summary>

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -86,8 +86,8 @@ let ``Intro test`` () =
     let tip = typeCheckResults.GetToolTipText(4, 7, inputLines.[1], ["foo"], identToken) |> Async.RunSynchronously
     // (sprintf "%A" tip).Replace("\n","") |> shouldEqual """FSharpToolTipText [Single ("val foo : unit -> unitFull name: Test.foo",None)]"""
     // Get declarations (autocomplete) for a location
-    let partialName = { QualifyingIdents = []; PartialIdent = "msg"; LastDotPos = None }
-    let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 7, 23, inputLines.[6], partialName, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let partialName = { QualifyingIdents = []; PartialIdent = "msg"; EndColumn = 22; LastDotPos = None }
+    let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 7, inputLines.[6], partialName, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
     CollectionAssert.AreEquivalent(stringMethods,[ for item in decls.Items -> item.Name ])
     // Get overloads of the String.Concat method
     let methods = typeCheckResults.GetMethods(5, 27, inputLines.[4], Some ["String"; "Concat"]) |> Async.RunSynchronously
@@ -286,7 +286,7 @@ let ``Expression typing test`` () =
     // gives the results for the string type. 
     // 
     for col in 42..43 do 
-        let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 2, col, inputLines.[1], PartialLongName.Default, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+        let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 2, inputLines.[1], PartialLongName.Empty(col), (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
         let autoCompleteSet = set [ for item in decls.Items -> item.Name ]
         autoCompleteSet |> shouldEqual (set stringMethods)
 
@@ -307,7 +307,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 21, inputLines.[3], PartialLongName.Default, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(20), (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
     let item = decls.Items |> Array.tryFind (fun d -> d.Name = "abc")
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
 
@@ -324,7 +324,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 22, inputLines.[3], PartialLongName.Default, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(21), (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
     let item = decls.Items |> Array.tryFind (fun d -> d.Name = "abc")
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
  
@@ -341,7 +341,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 15, inputLines.[3], PartialLongName.Default, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(14), (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
 
 [<Test; Ignore("Currently failing, see #139")>]
@@ -357,7 +357,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 21, inputLines.[3], PartialLongName.Default, fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(20), fun _ -> false)|> Async.RunSynchronously
     //decls |> List.map (fun d -> d.Head.Symbol.DisplayName) |> printfn "---> decls = %A"
     decls |> Seq.exists (fun d -> d.Head.Symbol.DisplayName = "abc") |> shouldEqual true
 
@@ -374,7 +374,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 22, inputLines.[3], PartialLongName.Default, fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(21), fun _ -> false)|> Async.RunSynchronously
     //decls |> List.map (fun d -> d.Head.Symbol.DisplayName) |> printfn "---> decls = %A"
     decls |> Seq.exists (fun d -> d.Head.Symbol.DisplayName = "abc") |> shouldEqual true
 
@@ -391,7 +391,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 15, inputLines.[3], PartialLongName.Default, fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(14), fun _ -> false)|> Async.RunSynchronously
     //decls |> List.map (fun d -> d.Head.Symbol.DisplayName) |> printfn "---> decls = %A"
     decls |> Seq.exists (fun d -> d.Head.Symbol.DisplayName = "abc") |> shouldEqual true
 

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -86,7 +86,8 @@ let ``Intro test`` () =
     let tip = typeCheckResults.GetToolTipText(4, 7, inputLines.[1], ["foo"], identToken) |> Async.RunSynchronously
     // (sprintf "%A" tip).Replace("\n","") |> shouldEqual """FSharpToolTipText [Single ("val foo : unit -> unitFull name: Test.foo",None)]"""
     // Get declarations (autocomplete) for a location
-    let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 7, 23, inputLines.[6], [], "msg", (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let partialName = { QualifyingIdents = []; PartialIdent = "msg"; LastDotPos = None }
+    let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 7, 23, inputLines.[6], partialName, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
     CollectionAssert.AreEquivalent(stringMethods,[ for item in decls.Items -> item.Name ])
     // Get overloads of the String.Concat method
     let methods = typeCheckResults.GetMethods(5, 27, inputLines.[4], Some ["String"; "Concat"]) |> Async.RunSynchronously
@@ -285,7 +286,7 @@ let ``Expression typing test`` () =
     // gives the results for the string type. 
     // 
     for col in 42..43 do 
-        let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 2, col, inputLines.[1], [], "", (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+        let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 2, col, inputLines.[1], PartialLongName.Default, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
         let autoCompleteSet = set [ for item in decls.Items -> item.Name ]
         autoCompleteSet |> shouldEqual (set stringMethods)
 
@@ -306,7 +307,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 21, inputLines.[3], [], "", (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 21, inputLines.[3], PartialLongName.Default, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
     let item = decls.Items |> Array.tryFind (fun d -> d.Name = "abc")
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
 
@@ -323,7 +324,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 22, inputLines.[3], [], "", (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 22, inputLines.[3], PartialLongName.Default, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
     let item = decls.Items |> Array.tryFind (fun d -> d.Name = "abc")
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
  
@@ -340,7 +341,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 15, inputLines.[3], [], "", (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, 15, inputLines.[3], PartialLongName.Default, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
 
 [<Test; Ignore("Currently failing, see #139")>]
@@ -356,7 +357,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 21, inputLines.[3], [], "", fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 21, inputLines.[3], PartialLongName.Default, fun _ -> false)|> Async.RunSynchronously
     //decls |> List.map (fun d -> d.Head.Symbol.DisplayName) |> printfn "---> decls = %A"
     decls |> Seq.exists (fun d -> d.Head.Symbol.DisplayName = "abc") |> shouldEqual true
 
@@ -373,7 +374,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 22, inputLines.[3], [], "", fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 22, inputLines.[3], PartialLongName.Default, fun _ -> false)|> Async.RunSynchronously
     //decls |> List.map (fun d -> d.Head.Symbol.DisplayName) |> printfn "---> decls = %A"
     decls |> Seq.exists (fun d -> d.Head.Symbol.DisplayName = "abc") |> shouldEqual true
 
@@ -390,7 +391,7 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 15, inputLines.[3], [], "", fun _ -> false)|> Async.RunSynchronously
+    let decls = typeCheckResults.GetDeclarationListSymbols(Some parseResult, 4, 15, inputLines.[3], PartialLongName.Default, fun _ -> false)|> Async.RunSynchronously
     //decls |> List.map (fun d -> d.Head.Symbol.DisplayName) |> printfn "---> decls = %A"
     decls |> Seq.exists (fun d -> d.Head.Symbol.DisplayName = "abc") |> shouldEqual true
 

--- a/vsintegration/Utils/LanguageServiceProfiling/Program.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Program.fs
@@ -164,10 +164,10 @@ let main argv =
                             fileResults.GetDeclarationListInfo(
                                 Some parseResult,
                                 completion.Position.Line,
-                                completion.Position.Column,
                                 getLine (completion.Position.Line),
                                 { QualifyingIdents = completion.QualifyingNames
                                   PartialIdent = completion.PartialName
+                                  EndColumn = completion.Position.Column - 1
                                   LastDotPos = None },
                                 fun() -> [])
                            

--- a/vsintegration/Utils/LanguageServiceProfiling/Program.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Program.fs
@@ -166,8 +166,9 @@ let main argv =
                                 completion.Position.Line,
                                 completion.Position.Column,
                                 getLine (completion.Position.Line),
-                                completion.QualifyingNames,
-                                completion.PartialName,
+                                { QualifyingIdents = completion.QualifyingNames
+                                  PartialIdent = completion.PartialName
+                                  LastDotPos = None },
                                 fun() -> [])
                            
                         for i in listInfo.Items do

--- a/vsintegration/src/FSharp.Editor/Commands/HelpContextService.fs
+++ b/vsintegration/src/FSharp.Editor/Commands/HelpContextService.fs
@@ -10,6 +10,7 @@ open Microsoft.CodeAnalysis.Classification
 open Microsoft.VisualStudio.FSharp.LanguageService
 open Microsoft.VisualStudio.LanguageServices.Implementation.F1Help
 open Microsoft.CodeAnalysis.Host.Mef
+open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler.SourceCodeServices
 

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -100,14 +100,14 @@ type internal FSharpCompletionProvider
             let caretLine = textLines.GetLineFromPosition(caretPosition)
             let fcsCaretLineNumber = Line.fromZ caretLinePos.Line  // Roslyn line numbers are zero-based, FSharp.Compiler.Service line numbers are 1-based
             let caretLineColumn = caretLinePos.Character
-            let qualifyingNames, partialName = QuickParse.GetPartialLongNameEx(caretLine.ToString(), caretLineColumn - 1) 
+            let qualifyingNames, partialName, lastDotPos = QuickParse.GetPartialLongNameEx(caretLine.ToString(), caretLineColumn - 1) 
             
             let getAllSymbols() = 
-                getAllSymbols() |> List.filter (fun entity -> entity.FullName.Contains "." && not (PrettyNaming.IsOperatorName entity.Symbol.DisplayName))
+                getAllSymbols() 
+                |> List.filter (fun entity -> entity.FullName.Contains "." && not (PrettyNaming.IsOperatorName entity.Symbol.DisplayName))
 
-            let! declarations =
-                checkFileResults.GetDeclarationListInfo(Some(parseResults), fcsCaretLineNumber, caretLineColumn, caretLine.ToString(), qualifyingNames, partialName, getAllSymbols, userOpName=userOpName) |> liftAsync
-            
+            let! declarations = checkFileResults.GetDeclarationListInfo(Some(parseResults), fcsCaretLineNumber, caretLineColumn, caretLine.ToString(), 
+                                                                        qualifyingNames, partialName, lastDotPos, getAllSymbols, userOpName=userOpName) |> liftAsync
             let results = List<Completion.CompletionItem>()
             
             let getKindPriority = function

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -106,7 +106,7 @@ type internal FSharpCompletionProvider
                 getAllSymbols() 
                 |> List.filter (fun entity -> entity.FullName.Contains "." && not (PrettyNaming.IsOperatorName entity.Symbol.DisplayName))
 
-            let! declarations = checkFileResults.GetDeclarationListInfo(Some(parseResults), fcsCaretLineNumber, caretLineColumn, caretLine.ToString(), 
+            let! declarations = checkFileResults.GetDeclarationListInfo(Some(parseResults), fcsCaretLineNumber, caretLine.ToString(), 
                                                                         partialName, getAllSymbols, userOpName=userOpName) |> liftAsync
             let results = List<Completion.CompletionItem>()
             

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -100,14 +100,14 @@ type internal FSharpCompletionProvider
             let caretLine = textLines.GetLineFromPosition(caretPosition)
             let fcsCaretLineNumber = Line.fromZ caretLinePos.Line  // Roslyn line numbers are zero-based, FSharp.Compiler.Service line numbers are 1-based
             let caretLineColumn = caretLinePos.Character
-            let qualifyingNames, partialName, lastDotPos = QuickParse.GetPartialLongNameEx(caretLine.ToString(), caretLineColumn - 1) 
+            let partialName = QuickParse.GetPartialLongNameEx(caretLine.ToString(), caretLineColumn - 1) 
             
             let getAllSymbols() = 
                 getAllSymbols() 
                 |> List.filter (fun entity -> entity.FullName.Contains "." && not (PrettyNaming.IsOperatorName entity.Symbol.DisplayName))
 
             let! declarations = checkFileResults.GetDeclarationListInfo(Some(parseResults), fcsCaretLineNumber, caretLineColumn, caretLine.ToString(), 
-                                                                        qualifyingNames, partialName, lastDotPos, getAllSymbols, userOpName=userOpName) |> liftAsync
+                                                                        partialName, getAllSymbols, userOpName=userOpName) |> liftAsync
             let results = List<Completion.CompletionItem>()
             
             let getKindPriority = function
@@ -186,7 +186,7 @@ type internal FSharpCompletionProvider
                 declarationItemsCache.Add(completionItem.DisplayText, declItem)
                 results.Add(completionItem))
 
-            if results.Count > 0 && not declarations.IsForType && not declarations.IsError && List.isEmpty qualifyingNames then
+            if results.Count > 0 && not declarations.IsForType && not declarations.IsError && List.isEmpty partialName.QualifyingIdents then
                 let lineStr = textLines.[caretLinePos.Line].ToString()
                 match UntypedParseImpl.TryGetCompletionContext(Pos.fromZ caretLinePos.Line caretLinePos.Character, Some parseResults, lineStr) with
                 | None -> results.AddRange(keywordCompletionItems)

--- a/vsintegration/src/FSharp.Editor/Debugging/LanguageDebugInfoService.fs
+++ b/vsintegration/src/FSharp.Editor/Debugging/LanguageDebugInfoService.fs
@@ -14,7 +14,7 @@ open Microsoft.CodeAnalysis.Editor.Implementation.Debugging
 open Microsoft.CodeAnalysis.Host.Mef
 open Microsoft.CodeAnalysis.Text
 
-open Microsoft.VisualStudio.FSharp.LanguageService
+open Microsoft.FSharp.Compiler
 
 [<Shared>]
 [<ExportLanguageService(typeof<ILanguageDebugInfoService>, FSharpConstants.FSharpLanguageName)>]

--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -69,7 +69,7 @@ type internal SimplifyNameDiagnosticAnalyzer() =
                         |> Array.Parallel.map (fun symbolUse ->
                             let lineStr = sourceText.Lines.[Line.toZ symbolUse.RangeAlternate.StartLine].ToString()
                             // for `System.DateTime.Now` it returns ([|"System"; "DateTime"|], "Now")
-                            let plid, name = QuickParse.GetPartialLongNameEx(lineStr, symbolUse.RangeAlternate.EndColumn - 1)
+                            let plid, name, _ = QuickParse.GetPartialLongNameEx(lineStr, symbolUse.RangeAlternate.EndColumn - 1)
                             // `symbolUse.RangeAlternate.Start` does not point to the start of plid, it points to start of `name`,
                             // so we have to calculate plid's start ourselves.
                             let plidStartCol = symbolUse.RangeAlternate.EndColumn - name.Length - (getPlidLength plid)

--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -69,11 +69,11 @@ type internal SimplifyNameDiagnosticAnalyzer() =
                         |> Array.Parallel.map (fun symbolUse ->
                             let lineStr = sourceText.Lines.[Line.toZ symbolUse.RangeAlternate.StartLine].ToString()
                             // for `System.DateTime.Now` it returns ([|"System"; "DateTime"|], "Now")
-                            let plid, name, _ = QuickParse.GetPartialLongNameEx(lineStr, symbolUse.RangeAlternate.EndColumn - 1)
+                            let partialName = QuickParse.GetPartialLongNameEx(lineStr, symbolUse.RangeAlternate.EndColumn - 1)
                             // `symbolUse.RangeAlternate.Start` does not point to the start of plid, it points to start of `name`,
                             // so we have to calculate plid's start ourselves.
-                            let plidStartCol = symbolUse.RangeAlternate.EndColumn - name.Length - (getPlidLength plid)
-                            symbolUse, plid, plidStartCol, name)
+                            let plidStartCol = symbolUse.RangeAlternate.EndColumn - partialName.PartialIdent.Length - (getPlidLength partialName.QualifyingIdents)
+                            symbolUse, partialName.QualifyingIdents, plidStartCol, partialName.PartialIdent)
                         |> Array.filter (fun (_, plid, _, name) -> name <> "" && not (List.isEmpty plid))
                         |> Array.groupBy (fun (symbolUse, _, plidStartCol, _) -> symbolUse.RangeAlternate.StartLine, plidStartCol)
                         |> Array.map (fun (_, xs) -> xs |> Array.maxBy (fun (symbolUse, _, _, _) -> symbolUse.RangeAlternate.EndColumn))

--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -532,7 +532,7 @@ module internal Tokenizer =
             | _ -> false) 
         |> Option.orElseWith (fun _ -> tokensUnderCursor |> List.tryFind (fun { DraftToken.Kind = k } -> k = LexerSymbolKind.Operator))
         |> Option.map (fun token ->
-            let plid, _ = QuickParse.GetPartialLongNameEx(lineStr, token.RightColumn)
+            let plid, _, _ = QuickParse.GetPartialLongNameEx(lineStr, token.RightColumn)
             let identStr = lineStr.Substring(token.Token.LeftColumn, token.Token.FullMatchedLength)
             {   Kind = token.Kind
                 Ident = 

--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -532,7 +532,7 @@ module internal Tokenizer =
             | _ -> false) 
         |> Option.orElseWith (fun _ -> tokensUnderCursor |> List.tryFind (fun { DraftToken.Kind = k } -> k = LexerSymbolKind.Operator))
         |> Option.map (fun token ->
-            let plid, _, _ = QuickParse.GetPartialLongNameEx(lineStr, token.RightColumn)
+            let partialName = QuickParse.GetPartialLongNameEx(lineStr, token.RightColumn)
             let identStr = lineStr.Substring(token.Token.LeftColumn, token.Token.FullMatchedLength)
             {   Kind = token.Kind
                 Ident = 
@@ -541,7 +541,7 @@ module internal Tokenizer =
                             fileName 
                             (Range.mkPos (linePos.Line + 1) token.Token.LeftColumn)
                             (Range.mkPos (linePos.Line + 1) (token.RightColumn + 1))) 
-                FullIsland = plid @ [identStr] })
+                FullIsland = partialName.QualifyingIdents @ [identStr] })
 
     let private getCachedSourceLineData(documentKey: DocumentId, sourceText: SourceText, position: int, fileName: string, defines: string list) = 
         let textLine = sourceText.Lines.GetLineFromPosition(position)

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -13,7 +13,7 @@ module DefaultTuning =
     let UnusedDeclarationsAnalyzerInitialDelay = 0 (* 1000 *) (* milliseconds *)
     let UnusedOpensAnalyzerInitialDelay = 0 (* 2000 *) (* milliseconds *)
     let SimplifyNameInitialDelay = 2000 (* milliseconds *)
-    let SimplifyNameEachItemDelay = 5 (* milliseconds *)
+    let SimplifyNameEachItemDelay = 0 (* milliseconds *)
 
 // CLIMutable to make the record work also as a view model
 [<CLIMutable>]

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -13,7 +13,7 @@ module DefaultTuning =
     let UnusedDeclarationsAnalyzerInitialDelay = 0 (* 1000 *) (* milliseconds *)
     let UnusedOpensAnalyzerInitialDelay = 0 (* 2000 *) (* milliseconds *)
     let SimplifyNameInitialDelay = 2000 (* milliseconds *)
-    let SimplifyNameEachItemDelay = 0 (* milliseconds *)
+    let SimplifyNameEachItemDelay = 5 (* milliseconds *)
 
 // CLIMutable to make the record work also as a view model
 [<CLIMutable>]

--- a/vsintegration/src/FSharp.LanguageService/FSharp.LanguageService.fsproj
+++ b/vsintegration/src/FSharp.LanguageService/FSharp.LanguageService.fsproj
@@ -55,7 +55,6 @@
     </EmbeddedResource>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Error.fs" />
-    <Compile Include="Quickparse.fs" />
     <Compile Include="Vs.fs" />
     <Compile Include="Colorize.fs" />
     <Compile Include="GotoDefinition.fs" />
@@ -66,7 +65,6 @@
     <Compile Include="Intellisense.fs" />
     <Compile Include="BackgroundRequests.fs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
@@ -83,7 +81,6 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Framework.dll</HintPath>
@@ -95,7 +92,7 @@
     <Reference Include="EnvDTE80">
       <HintPath>$(FSharpSourcesRoot)\..\packages\EnvDTE80.8.0.1\lib\net10\EnvDTE80.dll</HintPath>
       <Private>True</Private>
-    </Reference>  
+    </Reference>
     <Reference Include="VSLangProj">
       <HintPath>$(FSharpSourcesRoot)\..\packages\VSSDK.VSLangProj.7.0.4\lib\net20\VSLangProj.dll</HintPath>
       <Private>True</Private>
@@ -149,7 +146,7 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Designer.Interfaces">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualStudio.Designer.Interfaces.1.1.4322\lib\microsoft.visualstudio.designer.interfaces.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.VSHelp">
       <HintPath>$(FSharpSourcesRoot)\..\packages\VSSDK.VSHelp.7.0.4\lib\net20\Microsoft.VisualStudio.VSHelp.dll</HintPath>
       <Private>True</Private>

--- a/vsintegration/src/FSharp.LanguageService/GotoDefinition.fs
+++ b/vsintegration/src/FSharp.LanguageService/GotoDefinition.fs
@@ -57,7 +57,7 @@ module internal GotoDefinition =
                     | Some (s, colIdent, isQuoted) -> 
                         let qualId  = if isQuoted then [s] else s.Split '.' |> Array.toList // chop it up (in case it's a qualified ident)
                         // this is a bit irratiting: `GetTokenInfoAt` won't handle just-past-the-end, so we take the just-past-the-end position and adjust it by the `magicalAdjustmentConstant` to just-*at*-the-end
-                        let colIdentAdjusted = colIdent - QuickParse.magicalAdjustmentConstant
+                        let colIdentAdjusted = colIdent - QuickParse.MagicalAdjustmentConstant
             
                         // Corrrect the identifier (e.g. to correctly handle active pattern names that end with "BAR" token)
                         let tag = colourizer.GetTokenInfoAt(VsTextLines.TextColorState(VsTextView.Buffer textView), line, colIdentAdjusted).Token

--- a/vsintegration/src/FSharp.LanguageService/Intellisense.fs
+++ b/vsintegration/src/FSharp.LanguageService/Intellisense.fs
@@ -533,7 +533,7 @@ type internal FSharpIntellisenseInfo_DEPRECATED
                                 let oldTextSnapshot = oldTextSnapshotInfo :?> ITextSnapshot
                                 hasTextChangedSinceLastTypecheck (textSnapshot, oldTextSnapshot, Range.Range.toZ range)
 
-                            let! decls = typedResults.GetDeclarationListInfo(untypedParseInfoOpt, Range.Line.fromZ line, col, lineText, pname, (fun() -> []), detectTextChange) 
+                            let! decls = typedResults.GetDeclarationListInfo(untypedParseInfoOpt, Range.Line.fromZ line, lineText, pname, (fun() -> []), detectTextChange) 
                             return (new FSharpDeclarations_DEPRECATED(documentationBuilder, decls.Items, reason) :> Declarations_DEPRECATED) 
                     else
                         // no TypeCheckInfo in ParseResult.

--- a/vsintegration/src/FSharp.LanguageService/Intellisense.fs
+++ b/vsintegration/src/FSharp.LanguageService/Intellisense.fs
@@ -526,14 +526,14 @@ type internal FSharpIntellisenseInfo_DEPRECATED
                                 else
                                     None
                             // TODO don't use QuickParse below, we have parse info available
-                            let qname, pname, lastDotPos = QuickParse.GetPartialLongNameEx(lineText, col-1) 
+                            let pname = QuickParse.GetPartialLongNameEx(lineText, col-1) 
                             let _x = 1 // for breakpoint
 
                             let detectTextChange (oldTextSnapshotInfo: obj, range) = 
                                 let oldTextSnapshot = oldTextSnapshotInfo :?> ITextSnapshot
                                 hasTextChangedSinceLastTypecheck (textSnapshot, oldTextSnapshot, Range.Range.toZ range)
 
-                            let! decls = typedResults.GetDeclarationListInfo(untypedParseInfoOpt, Range.Line.fromZ line, col, lineText, qname, pname, lastDotPos, (fun() -> []), detectTextChange) 
+                            let! decls = typedResults.GetDeclarationListInfo(untypedParseInfoOpt, Range.Line.fromZ line, col, lineText, pname, (fun() -> []), detectTextChange) 
                             return (new FSharpDeclarations_DEPRECATED(documentationBuilder, decls.Items, reason) :> Declarations_DEPRECATED) 
                     else
                         // no TypeCheckInfo in ParseResult.

--- a/vsintegration/src/FSharp.LanguageService/Intellisense.fs
+++ b/vsintegration/src/FSharp.LanguageService/Intellisense.fs
@@ -526,14 +526,14 @@ type internal FSharpIntellisenseInfo_DEPRECATED
                                 else
                                     None
                             // TODO don't use QuickParse below, we have parse info available
-                            let plid = QuickParse.GetPartialLongNameEx(lineText, col-1) 
-                            ignore plid // for breakpoint
+                            let qname, pname, lastDotPos = QuickParse.GetPartialLongNameEx(lineText, col-1) 
+                            let _x = 1 // for breakpoint
 
                             let detectTextChange (oldTextSnapshotInfo: obj, range) = 
                                 let oldTextSnapshot = oldTextSnapshotInfo :?> ITextSnapshot
                                 hasTextChangedSinceLastTypecheck (textSnapshot, oldTextSnapshot, Range.Range.toZ range)
 
-                            let! decls = typedResults.GetDeclarationListInfo(untypedParseInfoOpt, Range.Line.fromZ line, col, lineText, fst plid, snd plid, (fun() -> []), detectTextChange) 
+                            let! decls = typedResults.GetDeclarationListInfo(untypedParseInfoOpt, Range.Line.fromZ line, col, lineText, qname, pname, lastDotPos, (fun() -> []), detectTextChange) 
                             return (new FSharpDeclarations_DEPRECATED(documentationBuilder, decls.Items, reason) :> Declarations_DEPRECATED) 
                     else
                         // no TypeCheckInfo in ParseResult.

--- a/vsintegration/tests/Salsa/salsa.fs
+++ b/vsintegration/tests/Salsa/salsa.fs
@@ -25,7 +25,7 @@ open Microsoft.VisualStudio.FSharp.LanguageService
 open Microsoft.VisualStudio.TextManager.Interop
 open UnitTests.TestLib.Utils.FilesystemHelpers
 open Microsoft.Build.Framework
-open Microsoft.FSharp.Compiler.Range
+open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.SourceCodeServices
 
 open Microsoft.Build.Evaluation

--- a/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
@@ -7774,6 +7774,15 @@ let rec f l =
                 let bar = 1""",
             marker = "(*Marker*)")
 
+    [<Test;Category("Repro")>]
+    member public this.``ExpressionDotting.Regression.Bug3709``() = 
+        this.VerifyCtrlSpaceListContainAllAtStartOfMarker(
+            fileContents = """
+                let foo = ""
+                let foo = foo.E(*marker*)n "a" """,
+            marker = "(*marker*)",
+            list = ["EndsWith"])  
+
 // Context project system
 [<TestFixture>] 
 type UsingProjectSystem() = 

--- a/vsintegration/tests/unittests/Tests.LanguageService.GotoDefinition.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.GotoDefinition.fs
@@ -1346,7 +1346,7 @@ type UsingMSBuild()  =
     member this.GetCompleteIdTest tolerate (s : string)(exp : string option) : unit =
       let n = s.IndexOf '$'
       let s = s.Remove (n, 1)
-      match (Microsoft.VisualStudio.FSharp.LanguageService.QuickParse.GetCompleteIdentifierIsland tolerate s n, exp) with
+      match (Microsoft.FSharp.Compiler.QuickParse.GetCompleteIdentifierIsland tolerate s n, exp) with
       | (Some (s1, _, _), Some s2) -> 
         printfn "%s" "Received result, as expected."
         Assert.AreEqual (s1, s2)

--- a/vsintegration/tests/unittests/Tests.LanguageService.QuickParse.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.QuickParse.fs
@@ -21,37 +21,37 @@ type QuickParse() =
         
     [<Test>]
     member public qp.CheckGetPartialLongName() = 
-        let CheckAt(line,index,expected) = 
-            let actual = QuickParse.GetPartialLongNameEx(line,index)
-            if (actual.QualifyingIdents, actual.PartialIdent) <> expected then
+        let CheckAt(line, index, expected) = 
+            let actual = QuickParse.GetPartialLongNameEx(line, index)
+            if (actual.QualifyingIdents, actual.PartialIdent, actual.LastDotPos) <> expected then
                 failwithf "Expected %A but got %A" expected actual
             
         let Check(line,expected) = 
             CheckAt(line, line.Length-1, expected)
     
         do Microsoft.FSharp.Compiler.AbstractIL.Diagnostics.setDiagnosticsChannel(Some(Console.Out));
-        Check("let y = List.",(["List"], ""))
-        Check("let y = List.conc",(["List"], "conc"))
-        Check("let y = S", ([], "S"))
-        Check("S", ([], "S"))
-        Check("let y=", ([], ""))
-        Check("Console.Wr", (["Console"], "Wr"))
-        Check(" .", ([""], ""))
-        Check(".", ([""], ""))
-        Check("System.Console.Wr", (["System";"Console"],"Wr"))
-        Check("let y=f'", ([], "f'"))
-        Check("let y=SomeModule.f'", (["SomeModule"], "f'"))
-        Check("let y=Some.OtherModule.f'", (["Some";"OtherModule"], "f'"))
-        Check("let y=f'g", ([], "f'g"))
-        Check("let y=SomeModule.f'g", (["SomeModule"], "f'g"))
-        Check("let y=Some.OtherModule.f'g", (["Some";"OtherModule"], "f'g"))
-        Check("let y=FSharp.Data.File.``msft-prices.csv``", ([], ""))
-        Check("let y=FSharp.Data.File.``msft-prices.csv", (["FSharp";"Data";"File"], "msft-prices.csv"))
-        Check("let y=SomeModule.  f", (["SomeModule"], "f"))
-        Check("let y=SomeModule  .f", (["SomeModule"], "f"))
-        Check("let y=SomeModule  .  f", (["SomeModule"], "f"))
-        Check("let y=SomeModule  .", (["SomeModule"], ""))
-        Check("let y=SomeModule  .  ", (["SomeModule"], ""))
+        Check("let y = List.",(["List"], "", Some 12))
+        Check("let y = List.conc",(["List"], "conc", Some 12))
+        Check("let y = S", ([], "S", None))
+        Check("S", ([], "S", None))
+        Check("let y=", ([], "", None))
+        Check("Console.Wr", (["Console"], "Wr", Some 7))
+        Check(" .", ([""], "", Some 1))
+        Check(".", ([""], "", Some 0))
+        Check("System.Console.Wr", (["System";"Console"],"Wr", Some 14))
+        Check("let y=f'", ([], "f'", None))
+        Check("let y=SomeModule.f'", (["SomeModule"], "f'", Some 16))
+        Check("let y=Some.OtherModule.f'", (["Some";"OtherModule"], "f'", Some 22))
+        Check("let y=f'g", ([], "f'g", None))
+        Check("let y=SomeModule.f'g", (["SomeModule"], "f'g", Some 16))
+        Check("let y=Some.OtherModule.f'g", (["Some";"OtherModule"], "f'g", Some 22))
+        Check("let y=FSharp.Data.File.``msft-prices.csv``", ([], "", None))
+        Check("let y=FSharp.Data.File.``msft-prices.csv", (["FSharp";"Data";"File"], "msft-prices.csv", Some 22))
+        Check("let y=SomeModule.  f", (["SomeModule"], "f", Some 16))
+        Check("let y=SomeModule  .f", (["SomeModule"], "f", Some 18))
+        Check("let y=SomeModule  .  f", (["SomeModule"], "f", Some 18))
+        Check("let y=SomeModule  .", (["SomeModule"], "", Some 18))
+        Check("let y=SomeModule  .  ", (["SomeModule"], "", Some 18))
         
         
     [<Test>] 

--- a/vsintegration/tests/unittests/Tests.LanguageService.QuickParse.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.QuickParse.fs
@@ -3,9 +3,8 @@
 namespace Tests.LanguageService
 
 open System
-open System.IO
 open NUnit.Framework
-open Microsoft.VisualStudio.FSharp.LanguageService
+open Microsoft.FSharp.Compiler
 
 [<TestFixture>]
 [<Category "LanguageService">] 

--- a/vsintegration/tests/unittests/Tests.LanguageService.QuickParse.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.QuickParse.fs
@@ -24,7 +24,7 @@ type QuickParse() =
     member public qp.CheckGetPartialLongName() = 
         let CheckAt(line,index,expected) = 
             let actual = QuickParse.GetPartialLongNameEx(line,index)
-            if actual <> expected then
+            if (actual.QualifyingIdents, actual.PartialIdent) <> expected then
                 failwithf "Expected %A but got %A" expected actual
             
         let Check(line,expected) = 


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/3709

Was:

![image](https://user-images.githubusercontent.com/873919/31319460-703c6b7c-ac6c-11e7-9ef9-35c662f0860d.png)

Now:

![image](https://user-images.githubusercontent.com/873919/31319469-81670614-ac6c-11e7-9664-7e7083e77210.png)
