### PR TITLE
[WIP] Fix inlline rename at end of file

### DIFF
--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -4,7 +4,6 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
 open System.Composition
-open System.Collections.Generic
 open System.Linq
 open System.Threading
 open System.Threading.Tasks
@@ -29,44 +28,43 @@ type internal FailureInlineRenameInfo private () =
         member __.DisplayName = ""
         member __.FullDisplayName = ""
         member __.Glyph = Glyph.MethodPublic
-        member __.GetFinalSymbolName _replacementText = ""
-        member __.GetReferenceEditSpan(_location, _cancellationToken) = Unchecked.defaultof<_>
-        member __.GetConflictEditSpan(_location, _replacementText, _cancellationToken) = Nullable()
-        member __.FindRenameLocationsAsync(_optionSet, _cancellationToken) = Task<IInlineRenameLocationSet>.FromResult null
-        member __.TryOnBeforeGlobalSymbolRenamed(_workspace, _changedDocumentIDs, _replacementText) = false
-        member __.TryOnAfterGlobalSymbolRenamed(_workspace, _changedDocumentIDs, _replacementText) = false
+        member __.GetFinalSymbolName _ = ""
+        member __.GetReferenceEditSpan(_, _) = Unchecked.defaultof<_>
+        member __.GetConflictEditSpan(_, _, _) = Nullable()
+        member __.FindRenameLocationsAsync(_, _) = Task<IInlineRenameLocationSet>.FromResult null
+        member __.TryOnBeforeGlobalSymbolRenamed(_, _, _) = false
+        member __.TryOnAfterGlobalSymbolRenamed(_, _, _) = false
     static member Instance = FailureInlineRenameInfo() :> IInlineRenameInfo
 
-type internal DocumentLocations =
-    { Document: Document
-      Locations: InlineRenameLocation [] }
-
-type internal InlineRenameLocationSet(locationsByDocument: DocumentLocations [], originalSolution: Solution, symbolKind: LexerSymbolKind, symbol: FSharpSymbol) =
+type internal InlineRenameLocationSet(locations: InlineRenameLocation [], originalSolution: Solution, symbolKind: LexerSymbolKind, symbol: FSharpSymbol) =
     interface IInlineRenameLocationSet with
-        member __.Locations : IList<InlineRenameLocation> =
-            upcast [| for doc in locationsByDocument do yield! doc.Locations |].ToList()
+        member __.Locations = upcast locations.ToList()
         
-        member this.GetReplacementsAsync(replacementText, _optionSet, cancellationToken) : Task<IInlineRenameReplacementInfo> =
-            let rec applyChanges i (solution: Solution) =
+        member __.GetReplacementsAsync(replacementText, _optionSet, cancellationToken) : Task<IInlineRenameReplacementInfo> =
+            let rec applyChanges (solution: Solution) (locationsByDocument: (Document * InlineRenameLocation list) list) =
                 async {
-                    if i = locationsByDocument.Length then 
-                        return solution
-                    else
-                        let doc = locationsByDocument.[i]
-                        let! oldSourceText = doc.Document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                        let changes = doc.Locations |> Seq.map (fun loc -> TextChange(loc.TextSpan, replacementText))
-                        let newSource = oldSourceText.WithChanges(changes)
-                        return! applyChanges (i + 1) (solution.WithDocumentText(doc.Document.Id, newSource))
+                    match locationsByDocument with
+                    | [] -> return solution
+                    | (document, locations) :: rest ->
+                        let! oldSource = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
+                        let newSource = oldSource.WithChanges(locations |> List.map (fun l -> TextChange(l.TextSpan, replacementText)))
+                        return! applyChanges (solution.WithDocumentText(document.Id, newSource)) rest
                 }
         
             async {
-                let! newSolution = applyChanges 0 originalSolution
+                let! newSolution = applyChanges originalSolution (locations |> Array.toList |> List.groupBy (fun x -> x.Document))
+                // > debug
+                let newDoc = newSolution.GetDocument(locations.[0].Document.Id)
+                let! newSource = newDoc.GetTextAsync(cancellationToken) |> Async.AwaitTask
+                let newText = newSource.ToString()
+                let _ = newText
+                // < debug
                 return 
                     { new IInlineRenameReplacementInfo with
                         member __.NewSolution = newSolution
                         member __.ReplacementTextValid = Tokenizer.isValidNameForSymbol(symbolKind, symbol, replacementText)
-                        member __.DocumentIds = locationsByDocument |> Seq.map (fun doc -> doc.Document.Id)
-                        member __.GetReplacements(documentId) = Seq.empty }
+                        member __.DocumentIds = locations |> Seq.map (fun doc -> doc.Document.Id) |> Seq.distinct
+                        member __.GetReplacements _ = Seq.empty }
             }
             |> RoslynHelpers.StartAsyncAsTask(cancellationToken)
 
