### PR TITLE
Breaking change in tuples after VS 15.4 update

### DIFF
--- a/tests/fsharpqa/Source/Conformance/PatternMatching/Tuple/UseItem1.fs
+++ b/tests/fsharpqa/Source/Conformance/PatternMatching/Tuple/UseItem1.fs
@@ -1,0 +1,15 @@
+// #Conformance #PatternMatching #Tuples 
+#light
+                      
+open System
+open System.Collections.Generic
+
+let f (items: IEnumerable<Tuple<int, string>>) =
+    items
+    |> Seq.iter (fun i -> printf "%d %s" i.Item1 i.Item2)
+    
+let x = seq { yield Tuple.Create(10, "ten") }
+
+f x
+
+exit 0

--- a/tests/fsharpqa/Source/Conformance/PatternMatching/Tuple/env.lst
+++ b/tests/fsharpqa/Source/Conformance/PatternMatching/Tuple/env.lst
@@ -1,5 +1,6 @@
 	SOURCE=tuples01.fs		# tuples01.fs
 	SOURCE=SimpleTuples01.fs	# SimpleTuples01.fs
+	SOURCE=UseItem1.fs	# UseItem1.fs
 	SOURCE=W_IncompleteMatches01.fs	# W_IncompleteMatches01.fs
 	SOURCE=W_RedundantPattern01.fs	# W_RedundantPattern01.fs
 	SOURCE=W_RedundantPattern02.fs	# W_RedundantPattern02.fs


### PR DESCRIPTION
With VS Update 15.3.5 we get:

![image](https://user-images.githubusercontent.com/57396/31435788-1cf76540-ae81-11e7-8a26-7a3b619259b8.png)


With VS Update 15.4 we see:

![image](https://user-images.githubusercontent.com/57396/31435781-16ab938c-ae81-11e7-8c8d-6212e2690e72.png)

/cc @mexx @drvink 