### PR TITLE
Fix System.ValueTuple on net 4.7.1   ---- issue 3896

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1776,19 +1776,6 @@ let GetFSharpCoreLibraryName () = "FSharp.Core"
 // If necessary assume a reference to the latest .NET Framework FSharp.Core with which those tools are built.
 let GetDefaultFSharpCoreReference() = typeof<list<int>>.Assembly.Location
 
-// If necessary assume a reference to the latest System.ValueTuple with which those tools are built.
-let GetDefaultSystemValueTupleReference() = 
-#if COMPILER_SERVICE_AS_DLL
-    None // TODO, right now FCS doesn't add this reference automatically
-#else
-    try 
-       let asm = typeof<System.ValueTuple<int, int>>.Assembly
-       if asm.FullName.StartsWith "System.ValueTuple" then 
-           Some asm.Location 
-       else None
-    with _ -> None
-#endif
-
 let GetFsiLibraryName () = "FSharp.Compiler.Interactive.Settings"  
 
 // This list is the default set of references for "non-project" files. 
@@ -1821,10 +1808,10 @@ let DefaultReferencesForScriptsAndOutOfProjectSources(assumeDotNetFramework) =
           yield "System.Collections" // System.Collections.Generic.List<T>
           yield "System.Runtime.Numerics" // BigInteger
           yield "System.Threading"  // OperationCanceledException
-          // always include a default reference to System.ValueTuple.dll in scripts and out-of-project sources
-          match GetDefaultSystemValueTupleReference() with 
-          | None -> ()
-          | Some v -> yield v
+#if !COMPILER_SERVICE_AS_DLL
+          // TODO, right now FCS doesn't add this reference automatically
+          yield "System.ValueTuple"
+#endif
 
           yield "System.Web"
           yield "System.Web.Services"

--- a/tests/fsharpqa/testenv/src/HostedCompilerServer/HostedCompilerServer.fsproj
+++ b/tests/fsharpqa/testenv/src/HostedCompilerServer/HostedCompilerServer.fsproj
@@ -49,6 +49,10 @@
       <Project>{2E4D67B4-522D-4CF7-97E4-BA940F0B18F3}</Project>
       <Name>FSharp.Compiler.Private</Name>
     </ProjectReference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>$(FSharpSourcesRoot)\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
   </ItemGroup>
 
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />

--- a/tests/fsharpqa/testenv/src/HostedCompilerServer/HostedCompilerServer.fsproj
+++ b/tests/fsharpqa/testenv/src/HostedCompilerServer/HostedCompilerServer.fsproj
@@ -50,7 +50,7 @@
       <Name>FSharp.Compiler.Private</Name>
     </ProjectReference>
     <Reference Include="System.ValueTuple">
-      <HintPath>$(FSharpSourcesRoot)\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>true</Private>
     </Reference>
   </ItemGroup>

--- a/tests/service/ProjectOptionsTests.fs
+++ b/tests/service/ProjectOptionsTests.fs
@@ -485,13 +485,12 @@ let ``Test OtherOptions order for GetProjectOptionsFromScript`` () =
         let scriptPath = __SOURCE_DIRECTORY__ + @"/data/ScriptProject/" + scriptName + ".fsx"
         let scriptSource = File.ReadAllText scriptPath
         let projOpts, _diagnostics = checker.GetProjectOptionsFromScript(scriptPath, scriptSource) |> Async.RunSynchronously
-
         projOpts.OtherOptions
         |> Array.map (fun s -> if s.StartsWith "--" then s else Path.GetFileNameWithoutExtension s)
         |> Array.forall (fun s -> Set.contains s expected2)
         |> shouldEqual true
 
-    let otherArgs = [|"--noframework"; "--warn:3"; "System.Numerics"; "mscorlib"; "FSharp.Core"; "System"; "System.Xml"; "System.Runtime.Remoting"; "System.Runtime.Serialization.Formatters.Soap"; "System.Data"; "System.Drawing"; "System.Core"; "System.Runtime"; "System.Linq"; "System.Reflection"; "System.Linq.Expressions"; "System.Threading.Tasks"; "System.IO"; "System.Net.Requests"; "System.Collections"; "System.Runtime.Numerics"; "System.Threading"; "System.Web"; "System.Web.Services"; "System.Windows.Forms"; "FSharp.Compiler.Interactive.Settings"|] |> Set.ofArray
+    let otherArgs = [|"--noframework"; "--warn:3"; "System.Numerics"; "System.ValueTuple"; "mscorlib"; "FSharp.Core"; "System"; "System.Xml"; "System.Runtime.Remoting"; "System.Runtime.Serialization.Formatters.Soap"; "System.Data"; "System.Drawing"; "System.Core"; "System.Runtime"; "System.Linq"; "System.Reflection"; "System.Linq.Expressions"; "System.Threading.Tasks"; "System.IO"; "System.Net.Requests"; "System.Collections"; "System.Runtime.Numerics"; "System.Threading"; "System.Web"; "System.Web.Services"; "System.Windows.Forms"; "FSharp.Compiler.Interactive.Settings"|] |> Set.ofArray
 
     test "Main1" otherArgs
     test "Main2" otherArgs

--- a/vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj
+++ b/vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj
@@ -71,6 +71,10 @@
       <Name>FSharp.Compiler.Private</Name>
       <Private>True</Private>
     </ProjectReference>
-  </ItemGroup>
+    <Reference Include="System.ValueTuple">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
 </Project>

--- a/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
+++ b/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
@@ -162,6 +162,10 @@
       <Private>True</Private>
       <HintPath>$(NUnitLibDir)\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>

--- a/vsintegration/tests/unittests/VisualFSharp.Unittests.fsproj
+++ b/vsintegration/tests/unittests/VisualFSharp.Unittests.fsproj
@@ -342,6 +342,10 @@
       <HintPath>$(FSharpSourcesRoot)\..\packages\System.Collections.Immutable.$(SystemCollectionsImmutableVersion)\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\System.ValueTuple.1.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>
@@ -361,7 +365,11 @@
       <Name>FSharp.Compiler.Private</Name>
       <Private>True</Private>
     </ProjectReference>
-    <ProjectReference Include="..\Salsa\VisualFSharp.Salsa.fsproj">
+    <Reference Include="System.ValueTuple">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+     <ProjectReference Include="..\Salsa\VisualFSharp.Salsa.fsproj">
       <Name>VisualFSharp.Salsa</Name>
       <Project>{fbd4b354-dc6e-4032-8ec7-c81d8dfb1af7}</Project>
       <Private>True</Private>


### PR DESCRIPTION
This fixes #3896 

What was happening is that on net471 the F# compiler was not fiunding any metadata describing the System.ValueTuple type because.  It was loading the System.ValueTuple from mscorlib.dll.

This change ensures that the compiler will load the type from the System.ValueTuple dll, that is provided either as a command line reference or by loading the System.ValueTuple.dll from all of the places we normally magically look.

It looks like the FCS doesn't require a deployed valuetuple dll, and so we disable default reference for it.
In general that won't be a problem because the standard F# templates reference the System.ValueTuple package anyway and so they are not reliant on this default reference specification.