@@ -98,7 +96,7 @@ type internal InlineRenameInfo
         member __.LocalizedErrorMessage = null
         member __.TriggerSpan = triggerSpan
         member __.HasOverloads = false
-        member __.ForceRenameOverloads = true
+        member __.ForceRenameOverloads = false
         member __.DisplayName = symbolUse.Symbol.DisplayName
         member __.FullDisplayName = try symbolUse.Symbol.FullName with _ -> symbolUse.Symbol.DisplayName
         member __.Glyph = Glyph.MethodPublic
@@ -108,30 +106,34 @@ type internal InlineRenameInfo
             let text = getDocumentText location.Document cancellationToken
             Tokenizer.fixupSpan(text, location.TextSpan)
         
-        member __.GetConflictEditSpan(location, _replacementText, _cancellationToken) = Nullable(location.TextSpan)
+        member __.GetConflictEditSpan(location, replacementText, cancellationToken) = 
+            let text = getDocumentText location.Document cancellationToken
+            let spanText = text.ToString(location.TextSpan)
+            let position = spanText.LastIndexOf(replacementText, StringComparison.Ordinal)
+            if position < 0 then Nullable()
+            else Nullable(TextSpan(location.TextSpan.Start + position, replacementText.Length))
         
         member __.FindRenameLocationsAsync(_optionSet, cancellationToken) =
             async {
                 let! symbolUsesByDocumentId = symbolUses
-                let! locationsByDocument =
+                let! locations =
                     symbolUsesByDocumentId
                     |> Seq.map (fun (KeyValue(documentId, symbolUses)) ->
                         async {
                             let document = document.Project.Solution.GetDocument(documentId)
-                            let! cancellationToken = Async.CancellationToken
                             let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                            let locations =
-                                symbolUses
-                                |> Array.choose (fun symbolUse ->
-                                    RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, symbolUse.RangeAlternate) 
-                                    |> Option.map (fun span -> 
-                                        let textSpan = Tokenizer.fixupSpan(sourceText, span)
-                                        InlineRenameLocation(document, textSpan)))
-
-                            return { Document = document; Locations = locations }
+                            return 
+                                [| for symbolUse in symbolUses do
+                                     match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, symbolUse.RangeAlternate) with
+                                     | Some span ->
+                                         let textSpan = Tokenizer.fixupSpan(sourceText, span)
+                                         yield InlineRenameLocation(document, textSpan) 
+                                     | None -> () |]
                         })
                     |> Async.Parallel
-                return InlineRenameLocationSet(locationsByDocument, document.Project.Solution, lexerSymbol.Kind, symbolUse.Symbol) :> IInlineRenameLocationSet
+                    |> Async.map Array.concat
+
+                return InlineRenameLocationSet(locations, document.Project.Solution, lexerSymbol.Kind, symbolUse.Symbol) :> IInlineRenameLocationSet
             } |> RoslynHelpers.StartAsyncAsTask(cancellationToken)
         
         member __.TryOnBeforeGlobalSymbolRenamed(_workspace, _changedDocumentIDs, _replacementText) = true

--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -144,8 +144,7 @@ type internal InlineRenameService
     [<ImportingConstructor>]
     (
         projectInfoManager: FSharpProjectOptionsManager,
-        checkerProvider: FSharpCheckerProvider,
-        [<ImportMany>] _refactorNotifyServices: seq<IRefactorNotifyService>
+        checkerProvider: FSharpCheckerProvider
     ) =
 
     static let userOpName = "InlineRename"

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -67,16 +67,8 @@ module internal SymbolHelpers =
                     |> Async.Parallel
                     |> Async.map Array.concat
             
-            let declarationLength = 
-                symbol.DeclarationLocation
-                |> Option.map (fun m -> m.EndColumn - m.StartColumn)
-
             return
                 (symbolUses
-                 |> Seq.filter (fun su -> 
-                     match declarationLength with
-                     | Some declLength -> su.RangeAlternate.EndColumn - su.RangeAlternate.StartColumn = declLength
-                     | None -> true)
                  |> Seq.collect (fun symbolUse -> 
                       solution.GetDocumentIdsWithFilePath(symbolUse.FileName) |> Seq.map (fun id -> id, symbolUse))
                  |> Seq.groupBy fst


### PR DESCRIPTION
This is how the editor looks (the bug):

![image](https://user-images.githubusercontent.com/873919/31681005-a548308a-b37e-11e7-939c-d116bdbdff60.png)

This is how the preview looks (OK):

![image](https://user-images.githubusercontent.com/873919/31681066-cde4bebe-b37e-11e7-988a-784deb691b34.png)

This is new document text in the debugger (OK):

![image](https://user-images.githubusercontent.com/873919/31680914-6a9f319a-b37e-11e7-960a-3d183dc5a6c6.png)

The renaming works correctly as well (I mean it changes the document properly after committing).

So the only place where we have bad behavior is the green spans. 

@Pilchie @dsyme Maybe it helps to narrow areas where the bug can sit? Thanks.