### PR TITLE
Do not trigger completion on operators

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -94,7 +94,7 @@ type internal FSharpCompletionProvider
             // Trigger completion depending on some conditions, including if we are on a valid classification type
             else
                 let documentId, filePath, defines = getInfo()
-                CompletionUtils.shouldProvideCompletion(documentId, filePath, defines, sourceText, triggerPosition, triggerChar, prevChar)
+                CompletionUtils.shouldProvideCompletion(documentId, filePath, defines, sourceText, triggerPosition, triggerChar)
                 
 
     static member ProvideCompletionsAsyncAux(checker: FSharpChecker, sourceText: SourceText, caretPosition: int, options: FSharpProjectOptions, filePath: string, 
@@ -219,7 +219,6 @@ type internal FSharpCompletionProvider
         asyncMaybe {
             let document = context.Document
             let! sourceText = context.Document.GetTextAsync(context.CancellationToken)
-            //let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)
             do! Option.guard (this.ShouldTriggerCompletion(sourceText, context.Position, context.Trigger, null))
             let! _parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
             let! textVersion = context.Document.GetTextVersionAsync(context.CancellationToken)

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -84,17 +84,18 @@ type internal FSharpCompletionProvider
         // Skip if we are not on a completion trigger
         else
             let triggerPosition = caretPosition - 1
-            let c = sourceText.[triggerPosition]
+            let triggerChar = sourceText.[triggerPosition]
+            let prevChar = sourceText.[triggerPosition - 1]
             
             // do not trigger completion if it's not single dot, i.e. range expression
-            if not Settings.IntelliSense.ShowAfterCharIsTyped && sourceText.[triggerPosition - 1] = '.' then
+            if not Settings.IntelliSense.ShowAfterCharIsTyped && prevChar = '.' then
                 false
             
-            // Trigger completion if we are on a valid classification type
+            // Trigger completion depending on some conditions, including if we are on a valid classification type
             else
                 let documentId, filePath, defines = getInfo()
-                CompletionUtils.shouldProvideCompletion(documentId, filePath, defines, sourceText, triggerPosition) &&
-                (c = '.' || (Settings.IntelliSense.ShowAfterCharIsTyped && CompletionUtils.isStartingNewWord(sourceText, triggerPosition)))
+                CompletionUtils.shouldProvideCompletion(documentId, filePath, defines, sourceText, triggerPosition, triggerChar, prevChar)
+                
 
     static member ProvideCompletionsAsyncAux(checker: FSharpChecker, sourceText: SourceText, caretPosition: int, options: FSharpProjectOptions, filePath: string, 
                                              textVersionHash: int, getAllSymbols: unit -> AssemblySymbol list) = 
@@ -218,8 +219,8 @@ type internal FSharpCompletionProvider
         asyncMaybe {
             let document = context.Document
             let! sourceText = context.Document.GetTextAsync(context.CancellationToken)
-            let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)
-            do! Option.guard (CompletionUtils.shouldProvideCompletion(document.Id, document.FilePath, defines, sourceText, context.Position))
+            //let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)
+            do! Option.guard (this.ShouldTriggerCompletion(sourceText, context.Position, context.Trigger, null))
             let! _parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document)
             let! textVersion = context.Document.GetTextVersionAsync(context.CancellationToken)
             let! _, _, fileCheckResults = checker.ParseAndCheckDocument(document, projectOptions, true, userOpName=userOpName)

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionUtils.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionUtils.fs
@@ -82,7 +82,7 @@ module internal CompletionUtils =
     let isStartingNewWord (sourceText, position) =
         CommonCompletionUtilities.IsStartingNewWord(sourceText, position, (fun ch -> isIdentifierStartCharacter ch), (fun ch -> isIdentifierPartCharacter ch))
 
-    let shouldProvideCompletion (documentId: DocumentId, filePath: string, defines: string list, sourceText: SourceText, triggerPosition: int, triggerChar: char) : bool =
+    let shouldProvideCompletion (documentId: DocumentId, filePath: string, defines: string list, sourceText: SourceText, triggerPosition: int) : bool =
         let textLines = sourceText.Lines
         let triggerLine = textLines.GetLineFromPosition triggerPosition
         let colorizationData = Tokenizer.getColorizationData(documentId, sourceText, triggerLine.Span, Some filePath, defines, CancellationToken.None)
@@ -98,5 +98,3 @@ module internal CompletionUtils =
                 | ClassificationTypeNames.NumericLiteral -> false
                 | _ -> true // anything else is a valid classification type
             ))
-        &&
-        (triggerChar = '.' || (Settings.IntelliSense.ShowAfterCharIsTyped && isStartingNewWord(sourceText, triggerPosition)))

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionUtils.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionUtils.fs
@@ -12,23 +12,6 @@ open System.Globalization
 
 module internal CompletionUtils =
 
-    let private isPotentialOperatorChar (ch: char) =
-        match ch with
-        | '<'
-        | '>'
-        | '/'
-        | '?'
-        | '@'
-        | '!'
-        | '%'
-        | '^'
-        | '&'
-        | '*'
-        | '|'
-        | '~'
-        | '.' -> true
-        | _ -> false
-
     let private isLetterChar (cat: UnicodeCategory) =
         // letter-character:
         //   A Unicode character of classes Lu, Ll, Lt, Lm, Lo, or Nl 
