### PR TITLE
[Experimental] Try to get rid of array allocations in sprintf 

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -602,6 +602,27 @@ type AsyncModule() =
         Assert.AreEqual(0, !errCount)
 #endif
 
+
+    [<TestCase(10)>]
+    [<TestCase(100)>]
+    [<TestCase(1000)>]
+    [<TestCase(10000)>]
+    member this.``Async parallel sprintf should work`` n = 
+        let parallelS =
+            [| for i in 1..n do
+                  yield async { 
+                            let s = sprintf "%s %s" "hello" "world"
+                            return sprintf "%s %d" s i
+                        }  
+            |] 
+            |> Async.Parallel 
+            |> Async.RunSynchronously
+
+        let simpleS =
+            [| for i in 1..n -> "hello world " + i.ToString() |]
+
+        Assert.AreEqual(simpleS, parallelS)    
+
     [<Test>]
     member this.``Async caching should work``() = 
         let x = ref 0

--- a/src/fsharp/FSharp.Core/printf.fs
+++ b/src/fsharp/FSharp.Core/printf.fs
@@ -1270,7 +1270,7 @@ module internal PrintfImpl =
     
     let [<Literal>] MAX_BUILDER_SIZE = 360
     let [<Literal>] MIN_BUILDER_CAPACITY = 128
-    type StringBuilderCache() =
+    type StringBuilderCache =
         // The value 360 was chosen in discussion with performance experts as a compromise between using
         // as litle memory (per thread) as possible and still covering a large part of short-lived
         // StringBuilder creations on the startup path of VS designers.
@@ -1288,11 +1288,9 @@ module internal PrintfImpl =
                     sb.Clear() |> ignore
                     sb
                 else
-                    let capacity = max capacity MIN_BUILDER_CAPACITY
-                    new StringBuilder(capacity)
+                    new StringBuilder(max capacity MIN_BUILDER_CAPACITY)
             else
-                let capacity = max capacity MIN_BUILDER_CAPACITY
-                new StringBuilder(capacity)
+                new StringBuilder(max capacity MIN_BUILDER_CAPACITY)
  
         static member Release(sb:StringBuilder) =
             if sb.Capacity <= MAX_BUILDER_SIZE then

--- a/src/fsharp/FSharp.Core/printf.fs
+++ b/src/fsharp/FSharp.Core/printf.fs
@@ -1281,16 +1281,12 @@ module internal PrintfImpl =
         static member Acquire(capacity) =
             if capacity <= MAX_BUILDER_SIZE then
                 let sb = StringBuilderCache.CachedInstance
-                if not (isNull sb) then
+                if not (isNull sb) && capacity <= sb.Capacity then
                     // Avoid stringbuilder block fragmentation by getting a new StringBuilder
                     // when the requested size is larger than the current capacity
-                    if capacity <= sb.Capacity then
-                        StringBuilderCache.CachedInstance <- null
-                        sb.Clear() |> ignore
-                        sb
-                    else
-                       let capacity = max capacity MIN_BUILDER_CAPACITY
-                       new StringBuilder(capacity)
+                    StringBuilderCache.CachedInstance <- null
+                    sb.Clear() |> ignore
+                    sb
                 else
                     let capacity = max capacity MIN_BUILDER_CAPACITY
                     new StringBuilder(capacity)

--- a/src/fsharp/FSharp.Core/printf.fs
+++ b/src/fsharp/FSharp.Core/printf.fs
@@ -1312,7 +1312,8 @@ module internal PrintfImpl =
         override __.Write(s : string) = 
             sb.Append s |> ignore
 
-        override this.WriteT(s) = this.Write s
+        override this.WriteT(s) = 
+            sb.Append s |> ignore
 
     type StringBuilderPrintfEnv<'Result>(k, buf) = 
         inherit PrintfEnv<Text.StringBuilder, unit, 'Result>(buf)

--- a/src/fsharp/FSharp.Core/printf.fs
+++ b/src/fsharp/FSharp.Core/printf.fs
@@ -1269,6 +1269,7 @@ module internal PrintfImpl =
                 v
     
     let [<Literal>] MAX_BUILDER_SIZE = 360
+    let [<Literal>] MIN_BUILDER_CAPACITY = 128
     type StringBuilderCache() =
         // The value 360 was chosen in discussion with performance experts as a compromise between using
         // as litle memory (per thread) as possible and still covering a large part of short-lived
@@ -1288,10 +1289,13 @@ module internal PrintfImpl =
                         sb.Clear() |> ignore
                         sb
                     else
+                       let capacity = max capacity MIN_BUILDER_CAPACITY
                        new StringBuilder(capacity)
                 else
+                    let capacity = max capacity MIN_BUILDER_CAPACITY
                     new StringBuilder(capacity)
             else
+                let capacity = max capacity MIN_BUILDER_CAPACITY
                 new StringBuilder(capacity)
  
         static member Release(sb:StringBuilder) =

--- a/src/fsharp/FSharp.Core/printf.fs
+++ b/src/fsharp/FSharp.Core/printf.fs
@@ -1290,7 +1290,7 @@ module internal PrintfImpl =
                 else
                     new StringBuilder(max capacity MIN_BUILDER_CAPACITY)
             else
-                new StringBuilder(max capacity MIN_BUILDER_CAPACITY)
+                new StringBuilder(capacity)
  
         static member Release(sb:StringBuilder) =
             if sb.Capacity <= MAX_BUILDER_SIZE then

--- a/src/fsharp/FSharp.Core/printf.fs
+++ b/src/fsharp/FSharp.Core/printf.fs
@@ -1286,7 +1286,11 @@ module internal PrintfImpl =
                     if capacity <= sb.Capacity then
                         StringBuilderCache.CachedInstance <- null
                         sb.Clear() |> ignore
-                sb
+                        sb
+                    else
+                       new StringBuilder(capacity)
+                else
+                    new StringBuilder(capacity)
             else
                 new StringBuilder(capacity)
  

--- a/src/fsharp/FSharp.Core/printf.fs
+++ b/src/fsharp/FSharp.Core/printf.fs
@@ -1286,11 +1286,7 @@ module internal PrintfImpl =
                     if capacity <= sb.Capacity then
                         StringBuilderCache.CachedInstance <- null
                         sb.Clear() |> ignore
-                        sb
-                    else
-                        new StringBuilder(capacity)
-                else
-                    new StringBuilder(capacity)
+                sb
             else
                 new StringBuilder(capacity)
  


### PR DESCRIPTION
* Currently every call to sprintf allocates an array and the calls Strin.Concat on the array
* String.Concat uses [StringBuilderCache](https://referencesource.microsoft.com/#mscorlib/system/string.cs,17dc4061ffe63730) to reduce StringBuilder allocations

StringBuilderCache is thread static singleton. I hope it's proper F# version of it

==> Let's try to do that directly an safe allocations