### PR TITLE
Allow passing additional symbol info in GetDeclarationListInfo

### DIFF
--- a/fcs/samples/EditorService/Program.fs
+++ b/fcs/samples/EditorService/Program.fs
@@ -40,8 +40,8 @@ printfn "%A" tip
 let partialName = GetPartialLongNameEx(inputLines.[4], 23)
 
 // Get declarations (autocomplete) for a location
-let decls = 
-    parsed.GetDeclarationListInfo(Some untyped, 5, inputLines.[4], partialName, (fun () -> [])) 
+let decls =
+    parsed.GetDeclarationListInfo<obj>(Some untyped, 5, inputLines.[4], partialName)
     |> Async.RunSynchronously
 
 for item in decls.Items do

--- a/fcs/samples/EditorService/Program.fs
+++ b/fcs/samples/EditorService/Program.fs
@@ -41,8 +41,9 @@ let partialName = GetPartialLongNameEx(inputLines.[4], 23)
 
 // Get declarations (autocomplete) for a location
 let decls =
-    parsed.GetDeclarationListInfo<obj>(Some untyped, 5, inputLines.[4], partialName)
+    parsed.GetDeclarationListInfo(Some untyped, 5, inputLines.[4], partialName)
     |> Async.RunSynchronously
 
-for item in decls.Items do
-    printfn " - %s" item.Name
+match decls with
+| FSharpDeclarationListInfo.Info (items, _, _) -> items |> Array.iter (fun item -> printfn " - %s" item.Name)
+| _ -> ()

--- a/src/fsharp/vs/ServiceDeclarationLists.fs
+++ b/src/fsharp/vs/ServiceDeclarationLists.fs
@@ -484,8 +484,8 @@ module internal DescriptionListsImpl =
 
 /// An intellisense declaration
 [<Sealed>]
-type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: string, glyph: FSharpGlyph, info, accessibility: FSharpAccessibility option,
-                               kind: CompletionItemKind, isOwnMember: bool, priority: int, isResolved: bool, namespaceToOpen: string option) =
+type FSharpDeclarationListItem<'T>(name: string, nameInCode: string, fullName: string, glyph: FSharpGlyph, info, additionalInfo: 'T option,
+                                   kind: CompletionItemKind, isOwnMember: bool, priority: int, isResolved: bool, namespaceToOpen: string option) =
 
     let mutable descriptionTextHolder: FSharpToolTipText<_> option = None
     let mutable task = null
@@ -545,7 +545,7 @@ type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: strin
        (fun err -> FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError err])
     member decl.DescriptionText = decl.StructuredDescriptionText |> Tooltips.ToFSharpToolTipText
     member __.Glyph = glyph 
-    member __.Accessibility = accessibility
+    member __.AdditionalInfo = additionalInfo
     member __.Kind = kind
     member __.IsOwnMember = isOwnMember
     member __.MinorPriority = priority
@@ -555,7 +555,7 @@ type FSharpDeclarationListItem(name: string, nameInCode: string, fullName: strin
 
 /// A table of declarations for Intellisense completion 
 [<Sealed>]
-type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[], isForType: bool, isError: bool) = 
+type FSharpDeclarationListInfo<'T>(declarations: FSharpDeclarationListItem<'T>[], isForType: bool, isError: bool) =
     member __.Items = declarations
     member __.IsForType = isForType
     member __.IsError = isError
@@ -690,14 +690,14 @@ type FSharpDeclarationListInfo(declarations: FSharpDeclarationListItem[], isForT
                         name, nameInCode, fullName, glyph, Choice1Of2 (items, infoReader, m, denv, reactor, checkAlive), getAccessibility item.Item, 
                         item.Kind, item.IsOwnMember, item.MinorPriority, item.Unresolved.IsNone, namespaceToOpen))
 
-        new FSharpDeclarationListInfo(Array.ofList decls, isForType, false)
+        new FSharpDeclarationListInfo<'T>(Array.ofList decls, isForType, false)
     
     static member Error msg = 
-        new FSharpDeclarationListInfo(
+        new FSharpDeclarationListInfo<'T>(
                 [| FSharpDeclarationListItem("<Note>", "<Note>", "<Note>", FSharpGlyph.Error, Choice2Of2 (FSharpToolTipText [FSharpStructuredToolTipElement.CompositionError msg]), 
                                              None, CompletionItemKind.Other, false, 0, false, None) |], false, true)
     
