### PR TITLE
enable publishing NuGet packages to an Azure Blob feed

### DIFF
--- a/PublishToBlob.proj
+++ b/PublishToBlob.proj
@@ -1,0 +1,29 @@
+<Project>
+
+  <!--
+
+  This is for the internal orchestrated build scenarios and will likely never be run on a
+  developer's machine.  The official build definition builds this file directly.
+
+  -->
+
+  <PropertyGroup>
+    <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
+    <!-- This version should be kept in sync with `packages.config` -->
+    <FeedTasksPackageVersion>1.0.0-prerelease-02121-01</FeedTasksPackageVersion>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)packages\$(FeedTasksPackage).$(FeedTasksPackageVersion)\build\$(FeedTasksPackage).targets" />
+
+  <ItemGroup>
+    <ItemsToPush Include="$(MSBuildThisFileDirectory)artifacts\**\*.nupkg" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(ItemsToPush)"
+                    Overwrite="$(PublishOverwrite)" />
+  </Target>
+
+</Project>

--- a/packages.config
+++ b/packages.config
@@ -11,6 +11,9 @@
   <package id="MicroBuild.Core" version="0.2.0" />
   <package id="MicroBuild.Core.Sentinel" version="1.0.0" />
 
+  <!-- For the internal orchestrated build.  This version should be kept in sync with `PublishToBlob.proj` -->
+  <package id="Microsoft.DotNet.Build.Tasks.Feed" version="1.0.0-prerelease-02121-01" />
+
   <!-- Actual dependencies of FSharp.Compiler.dll and FSharp.Core.dll -->
   <package id="System.Collections.Immutable" version="1.3.1" />
   <package id="System.Reflection.Metadata" version="1.4.2" />


### PR DESCRIPTION
This file will only ever be build in the official build definition when the publish type is set to `blob`.

It is built with `/p:ExpectedFeedUrl=$(PB_AzureFeedUrl) /p:AccountKey=$(PB_PublishAccontKey)`.

@mmitche for review.