### PR TITLE
For FSI on CoreCLR use ResolutionEnvironment.CompilationAndEvaluation just like on desktop

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -5065,13 +5065,7 @@ module private ScriptPreprocessClosure =
             match codeContext with 
             | CodeContext.Editing -> ResolutionEnvironment.EditingOrCompilation true
             | CodeContext.Compilation -> ResolutionEnvironment.EditingOrCompilation false
-            | CodeContext.CompilationAndEvaluation -> 
-#if FSI_TODO_NETCORE
-                // "CompilationAndEvaluation" assembly resolution for F# Interactive is not yet properly figured out on .NET Core
-                ResolutionEnvironment.EditingOrCompilation false
-#else
-                ResolutionEnvironment.CompilationAndEvaluation
-#endif
+            | CodeContext.CompilationAndEvaluation -> ResolutionEnvironment.CompilationAndEvaluation
         tcConfigB.framework <- false 
         tcConfigB.useSimpleResolution <- useSimpleResolution
         // Indicates that there are some references not in BasicReferencesForScriptLoadClosure which should

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2464,8 +2464,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     do tcConfigB.useFsiAuxLib <- fsi.UseFsiAuxLib
 
 #if FSI_TODO_NETCORE
-    // "CompilationAndEvaluation" assembly resolution for F# Interactive is not yet properly figured out on .NET Core
-    do tcConfigB.resolutionEnvironment <- ResolutionEnvironment.EditingOrCompilation false
     do tcConfigB.useSimpleResolution <- true
     do SetTargetProfile tcConfigB "netcore" // always assume System.Runtime codegen
 #endif


### PR DESCRIPTION
Now that we have netcore 2.0 and netstandard 2.0.  The coreclr doesn't need quite such a rigid ResolutionEnvironment.

This PR removes a couple of places where we special cased the resolutionenvironment for the coreclr compiler.

This change enables FSI on the coreclr to resolve from the shared framework directory.  Sort of the moral equivalent of loading from the Windows Desktop Framework directory.

