### PR TITLE
[WIP] - Add global commands for dotnet cli

### DIFF
--- a/src/globaltools/dotnet-fsc/Program.fs
+++ b/src/globaltools/dotnet-fsc/Program.fs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+// Implement a global command to execute the built in F# compiler.
+//
+// This is a simple bootstrapper that bootstraps fsc using the fsc.exe that is deployed with the dotnet cli.
+//
+// The program figures out the location of fsc.exe by calling dotnet.exe --version
+//
+// fsc is located in a subdirectory below the executing dotnet.exe 
+//  at the location sdk/%sdkversion%/FSharp/fsc.exe
+//
+// All command line arguments are passed through to the fsc.exe
+
+module Microsoft.FSharp.Dotnet.Fsc
+
+open System
+open System.Diagnostics
+open System.IO
+open Microsoft.FSharp.Dotnet.GlobalTools.Shared
+
+[<EntryPoint>]
+let main arguments =
+
+    let dotnetExe = Process.GetCurrentProcess().MainModule.FileName
+    Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "false")
+
+    match executeProcessScrapeOutput dotnetExe argumentBasePath (Some scrapeOutputForBasePath) with
+    | Some basePath ->
+        let fullPathToFsc = Path.Combine(basePath, "FSharp", "fsc.exe")
+        startProcess dotnetExe fullPathToFsc arguments
+
+    | _ ->
+        printfn "Unable to execute the command: %s %s" dotnetExe argumentBasePath
+        1
+ 

--- a/src/globaltools/dotnet-fsc/dotnet-fsc.fsproj
+++ b/src/globaltools/dotnet-fsc/dotnet-fsc.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\StartProcess.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/src/globaltools/dotnet-fsi/Program.fs
+++ b/src/globaltools/dotnet-fsi/Program.fs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+// Implement a global command to execute the built in F# interactive sesssion.
+//
+// This is a simple bootstrapper that bootstraps fsi using the fsi.exe that is deployed with the dotnet cli.
+//
+// The program figures out the location of fsi.exe by calling dotnet.exe --version
+//
+// fsi is located in a subdirectory below the executing dotnet.exe 
+//  at the location sdk/%sdkversion%/FSharp/fsi.exe
+//
+// All command line arguments are passed through to the fsi.exe
+
+module Microsoft.FSharp.Dotnet.Fsi
+
+open System
+open System.Diagnostics
+open System.IO
+open Microsoft.FSharp.Dotnet.GlobalTools.Shared
+
+[<EntryPoint>]
+let main arguments =
+
+    let dotnetExe = Process.GetCurrentProcess().MainModule.FileName
+    Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "false")
+
+    match executeProcessScrapeOutput dotnetExe argumentBasePath (Some scrapeOutputForBasePath) with
+    | Some basePath ->
+        let fullPathToFsi = Path.Combine(basePath, "FSharp", "fsi.exe")
+        startProcess dotnetExe fullPathToFsi arguments
+
+    | _ ->
+        printfn "Unable to execute the command: %s %s" dotnetExe argumentBasePath
+        1
+ 

--- a/src/globaltools/dotnet-fsi/dotnet-fsi.fsproj
+++ b/src/globaltools/dotnet-fsi/dotnet-fsi.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\StartProcess.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/src/globaltools/dotnet-proto_fsc/Program.fs
+++ b/src/globaltools/dotnet-proto_fsc/Program.fs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+// Implement a global command to execute the built in F# interactive sesssion.
+//
+// This is a simple bootstrapper that bootstraps fsi using the fsi.exe that is deployed with the dotnet cli.
+//
+// The program figures out the location of fsi.exe by calling dotnet.exe --version
+//
+// fsi is located in a subdirectory below the executing dotnet.exe 
+//  at the location sdk/%sdkversion%/FSharp/fsi.exe
+//
+// All command line arguments are passed through to the fsi.exe
+
+module Microsoft.FSharp.Dotnet.LkgFsi
+
+open System
+open System.Diagnostics
+open System.IO
+open Microsoft.FSharp.Dotnet.GlobalTools.Shared
+
+[<EntryPoint>]
+let main arguments =
+
+    let dotnetExe = Process.GetCurrentProcess().MainModule.FileName
+    Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "false")
+
+    match executeProcessScrapeOutput dotnetExe argumentBasePath (Some scrapeOutputForBasePath) with
+    | Some basePath ->
+        let fullPathToFsi = Path.Combine(basePath, "FSharpProto", "fsc.exe")
+        startProcess dotnetExe fullPathToFsi arguments
+
+    | _ ->
+        printfn "Unable to execute the command: %s %s" dotnetExe argumentBasePath
+        1
+ 

