### PR TITLE
[WIP] fix attribute parsing

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -3384,10 +3384,10 @@ let decodeILAttribData (ilg: ILGlobals) (ca: ILAttribute) =
           let n,sigptr = sigptr_get_i32 bytes sigptr
           if n = 0xFFFFFFFF then ILAttribElem.Null,sigptr else
           let rec parseElems acc n sigptr = 
-            if n = 0 then List.rev acc else
+            if n = 0 then List.rev acc, sigptr else
             let v,sigptr = parseVal elemTy sigptr
             parseElems (v ::acc) (n-1) sigptr
-          let elems = parseElems [] n sigptr
+          let elems, sigptr = parseElems [] n sigptr 
           ILAttribElem.Array(elemTy,elems), sigptr
       | ILType.Value _ ->  (* assume it is an enumeration *)
           let n,sigptr = sigptr_get_i32 bytes sigptr
@@ -3409,7 +3409,7 @@ let decodeILAttribData (ilg: ILGlobals) (ca: ILAttribute) =
       let et,sigptr = sigptr_get_u8 bytes sigptr
       // We have a named value 
       let ty,sigptr = 
-        if (0x50 = (int et) || 0x55 = (int et)) then
+        if ( (* 0x50 = (int et) || *) 0x55 = (int et)) then
             let qualified_tname,sigptr = sigptr_get_serstring bytes sigptr
             let unqualified_tname, rest = 
                 let pieces = qualified_tname.Split(',')


### PR DESCRIPTION
While working on the type provider SDK I noticed two places where the Abstract IL binary reader used by the F# compiler has incorrect code when reading custom attributes from binaries, e.g. when arrays of values or some other less common constructs are used.

We should add some test cases for these before accepting this PR, e.g. by parsing all the attributes in all assemblies in the .NET Framework (in both cases the problem caused a total failure in attribute parsing, so simply checking attribute parsing succeeds should be enough)