### PR TITLE
don't run tests if the `PB_SKIPTESTS` variable is set to true

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -389,6 +389,17 @@ REM ------------------ Report config -----------------------
 
 REM after this point, ARG variable should not be used, use only BUILD_* or TEST_*
 
+REM if the `PB_SKIPTESTS` variable is set to 'true' then no tests should be built or run, even if explicitly specified
+if /i "%PB_SKIPTESTS%" == "true" (
+    set TEST_NET40_COMPILERUNIT_SUITE=0
+    set TEST_NET40_COREUNIT_SUITE=0
+    set TEST_NET40_FSHARP_SUITE=0
+    set TEST_NET40_FSHARPQA_SUITE=0
+    set TEST_CORECLR_COREUNIT_SUITE=0
+    set TEST_CORECLR_FSHARP_SUITE=0
+    set TEST_VS_IDEUNIT_SUITE=0
+)
+
 echo Build/Tests configuration:
 echo.
 echo BUILD_PROTO=%BUILD_PROTO%
@@ -404,6 +415,7 @@ echo BUILD_NUGET=%BUILD_NUGET%
 echo BUILD_CONFIG=%BUILD_CONFIG%
 echo BUILD_PUBLICSIGN=%BUILD_PUBLICSIGN%
 echo.
+echo PB_SKIPTESTS=%PB_SKIPTESTS%
 echo TEST_NET40_COMPILERUNIT_SUITE=%TEST_NET40_COMPILERUNIT_SUITE%
 echo TEST_NET40_COREUNIT_SUITE=%TEST_NET40_COREUNIT_SUITE%
 echo TEST_NET40_FSHARP_SUITE=%TEST_NET40_FSHARP_SUITE%

--- a/build.sh
+++ b/build.sh
@@ -350,6 +350,18 @@ if [ $_autoselect_tests -eq 1 ]; then
     fi
 fi
 
+# If the `PB_SKIPTESTS` variable is set to 'true' then no tests should be built or run, even if explicitly specified
+if [ $PB_SKIPTESTS -eq "true" ]; then
+    export TEST_NET40_COMPILERUNIT_SUITE=0
+    export TEST_NET40_COREUNIT_SUITE=0
+    export TEST_NET40_FSHARP_SUITE=0
+    export TEST_NET40_FSHARPQA_SUITE=0
+    export TEST_CORECLR_COREUNIT_SUITE=0
+    export TEST_CORECLR_FSHARP_SUITE=0
+    export TEST_PORTABLE_COREUNIT_SUITE=0
+    export TEST_VS_IDEUNIT_SUITE=0
+fi
+
 #
 # Report config
 #
@@ -367,6 +379,7 @@ printf "BUILD_SETUP=%s\n" "$BUILD_SETUP"
 printf "BUILD_CONFIG=%s\n" "$BUILD_CONFIG"
 printf "BUILD_PUBLICSIGN=%s\n" "$BUILD_PUBLICSIGN"
 printf "\n"
+printf "PB_SKIPTESTS=%s\n" "$PB_SKIPTESTS"
 printf "TEST_NET40_COMPILERUNIT_SUITE=%s\n" "$TEST_NET40_COMPILERUNIT_SUITE"
 printf "TEST_NET40_COREUNIT_SUITE=%s\n" "$TEST_NET40_COREUNIT_SUITE"
 printf "TEST_NET40_FSHARP_SUITE=%s\n" "$TEST_NET40_FSHARP_SUITE"


### PR DESCRIPTION
This is part of a larger division-wide effort at making certain parts of our build API consistent.

All of the `TEST_*` variables control test building/running either further down in `build.cmd/sh` or through [`build-everything.proj`](https://github.com/Microsoft/visualfsharp/blob/master/build-everything.proj).

For @mmitche, our official internal build is simply invoked via `build.cmd microbuild`, hence consuming `PB_SkipTests` as an environment variable instead of an MSBuild property.