### PR TITLE
augment instead of replace the package source list when %PB_RestoreSource% is specified

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -572,7 +572,7 @@ if "%RestorePackages%" == "true" (
     %_ngenexe% install %_nugetexe%  /nologo
     set _nugetoptions=-PackagesDirectory packages -ConfigFile %_nugetconfig%
     if not "%PB_RESTORESOURCE%" == "" (
-        set _nugetoptions=!_nugetoptions! -Source %PB_RESTORESOURCE%
+        set _nugetoptions=!_nugetoptions! -FallbackSource %PB_RESTORESOURCE%
     )
 
     echo _nugetoptions=!_nugetoptions!

--- a/build.sh
+++ b/build.sh
@@ -450,7 +450,7 @@ if [ "${RestorePackages:-true}" = 'true' ]; then
 
     _nugetoptions="-PackagesDirectory packages -ConfigFile $_nugetconfig"
     if [ "$PB_RESTORESOURCE" != "" ]; then
-        _nugetoptions="$_nugetoptions -Source $PB_RESTORESOURCE"
+        _nugetoptions="$_nugetoptions -FallbackSource $PB_RESTORESOURCE"
     fi
 
     eval "$_nugetexe restore packages.config $_nugetoptions"


### PR DESCRIPTION
The `-Source` argument for NuGet replaces the package sources specified in `NuGet.config`.  `-FallbackSource` is a better option since it augments the list.

Fixes dotnet/core-eng#2233.

Edit: This was tested by:

1. Creating a simple `.nupkg` and copying it to `D:\bin`.
2. Updating `packages.config` to contain a reference to this package.
3. Deleting an already restored package.
4. Running `nuget.exe` with `-FallbackSource D:\bin`.

Result:
The deleted package (step 3) was appropriately restored from a custom source in `NuGet.config` **and** the package placed in `D:\bin` was also restored.