### PR TITLE
normalize backslashes in .nuspec files

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.netcore.nuspec
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.netcore.nuspec
@@ -38,6 +38,6 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="FSharp.Compiler.Private.dll"     target="lib/netstandard1.6" />
+        <file src="FSharp.Compiler.Private.dll"     target="lib\netstandard1.6" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -38,11 +38,11 @@
             </group>
         </dependencies>
         <contentFiles>
-            <files include="any/any/default.win32manifest"                       buildAction="Content" copyToOutput="true" flatten="false"  />
-            <files include="any/any/Microsoft.FSharp.Targets"                    buildAction="Content" copyToOutput="true" flatten="false"  />
-            <files include="any/any/Microsoft.Portable.FSharp.targets"           buildAction="Content" copyToOutput="true" flatten="false"  />
-            <files include="any/any/Microsoft.FSharp.NetSdk.targets"             buildAction="Content" copyToOutput="true" flatten="false"  />
-            <files include="any/any/Microsoft.FSharp.NetSdk.props"               buildAction="Content" copyToOutput="true" flatten="false"  />
+            <files include="any\any\default.win32manifest"                       buildAction="Content" copyToOutput="true" flatten="false"  />
+            <files include="any\any\Microsoft.FSharp.Targets"                    buildAction="Content" copyToOutput="true" flatten="false"  />
+            <files include="any\any\Microsoft.Portable.FSharp.targets"           buildAction="Content" copyToOutput="true" flatten="false"  />
+            <files include="any\any\Microsoft.FSharp.NetSdk.targets"             buildAction="Content" copyToOutput="true" flatten="false"  />
+            <files include="any\any\Microsoft.FSharp.NetSdk.props"               buildAction="Content" copyToOutput="true" flatten="false"  />
         </contentFiles>
     </metadata>
     <files>
@@ -54,16 +54,16 @@
             tools, build and runtime/native make unnecessary copies.
             this approach gives a very small deployment. Which is kind of necessary.
         -->
-        <file src="fsc.exe"                                     target="lib/netstandard1.6" />
-        <file src="fsi.exe"                                     target="lib/netstandard1.6" />
-        <file src="FSharp.Core.dll"                             target="lib/netstandard1.6" />
-        <file src="FSharp.Compiler.Private.dll"                 target="lib/netstandard1.6" />
-        <file src="FSharp.Build.dll"                            target="lib/netstandard1.6" />
-        <file src="FSharp.Compiler.Interactive.Settings.dll"    target="lib/netstandard1.6" />
-        <file src="default.win32manifest"                       target="contentFiles/any/any/"  />
-        <file src="Microsoft.FSharp.Targets"                    target="contentFiles/any/any/"  />
-        <file src="Microsoft.Portable.FSharp.Targets"           target="contentFiles/any/any/"  />
-        <file src="Microsoft.FSharp.NetSdk.targets"             target="contentFiles/any/any/"  />
-        <file src="Microsoft.FSharp.NetSdk.props"               target="contentFiles/any/any/"  />
+        <file src="fsc.exe"                                     target="lib\netstandard1.6" />
+        <file src="fsi.exe"                                     target="lib\netstandard1.6" />
+        <file src="FSharp.Core.dll"                             target="lib\netstandard1.6" />
+        <file src="FSharp.Compiler.Private.dll"                 target="lib\netstandard1.6" />
+        <file src="FSharp.Build.dll"                            target="lib\netstandard1.6" />
+        <file src="FSharp.Compiler.Interactive.Settings.dll"    target="lib\netstandard1.6" />
+        <file src="default.win32manifest"                       target="contentFiles\any\any"  />
+        <file src="Microsoft.FSharp.Targets"                    target="contentFiles\any\any"  />
+        <file src="Microsoft.Portable.FSharp.Targets"           target="contentFiles\any\any"  />
+        <file src="Microsoft.FSharp.NetSdk.targets"             target="contentFiles\any\any"  />
+        <file src="Microsoft.FSharp.NetSdk.props"               target="contentFiles\any\any"  />
     </files>
 </package>

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
@@ -46,16 +46,16 @@
             tools, build and runtime/native make unnecessary copies.
             this approach gives a very small deployment. Which is kind of necessary.
         -->
