### PR TITLE
restore coreclr.dll from a NuGet package instead of assuming its location

### DIFF
--- a/tests/fsharp/packages.config
+++ b/tests/fsharp/packages.config
@@ -3,6 +3,8 @@
   <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net45" />
   <package id="runtime.win-x64.Microsoft.NETCore.ILDAsm" version="2.0.3" />
   <package id="runtime.win-x86.Microsoft.NETCore.ILDAsm" version="2.0.3" />
+  <package id="runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR" version="2.0.3" />
+  <package id="runtime.win-x86.Microsoft.NETCore.Runtime.CoreCLR" version="2.0.3" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net45" />
 </packages>

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -178,6 +178,7 @@ let config configurationName envVars =
     let architectureMoniker = if Is64BitOperatingSystem then "x64" else "x86"
     let CSC = requireFile (CORDIR ++ "csc.exe")
     let ILDASM = requireFile (packagesDir ++ ("runtime.win-" + architectureMoniker + ".Microsoft.NETCore.ILDAsm.2.0.3") ++ "runtimes" ++ ("win-" + architectureMoniker) ++ "native" ++ "ildasm.exe")
+    let coreclrdll = requireFile (packagesDir ++ ("runtime.win-" + architectureMoniker + ".Microsoft.NETCore.Runtime.CoreCLR.2.0.3") ++ "runtimes" ++ ("win-" + architectureMoniker) ++ "native" ++ "coreclr.dll")
     let PEVERIFY = requireFile (CORSDK ++ "peverify.exe")
     let FSI_FOR_SCRIPTS =
         match envVars |> Map.tryFind "_fsiexe" with
@@ -191,9 +192,8 @@ let config configurationName envVars =
             | _ -> failwithf "Found more than one 'FSharp.Compiler.Tools' inside '%s', please clean up." packagesDir
     let toolsDir = SCRIPT_ROOT ++ ".." ++ ".." ++ "Tools"
     let dotNetExe = toolsDir ++ "dotnetcli" ++ "dotnet.exe"
-    // ildasm requires coreclr.dll to run which has already been restored to the tools directory
-    let coreclrSource = toolsDir ++ "dotnet20" ++ "shared" ++ "Microsoft.NETCore.App" ++ "2.0.0" ++ "coreclr.dll"
-    File.Copy(coreclrSource, Path.GetDirectoryName(ILDASM) ++ "coreclr.dll", overwrite=true)
+    // ildasm requires coreclr.dll to run which has already been restored to the packages directory
+    File.Copy(coreclrdll, Path.GetDirectoryName(ILDASM) ++ "coreclr.dll", overwrite=true)
 
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
     let FSI = requireFile (FSCBinPath ++ "fsi.exe")


### PR DESCRIPTION
This should improve test stability for non-coreclr scenarios where that file won't necessarily be in the `Tools` directory.