### PR TITLE
change nightly publishing branches to be from GitHub

### DIFF
--- a/setup/publish-assets.ps1
+++ b/setup/publish-assets.ps1
@@ -27,10 +27,10 @@ try {
     $requestUrl = ""
 
     switch ($branchName) {
-        "microbuild" {
+        "master" {
             $requestUrl = "https://dotnet.myget.org/F/fsharp/vsix/upload"
         }
-        "microbuild-dev15.5" {
+        "dev15.5" {
             $requestUrl = "https://dotnet.myget.org/F/fsharp-preview/vsix/upload"
         }
         default {


### PR DESCRIPTION
Update the branch names that are allowed to publish nightly packages.  In the past `master` corresponded to the internal branch `microbuild` and `dev15.5` mapped to `microbuild-dev15.5`, but with #4047 the internal branches (and the entire internal repo) will no longer be necessary so we can publish nightly packages directly from the GH branches.
