### PR TITLE
install templates VSIX to a unique directory

### DIFF
--- a/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
+++ b/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
@@ -35,7 +35,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <IsProductComponent>true</IsProductComponent>
     <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
-    <ExtensionInstallationFolder>Microsoft\FSharp</ExtensionInstallationFolder>
+    <ExtensionInstallationFolder>Microsoft\FSharpTemplates</ExtensionInstallationFolder>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>


### PR DESCRIPTION
Install the templates extension into a unique directory to prevent overwriting of `extension.vsixmanifest`.

Fixes #3799.