### PR TITLE
Fix 4040 - incorrect code generation for generic function

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -12697,7 +12697,8 @@ module IncrClassChecking =
                     | Expr.TyLambda (_, tps, b, m, returnTy) -> tps, [], b, returnTy, m 
                     | e -> [], [], e, (tyOfExpr cenv.g e), e.Range
                     
-                let chooseTps = chooseTps @ freeChoiceTypars
+                let chooseTps = chooseTps @ (ListSet.subtract typarEq freeChoiceTypars methodVal.Typars)
+
                 // Add the 'this' variable as an argument
                 let tauExpr, tauTy = 
                     if isStatic then 
@@ -12705,6 +12706,7 @@ module IncrClassChecking =
                     else
                         let e = mkLambda m thisVal (tauExpr, tauTy)
                         e, tyOfExpr cenv.g e
+
                 // Replace the type parameters that used to be on the rhs with 
                 // the full set of type parameters including the type parameters of the enclosing class
                 let rhsExpr = mkTypeLambda m methodVal.Typars (mkTypeChoose m chooseTps tauExpr, tauTy)

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -1791,6 +1791,51 @@ module SRTPFix =
       printfn "%A" <| replace 'q' (test("HI"))
      *)
 
+// See https://github.com/Microsoft/visualfsharp/issues/4040
+module InferenceRegression4040 = 
+    type Foo() =
+        static let test (t : 'T) : 'T list = 
+            let b : Bar<'T> = new Bar<'T>(t)
+            [b.Value]
+
+        static member Test(t : int) = test t
+
+    and Bar<'U>(value : 'U) =
+        member __.Value = value
+
+    printfn "%A" (Foo.Test 42)
+
+
+// See https://github.com/Microsoft/visualfsharp/issues/4040
+module InferenceRegression4040b = 
+    type Foo() =
+        static let test (t : 'T) : 'T list = 
+            let b : Bar<'T> = new Bar<'T>(t)
+            [b.Value]
+
+        static member Test(t : int) = test t
+
+    and Bar<'T>(value : 'T) =
+        member __.Value = value
+
+    printfn "%A" (Foo.Test 42)
+
+// See https://github.com/Microsoft/visualfsharp/issues/4040
+module InferenceRegression4040C = 
+    type Foo() =
+        static let test (t : 'T) : 'T list = 
+            let b : Bar<'T> = new Bar<'T>(t)
+            [b.Value]
+
+        static member Test(t : int) = test t
+
+    and Bar<'U>(value : 'U) =
+        member __.Value : 'U = value
+
+    printfn "%A" (Foo.Test 42)
+
+
+
 #if TESTS_AS_APP
 let RUN() = !failures
 #else


### PR DESCRIPTION

This is the proposed fix for https://github.com/Microsoft/visualfsharp/issues/4040

If the fix is correct, the error comes from a fairly straightforward mistake in constructing the TAST for a generalized let-bound function in a class.

