### PR TITLE
Revert "use a stable up-to-date version of MSBuild"

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -484,7 +484,43 @@ if "%RestorePackages%"=="" (
 
 @call src\update.cmd signonly
 
-set _msbuildexe=%~dp0packages\RoslynTools.MSBuild.0.4.0-alpha\tools\msbuild\MSBuild.exe
+:: Check prerequisites
+if not "%VisualStudioVersion%" == "" goto vsversionset
+if exist "%VS150COMNTOOLS%\..\ide\devenv.exe" set VisualStudioVersion=15.0
+if not "%VisualStudioVersion%" == "" goto vsversionset
+
+if not "%VisualStudioVersion%" == "" goto vsversionset
+if exist "%VS150COMNTOOLS%\..\..\ide\devenv.exe" set VisualStudioVersion=15.0
+if not "%VisualStudioVersion%" == "" goto vsversionset
+
+if exist "%VS140COMNTOOLS%\..\ide\devenv.exe" set VisualStudioVersion=14.0
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
+if exist "%ProgramFiles%\Microsoft Visual Studio 14.0\common7\ide\devenv.exe" set VisualStudioVersion=14.0
+if not "%VisualStudioVersion%" == "" goto vsversionset
+
+if exist "%VS120COMNTOOLS%\..\ide\devenv.exe" set VisualStudioVersion=12.0
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
+if exist "%ProgramFiles%\Microsoft Visual Studio 12.0\common7\ide\devenv.exe" set VisualStudioVersion=12.0
+
+:vsversionset
+if "%VisualStudioVersion%" == "" echo Error: Could not find an installation of Visual Studio && goto :failure
+
+if exist "%VS150COMNTOOLS%\..\..\MSBuild\15.0\Bin\MSBuild.exe" (
+    set _msbuildexe="%VS150COMNTOOLS%\..\..\MSBuild\15.0\Bin\MSBuild.exe"
+    goto :havemsbuild
+)
+if exist "%ProgramFiles(x86)%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe" (
+    set _msbuildexe="%ProgramFiles(x86)%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe"
+    goto :havemsbuild
+)
+if exist "%ProgramFiles%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe" (
+    set _msbuildexe="%ProgramFiles%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe"
+    goto :havemsbuild
+)
+echo Error: Could not find MSBuild.exe. && goto :failure
+goto :eof
+
+:havemsbuild
 set _nrswitch=/nr:false
 
 :: See <http://www.appveyor.com/docs/environment-variables>

--- a/packages.config
+++ b/packages.config
@@ -10,7 +10,6 @@
   <!-- Build infrastructure-->
   <package id="MicroBuild.Core" version="0.2.0" />
   <package id="MicroBuild.Core.Sentinel" version="1.0.0" />
-  <package id="RoslynTools.MSBuild" version="0.4.0-alpha" />
 
   <!-- For the internal orchestrated build.  This version should be kept in sync with `PublishToBlob.proj` -->
   <package id="Microsoft.DotNet.Build.Tasks.Feed" version="1.0.0-prerelease-02121-01" />


### PR DESCRIPTION
This reverts commit 6b4a0bd74fd22be50bded5b17dab5a4ea1e9593f.

This original change doesn't build successfully on any of my machines, on Monday, @brettfo and I will look at whether it's needed.
