### PR TITLE
Add option to toggle unused declarations analyzer

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/RenameUnusedValue.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/RenameUnusedValue.fs
@@ -47,6 +47,9 @@ type internal FSharpRenameUnusedValueCodeFixProvider
 
     override __.RegisterCodeFixesAsync context : Task =
         asyncMaybe {
+            // Don't show code fixes for unused values, even if they are compiler-generated.
+            do! Option.guard Settings.CodeFixes.UnusedDeclarations
+
             let document = context.Document
             let! sourceText = document.GetTextAsync()
             let ident = sourceText.ToString(context.Span)

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
@@ -100,6 +100,8 @@ type internal UnusedDeclarationsAnalyzer() =
 
     override __.AnalyzeSemanticsAsync(document, cancellationToken) =
         asyncMaybe {
+            do! Option.guard Settings.CodeFixes.UnusedDeclarations
+
             do Trace.TraceInformation("{0:n3} (start) UnusedDeclarationsAnalyzer", DateTime.Now.TimeOfDay.TotalSeconds)
             do! Async.Sleep DefaultTuning.UnusedDeclarationsAnalyzerInitialDelay |> liftAsync // be less intrusive, give other work priority most of the time
             match getProjectInfoManager(document).TryGetOptionsForEditingDocumentOrProject(document) with

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -34,7 +34,8 @@ type QuickInfoOptions =
 type CodeFixesOptions =
     { SimplifyName: bool
       AlwaysPlaceOpensAtTopLevel: bool
-      UnusedOpens: bool }
+      UnusedOpens: bool 
+      UnusedDeclarations: bool }
 
 [<CLIMutable>]
 type LanguageServicePerformanceOptions = 
@@ -59,7 +60,8 @@ type internal Settings [<ImportingConstructor>](store: SettingsStore) =
               // See https://github.com/Microsoft/visualfsharp/pull/3238#issue-237699595
               SimplifyName = false 
               AlwaysPlaceOpensAtTopLevel = false
-              UnusedOpens = true }
+              UnusedOpens = true 
+              UnusedDeclarations = true }
 
         store.RegisterDefault
             { EnableInMemoryCrossProjectReferences = true

--- a/vsintegration/src/FSharp.UIResources/CodeFixesOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/CodeFixesOptionControl.xaml
@@ -26,6 +26,8 @@
                         <StackPanel Margin="15 0 0 0"/>
                         <CheckBox x:Name="unusedOpens" IsChecked="{Binding UnusedOpens}"
                                   Content="{x:Static local:Strings.Unused_opens_code_fix}"/>
+                        <CheckBox x:Name="unusedDeclaration" IsChecked="{Binding UnusedDeclarations}"
+                                  Content="{x:Static local:Strings.Unused_declaration_code_fix}"/>
                     </StackPanel>
                 </GroupBox>
             </StackPanel>

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -192,6 +192,15 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         public static string Solid_underline {
             get {
                 return ResourceManager.GetString("Solid_underline", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show code fixes for unused values.
+        /// </summary>
+        public static string Unused_declaration_code_fix {
+            get {
+                return ResourceManager.GetString("Unused_declaration_code_fix", resourceCulture);
             }
         }
         

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -196,7 +196,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show code fixes for unused values.
+        ///   Looks up a localized string similar to Analyze and suggest fixes for unused values.
         /// </summary>
         public static string Unused_declaration_code_fix {
             get {

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -165,4 +165,7 @@
   <data name="Unused_opens_code_fix" xml:space="preserve">
     <value>Remove unused open statements</value>
   </data>
+  <data name="Unused_declaration_code_fix" xml:space="preserve">
+    <value>Show code fixes for unused values</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -166,6 +166,6 @@
     <value>Remove unused open statements</value>
   </data>
   <data name="Unused_declaration_code_fix" xml:space="preserve">
-    <value>Show code fixes for unused values</value>
+    <value>Analyze and suggest fixes for unused values</value>
   </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Odebrat nepoužívané otevřené výkazy</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Nicht verwendete "open"-Anweisungen entfernen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
@@ -82,6 +82,11 @@
         <target state="new">Remove unused open statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Quitar instrucciones open no usadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Supprimer les instructions open inutilisées</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Rimuovi istruzioni OPEN inutilizzate</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">未使用の Open ステートメントを削除する</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">사용되지 않는 open 문 제거</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Usuń nieużywane otwarte instrukcje</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Remover instruções abertas não usadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Удалить неиспользуемые открытые операторы</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Kullanılmayan açık deyimleri kaldır</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">删除未使用的 open 语句</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Unused_declaration_code_fix">
-        <source>Show code fixes for unused values</source>
-        <target state="new">Show code fixes for unused values</target>
+        <source>Analyze and suggest fixes for unused values</source>
+        <target state="new">Analyze and suggest fixes for unused values</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">移除未使用的 open 陳述式</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unused_declaration_code_fix">
+        <source>Show code fixes for unused values</source>
+        <target state="new">Show code fixes for unused values</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Workaround for #3056 and configuration we should probably just have.

Because of how the editor works, I think, you need to either:

* Type something new to trigger the analyzer
* Close and re-open the document

to see changes in your settings.

Since locale-based text is now in this repo, there are more files touched than before.  All the text is still in English.  I'm not sure if I like using a translation tool to make the other languages good, but maybe that can be done...

Anyways, I don't feel too strongly about how I named it in the options, so I welcome feedback on the wording.

![demo](https://user-images.githubusercontent.com/6309070/33742141-d50d6bc8-db5b-11e7-99f6-27e99945fc23.gif)
