### PR TITLE
undo #3536 (#3746)

### DIFF
--- a/src/fsharp/LowerCallsAndSeqs.fs
+++ b/src/fsharp/LowerCallsAndSeqs.fs
@@ -394,6 +394,7 @@ let LowerSeqExpr g amap overallExpr =
             | None -> 
                 None
 
+(*
         | Expr.LetRec(binds,e2,m,_) 
               when  // Restriction: only limited forms of "let rec" in sequence expressions can be handled by assignment to state local values
 
@@ -422,7 +423,7 @@ let LowerSeqExpr g amap overallExpr =
                 Some res4
             | None -> 
                 None
-
+*)
         | Expr.Match (spBind,exprm,pt,targets,m,ty) when targets |> Array.forall (fun (TTarget(vs,_e,_spTarget)) -> isNil vs) ->
             // lower all the targets. abandon if any fail to lower
             let tgl = targets |> Array.map (fun (TTarget(_vs,e,_spTarget)) -> Lower false isTailCall noDisposeContinuationLabel currentDisposeContinuationLabel e) |> Array.toList

--- a/tests/fsharp/core/seq/test.fsx
+++ b/tests/fsharp/core/seq/test.fsx
@@ -572,6 +572,7 @@ module InfiniteSequenceExpressionsExecuteWithFiniteResources =
             yield! seqThreeRecCapturingOne r
     }
 
+    //
     // These tests will stackoverflow or out-of-memory if the above functions are not compiled to "sequence epression tailcalls",
     // i.e. by compiling them to a state machine
     let tests() = 
@@ -697,8 +698,22 @@ module InfiniteSequenceExpressionsExecuteWithFiniteResources =
 
     *)
 
-InfiniteSequenceExpressionsExecuteWithFiniteResources.tests()
+// Tests disabled due to bug https://github.com/Microsoft/visualfsharp/issues/3743
+//InfiniteSequenceExpressionsExecuteWithFiniteResources.tests()
 
+    // This is the additional test case related to bug https://github.com/Microsoft/visualfsharp/issues/3743
+    let TestRecFuncInSeq() = 
+        let factorials =
+            [ for x in 0..10 do
+                let rec factorial x =
+                    match x with
+                    | 0 -> 1
+                    | x -> x * factorial(x - 1)
+                yield factorial x
+            ]
+
+        for f in factorials do printf "%i" f
+    TestRecFuncInSeq()
 
 (*---------------------------------------------------------------------------
 !* wrap up


### PR DESCRIPTION
* undo https://github.com/Microsoft/visualfsharp/pull/3536

* undo https://github.com/Microsoft/visualfsharp/pull/3536

This is the same as #3746, but into `vs2017-rtm`.

@dsyme @KevinRansom 