-    static member Empty = FSharpDeclarationListInfo([| |], false, false)
+    static member Empty = FSharpDeclarationListInfo<'T>([| |], false, false)
 
 
 

--- a/src/fsharp/vs/ServiceDeclarationLists.fsi
+++ b/src/fsharp/vs/ServiceDeclarationLists.fsi
@@ -21,9 +21,9 @@ open Microsoft.FSharp.Compiler.Tastops
 //
 // Note: this type holds a weak reference to compiler resources. 
 #if COMPILER_PUBLIC_API
-type FSharpDeclarationListItem =
+type FSharpDeclarationListItem<'T> =
 #else
-type internal FSharpDeclarationListItem =
+type internal FSharpDeclarationListItem<'T> =
 #endif
     /// Get the display name for the declaration.
     member Name : string
@@ -46,7 +46,7 @@ type internal FSharpDeclarationListItem =
 
     member Glyph : FSharpGlyph
 
-    member Accessibility : FSharpAccessibility option
+    member AdditionalInfo : 'T option
 
     member Kind : CompletionItemKind
 
@@ -67,23 +67,23 @@ type internal FSharpDeclarationListItem =
 //
 // Note: this type holds a weak reference to compiler resources. 
 #if COMPILER_PUBLIC_API
-type FSharpDeclarationListInfo =
+type FSharpDeclarationListInfo<'T> =
 #else
-type internal FSharpDeclarationListInfo =
+type internal FSharpDeclarationListInfo<'T> =
 #endif
 
-    member Items : FSharpDeclarationListItem[]
+    member Items : FSharpDeclarationListItem<'T>[]
 
     member IsForType : bool
 
     member IsError : bool
 
     // Implementation details used by other code in the compiler    