--- a/src/globaltools/dotnet-proto_fsc/dotnet-proto_fsc.fsproj
+++ b/src/globaltools/dotnet-proto_fsc/dotnet-proto_fsc.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\StartProcess.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/src/globaltools/dotnet-proto_fsi/Program.fs
+++ b/src/globaltools/dotnet-proto_fsi/Program.fs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+// Implement a global command to execute the built in F# interactive sesssion.
+//
+// This is a simple bootstrapper that bootstraps fsi using the fsi.exe that is deployed with the dotnet cli.
+//
+// The program figures out the location of fsi.exe by calling dotnet.exe --version
+//
+// fsi is located in a subdirectory below the executing dotnet.exe 
+//  at the location sdk/%sdkversion%/FSharp/fsi.exe
+//
+// All command line arguments are passed through to the fsi.exe
+
+module Microsoft.FSharp.Dotnet.LkgFsi
+
+open System
+open System.Diagnostics
+open System.IO
+open Microsoft.FSharp.Dotnet.GlobalTools.Shared
+
+[<EntryPoint>]
+let main arguments =
+
+    let dotnetExe = Process.GetCurrentProcess().MainModule.FileName
+    Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "false")
+
+    match executeProcessScrapeOutput dotnetExe argumentBasePath (Some scrapeOutputForBasePath) with
+    | Some basePath ->
+        let fullPathToFsi = Path.Combine(basePath, "FSharpProto", "fsi.exe")
+        startProcess dotnetExe fullPathToFsi arguments
+
+    | _ ->
+        printfn "Unable to execute the command: %s %s" dotnetExe argumentBasePath
+        1
+ 