-        <file src="fsc.exe"                                     target="lib/netstandard1.6" />
-        <file src="fsi.exe"                                     target="lib/netstandard1.6" />
-        <file src="FSharp.Core.dll"                             target="lib/netstandard1.6" />
-        <file src="FSharp.Compiler.Private.dll"                 target="lib/netstandard1.6" />
-        <file src="FSharp.Build.dll"                            target="lib/netstandard1.6" />
-        <file src="FSharp.Compiler.Interactive.Settings.dll"    target="lib/netstandard1.6" />
-        <file src="default.win32manifest"                       target="runtimes/any/native"  />
-        <file src="Microsoft.FSharp.Targets"                    target="runtimes/any/native"  />
-        <file src="Microsoft.Portable.FSharp.Targets"           target="runtimes/any/native"  />
-        <file src="Microsoft.FSharp.NetSdk.targets"             target="runtimes/any/native"  />
-        <file src="Microsoft.FSharp.NetSdk.props"               target="runtimes/any/native"  />
+        <file src="fsc.exe"                                     target="lib\netstandard1.6" />
+        <file src="fsi.exe"                                     target="lib\netstandard1.6" />
+        <file src="FSharp.Core.dll"                             target="lib\netstandard1.6" />
+        <file src="FSharp.Compiler.Private.dll"                 target="lib\netstandard1.6" />
+        <file src="FSharp.Build.dll"                            target="lib\netstandard1.6" />
+        <file src="FSharp.Compiler.Interactive.Settings.dll"    target="lib\netstandard1.6" />
+        <file src="default.win32manifest"                       target="runtimes\any\native"  />
+        <file src="Microsoft.FSharp.Targets"                    target="runtimes\any\native"  />
+        <file src="Microsoft.Portable.FSharp.Targets"           target="runtimes\any\native"  />
+        <file src="Microsoft.FSharp.NetSdk.targets"             target="runtimes\any\native"  />
+        <file src="Microsoft.FSharp.NetSdk.props"               target="runtimes\any\native"  />
     </files>
 </package>

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/SampleTuples/Microsoft.FSharp.TupleSample.nuspec
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/SampleTuples/Microsoft.FSharp.TupleSample.nuspec
@@ -17,7 +17,7 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="lib/netstandard1.1/TupleSample.dll"     target="lib/netstandard1.1" />
-        <file src="lib/portable-net40+sl4+win8+wp8/TupleSample.dll"     target="lib/portable-net40+sl4+win8+wp8" />
+        <file src="lib\netstandard1.1\TupleSample.dll"     target="lib\netstandard1.1" />
+        <file src="lib\portable-net40+sl4+win8+wp8\TupleSample.dll"     target="lib\portable-net40+sl4+win8+wp8" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.4.1.xxx.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.4.1.xxx.nuspec
@@ -71,56 +71,56 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="profiles/net20/FSharp.Core.dll"     target="lib/net20/" />
-        <file src="profiles/net20/FSharp.Core.sigdata" target="lib/net20/" />
-        <file src="profiles/net20/FSharp.Core.optdata" target="lib/net20/" />
-        <file src="profiles/net20/FSharp.Core.xml"     target="lib/net20/" />
+        <file src="profiles\net20\FSharp.Core.dll"     target="lib\net20\" />
+        <file src="profiles\net20\FSharp.Core.sigdata" target="lib\net20\" />
+        <file src="profiles\net20\FSharp.Core.optdata" target="lib\net20\" />
+        <file src="profiles\net20\FSharp.Core.xml"     target="lib\net20\" />
 
-        <file src="profiles/net40/FSharp.Core.dll"     target="lib/net40/" />
-        <file src="profiles/net40/FSharp.Core.sigdata" target="lib/net40/" />
-        <file src="profiles/net40/FSharp.Core.optdata" target="lib/net40/" />
-        <file src="profiles/net40/FSharp.Core.xml"     target="lib/net40/" />
+        <file src="profiles\net40\FSharp.Core.dll"     target="lib\net40\" />
+        <file src="profiles\net40\FSharp.Core.sigdata" target="lib\net40\" />
+        <file src="profiles\net40\FSharp.Core.optdata" target="lib\net40\" />
+        <file src="profiles\net40\FSharp.Core.xml"     target="lib\net40\" />
 
