### PR TITLE
Use WaitForExit(timeout) rather than loop on HasExited property for some tests

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
-rem Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+ rem Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 @if "%_echo%"=="" echo off 
 
 setlocal enableDelayedExpansion

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
- rem Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+rem Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 @if "%_echo%"=="" echo off 
 
 setlocal enableDelayedExpansion

--- a/tests/fsharpqa/Source/CodeGen/Structure/DoNotInlineX.fs
+++ b/tests/fsharpqa/Source/CodeGen/Structure/DoNotInlineX.fs
@@ -4,7 +4,7 @@ open System
 open System.Diagnostics
 open System.IO
 
-let longtime = TimeSpan.FromSeconds(30).TotalMilliseconds               // longtime is 30 seconds
+let longtime = TimeSpan.FromSeconds(30).Milliseconds               // longtime is 30 seconds
 
 let programFiles = 
     let pf86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)")

--- a/tests/fsharpqa/Source/CodeGen/Structure/DoNotInlineX.fs
+++ b/tests/fsharpqa/Source/CodeGen/Structure/DoNotInlineX.fs
@@ -4,7 +4,7 @@ open System
 open System.Diagnostics
 open System.IO
 
-let longtime = 30000                    // longtime is 30 seconds
+let longtime = TimeSpan.FromSeconds(30).TotalMilliseconds               // longtime is 30 seconds
 
 let programFiles = 
     let pf86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)")

--- a/tests/fsharpqa/Source/CodeGen/Structure/DoNotInlineX.fs
+++ b/tests/fsharpqa/Source/CodeGen/Structure/DoNotInlineX.fs
@@ -4,6 +4,8 @@ open System
 open System.Diagnostics
 open System.IO
 
+let longtime = 30000                    // longtime is 30 seconds
+
 let programFiles = 
     let pf86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)")
     if String.IsNullOrEmpty(pf86) then Environment.GetEnvironmentVariable("ProgramFiles") else pf86
@@ -26,7 +28,7 @@ let start (p1 : string) = Process.Start(p1)
 
 let CompileFile file args = 
     let p = Process.Start(fsc, file + " " + args)
-    while not (p.HasExited) do ()
+    p.WaitForExit()
 
 [<EntryPoint>]
 let main (args : string[]) =
@@ -40,13 +42,13 @@ let main (args : string[]) =
                 printfn "Compiled DerivedType with %A" derivedFlag
 
                 let r1 = start "DerivedType.exe"
-                while not r1.HasExited do ()
+                r1.WaitForExit(longtime)
                 printfn "Ran DerivedType.exe with result: %A" r1.ExitCode
 
                 CompileFile "BaseType.fs" "-a"
                 printfn "Compiled BaseType without %A" baseFlag
                 let r2 = start "DerivedType.exe"
-                while not r2.HasExited do ()
+                r2.WaitForExit(longtime)
                 printfn "Ran DerivedType.exe with result: %A" r2.ExitCode
 
                 if r1.ExitCode = expectedResult1 && r2.ExitCode = expectedResult2 then 0 else 1

--- a/tests/fsharpqa/Source/CodeGen/Structure/DoNotInlineX.fs
+++ b/tests/fsharpqa/Source/CodeGen/Structure/DoNotInlineX.fs
@@ -4,7 +4,7 @@ open System
 open System.Diagnostics
 open System.IO
 
-let longtime = TimeSpan.FromSeconds(30).Milliseconds               // longtime is 30 seconds
+let longtime = int(System.TimeSpan.FromSeconds(30.0).TotalMilliseconds)               // longtime is 30 seconds
 
 let programFiles = 
     let pf86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)")

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -77,7 +77,7 @@ type PEVerifier () =
 
     static let execute (fileName : string, arguments : string) =
         // Peverify may run quite a while some assemblies are pretty big.  Make the timeout 3 minutes just in case.
-        let longtime = TimeSpan.FromMinutes(3).Milliseconds
+        let longtime = int (TimeSpan.FromMinutes(3.0).TotalMilliseconds)
         printfn "executing '%s' with arguments %s" fileName arguments
         let psi = new ProcessStartInfo(fileName, arguments)
         psi.UseShellExecute <- false

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -76,7 +76,8 @@ type PEVerifier () =
 #endif
 
     static let execute (fileName : string, arguments : string) =
-        let longtime = 30000
+        // Peverify may run quite a while some assemblies are pretty big.  Make the timeout 3 minutes just in case.
+        let longtime = 180000
         printfn "executing '%s' with arguments %s" fileName arguments
         let psi = new ProcessStartInfo(fileName, arguments)
         psi.UseShellExecute <- false

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -77,7 +77,7 @@ type PEVerifier () =
 
     static let execute (fileName : string, arguments : string) =
         // Peverify may run quite a while some assemblies are pretty big.  Make the timeout 3 minutes just in case.
-        let longtime = TimeSpan.FromMinutes(3).TotalMilliseconds               // longtime is 30 seconds
+        let longtime = TimeSpan.FromMinutes(3).TotalMilliseconds
         printfn "executing '%s' with arguments %s" fileName arguments
         let psi = new ProcessStartInfo(fileName, arguments)
         psi.UseShellExecute <- false

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -77,7 +77,7 @@ type PEVerifier () =
 
     static let execute (fileName : string, arguments : string) =
         // Peverify may run quite a while some assemblies are pretty big.  Make the timeout 3 minutes just in case.
-        let longtime = 180000
+        let longtime = TimeSpan.FromMinutes(3).TotalMilliseconds               // longtime is 30 seconds
         printfn "executing '%s' with arguments %s" fileName arguments
         let psi = new ProcessStartInfo(fileName, arguments)
         psi.UseShellExecute <- false

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -77,7 +77,7 @@ type PEVerifier () =
 
     static let execute (fileName : string, arguments : string) =
         // Peverify may run quite a while some assemblies are pretty big.  Make the timeout 3 minutes just in case.
-        let longtime = TimeSpan.FromMinutes(3).TotalMilliseconds
+        let longtime = TimeSpan.FromMinutes(3).Milliseconds
         printfn "executing '%s' with arguments %s" fileName arguments
         let psi = new ProcessStartInfo(fileName, arguments)
         psi.UseShellExecute <- false

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -76,6 +76,7 @@ type PEVerifier () =
 #endif
 
     static let execute (fileName : string, arguments : string) =
+        let longtime = 30000
         printfn "executing '%s' with arguments %s" fileName arguments
         let psi = new ProcessStartInfo(fileName, arguments)
         psi.UseShellExecute <- false
@@ -87,7 +88,7 @@ type PEVerifier () =
         use proc = Process.Start(psi)
         let stdOut = proc.StandardOutput.ReadToEnd()
         let stdErr = proc.StandardError.ReadToEnd()
-        while not proc.HasExited do ()
+        proc.WaitForExit(longtime)
         proc.ExitCode, stdOut, stdErr
 
     member __.Verify(assemblyPath : string) =


### PR DESCRIPTION
For an age now the ci_part2 has hung perhaps one time in 3 or 4.  This is super irritating and a waste of CI resources.

I was about to remove what I think the offending tests are, but I noticed that they loop on the process.HasExited property.

I can easily imagine since the symptom is a hang that the process class may not be super good about setting this property.  So instead I changed it to the WaitForExit event with a time out of 30 seconds.

Hopefully this will cause the tests to not hang anymore, and behave properly.