-    static member internal Create : infoReader:InfoReader * m:range * denv:DisplayEnv * getAccessibility:(Item -> FSharpAccessibility option) * items:CompletionItem list * reactor:IReactorOperations * currentNamespace:string[] option * isAttributeApplicationContex:bool * checkAlive:(unit -> bool) -> FSharpDeclarationListInfo
+    static member internal Create : infoReader:InfoReader * m:range * denv:DisplayEnv * getAdditionalInfo:(Item -> 'T option) * items:CompletionItem list * reactor:IReactorOperations * currentNamespace:string[] option * isAttributeApplicationContex:bool * checkAlive:(unit -> bool) -> FSharpDeclarationListInfo<'T>
 
-    static member internal Error : message:string -> FSharpDeclarationListInfo
+    static member internal Error : message:string -> FSharpDeclarationListInfo<'T>
 
-    static member Empty : FSharpDeclarationListInfo
+    static member Empty : FSharpDeclarationListInfo<'T>
 
 /// Represents one parameter for one method (or other item) in a group. 
 [<Sealed>]

--- a/src/fsharp/vs/ServiceDeclarationLists.fsi
+++ b/src/fsharp/vs/ServiceDeclarationLists.fsi
@@ -21,9 +21,9 @@ open Microsoft.FSharp.Compiler.Tastops
 //
 // Note: this type holds a weak reference to compiler resources. 
 #if COMPILER_PUBLIC_API
-type FSharpDeclarationListItem<'T> =
+type FSharpDeclarationListItem =
 #else
-type internal FSharpDeclarationListItem<'T> =
+type internal FSharpDeclarationListItem =
 #endif
     /// Get the display name for the declaration.
     member Name : string
@@ -46,7 +46,7 @@ type internal FSharpDeclarationListItem<'T> =
 
     member Glyph : FSharpGlyph
 
-    member AdditionalInfo : 'T option
+    member Symbol : FSharpSymbol
 
     member Kind : CompletionItemKind
 
@@ -60,30 +60,21 @@ type internal FSharpDeclarationListItem<'T> =
 
     member NamespaceToOpen : string option
 
-
-[<Sealed>]
+[<RequireQualifiedAccess>]
 /// Represents a set of declarations in F# source code, with information attached ready for display by an editor.
 /// Returned by GetDeclarations.
 //
 // Note: this type holds a weak reference to compiler resources. 
 #if COMPILER_PUBLIC_API
-type FSharpDeclarationListInfo<'T> =
+type FSharpDeclarationListInfo =
 #else
-type internal FSharpDeclarationListInfo<'T> =
+type internal FSharpDeclarationListInfo =
 #endif
-
-    member Items : FSharpDeclarationListItem<'T>[]
-
-    member IsForType : bool
-
-    member IsError : bool
-
-    // Implementation details used by other code in the compiler    
-    static member internal Create : infoReader:InfoReader * m:range * denv:DisplayEnv * getAdditionalInfo:(Item -> 'T option) * items:CompletionItem list * reactor:IReactorOperations * currentNamespace:string[] option * isAttributeApplicationContex:bool * checkAlive:(unit -> bool) -> FSharpDeclarationListInfo<'T>
-
-    static member internal Error : message:string -> FSharpDeclarationListInfo<'T>
-
-    static member Empty : FSharpDeclarationListInfo<'T>
+    | Empty
+    | Info of Items: FSharpDeclarationListItem[] * IsForType: bool * DisplayContext: FSharpDisplayContext
+    | Error of FSharpToolTipText<Layout>
+    // Implementation details used by other code in the compiler
+    static member internal Create: infoReader:InfoReader * m:range * denv:DisplayEnv * createSymbol: (Item -> FSharpSymbol) * items:CompletionItem list * reactor:IReactorOperations * currentNamespace:string[] option * isAttributeApplicationContex:bool * checkAlive:(unit -> bool) -> FSharpDeclarationListInfo
 
 /// Represents one parameter for one method (or other item) in a group. 
 [<Sealed>]

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -915,8 +915,8 @@ type TypeCheckInfo
                     let displayContext = FSharpDisplayContext(fun _ -> denv)
                     let getAdditionalInfo item =
                         try getAdditionalInfo(FSharpSymbol.Create(g, thisCcu, tcImports, item), displayContext)
-                        with _ ->
-                            Trace.TraceInformation(sprintf "FCS: could not get additional info for %A" item)
+                        with e ->
+                            Trace.TraceInformation(sprintf "FCS: could not get additional info for %A: %O" item e)
                             None
                     let items = if isInterfaceFile then items |> List.filter (fun x -> IsValidSignatureFileItem x.Item) else items
                     let currentNamespaceOrModule =

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -904,21 +904,27 @@ type TypeCheckInfo
         scope.IsRelativeNameResolvable(cursorPos, plid, symbol.Item)
         
     /// Get the auto-complete items at a location
-    member __.GetDeclarations (ctok, parseResultsOpt, line, lineStr, partialName, getAllSymbols, hasTextChangedSinceLastTypecheck) =
+    member __.GetDeclarations (ctok, parseResultsOpt, line, lineStr, partialName, getAllSymbols, getAdditionalInfo, shortTypeNames, hasTextChangedSinceLastTypecheck) =
         let isInterfaceFile = SourceFileImpl.IsInterfaceFile mainInputFileName
         ErrorScope.Protect Range.range0 
             (fun () ->
                 match GetDeclItemsForNamesAtPosition(ctok, parseResultsOpt, Some partialName.QualifyingIdents, Some partialName.PartialIdent, partialName.LastDotPos, line, lineStr, partialName.EndColumn + 1, ResolveTypeNamesToCtors, ResolveOverloads.Yes, getAllSymbols, hasTextChangedSinceLastTypecheck) with
                 | None -> FSharpDeclarationListInfo.Empty  
-                | Some (items, denv, ctx, m) -> 
+                | Some (items, denv, ctx, m) ->
+                    let denv = if shortTypeNames then { denv with shortTypeNames = true } else denv
+                    let displayContext = FSharpDisplayContext(fun _ -> denv)
+                    let getAdditionalInfo item =
+                        try getAdditionalInfo(FSharpSymbol.Create(g, thisCcu, tcImports, item), displayContext)
+                        with _ ->
+                            Trace.TraceInformation(sprintf "FCS: could not get additional info for %A" item)
+                            None
                     let items = if isInterfaceFile then items |> List.filter (fun x -> IsValidSignatureFileItem x.Item) else items
-                    let getAccessibility item = FSharpSymbol.GetAccessibility (FSharpSymbol.Create(g, thisCcu, tcImports, item))
                     let currentNamespaceOrModule =
                         parseResultsOpt
                         |> Option.bind (fun x -> x.ParseTree)
                         |> Option.map (fun parsedInput -> UntypedParseImpl.GetFullNameOfSmallestModuleOrNamespaceAtPoint(parsedInput, mkPos line 0))
                     let isAttributeApplication = ctx = Some CompletionContext.AttributeApplication
-                    FSharpDeclarationListInfo.Create(infoReader,m,denv,getAccessibility,items,reactorOps,currentNamespaceOrModule,isAttributeApplication,checkAlive))
+                    FSharpDeclarationListInfo.Create(infoReader,m,denv,getAdditionalInfo,items,reactorOps,currentNamespaceOrModule,isAttributeApplication,checkAlive))
             (fun msg -> 
                 Trace.TraceInformation(sprintf "FCS: recovering from error in GetDeclarations: '%s'" msg)
                 FSharpDeclarationListInfo.Error msg)
@@ -1891,13 +1897,16 @@ type FSharpCheckFileResults(filename: string, errors: FSharpErrorInfo[], scopeOp
     member info.Errors = errors
 
     member info.HasFullTypeCheckInfo = details.IsSome
-    
+
     /// Intellisense autocompletions
-    member info.GetDeclarationListInfo(parseResultsOpt, line, lineStr, partialName, getAllEntities, ?hasTextChangedSinceLastTypecheck, ?userOpName: string) = 
+    member info.GetDeclarationListInfo(parseResultsOpt, line, lineStr, partialName, ?getAllEntities, ?getAdditionalInfo: (FSharpSymbol * FSharpDisplayContext -> 'T option), ?shortTypeNames, ?hasTextChangedSinceLastTypecheck, ?userOpName: string) =
         let userOpName = defaultArg userOpName "Unknown"
+        let getAllEntities = defaultArg getAllEntities (fun _ -> [])
+        let getAdditionalInfo = defaultArg getAdditionalInfo (fun _ -> None)
+        let shortTypeNames = defaultArg shortTypeNames false
         let hasTextChangedSinceLastTypecheck = defaultArg hasTextChangedSinceLastTypecheck (fun _ -> false)
         reactorOp userOpName "GetDeclarations" FSharpDeclarationListInfo.Empty (fun ctok scope -> 
-            scope.GetDeclarations(ctok, parseResultsOpt, line, lineStr, partialName, getAllEntities, hasTextChangedSinceLastTypecheck))
+            scope.GetDeclarations(ctok, parseResultsOpt, line, lineStr, partialName, getAllEntities, getAdditionalInfo, shortTypeNames, hasTextChangedSinceLastTypecheck))
 
     member info.GetDeclarationListSymbols(parseResultsOpt, line, lineStr, partialName, ?hasTextChangedSinceLastTypecheck, ?userOpName: string) = 
         let userOpName = defaultArg userOpName "Unknown"

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -156,7 +156,7 @@ type internal FSharpCheckFileResults =
     ///    and assume that we're going to repeat the operation later on.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * lineText:string * partialName: PartialLongName * ?getAllSymbols: (unit -> AssemblySymbol list) * ?getAdditionalInfo: (FSharpSymbol * FSharpDisplayContext -> 'T option) * ?shortTypeNames: bool * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo<'T>>
+    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * lineText:string * partialName: PartialLongName * ?getAllSymbols: (unit -> AssemblySymbol list) * ?shortTypeNames: bool * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo>
 
     /// <summary>Get the items for a declaration list in FSharpSymbol format</summary>
     ///
@@ -264,6 +264,8 @@ type internal FSharpCheckFileResults =
 
     /// Get all textual usages of all symbols throughout the file
     member GetAllUsesOfAllSymbolsInFile :  unit -> Async<FSharpSymbolUse[]>
+
+    member GetAllResolvedSymbols: unit -> Async<(range * FSharpSymbol)[]>
 
     /// Get the textual usages that resolved to the given symbol throughout the file
     member GetUsesOfSymbolInFile : symbol:FSharpSymbol -> Async<FSharpSymbolUse[]>

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -148,7 +148,7 @@ type internal FSharpCheckFileResults =
     ///    and assume that we're going to repeat the operation later on.
     /// </param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * lineText:string * partialName: PartialLongName * getAllSymbols: (unit -> AssemblySymbol list) * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo>
+    member GetDeclarationListInfo : ParsedFileResultsOpt:FSharpParseFileResults option * line: int * lineText:string * partialName: PartialLongName * ?getAllSymbols: (unit -> AssemblySymbol list) * ?getAdditionalInfo: (FSharpSymbol * FSharpDisplayContext -> 'T option) * ?shortTypeNames: bool * ?hasTextChangedSinceLastTypecheck: (obj * range -> bool) * ?userOpName: string -> Async<FSharpDeclarationListInfo<'T>>
 
     /// <summary>Get the items for a declaration list in FSharpSymbol format</summary>
     ///

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -142,6 +142,14 @@ type internal FSharpCheckFileResults =
     /// <param name="getAllSymbols">
     ///    Function that returns all symbols from current and referenced assemblies.
     /// </param>
+    /// </param>
+    /// <param name="getAdditionalInfo">
+    ///    Function that returns additional info about a symbol in completion context.
+    /// </param>
+    /// </param>
+    /// <param name="shortTypeNames">
+    ///    Hide non-opened namespaces in type names in item descriptions and additional info.
+    /// </param>
     /// <param name="hasTextChangedSinceLastTypecheck">
     ///    If text has been used from a captured name resolution from the typecheck, then 
     ///    callback to the client to check if the text has changed. If it has, then give up

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -87,7 +87,10 @@ let ``Intro test`` () =
     // (sprintf "%A" tip).Replace("\n","") |> shouldEqual """FSharpToolTipText [Single ("val foo : unit -> unitFull name: Test.foo",None)]"""
     // Get declarations (autocomplete) for a location
     let partialName = { QualifyingIdents = []; PartialIdent = "msg"; EndColumn = 22; LastDotPos = None }
-    let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 7, inputLines.[6], partialName, (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls =
+        typeCheckResults.GetDeclarationListInfo(Some parseResult, 7, inputLines.[6], partialName,
+                                                hasTextChangedSinceLastTypecheck = (fun _ -> false))
+        |> Async.RunSynchronously
     CollectionAssert.AreEquivalent(stringMethods,[ for item in decls.Items -> item.Name ])
     // Get overloads of the String.Concat method
     let methods = typeCheckResults.GetMethods(5, 27, inputLines.[4], Some ["String"; "Concat"]) |> Async.RunSynchronously
@@ -286,7 +289,10 @@ let ``Expression typing test`` () =
     // gives the results for the string type. 
     // 
     for col in 42..43 do 
-        let decls =  typeCheckResults.GetDeclarationListInfo(Some parseResult, 2, inputLines.[1], PartialLongName.Empty(col), (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+        let decls =
+            typeCheckResults.GetDeclarationListInfo(Some parseResult, 2, inputLines.[1], PartialLongName.Empty(col),
+                                                    hasTextChangedSinceLastTypecheck = (fun _ -> false))
+            |> Async.RunSynchronously
         let autoCompleteSet = set [ for item in decls.Items -> item.Name ]
         autoCompleteSet |> shouldEqual (set stringMethods)
 
@@ -307,7 +313,10 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(20), (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls =
+        typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(20),
+                                                hasTextChangedSinceLastTypecheck = (fun _ -> false))
+        |> Async.RunSynchronously
     let item = decls.Items |> Array.tryFind (fun d -> d.Name = "abc")
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
 
@@ -324,7 +333,10 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(21), (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls =
+        typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(21),
+                                                hasTextChangedSinceLastTypecheck = (fun _ -> false))
+        |> Async.RunSynchronously
     let item = decls.Items |> Array.tryFind (fun d -> d.Name = "abc")
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
  
@@ -341,7 +353,10 @@ type Test() =
     let file = "/home/user/Test.fsx"
     let parseResult, typeCheckResults =  parseAndCheckScript(file, input) 
 
-    let decls = typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(14), (fun _ -> []), fun _ -> false)|> Async.RunSynchronously
+    let decls =
+        typeCheckResults.GetDeclarationListInfo(Some parseResult, 4, inputLines.[3], PartialLongName.Empty(14),
+                                                hasTextChangedSinceLastTypecheck = (fun _ -> false))
+        |> Async.RunSynchronously
     decls.Items |> Seq.exists (fun d -> d.Name = "abc") |> shouldEqual true
 
 [<Test; Ignore("Currently failing, see #139")>]

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -111,13 +111,15 @@ type internal FSharpCompletionProvider
             let fcsCaretLineNumber = Line.fromZ caretLinePos.Line  // Roslyn line numbers are zero-based, FSharp.Compiler.Service line numbers are 1-based
             let caretLineColumn = caretLinePos.Character
             let partialName = QuickParse.GetPartialLongNameEx(caretLine.ToString(), caretLineColumn - 1) 
-            
+
             let getAllSymbols() = 
                 getAllSymbols() 
                 |> List.filter (fun entity -> entity.FullName.Contains "." && not (PrettyNaming.IsOperatorName entity.Symbol.DisplayName))
 
+            let getAdditionalInfo = fun (symbol, _) -> FSharpSymbol.GetAccessibility symbol
+
             let! declarations = checkFileResults.GetDeclarationListInfo(Some(parseResults), fcsCaretLineNumber, caretLine.ToString(), 
-                                                                        partialName, getAllSymbols, userOpName=userOpName) |> liftAsync
+                                                                        partialName, getAllSymbols, getAdditionalInfo, userOpName=userOpName) |> liftAsync
             let results = List<Completion.CompletionItem>()
             
             let getKindPriority = function

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -34,7 +34,7 @@ type internal FSharpCompletionProvider
     inherit CompletionProvider()
 
     static let userOpName = "CompletionProvider"
-    static let declarationItemsCache = ConditionalWeakTable<string, FSharpDeclarationListItem>()
+    static let declarationItemsCache = ConditionalWeakTable<string, FSharpDeclarationListItem<_>>()
     static let [<Literal>] NameInCodePropName = "NameInCode"
     static let [<Literal>] FullNamePropName = "FullName"
     static let [<Literal>] IsExtensionMemberPropName = "IsExtensionMember"
@@ -147,7 +147,7 @@ type internal FSharpCompletionProvider
             let maxHints = if mruItems.Values.Count = 0 then 0 else Seq.max mruItems.Values
 
             sortedDeclItems |> Array.iteri (fun number declItem ->
-                let glyph = Tokenizer.FSharpGlyphToRoslynGlyph (declItem.Glyph, declItem.Accessibility)
+                let glyph = Tokenizer.FSharpGlyphToRoslynGlyph (declItem.Glyph, declItem.AdditionalInfo)
                 let name =
                     match declItem.NamespaceToOpen with
                     | Some namespaceToOpen -> sprintf "%s (open %s)" declItem.Name namespaceToOpen

--- a/vsintegration/src/FSharp.LanguageService/Intellisense.fs
+++ b/vsintegration/src/FSharp.LanguageService/Intellisense.fs
@@ -116,7 +116,7 @@ type internal ObsoleteGlyph =
 // functionality and thus have considerable value, they should ony be deleted if we are sure this 
 // is not the case.
 //
-type internal FSharpDeclarations_DEPRECATED(documentationBuilder, declarations: FSharpDeclarationListItem[], reason: BackgroundRequestReason) = 
+type internal FSharpDeclarations_DEPRECATED(documentationBuilder, declarations: FSharpDeclarationListItem<_>[], reason: BackgroundRequestReason) =
         
     inherit Declarations_DEPRECATED()  
 
@@ -125,7 +125,7 @@ type internal FSharpDeclarations_DEPRECATED(documentationBuilder, declarations: 
     let mutable lastBestMatch = ""
     let isEmpty = (declarations.Length = 0)
 
-    let tab = Dictionary<string,FSharpDeclarationListItem[]>()
+    let tab = Dictionary<string,FSharpDeclarationListItem<_>[]>()
 
     // Given a prefix, narrow the items to the include the ones containing that prefix, and store in a lookaside table
     // attached to this declaration set.
@@ -535,7 +535,7 @@ type internal FSharpIntellisenseInfo_DEPRECATED
                                 let oldTextSnapshot = oldTextSnapshotInfo :?> ITextSnapshot
                                 hasTextChangedSinceLastTypecheck (textSnapshot, oldTextSnapshot, Range.Range.toZ range)
 
-                            let! decls = typedResults.GetDeclarationListInfo(untypedParseInfoOpt, Range.Line.fromZ line, lineText, pname, (fun() -> []), detectTextChange) 
+                            let! decls = typedResults.GetDeclarationListInfo(untypedParseInfoOpt, Range.Line.fromZ line, lineText, pname, hasTextChangedSinceLastTypecheck = detectTextChange)
                             return (new FSharpDeclarations_DEPRECATED(documentationBuilder, decls.Items, reason) :> Declarations_DEPRECATED) 
                     else
                         // no TypeCheckInfo in ParseResult.


### PR DESCRIPTION
We don't use Accessibility field in `FSharpDeclarationListItem` and want to pass other symbol info instead.
I added two optional parameters to `GetDeclarationListInfo`:
* `getAdditionalInfo`: function to replace `getAccessibility` which takes `FSharpSymbol` and `FSharpDisplayContext` and allows passing arbitrary symbol info.
* `shortTypeNames`: use short type names in the display context