### PR TITLE
Added tests to CompletionProvider tests. Cleaned up formatting for CompletionProvider tests.

### DIFF
--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -260,6 +260,37 @@ x.
     VerifyCompletionListExactly(fileContents, "x.", expected)
 
 [<Test>]
+let ``Constructing a new class with object initializer syntax``() =
+    let fileContents = """
+type A() =
+    member val SettableProperty = 1 with get, set
+    member val AnotherSettableProperty = 1 with get, set
+    member val NonSettableProperty = 1
+    
+let _ = new A(Setta
+"""
+
+    let expected = ["SettableProperty"; "AnotherSettableProperty"]
+    let notExpected = ["NonSettableProperty"]
+    VerifyCompletionList(fileContents, "(Setta", expected, notExpected)
+
+[<Test>]
+let ``Constructing a new fully qualified class with object initializer syntax``() =
+    let fileContents = """
+module M =
+    type A() =
+        member val SettableProperty = 1 with get, set
+        member val AnotherSettableProperty = 1 with get, set
+        member val NonSettableProperty = 1
+    
+let _ = new M.A(Setta
+"""
+
+    let expected = ["SettableProperty"; "AnotherSettableProperty"]
+    let notExpected = ["NonSettableProperty"]
+    VerifyCompletionList(fileContents, "(Setta", expected, notExpected)
+
+[<Test>]
 let ``Extension methods go after everything else, extension properties are treated as normal ones``() =
     let fileContents = """
 open System.Collections.Generic

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -77,8 +77,8 @@ let VerifyCompletionList(fileContents: string, marker: string, expected: string 
         |> Seq.filter (unexpectedNotFound.Contains >> not)
 
     // If either of these are true, then the test fails.
-    let hasExpectedNotFound = expectedNotFound.Count() > 0
-    let hasUnexpectedFound = unexpectedFound.Count() > 0
+    let hasExpectedNotFound = not (Seq.isEmpty expectedNotFound)
+    let hasUnexpectedFound = not (Seq.isEmpty unexpectedFound)
 
     if hasExpectedNotFound || hasUnexpectedFound then
         let expectedNotFoundMsg = 

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -83,19 +83,19 @@ let VerifyCompletionList(fileContents: string, marker: string, expected: string 
     if hasExpectedNotFound || hasUnexpectedFound then
         let expectedNotFoundMsg = 
             if hasExpectedNotFound then
-                sprintf "Expected completions not found:%s" (formatCompletions expectedNotFound)
+                sprintf "\nExpected completions not found:%s\n" (formatCompletions expectedNotFound)
             else
                 String.Empty
 
         let unexpectedFoundMsg = 
             if hasUnexpectedFound then
-                sprintf "Unexpected completions found:%s" (formatCompletions unexpectedFound)
+                sprintf "\nUnexpected completions found:%s\n" (formatCompletions unexpectedFound)
             else
                 String.Empty
 
-        let completionsMsg = sprintf "Completions:%s" (formatCompletions results)
+        let completionsMsg = sprintf "\nin Completions:%s" (formatCompletions results)
 
-        let msg = sprintf "\n%s\n%s\n in %s" expectedNotFoundMsg unexpectedFoundMsg completionsMsg
+        let msg = sprintf "%s%s%s" expectedNotFoundMsg unexpectedFoundMsg completionsMsg
 
         Assert.Fail(msg)
 
@@ -295,7 +295,7 @@ x.
                     "ToArray"; "ToString"; "TrimExcess"; "TrueForAll"]
     VerifyCompletionListExactly(fileContents, "x.", expected)
 
-[<Test>]
+[<Test;Ignore("Before this test can pass, the test below needs to pass. Related to: https://github.com/Microsoft/visualfsharp/issues/2973")>]
 let ``Constructing a new class with object initializer syntax``() =
     let fileContents = """
 type A() =
@@ -310,7 +310,22 @@ let _ = new A(Setta
     let notExpected = ["NonSettableProperty"]
     VerifyCompletionList(fileContents, "(Setta", expected, notExpected)
 
-[<Test>]
+[<Test;Ignore("https://github.com/Microsoft/visualfsharp/issues/2973")>]
+let ``Constructing a new class with object initializer syntax and verifying 'at' character doesn't exist.``() =
+    let fileContents = """
+type A() =
+    member val SettableProperty = 1 with get, set
+    member val AnotherSettableProperty = 1 with get, set
+    member val NonSettableProperty = 1
+    
+let _ = new A(Setta
+"""
+
+    let expected = []
+    let notExpected = ["SettableProperty@"; "AnotherSettableProperty@"; "NonSettableProperty@"]
+    VerifyCompletionList(fileContents, "(Setta", expected, notExpected)
+
+[<Test;Ignore("https://github.com/Microsoft/visualfsharp/issues/3954")>]
 let ``Constructing a new fully qualified class with object initializer syntax``() =
     let fileContents = """
 module M =

--- a/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
@@ -596,7 +596,6 @@ a.
         AssertCtrlSpaceCompleteContains (typeDef3 @ ["new M.A((**))"]) "A((**)" ["SettableProperty"; "AnotherSettableProperty"] ["NonSettableProperty"] 
         AssertCtrlSpaceCompleteContains (typeDef3 @ ["new M.A(S = 1)"]) "A(S" ["SettableProperty"] ["NonSettableProperty"] 
         AssertCtrlSpaceCompleteContains (typeDef3 @ ["new M.A(S = 1)"]) "A(S = 1" [] ["NonSettableProperty"; "SettableProperty"] // neg test 
-        AssertCtrlSpaceCompleteContains (typeDef3 @ ["new M.A(S = 1,)"]) "A(S = 1," ["AnotherSettableProperty"] ["NonSettableProperty"] 
 
         let typeDef4 = 
             [


### PR DESCRIPTION
This adds three new tests to CompletionProviderTests.fs. These tests currently fail, so they are ignored with a respective GitHub bug issue link. 

One test has been removed from the old completion tests as it doesn't fail when it should; that particular test is one of the three new tests in CompletionProviderTests.fs.

Also, the formatting and message has been changed when a test fails in CompletionProviderTests.fs so it's more readable.