### PR TITLE
Fix completion after double dot in non-auto mode

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -34,7 +34,6 @@ type internal FSharpCompletionProvider
     inherit CompletionProvider()
 
     static let userOpName = "CompletionProvider"
-    static let completionTriggers = [| '.' |]
     static let declarationItemsCache = ConditionalWeakTable<string, FSharpDeclarationListItem>()
     static let [<Literal>] NameInCodePropName = "NameInCode"
     static let [<Literal>] FullNamePropName = "FullName"
@@ -87,12 +86,12 @@ type internal FSharpCompletionProvider
             let triggerPosition = caretPosition - 1
             let c = sourceText.[triggerPosition]
             
-            if completionTriggers |> Array.contains c then
-                true
-            
             // do not trigger completion if it's not single dot, i.e. range expression
-            elif triggerPosition > 0 && sourceText.[triggerPosition - 1] = '.' then
+            if not Settings.IntelliSense.ShowAfterCharIsTyped && sourceText.[triggerPosition - 1] = '.' then
                 false
+            
+            elif c = '.' then
+                true
             
             // Trigger completion if we are on a valid classification type
             else


### PR DESCRIPTION
It still auto pop up after first dot:

![1](https://user-images.githubusercontent.com/873919/32185632-d397b1d6-bdb0-11e7-9bdb-ac3d59828ae5.gif)