@@ -99,7 +82,7 @@ module internal CompletionUtils =
     let isStartingNewWord (sourceText, position) =
         CommonCompletionUtilities.IsStartingNewWord(sourceText, position, (fun ch -> isIdentifierStartCharacter ch), (fun ch -> isIdentifierPartCharacter ch))
 
-    let shouldProvideCompletion (documentId: DocumentId, filePath: string, defines: string list, sourceText: SourceText, triggerPosition: int, triggerChar: char, prevChar: char) : bool =
+    let shouldProvideCompletion (documentId: DocumentId, filePath: string, defines: string list, sourceText: SourceText, triggerPosition: int, triggerChar: char) : bool =
         let textLines = sourceText.Lines
         let triggerLine = textLines.GetLineFromPosition triggerPosition
         let colorizationData = Tokenizer.getColorizationData(documentId, sourceText, triggerLine.Span, Some filePath, defines, CancellationToken.None)
@@ -111,10 +94,9 @@ module internal CompletionUtils =
                 | ClassificationTypeNames.Comment
                 | ClassificationTypeNames.StringLiteral
                 | ClassificationTypeNames.ExcludedCode
+                | ClassificationTypeNames.Operator
                 | ClassificationTypeNames.NumericLiteral -> false
                 | _ -> true // anything else is a valid classification type
             ))
         &&
         (triggerChar = '.' || (Settings.IntelliSense.ShowAfterCharIsTyped && isStartingNewWord(sourceText, triggerPosition)))
-        && 
-        not (isPotentialOperatorChar prevChar)

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -215,7 +215,8 @@ let ShouldTriggerCompletionInAttribute() =
 [<A
 module Foo = module end
 """
-    let caretPosition = fileContents.IndexOf("A")
+    let marker = "A"
+    let caretPosition = fileContents.IndexOf(marker) + marker.Length
     let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
     let getInfo() = documentId, filePath, []
     let triggered = FSharpCompletionProvider.ShouldTriggerCompletionAux(SourceText.From(fileContents), caretPosition, CompletionTriggerKind.Insertion, getInfo)
@@ -227,7 +228,8 @@ let ShouldTriggerCompletionAfterDerefOperator() =
 let foo = ref 12
 printfn "%d" !f
 """
-    let caretPosition = fileContents.IndexOf("!f")
+    let marker = "!f"
+    let caretPosition = fileContents.IndexOf(marker) + marker.Length
     let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
     let getInfo() = documentId, filePath, []
     let triggered = FSharpCompletionProvider.ShouldTriggerCompletionAux(SourceText.From(fileContents), caretPosition, CompletionTriggerKind.Insertion, getInfo)
@@ -240,7 +242,8 @@ type Point = { mutable X: int; mutable Y: int }
 let pnt = { X = 1; Y = 2 }
 use ptr = fixed &p
 """
-    let caretPosition = fileContents.IndexOf("&p")
+    let marker = "&p"
+    let caretPosition = fileContents.IndexOf(marker) + marker.Length
     let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
     let getInfo() = documentId, filePath, []
     let triggered = FSharpCompletionProvider.ShouldTriggerCompletionAux(SourceText.From(fileContents), caretPosition, CompletionTriggerKind.Insertion, getInfo)
@@ -264,7 +267,7 @@ xVal**y
     let markers = [ "+y"; "-y"; "*y"; "/y"; "%y";  "**y"]
 
     for marker in markers do 
-        let caretPosition = fileContents.IndexOf(marker)
+        let caretPosition = fileContents.IndexOf(marker) + marker.Length
         let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
         let getInfo() = documentId, filePath, []
         let triggered = FSharpCompletionProvider.ShouldTriggerCompletionAux(SourceText.From(fileContents), caretPosition, CompletionTriggerKind.Insertion, getInfo)

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -197,6 +197,19 @@ System.Console.WriteLine()
     Assert.IsFalse(triggered, "FSharpCompletionProvider.ShouldTriggerCompletionAux() should not trigger")
 
 [<Test>]
+let ShouldNotTriggerCompletionInOperator() =
+    // Simulate mistyping '|>'
+    let fileContents = """
+let f() =
+    12.0 |. sqrt
+"""
+    let caretPosition = fileContents.IndexOf("|.")
+    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
+    let getInfo() = documentId, filePath, []
+    let triggered = FSharpCompletionProvider.ShouldTriggerCompletionAux(SourceText.From(fileContents), caretPosition, CompletionTriggerKind.Insertion, getInfo)
+    Assert.IsFalse(triggered, "FSharpCompletionProvider.ShouldTriggerCompletionAux() should not trigger on operators")
+
+[<Test>]
 let ShouldDisplayTypeMembers() =
     let fileContents = """
 type T1() =


### PR DESCRIPTION
I noticed this when I mistyped `|.` the other day.  I threw this together quickly and must now leave for the office on the ferry, so I likely won't be able to address feedback until tomorrow.  I installed it into my VS and things seemed to work.