-        <file src="net40/bin/FSharp.Core.dll"     target="lib/net45/" />
-        <file src="net40/bin/FSharp.Core.sigdata" target="lib/net45/" />
-        <file src="net40/bin/FSharp.Core.optdata" target="lib/net45/" />
-        <file src="net40/bin/FSharp.Core.xml"     target="lib/net45/" />
+        <file src="net40\bin\FSharp.Core.dll"     target="lib\net45" />
+        <file src="net40\bin\FSharp.Core.sigdata" target="lib\net45" />
+        <file src="net40\bin\FSharp.Core.optdata" target="lib\net45" />
+        <file src="net40\bin\FSharp.Core.xml"     target="lib\net45" />
 
-        <file src="coreclr/bin/FSharp.Core.dll"     target="lib/netstandard1.6/" />
-        <file src="coreclr/bin/FSharp.Core.sigdata" target="lib/netstandard1.6/" />
-        <file src="coreclr/bin/FSharp.Core.optdata" target="lib/netstandard1.6/" />
-        <file src="coreclr/bin/FSharp.Core.xml"     target="lib/netstandard1.6/" />
-        <file src="coreclr/bin/FSharp.Core.sigdata" target="runtimes/any/native/" />
-        <file src="coreclr/bin/FSharp.Core.optdata" target="runtimes/any/native/" />
+        <file src="coreclr\bin\FSharp.Core.dll"     target="lib\netstandard1.6" />
+        <file src="coreclr\bin\FSharp.Core.sigdata" target="lib\netstandard1.6" />
+        <file src="coreclr\bin\FSharp.Core.optdata" target="lib\netstandard1.6" />
+        <file src="coreclr\bin\FSharp.Core.xml"     target="lib\netstandard1.6" />
+        <file src="coreclr\bin\FSharp.Core.sigdata" target="runtimes\any\native" />
+        <file src="coreclr\bin\FSharp.Core.optdata" target="runtimes\any\native" />
 
-        <file src="profiles/portable-net45+monoandroid10+monotouch10+xamarinios10/FSharp.Core.dll"     target="lib/portable-net45+monoandroid10+monotouch10+xamarinios10/" />
-        <file src="profiles/portable-net45+monoandroid10+monotouch10+xamarinios10/FSharp.Core.sigdata" target="lib/portable-net45+monoandroid10+monotouch10+xamarinios10/" />
-        <file src="profiles/portable-net45+monoandroid10+monotouch10+xamarinios10/FSharp.Core.optdata" target="lib/portable-net45+monoandroid10+monotouch10+xamarinios10/" />
-        <file src="profiles/portable-net45+monoandroid10+monotouch10+xamarinios10/FSharp.Core.xml"     target="lib/portable-net45+monoandroid10+monotouch10+xamarinios10/" />
+        <file src="profiles\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll"     target="lib\portable-net45+monoandroid10+monotouch10+xamarinios10" />
+        <file src="profiles\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.sigdata" target="lib\portable-net45+monoandroid10+monotouch10+xamarinios10" />
+        <file src="profiles\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.optdata" target="lib\portable-net45+monoandroid10+monotouch10+xamarinios10" />
+        <file src="profiles\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.xml"     target="lib\portable-net45+monoandroid10+monotouch10+xamarinios10" />
 
-        <file src="profiles/portable-net45+netcore45/FSharp.Core.dll"     target="lib/portable-net45+netcore45/" />
-        <file src="profiles/portable-net45+netcore45/FSharp.Core.sigdata" target="lib/portable-net45+netcore45/" />
-        <file src="profiles/portable-net45+netcore45/FSharp.Core.optdata" target="lib/portable-net45+netcore45/" />
-        <file src="profiles/portable-net45+netcore45/FSharp.Core.xml"     target="lib/portable-net45+netcore45/" />
+        <file src="profiles\portable-net45+netcore45\FSharp.Core.dll"     target="lib\portable-net45+netcore45" />
+        <file src="profiles\portable-net45+netcore45\FSharp.Core.sigdata" target="lib\portable-net45+netcore45" />
+        <file src="profiles\portable-net45+netcore45\FSharp.Core.optdata" target="lib\portable-net45+netcore45" />
+        <file src="profiles\portable-net45+netcore45\FSharp.Core.xml"     target="lib\portable-net45+netcore45" />
 
