### PR TITLE
undo #3536

### DIFF
--- a/src/fsharp/LowerCallsAndSeqs.fs
+++ b/src/fsharp/LowerCallsAndSeqs.fs
@@ -394,6 +394,7 @@ let LowerSeqExpr g amap overallExpr =
             | None -> 
                 None
 
+(*
         | Expr.LetRec(binds,e2,m,_) 
               when  // Restriction: only limited forms of "let rec" in sequence expressions can be handled by assignment to state local values
 
@@ -422,7 +423,7 @@ let LowerSeqExpr g amap overallExpr =
                 Some res4
             | None -> 
                 None
-
+*)
         | Expr.Match (spBind,exprm,pt,targets,m,ty) when targets |> Array.forall (fun (TTarget(vs,_e,_spTarget)) -> isNil vs) ->
             // lower all the targets. abandon if any fail to lower
             let tgl = targets |> Array.map (fun (TTarget(_vs,e,_spTarget)) -> Lower false isTailCall noDisposeContinuationLabel currentDisposeContinuationLabel e) |> Array.toList

--- a/tests/fsharp/core/seq/test.fsx
+++ b/tests/fsharp/core/seq/test.fsx
@@ -701,6 +701,19 @@ module InfiniteSequenceExpressionsExecuteWithFiniteResources =
 // Tests disabled due to bug https://github.com/Microsoft/visualfsharp/issues/3743
 //InfiniteSequenceExpressionsExecuteWithFiniteResources.tests()
 
+    // This is the additional test case related to bug https://github.com/Microsoft/visualfsharp/issues/3743
+    let TestRecFuncInSeq() = 
+        let factorials =
+            [ for x in 0..10 do
+                let rec factorial x =
+                    match x with
+                    | 0 -> 1
+                    | x -> x * factorial(x - 1)
+                yield factorial x
+            ]
+
+        for f in factorials do printf "%i" f
+    TestRecFuncInSeq()
 
 (*---------------------------------------------------------------------------
 !* wrap up

--- a/tests/fsharp/core/seq/test.fsx
+++ b/tests/fsharp/core/seq/test.fsx
@@ -572,6 +572,7 @@ module InfiniteSequenceExpressionsExecuteWithFiniteResources =
             yield! seqThreeRecCapturingOne r
     }
 
+    //
     // These tests will stackoverflow or out-of-memory if the above functions are not compiled to "sequence epression tailcalls",
     // i.e. by compiling them to a state machine
     let tests() = 
@@ -697,7 +698,8 @@ module InfiniteSequenceExpressionsExecuteWithFiniteResources =
 
     *)
 
-InfiniteSequenceExpressionsExecuteWithFiniteResources.tests()
+// Tests disabled due to bug https://github.com/Microsoft/visualfsharp/issues/3743
+//InfiniteSequenceExpressionsExecuteWithFiniteResources.tests()
 
 
 (*---------------------------------------------------------------------------


### PR DESCRIPTION

@cartermp Bug https://github.com/Microsoft/visualfsharp/issues/3743 is a regression

This disables the optimization that causes the regression  https://github.com/Microsoft/visualfsharp/pull/3536.  The testing of the optimization was flawed, in particular the code https://github.com/Microsoft/visualfsharp/pull/3536/files#diff-ebddd0dd8ddd9195acef989b49ecfb67R542 has ``x > 0`` when it should have ``x = 0`` which means that the recursive calls were not being made in the tests.

We should prioritize this as much as possible, e.g. into 15.5 escrow if that's feasible

thanks
don
