### PR TITLE
Remove unused mapFold and mapFoldBack functions

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -115,16 +115,6 @@ module Array =
         Array.length l1 = Array.length l2 &&
         Array.forall2 p l1 l2
 
-    let mapFold f s l = 
-        let mutable acc = s
-        let n = Array.length l
-        let mutable res = Array.zeroCreate n
-        for i = 0 to n - 1 do
-            let h',s' = f acc l.[i]
-            res.[i] <- h';
-            acc <- s'
-        res, acc
-
     let order (eltOrder: IComparer<'T>) = 
         { new IComparer<array<'T>> with 
               member __.Compare(xs,ys) = 
@@ -449,15 +439,6 @@ module List =
         match l with 
         | [] -> false 
         | h::t -> LanguagePrimitives.PhysicalEquality x h || memq x t
-        
-    // Not tail recursive 
-    let rec mapFoldBack f l s = 
-        match l with 
-        | [] -> ([],s)
-        | h::t -> 
-           let t',s = mapFoldBack f t s
-           let h',s = f h s
-           (h'::t', s)
 
     let mapNth n f xs =
         let rec mn i = function


### PR DESCRIPTION
It doesn't look like mapFold or mapFoldBack are used from src/absil/illib.fs anymore so can be removed