### PR TITLE
Symbol uses for namespaces

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3174,13 +3174,13 @@ let private ResolveExprDotLongIdent (ncenv:NameResolver) m ad nenv typ lid findF
         ForceRaise adhoctDotSearchAccessible
 
 let ComputeItemRange wholem (lid: Ident list) rest =
-    match rest with
-    | [] -> wholem
-    | _ -> 
+    match rest, lid with
+    | [], [] -> wholem
+    | _ ->
         let ids = List.take (max 0 (lid.Length - rest.Length)) lid
         match ids with 
         | [] -> wholem
-        | _ -> rangeOfLid ids
+        | _ -> (List.last ids).idRange
 
 /// Filters method groups that will be sent to Visual Studio IntelliSense
 /// to include only static/instance members

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3174,13 +3174,13 @@ let private ResolveExprDotLongIdent (ncenv:NameResolver) m ad nenv typ lid findF
         ForceRaise adhoctDotSearchAccessible
 
 let ComputeItemRange wholem (lid: Ident list) rest =
-    match rest, lid with
-    | [], [] -> wholem
-    | _ ->
+    match rest with
+    | [] -> wholem
+    | _ -> 
         let ids = List.take (max 0 (lid.Length - rest.Length)) lid
         match ids with 
         | [] -> wholem
-        | _ -> (List.last ids).idRange
+        | _ -> rangeOfLid ids
 
 /// Filters method groups that will be sent to Visual Studio IntelliSense
 /// to include only static/instance members

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -455,7 +455,7 @@ let OpenModulesOrNamespaces tcSink g amap scopem root env mvvs openDeclaration =
             | id :: rest ->
                 let idents = List.rev idents
                 let range = id.idRange
-                match ResolveLongIndentAsModuleOrNamespace ResultCollectionSettings.AtMostOneResult amap range OpenQualified env.NameEnv env.eAccessRights idents with
+                match ResolveLongIndentAsModuleOrNamespace ResultCollectionSettings.AllResults amap range OpenQualified env.NameEnv env.eAccessRights idents with
                 | Result modrefs ->
                     for _, modref, _ in modrefs do
                         let item = Item.ModuleOrNamespaces [modref] 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -453,10 +453,11 @@ let OpenModulesOrNamespaces tcSink g amap scopem root env mvvs openDeclaration =
         let rec loop (acc: (Item * range) list) (idents: Ident list) =
             match idents with
             | [] -> acc
+            | [id] when id.idText = MangledGlobalName -> acc
             | id :: rest ->
                 let idents = List.rev idents
                 let range = id.idRange
-                let acc = 
+                let acc =
                     match ResolveLongIndentAsModuleOrNamespace ResultCollectionSettings.AllResults amap range OpenQualified env.NameEnv env.eAccessRights idents with
                     | Result modrefs ->
                         (acc, modrefs) ||> List.fold (fun acc (_, modref, _) ->

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -450,10 +450,11 @@ let OpenModulesOrNamespaces tcSink g amap scopem root env mvvs openDeclaration =
     match openDeclaration.Range with
     | None -> ()
     | Some _ ->
-        let rec loop = function
-            | (_ :: rest) as idents ->
+        let rec loop (idents: Ident list) =
+            match idents with
+            | id :: rest ->
                 let idents = List.rev idents
-                let range = rangeOfLid idents
+                let range = id.idRange
                 match ResolveLongIndentAsModuleOrNamespace ResultCollectionSettings.AtMostOneResult amap range OpenQualified env.NameEnv env.eAccessRights idents with
                 | Result modrefs ->
                     for _, modref, _ in modrefs do

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -230,7 +230,7 @@ and FSharpEntity(cenv:cenv, entity:EntityRef) =
     inherit FSharpSymbol(cenv, 
                          (fun () -> 
                               checkEntityIsResolved(entity); 
-                              if entity.IsModule then Item.ModuleOrNamespaces [entity] 
+                              if entity.IsModuleOrNamespace then Item.ModuleOrNamespaces [entity] 
                               else Item.UnqualifiedType [entity]), 
                          (fun _this thisCcu2 ad -> 
                              checkForCrossProjectAccessibility (thisCcu2, ad) (cenv.thisCcu, getApproxFSharpAccessibilityOfEntity entity)) 

--- a/tests/service/CSharpProjectAnalysis.fs
+++ b/tests/service/CSharpProjectAnalysis.fs
@@ -111,8 +111,9 @@ let _ = CSharpOuterClass.InnerClass.StaticMember()
     |> Async.RunSynchronously
     |> Array.map (fun su -> su.Symbol.ToString())
     |> shouldEqual 
-          [|"Tests"; "InnerEnum"; "CSharpOuterClass"; "field Case1"; "InnerClass";
-            "CSharpOuterClass"; "member StaticMember"; "NestedEnumClass"|]
+          [|"FSharp"; "FSharp"; "Compiler"; "Service"; "Tests"; "InnerEnum";
+            "CSharpOuterClass"; "field Case1"; "InnerClass"; "CSharpOuterClass";
+            "member StaticMember"; "NestedEnumClass"|]
 
 [<Test>]
 let ``Ctor test`` () =

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -3688,8 +3688,10 @@ let ``Test Project25 symbol uses of type-provided members`` () =
 
     allUses |> shouldEqual 
 
-         [|("FSharp.Data", "file1", ((3, 5), (3, 16)), ["namespace"; "provided"]);
-           ("Microsoft.FSharp.Data", "file1", ((3, 5), (3, 16)), ["namespace"]);
+         [|("Microsoft.FSharp", "file1", ((3, 5), (3, 11)), ["namespace"]);
+           ("FSharp", "file1", ((3, 5), (3, 11)), ["namespace"]);
+           ("Microsoft.FSharp.Data", "file1", ((3, 12), (3, 16)), ["namespace"]);
+           ("FSharp.Data", "file1", ((3, 12), (3, 16)), ["namespace"; "provided"]);
            ("FSharp.Data.XmlProvider", "file1", ((4, 15), (4, 26)),
             ["class"; "provided"; "erased"]);
            ("FSharp.Data.XmlProvider", "file1", ((4, 15), (4, 26)),


### PR DESCRIPTION
This brings `FSharpSymbolUse` for namespaces at all places (and fixes https://github.com/Microsoft/visualfsharp/issues/3919):

![image](https://user-images.githubusercontent.com/873919/32697482-2379f3d0-c7a2-11e7-9bb0-08923a61bd02.png)
