### PR TITLE
skip publishing packages unless the variable `PB_PUBLISHTYPE` is set to `myget`

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -389,6 +389,8 @@ REM ------------------ Report config -----------------------
 
 REM after this point, ARG variable should not be used, use only BUILD_* or TEST_*
 
+REM all PB_* variables override any settings
+
 REM if the `PB_SKIPTESTS` variable is set to 'true' then no tests should be built or run, even if explicitly specified
 if /i "%PB_SKIPTESTS%" == "true" (
     set TEST_NET40_COMPILERUNIT_SUITE=0
@@ -398,6 +400,12 @@ if /i "%PB_SKIPTESTS%" == "true" (
     set TEST_CORECLR_COREUNIT_SUITE=0
     set TEST_CORECLR_FSHARP_SUITE=0
     set TEST_VS_IDEUNIT_SUITE=0
+)
+
+REM MyGet packages published as part of the build are only for nightly dogfooding, so any other value means publishing should be skipped
+REM   The official build definition sets PB_PUBLISHTYPE to "myget" by default.
+if /i not "%PB_PUBLISHTYPE%" == "myget" (
+    set PUBLISH_VSIX=0
 )
 
 echo Build/Tests configuration:
@@ -416,6 +424,8 @@ echo BUILD_CONFIG=%BUILD_CONFIG%
 echo BUILD_PUBLICSIGN=%BUILD_PUBLICSIGN%
 echo.
 echo PB_SKIPTESTS=%PB_SKIPTESTS%
+echo PB_PUBLISHTYPE=%PB_PUBLISHTYPE%
+echo.
 echo TEST_NET40_COMPILERUNIT_SUITE=%TEST_NET40_COMPILERUNIT_SUITE%
 echo TEST_NET40_COREUNIT_SUITE=%TEST_NET40_COREUNIT_SUITE%
 echo TEST_NET40_FSHARP_SUITE=%TEST_NET40_FSHARP_SUITE%


### PR DESCRIPTION
More of the internal division-wide push to standardize a build API, this time to only allow package publishing if the `%PB_PUBLISHTYPE%` variable is set to `myget`.

@mmitche Same comment in #3847 applies; our build is invoked via the command `build.cmd microbuild` so I'm consuming the environment variables directly.