### PR TITLE
Do not trim error ranges

### DIFF
--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -361,7 +361,7 @@ csCtorHasNoArgumentOrReturnProperty,"The object constructor '%s' has no argument
 csNoOverloadsFound,"No overloads match for method '%s'."
 csMethodIsOverloaded,"A unique overload for method '%s' could not be determined based on type information prior to this program point. A type annotation may be needed."
 csCandidates,"Candidates: %s"
-csSeeAvailableOverloads,"The available overloads are shown below (or in the Error List window)."
+csSeeAvailableOverloads,"The available overloads are shown below."
 512,parsDoCannotHaveVisibilityDeclarations,"Accessibility modifiers are not permitted on 'do' bindings, but '%s' was given."
 513,parsEofInHashIf,"End of file in #if section begun at or after here"
 514,parsEofInString,"End of file in string begun at or before here"

--- a/src/fsharp/symbols/SymbolHelpers.fsi
+++ b/src/fsharp/symbols/SymbolHelpers.fsi
@@ -46,8 +46,8 @@ type internal FSharpErrorInfo =
     member Message:string
     member Subcategory:string
     member ErrorNumber:int
-    static member internal CreateFromExceptionAndAdjustEof : PhasedDiagnostic * isError: bool * trim: bool * range * lastPosInFile:(int*int) -> FSharpErrorInfo
-    static member internal CreateFromException : PhasedDiagnostic * isError: bool * trim: bool * range -> FSharpErrorInfo
+    static member internal CreateFromExceptionAndAdjustEof : PhasedDiagnostic * isError: bool * range * lastPosInFile:(int*int) -> FSharpErrorInfo
+    static member internal CreateFromException : PhasedDiagnostic * isError: bool * range -> FSharpErrorInfo
 
 //----------------------------------------------------------------------------
 // Object model for quick info

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2104,10 +2104,10 @@ module CompileHelpers =
         let errors = ResizeArray<_>()
 
         let errorSink isError exn = 
