### PR TITLE
enable additional NuGet restore sources to be passed in

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -570,18 +570,24 @@ if "%RestorePackages%" == "true" (
     cd..
     @if ERRORLEVEL 1 echo Error: Paket restore failed  && goto :failure
 
-    %_ngenexe% install %_nugetexe%  /nologo 
+    %_ngenexe% install %_nugetexe%  /nologo
+    set _nugetoptions=-PackagesDirectory packages -ConfigFile %_nugetconfig%
+    if not "%PB_RESTORESOURCE%" == "" (
+        set _nugetoptions=!_nugetoptions! -Source %PB_RESTORESOURCE%
+    )
 
-    %_nugetexe% restore packages.config -PackagesDirectory packages -ConfigFile %_nugetconfig%
+    echo _nugetoptions=!_nugetoptions!
+
+    %_nugetexe% restore packages.config !_nugetoptions!
     @if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
 
     if "%BUILD_VS%" == "1" (
-        %_nugetexe% restore vsintegration\packages.config -PackagesDirectory packages -ConfigFile %_nugetconfig%
+        %_nugetexe% restore vsintegration\packages.config !_nugetoptions!
         @if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
     )
 
     if "%BUILD_SETUP%" == "1" (
-        %_nugetexe% restore setup\packages.config -PackagesDirectory packages -ConfigFile %_nugetconfig%
+        %_nugetexe% restore setup\packages.config !_nugetoptions!
         @if ERRORLEVEL 1 echo Error: Nuget restore failed  && goto :failure
     )
 )

--- a/build.sh
+++ b/build.sh
@@ -432,21 +432,26 @@ if [ "${RestorePackages:-true}" = 'true' ]; then
     if [ $exit_code -ne 0 ]; then
         exit $exit_code
     fi
-    
-    eval "$_nugetexe restore packages.config -PackagesDirectory packages -ConfigFile $_nugetconfig"
+
+    _nugetoptions="-PackagesDirectory packages -ConfigFile $_nugetconfig"
+    if [ "$PB_RESTORESOURCE" != "" ]; then
+        _nugetoptions="$_nugetoptions -Source $PB_RESTORESOURCE"
+    fi
+
+    eval "$_nugetexe restore packages.config $_nugetoptions"
     if [ $? -ne 0 ]; then
         failwith "Nuget restore failed"
     fi
 
     if [ "$BUILD_VS" = '1' ]; then
-        eval "$_nugetexe restore vsintegration/packages.config -PackagesDirectory packages -ConfigFile $_nugetconfig"
+        eval "$_nugetexe restore vsintegration/packages.config $_nugetoptions"
         if [ $? -ne 0 ]; then
             failwith "Nuget restore failed"
         fi
     fi
 
     if [ "$BUILD_SETUP" = '1' ]; then
-        eval "$_nugetexe restore setup/packages.config -PackagesDirectory packages -ConfigFile $_nugetconfig"
+        eval "$_nugetexe restore setup/packages.config $_nugetoptions"
         if [ $? -ne 0 ]; then
             failwith "Nuget restore failed"
         fi


### PR DESCRIPTION
As part of the higher orchestrated build movement, we need to honor the environment variable `%PB_RESTORESOURCE%` when doing NuGet package restores.

@mmitche