-        <file src="profiles/portable-net45+netcore45+wp8/FSharp.Core.dll"     target="lib/portable-net45+netcore45+wp8/" />
-        <file src="profiles/portable-net45+netcore45+wp8/FSharp.Core.sigdata" target="lib/portable-net45+netcore45+wp8/" />
-        <file src="profiles/portable-net45+netcore45+wp8/FSharp.Core.optdata" target="lib/portable-net45+netcore45+wp8/" />
-        <file src="profiles/portable-net45+netcore45+wp8/FSharp.Core.xml"     target="lib/portable-net45+netcore45+wp8/" />
+        <file src="profiles\portable-net45+netcore45+wp8\FSharp.Core.dll"     target="lib\portable-net45+netcore45+wp8" />
+        <file src="profiles\portable-net45+netcore45+wp8\FSharp.Core.sigdata" target="lib\portable-net45+netcore45+wp8" />
+        <file src="profiles\portable-net45+netcore45+wp8\FSharp.Core.optdata" target="lib\portable-net45+netcore45+wp8" />
+        <file src="profiles\portable-net45+netcore45+wp8\FSharp.Core.xml"     target="lib\portable-net45+netcore45+wp8" />
 
-        <file src="profiles/portable-net45+netcore45+wpa81+wp8/FSharp.Core.dll"     target="lib/portable-net45+netcore45+wpa81+wp8/" />
-        <file src="profiles/portable-net45+netcore45+wpa81+wp8/FSharp.Core.sigdata" target="lib/portable-net45+netcore45+wpa81+wp8/" />
-        <file src="profiles/portable-net45+netcore45+wpa81+wp8/FSharp.Core.optdata" target="lib/portable-net45+netcore45+wpa81+wp8/" />
-        <file src="profiles/portable-net45+netcore45+wpa81+wp8/FSharp.Core.xml"     target="lib/portable-net45+netcore45+wpa81+wp8/" />
+        <file src="profiles\portable-net45+netcore45+wpa81+wp8\FSharp.Core.dll"     target="lib\portable-net45+netcore45+wpa81+wp8" />
+        <file src="profiles\portable-net45+netcore45+wpa81+wp8\FSharp.Core.sigdata" target="lib\portable-net45+netcore45+wpa81+wp8" />
+        <file src="profiles\portable-net45+netcore45+wpa81+wp8\FSharp.Core.optdata" target="lib\portable-net45+netcore45+wpa81+wp8" />
+        <file src="profiles\portable-net45+netcore45+wpa81+wp8\FSharp.Core.xml"     target="lib\portable-net45+netcore45+wpa81+wp8" />
 
-        <file src="profiles/portable-net45+sl5+netcore45/FSharp.Core.dll"     target="lib/portable-net45+sl5+netcore45/" />
-        <file src="profiles/portable-net45+sl5+netcore45/FSharp.Core.sigdata" target="lib/portable-net45+sl5+netcore45/" />
-        <file src="profiles/portable-net45+sl5+netcore45/FSharp.Core.optdata" target="lib/portable-net45+sl5+netcore45/" />
-        <file src="profiles/portable-net45+sl5+netcore45/FSharp.Core.xml"     target="lib/portable-net45+sl5+netcore45/" />
+        <file src="profiles\portable-net45+sl5+netcore45\FSharp.Core.dll"     target="lib\portable-net45+sl5+netcore45" />
+        <file src="profiles\portable-net45+sl5+netcore45\FSharp.Core.sigdata" target="lib\portable-net45+sl5+netcore45" />
+        <file src="profiles\portable-net45+sl5+netcore45\FSharp.Core.optdata" target="lib\portable-net45+sl5+netcore45" />
+        <file src="profiles\portable-net45+sl5+netcore45\FSharp.Core.xml"     target="lib\portable-net45+sl5+netcore45" />
 