--- a/src/globaltools/dotnet-proto_fsi/dotnet-proto_fsi.fsproj
+++ b/src/globaltools/dotnet-proto_fsi/dotnet-proto_fsi.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\StartProcess.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/src/globaltools/dotnet.GlobalTools.sln
+++ b/src/globaltools/dotnet.GlobalTools.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27120.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "dotnet-fsc", "dotnet-fsc\dotnet-fsc.fsproj", "{9A795063-F927-49FE-ABF6-C8583F6937D7}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "dotnet-fsi", "dotnet-fsi\dotnet-fsi.fsproj", "{789C31EE-F8A2-4D48-A77F-46C1F89BDC99}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "dotnet-proto_fsc", "dotnet-proto_fsc\dotnet-proto_fsc.fsproj", "{E21B5850-2421-4B86-AEE2-9356DAFAF41E}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "dotnet-proto_fsi", "dotnet-proto_fsi\dotnet-proto_fsi.fsproj", "{E3A7EEA8-2B44-4C0E-845E-3EC5877024B0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9A795063-F927-49FE-ABF6-C8583F6937D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A795063-F927-49FE-ABF6-C8583F6937D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A795063-F927-49FE-ABF6-C8583F6937D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A795063-F927-49FE-ABF6-C8583F6937D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{789C31EE-F8A2-4D48-A77F-46C1F89BDC99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{789C31EE-F8A2-4D48-A77F-46C1F89BDC99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{789C31EE-F8A2-4D48-A77F-46C1F89BDC99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{789C31EE-F8A2-4D48-A77F-46C1F89BDC99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E21B5850-2421-4B86-AEE2-9356DAFAF41E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E21B5850-2421-4B86-AEE2-9356DAFAF41E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E21B5850-2421-4B86-AEE2-9356DAFAF41E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E21B5850-2421-4B86-AEE2-9356DAFAF41E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3A7EEA8-2B44-4C0E-845E-3EC5877024B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3A7EEA8-2B44-4C0E-845E-3EC5877024B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3A7EEA8-2B44-4C0E-845E-3EC5877024B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3A7EEA8-2B44-4C0E-845E-3EC5877024B0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1719A171-4883-49D3-80C1-83C5EB1DA4FE}
+	EndGlobalSection
+EndGlobal

--- a/src/globaltools/shared/StartProcess.fs
+++ b/src/globaltools/shared/StartProcess.fs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+// Implement a global command to execute the built in F# compiler.
+// 
+// CreateProcess Utilities
+//
+
+module Microsoft.FSharp.Dotnet.GlobalTools.Shared
+
+open System
+open System.Diagnostics
+open System.IO
+
+///
+/// Execute dotnet.exe passing in the path to F# tool and the arguments
+///
+let startProcess path fullPathToApp args =
+
+    let info = 
+        ProcessStartInfo(
+            Arguments = "\"" + fullPathToApp + "\" " + (args |> String.concat " "),
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            CreateNoWindow = false,
+            FileName = path)
+    use p = new Process(StartInfo = info)
+    if p.Start() then
+        p.WaitForExit()
+        p.ExitCode
+    else
+        1
+
+///
+/// Execute dotnet.exe argument and scrape the Output
+///
+let executeProcessScrapeOutput path arguments (scrapeOutput:(StreamReader -> string option) option) : string option =
+
+    let executeTimeOut = 5000
+
+    let info = 
+        ProcessStartInfo(
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = false,
+            CreateNoWindow = true,
+            FileName = path)
+
+    let stream = new MemoryStream()
+    let streamWriter = new StreamWriter(stream)
+    use p = new Process(StartInfo = info)
+    p.OutputDataReceived.Add(fun x -> if not (isNull(x.Data)) then streamWriter.WriteLine(x.Data))
+
+    let gotIt =
+        if p.Start() then
+            p.BeginOutputReadLine()
+            if not (p.WaitForExit(executeTimeOut)) then false
+            else p.ExitCode = 0
+        else
+            false
+
+    streamWriter.Flush()
+
+    if gotIt then
+        if Option.isSome scrapeOutput then
+            stream.Position <- 0L
+            use rdr = new StreamReader(stream)
+            let result = scrapeOutput.Value rdr
+            result
+        else
+            None
+    else
+        None
+
+///
+/// Scrape the baseBath from dotnet.exe --info
+///
+let argumentBasePath = "--info"
+let basePath = "Base Path:"
+let rec scrapeOutputForBasePath (rdr:StreamReader) =
+
+    if rdr.EndOfStream then
+        None
+    else 
+        let v = rdr.ReadLine()
+        if String.IsNullOrEmpty (v) || not (v.Contains(basePath)) then
+            scrapeOutputForBasePath rdr
+        else
+            let index = v.IndexOf(basePath)
+            if index > 0 then Some (v.Substring(index + basePath.Length).Trim())
+            else Some v
+ 


### PR DESCRIPTION
The dotnet CLI is adding the idea of global commands..  A global command is a nuget package that installs dotnet applications, with scripts that start them.

This PR contains:
* Commands for fsc, fsi.
* A proto fsi and a proto fcs during build for this repo.

So .. unlike most global command F# is in an awkward place.  F# ships as part of the dotnet sdk, which ships alongside the dotnet cli.

The dotnet CLI team do not want an open ended commitment to ship every command anyone can ever make an argument for.  To this end they are designing a mechanism know as global commands.  the dotnet cli, cannot activate fsi and fsi, outside of the dotnet sdk.  To enable those scenarios, an fsc and an fsi command we will ship these global commands.

Because fsc and fsi ship in the box and are crossgened for performance, these global commands will peek into the dotnet cli to find fsi and fsc.rather than deploy a new fsc/fsi.

dotnet.exe has a command --info, which can be scraped to find the dotnet sdk base path.  This is an unsupported scenario, although unlikely to change.  Note this command output is specifically not localized, and is likely to continue to exist.

Yet todo:
* When the specification for the nuget packaging for global commands is ready, I need to add them.
* Integrate fully into the oss build


