### PR TITLE
Fixed file sharing on F# projects, removes annoying message that file is open in another project

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/Constants.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Constants.fs
@@ -19,10 +19,6 @@ module internal FSharpConstants =
     let languageServiceGuidString = "BC6DD5A5-D4D6-4dab-A00D-A51242DBAF1B"
     
     [<Literal>]
-    /// "4EB7CCB7-4336-4FFD-B12B-396E9FD079A9"
-    let editorFactoryGuidString = "4EB7CCB7-4336-4FFD-B12B-396E9FD079A9"
-    
-    [<Literal>]
     /// "F#"
     let FSharpLanguageName = "F#"
     

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -315,12 +315,6 @@ type
     [<ProvideLanguageExtension(typeof<FSharpLanguageService>, ".fsscript")>]
     [<ProvideLanguageExtension(typeof<FSharpLanguageService>, ".ml")>]
     [<ProvideLanguageExtension(typeof<FSharpLanguageService>, ".mli")>]
-    [<ProvideEditorExtension(FSharpConstants.editorFactoryGuidString, ".fs", 97)>]
-    [<ProvideEditorExtension(FSharpConstants.editorFactoryGuidString, ".fsi", 97)>]
-    [<ProvideEditorExtension(FSharpConstants.editorFactoryGuidString, ".fsx", 97)>]
-    [<ProvideEditorExtension(FSharpConstants.editorFactoryGuidString, ".fsscript", 97)>]
-    [<ProvideEditorExtension(FSharpConstants.editorFactoryGuidString, ".ml", 97)>]
-    [<ProvideEditorExtension(FSharpConstants.editorFactoryGuidString, ".mli", 97)>]
     internal FSharpLanguageService(package : FSharpPackage) =
     inherit AbstractLanguageService<FSharpPackage, FSharpLanguageService>(package)
 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/FSharpEditorFactory.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/FSharpEditorFactory.cs
@@ -16,6 +16,7 @@ using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
+    // 64 represents a hex number. It needs to be greater than 37 so the TextMate editor will not be chosen as higher priority.
     [Guid(Constants.FSharpEditorFactoryIdString)]
     [ProvideEditorFactory(typeof(FSharpEditorFactory), 101, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_SupportsPreview)]
     [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fs", 64)]

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/FSharpEditorFactory.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/FSharpEditorFactory.cs
@@ -18,10 +18,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
     [Guid(Constants.FSharpEditorFactoryIdString)]
     [ProvideEditorFactory(typeof(FSharpEditorFactory), 101, CommonPhysicalViewAttributes = (int)__VSPHYSICALVIEWATTRIBUTES.PVA_SupportsPreview)]
-    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fs", 32)]
-    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fsi", 32)]
-    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fsscript", 32)]
-    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fsx", 32)]
+    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fs", 64)]
+    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fsi", 64)]
+    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fsscript", 64)]
+    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".fsx", 64)]
+    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".ml", 64)]
+    [ProvideEditorExtension(typeof(FSharpEditorFactory), ".mli", 64)]
     public class FSharpEditorFactory : IVsEditorFactory
     {
         private Package _parentPackage;

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
@@ -306,7 +306,8 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         IReferenceContainerProvider,
         IVsProjectSpecialFiles, 
         IVsDesignTimeAssemblyResolution, 
-        IVsProjectUpgrade
+        IVsProjectUpgrade,
+        IVsSupportItemHandoff
     {
         /// <summary>
         /// This class stores mapping from ids -> objects. Uses as a replacement of EventSinkCollection (ESC)
@@ -5398,10 +5399,6 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             if (oldMkDoc == null || newMkDoc == null)
                 return VSConstants.E_INVALIDARG;
 
-            // Fail if the document names passed are equal.
-            if (oldMkDoc == newMkDoc)
-                return VSConstants.E_INVALIDARG;
-
             int hr = VSConstants.S_OK;
             VSDOCUMENTPRIORITY[] priority = new VSDOCUMENTPRIORITY[1];
             uint itemid = VSConstants.VSITEMID_NIL;
@@ -6613,6 +6610,16 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
             return hierarchy;
+        }
+
+        public int HandoffItem(uint itemid, IVsProject3 pProjDest, string pszMkDocumentOld, string pszMkDocumentNew, IVsWindowFrame punkWindowFrame)
+        {
+            if (pProjDest == null)
+            {
+                return VSConstants.E_POINTER;
+            }
+
+            return pProjDest.TransferItem(pszMkDocumentOld, pszMkDocumentNew, punkWindowFrame);
         }
     }
     internal enum AddItemContext

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -1593,7 +1593,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     // in the registry hive so that more editors can be added without changing this part of the
                     // code. FSharp only makes usage of one Editor Factory and therefore we will return 
                     // that guid
-                    guidEditorType <- new Guid(FSharpConstants.editorFactoryGuidString)
+                    guidEditorType <- new Guid(Constants.FSharpEditorFactoryIdString)
                     VSConstants.S_OK
 
             interface IVsProjectSpecificEditorMap2 with 
@@ -1607,7 +1607,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     // in the registry hive so that more editors can be added without changing this part of the
                     // code. FSharp only makes usage of one Editor Factory and therefore we will return 
                     // that guid
-                    guidEditorType <- new Guid(FSharpConstants.editorFactoryGuidString)
+                    guidEditorType <- new Guid(Constants.FSharpEditorFactoryIdString)
                     VSConstants.S_OK
 
                 member x.GetSpecificLanguageService(_mkDocument:string, guidLanguageService:byref<Guid> ) =

--- a/vsintegration/src/FSharp.VS.FSI/fsiCommands.vsct
+++ b/vsintegration/src/FSharp.VS.FSI/fsiCommands.vsct
@@ -249,7 +249,6 @@
     <!-- GuidSymbol name="guidFsiPkg" value="{eeeeeeee-9342-42f1-8ea9-42f0e8a6be55}" /-->  <!-- fsi package guid    -->
     <GuidSymbol name="guidFsiPkg" value="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" />        <!-- project system guid -->
 
-    <GuidSymbol name="guidEditorFactory"      value="{4EB7CCB7-4336-4FFD-B12B-396E9FD079A9}" /> <!-- Linked to constants in project system -->
     <GuidSymbol name="guidFSharpEditorFactory" value="{8a5aa6cf-46e3-4520-a70a-7393d15233e9}" /> <!-- FSharpEditorFactory Guid --> 
     <GuidSymbol name="GUID_CMDSETID_StandardCommandSet2K" value="{1496A755-94DE-11D0-8C3F-00C04FC2AAE2}" /> <!-- See stdidcmd.h -->
     <GuidSymbol name="guidFsiToolWindow"      value="{dee22b65-9761-4a26-8fb2-759b971d6dfc}" />


### PR DESCRIPTION
The FSharpEditor was given less priority than the TextMate editor. This was causing the original bug with the message. This was fixed by increasing the priority.

Also, there were two different guids for the FSharpEditor. One of the guids has been removed, and we now have a single guid.