-        <file src="profiles/xamarinmac20/FSharp.Core.dll"     target="lib/xamarinmac20/" />
-        <file src="profiles/xamarinmac20/FSharp.Core.sigdata" target="lib/xamarinmac20/" />
-        <file src="profiles/xamarinmac20/FSharp.Core.optdata" target="lib/xamarinmac20/" />
-        <file src="profiles/xamarinmac20/FSharp.Core.xml"     target="lib/xamarinmac20/" />
+        <file src="profiles\xamarinmac20\FSharp.Core.dll"     target="lib\xamarinmac20" />
+        <file src="profiles\xamarinmac20\FSharp.Core.sigdata" target="lib\xamarinmac20" />
+        <file src="profiles\xamarinmac20\FSharp.Core.optdata" target="lib\xamarinmac20" />
+        <file src="profiles\xamarinmac20\FSharp.Core.xml"     target="lib\xamarinmac20" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.4.2.xxx.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.4.2.xxx.nuspec
@@ -52,15 +52,15 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="coreclr/bin/FSharp.Core.dll"          target="lib/netstandard1.6/" />
-        <file src="coreclr/bin/FSharp.Core.sigdata"      target="lib/netstandard1.6/" />
-        <file src="coreclr/bin/FSharp.Core.optdata"      target="lib/netstandard1.6/" />
-        <file src="coreclr/bin/FSharp.Core.xml"          target="lib/netstandard1.6/" />
+        <file src="coreclr\bin\FSharp.Core.dll"          target="lib\netstandard1.6" />
+        <file src="coreclr\bin\FSharp.Core.sigdata"      target="lib\netstandard1.6" />
+        <file src="coreclr\bin\FSharp.Core.optdata"      target="lib\netstandard1.6" />
+        <file src="coreclr\bin\FSharp.Core.xml"          target="lib\netstandard1.6" />
 
-        <file src="net40/bin/FSharp.Core.dll"            target="lib/net45/" />
-        <file src="net40/bin/FSharp.Core.sigdata"        target="lib/net45/" />
-        <file src="net40/bin/FSharp.Core.optdata"        target="lib/net45/" />
-        <file src="net40/bin/FSharp.Core.xml"            target="lib/net45/" />
+        <file src="net40\bin\FSharp.Core.dll"            target="lib\net45" />
+        <file src="net40\bin\FSharp.Core.sigdata"        target="lib\net45" />
+        <file src="net40\bin\FSharp.Core.optdata"        target="lib\net45" />
+        <file src="net40\bin\FSharp.Core.xml"            target="lib\net45" />
 
     </files>
 </package>

--- a/src/fsharp/FSharp.Core.nuget/Microsoft.Portable.FSharp.Core.4.1.xxx.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/Microsoft.Portable.FSharp.Core.4.1.xxx.nuspec
@@ -14,14 +14,14 @@
         <dependencies></dependencies>
     </metadata>
     <files>
-        <file src="profiles/net20/**/**" target="lib/" />
-        <file src="profiles/net40/**/**" target="lib/" />
-        <file src="profiles/portable-net45+monoandroid10+monotouch10+xamarinios10/**/**" target="lib/" />
-        <file src="profiles/portable-net45+netcore45/**/**"                              target="lib/" />
-        <file src="profiles/portable-net45+netcore45+wp8/**/**"                          target="lib/" />
-        <file src="profiles/portable-net45+netcore45+wpa81+wp8/**/**"                    target="lib/" />
-        <file src="profiles/portable-net45+sl5+netcore45/**/**"                          target="lib/" />
-        <file src="profiles/xamarinmac20/**/**"                                          target="lib/" />
+        <file src="profiles\net20\**\**" target="lib" />
+        <file src="profiles\net40\**\**" target="lib" />
+        <file src="profiles\portable-net45+monoandroid10+monotouch10+xamarinios10\**\**" target="lib" />
+        <file src="profiles\portable-net45+netcore45\**\**"                              target="lib" />
+        <file src="profiles\portable-net45+netcore45+wp8\**\**"                          target="lib" />
+        <file src="profiles\portable-net45+netcore45+wpa81+wp8\**\**"                    target="lib" />
+        <file src="profiles\portable-net45+sl5+netcore45\**\**"                          target="lib" />
+        <file src="profiles\xamarinmac20\**\**"                                          target="lib" />
 
     </files>
 </package>

--- a/src/fsharp/FSharp.Core/Testing.FSharp.Core.nuspec
+++ b/src/fsharp/FSharp.Core/Testing.FSharp.Core.nuspec
@@ -42,8 +42,8 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="FSharp.Core.dll"     target="lib/netstandard1.6" />
-        <file src="FSharp.Core.xml"     target="lib/netstandard1.6" />
-        <file src="FSharp.Core.runtimeconfig.json" target="lib/netstandard1.6" />
+        <file src="FSharp.Core.dll"     target="lib\netstandard1.6" />
+        <file src="FSharp.Core.xml"     target="lib\netstandard1.6" />
+        <file src="FSharp.Core.runtimeconfig.json" target="lib\netstandard1.6" />
     </files>
 </package>


### PR DESCRIPTION
This cleans up a bunch of build warnings saying that nothing could be found in the `lib\` directory.