-            let mainError,relatedErrors = SplitRelatedDiagnostics exn 
-            let oneError trim e = errors.Add(FSharpErrorInfo.CreateFromException (e, isError, trim, Range.range0))
-            oneError false mainError
-            List.iter (oneError true) relatedErrors
+            let mainError, relatedErrors = SplitRelatedDiagnostics exn
+            let oneError e = errors.Add(FSharpErrorInfo.CreateFromException (e, isError, Range.range0))
+            oneError mainError
+            List.iter oneError relatedErrors
 
         let errorLogger = 
             { new ErrorLogger("CompileAPI") with 

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -159,7 +159,7 @@ neg20.fs(129,19,129,22): typecheck error FS0001: This expression was expected to
 but here has type
     'string'    
 
-neg20.fs(131,5,131,24): typecheck error FS0041: No overloads match for method 'OM3'. The available overloads are shown below (or in the Error List window).
+neg20.fs(131,5,131,24): typecheck error FS0041: No overloads match for method 'OM3'. The available overloads are shown below.
 neg20.fs(131,5,131,24): typecheck error FS0041: Possible overload: 'static member C.OM3 : x:'b * y:int -> int'. Type constraint mismatch. The type 
     'obj'    
 is not compatible with type
@@ -199,7 +199,7 @@ neg20.fs(166,13,166,35): typecheck error FS0502: The member or object constructo
 
 neg20.fs(167,13,167,31): typecheck error FS0502: The member or object constructor 'M5' takes 2 type argument(s) but is here given 1. The required signature is 'member C.M5 : y:'a * z:'b -> int'.
 
-neg20.fs(182,14,182,31): typecheck error FS0041: No overloads match for method 'M'. The available overloads are shown below (or in the Error List window).
+neg20.fs(182,14,182,31): typecheck error FS0041: No overloads match for method 'M'. The available overloads are shown below.
 neg20.fs(182,14,182,31): typecheck error FS0041: Possible overload: 'static member C2.M : fmt:string * [<System.ParamArray>] args:int [] -> string'. Type constraint mismatch. The type 
     'obj'    
 is not compatible with type
@@ -236,7 +236,7 @@ neg20.fs(184,34,184,39): typecheck error FS0001: This expression was expected to
 but here has type
     'obj'    
 
-neg20.fs(188,14,188,31): typecheck error FS0041: No overloads match for method 'M'. The available overloads are shown below (or in the Error List window).
+neg20.fs(188,14,188,31): typecheck error FS0041: No overloads match for method 'M'. The available overloads are shown below.
 neg20.fs(188,14,188,31): typecheck error FS0041: Possible overload: 'static member C3.M : fmt:string * [<System.ParamArray>] args:string [] -> string'. Type constraint mismatch. The type 
     'obj'    
 is not compatible with type

--- a/tests/fsharp/typecheck/sigs/neg61.bsl
+++ b/tests/fsharp/typecheck/sigs/neg61.bsl
@@ -83,7 +83,7 @@ neg61.fs(156,21,156,22): typecheck error FS3147: This 'let' definition may not b
 
 neg61.fs(171,13,171,18): typecheck error FS3099: 'sumBy' is used with an incorrect number of arguments. This is a custom operation in this query or computation expression. Expected 1 argument(s), but given 0.
 
-neg61.fs(174,22,174,23): typecheck error FS0041: No overloads match for method 'Source'. The available overloads are shown below (or in the Error List window).
+neg61.fs(174,22,174,23): typecheck error FS0041: No overloads match for method 'Source'. The available overloads are shown below.
 neg61.fs(174,22,174,23): typecheck error FS0041: Possible overload: 'member Linq.QueryBuilder.Source : source:System.Linq.IQueryable<'T> -> Linq.QuerySource<'T,'Q>'. Type constraint mismatch. The type 
     'int'    
 is not compatible with type

--- a/tests/fsharpqa/Source/Conformance/Expressions/Type-relatedExpressions/E_RigidTypeAnnotation03.fsx
+++ b/tests/fsharpqa/Source/Conformance/Expressions/Type-relatedExpressions/E_RigidTypeAnnotation03.fsx
@@ -23,11 +23,11 @@ let _ = T.M( @"\" : char )
 exit 1
 // Way more errors are reported, but this is a good enough list.
 //<Expects id="FS0001" span="(17,13-17,16)" status="error">This expression was expected to have type.    'sbyte'    .but here has type.    'byte'</Expects>
-//<Expects id="FS0041" span="(17,9-17,25)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(17,9-17,25)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 //<Expects id="FS0001" span="(18,13-18,19)" status="error">This expression was expected to have type.    'float32'    .but here has type.    'float<'u>'</Expects>
-//<Expects id="FS0041" span="(18,9-18,30)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(18,9-18,30)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 //<Expects id="FS0001" span="(19,13-19,20)" status="error">This expression was expected to have type.    'float32<'u>'    .but here has type.    'decimal<s>'</Expects>
 //<Expects id="FS0001" span="(20,13-20,21)" status="error">Type mismatch\. Expecting a.    'decimal<N s \^ 2>'    .but given a.    'decimal<Kg>'</Expects>
-//<Expects id="FS0041" span="(20,9-20,39)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(20,9-20,39)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 //<Expects id="FS0001" span="(21,14-21,18)" status="error">This expression was expected to have type.    'char'    .but here has type.    'string'</Expects>
-//<Expects id="FS0041" span="(21,9-21,27)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(21,9-21,27)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>

--- a/tests/fsharpqa/Source/Conformance/InferenceProcedures/TypeInference/E_TwoDifferentTypeVariablesGen00.fs
+++ b/tests/fsharpqa/Source/Conformance/InferenceProcedures/TypeInference/E_TwoDifferentTypeVariablesGen00.fs
@@ -7,11 +7,11 @@
 //<Expects id="FS0001" span="(105,48-105,49)" status="error">This expression was expected to have type.    'int'    .but here has type.    ''b'</Expects>
 //<Expects id="FS0001" span="(106,48-106,49)" status="error">A type parameter is missing a constraint 'when 'b :> C'</Expects>
 //<Expects id="FS0193" span="(106,48-106,49)" status="error">Type constraint mismatch. The type.+''b'.+is not compatible with type</Expects>
-//<Expects id="FS0041" span="(107,41-107,51)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(107,41-107,51)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 
 
 
-//<Expects id="FS0041" span="(108,41-108,51)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(108,41-108,51)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 
 
 
@@ -20,12 +20,12 @@
 //<Expects id="FS0001" span="(110,52-110,53)" status="error">This expression was expected to have type.    'int'    .but here has type.    ''b'</Expects>
 //<Expects id="FS0001" span="(111,52-111,53)" status="error">A type parameter is missing a constraint 'when 'b :> C'</Expects>
 //<Expects id="FS0193" span="(111,52-111,53)" status="error">Type constraint mismatch. The type.+''b'.+is not compatible with type</Expects>
-//<Expects id="FS0041" span="(112,41-112,55)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(112,41-112,55)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 
 
 
 
-//<Expects id="FS0041" span="(113,41-113,55)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(113,41-113,55)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 
 
 
@@ -34,12 +34,12 @@
 //<Expects id="FS0001" span="(115,51-115,52)" status="error">This expression was expected to have type.    'int'    .but here has type.    ''b'</Expects>
 //<Expects id="FS0001" span="(116,51-116,52)" status="error">A type parameter is missing a constraint 'when 'b :> C'</Expects>
 //<Expects id="FS0193" span="(116,51-116,52)" status="error">Type constraint mismatch. The type.+''b'.+is not compatible with type</Expects>
-//<Expects id="FS0041" span="(117,41-117,54)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(117,41-117,54)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 
 
 
 
-//<Expects id="FS0041" span="(118,41-118,54)" status="error">No overloads match for method 'M'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects id="FS0041" span="(118,41-118,54)" status="error">No overloads match for method 'M'\. The available overloads are shown below\.</Expects>
 
 
 

--- a/tests/fsharpqa/Source/Conformance/LexicalAnalysis/SymbolicOperators/E_LessThanDotOpenParen001.fs
+++ b/tests/fsharpqa/Source/Conformance/LexicalAnalysis/SymbolicOperators/E_LessThanDotOpenParen001.fs
@@ -4,9 +4,9 @@
 // want to verify we do not crash!
 //<Expects status="warning" id="FS0064">This construct causes code to be less generic than indicated by the type annotations\. The type variable 'S has been constrained to be type 'int'</Expects>
 //<Expects status="error" id="FS0670">This code is not sufficiently generic\. The type variable  \^T when  \^T : \(static member \( \+ \) :  \^T \*  \^T ->  \^a\) could not be generalized because it would escape its scope</Expects>
-//<Expects status="error" id="FS0043">No overloads match for method 'op_PlusPlusPlus'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
-//<Expects status="error" id="FS0041">No overloads match for method 'op_PlusPlusPlus'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
-//<Expects status="error" id="FS0041">No overloads match for method 'op_PlusPlusPlus'\. The available overloads are shown below \(or in the Error List window\)\.</Expects>
+//<Expects status="error" id="FS0043">No overloads match for method 'op_PlusPlusPlus'\. The available overloads are shown below\.</Expects>
+//<Expects status="error" id="FS0041">No overloads match for method 'op_PlusPlusPlus'\. The available overloads are shown below\.</Expects>
+//<Expects status="error" id="FS0041">No overloads match for method 'op_PlusPlusPlus'\. The available overloads are shown below\.</Expects>
  
 type public TestType<'T,'S>() =
     

--- a/vsintegration/tests/unittests/Tests.LanguageService.ErrorList.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.ErrorList.fs
@@ -184,7 +184,7 @@ let g (t : T) = t.Count()
         CheckErrorList content <|
             fun errors ->
                 Assert.AreEqual(3, List.length errors)
-                assertContains errors "No overloads match for method 'X'. The available overloads are shown below (or in the Error List window)."
+                assertContains errors "No overloads match for method 'X'. The available overloads are shown below."
                 for expected in expectedMessages do
                    errors
                    |> List.exists (fun e -> e.Message.StartsWith expected)


### PR DESCRIPTION
Fixes  #3685.
It works for us this way in Rider, however I don't know whether VS/Ionide/VS4Mac/others will handle proper error ranges correctly.