### PR TITLE
Work around corecompile.cache bugs

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -328,6 +328,48 @@ this file.
             ============================================================
         -->
 
+    <!--
+    ============================================================
+    Override _GenerateCompileDependencyCache
+
+    Workaround for Issue #3824 and #3739
+
+    MsBuild does some optimisations around CompileInputs
+    The project system erroneously uses this to determine whether 
+    to notify language services of CommandLine Information changes.
+    C# accidently changes it's file lists every build ... and so 
+    gets the notifications.
+    F# doesn't ... so we don't get CL notifications following rebuilds
+    or build.
+    This workaround is basically to adds the current time (in ticks) 
+    into the hash of CoreCompileInputs.cache at design time so that 
+    we always appear to have different options and overcome the
+    brokencache behaviour.
+    
+    Both msbuild and the project-system will fix their code at which time
+    this can go away.
+
+    ============================================================
+    -->
+    <Target Name="_GenerateCompileDependencyCache" DependsOnTargets="ResolveAssemblyReferences" Condition="'$(DesignTimeBuild)' == 'true'">
+        <ItemGroup>
+          <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
+          <CoreCompileCache Remove="@(Compile)" />
+          <CoreCompileCache Include="@(ReferencePath)" />
+          <CoreCompileCache Include="$([System.DateTime]::Now.Ticks)" />
+        </ItemGroup>
+
+        <Hash ItemsToHash="@(CoreCompileCache)">
+          <Output TaskParameter="HashResult" PropertyName="CoreCompileDependencyHash" />
+        </Hash>
+
+        <WriteLinesToFile Lines="$(CoreCompileDependencyHash)" File="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
+
+        <ItemGroup>
+          <FileWrites Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
+        </ItemGroup>
+    </Target>
+
     <Target Name="GenerateTargetFrameworkMonikerAttribute" BeforeTargets="BeforeCompile" DependsOnTargets="PrepareForBuild;GetReferenceAssemblyPaths" Inputs="$(MSBuildThisFileFullPath)" Outputs="$(TargetFrameworkMonikerAssemblyAttributesPath)" Condition="'$(GenerateTargetFrameworkAttribute)' == 'true'">
 
         <PropertyGroup>


### PR DESCRIPTION
Fixes  #3824 and #3739 

This is a work around for issues #3824 and #3739.  This is due to bugs in the project system and msbuild around caching command line options.

The fix is to ensure the hash includes a different file every time, so the caching doesn't actually achieve it's intended goal.
