### PR TITLE
Make Structure public in FCS

### DIFF
--- a/src/fsharp/vs/ServiceStructure.fsi
+++ b/src/fsharp/vs/ServiceStructure.fsi
@@ -7,7 +7,11 @@ open System.Collections.Generic
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Range
 
+#if COMPILER_PUBLIC_API
+module Structure =
+#else
 module internal Structure =
+#endif
     /// Collapse indicates the way a range/snapshot should be collapsed. `Same` is for a scope inside
     /// some kind of scope delimiter, e.g. `[| ... |]`, `[ ... ]`, `{ ... }`, etc.  `Below` is for expressions
     /// following a binding or the right hand side of a pattern, e.g. `let x = ...`


### PR DESCRIPTION
`Structure` can be used by FCS clients, so let's open it.
Making `MSBuildReferenceResolver` accessible from another assemblies was needed in our case for it to be picked by ReSharper component container from a plugin at runtime.