### PR TITLE
Fix nice print for sbyte and byte IL fields

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -321,9 +321,11 @@ module private PrintIL =
                     then Some Literals.keywordTrue
                     else Some Literals.keywordFalse
                 | ILFieldInit.Char c   -> ("'" + (char c).ToString () + "'") |> (tagStringLiteral >> Some)
+                | ILFieldInit.Int8 x  -> ((x |> int32 |> string) + "y") |> (tagNumericLiteral >> Some)
                 | ILFieldInit.Int16 x  -> ((x |> int32 |> string) + "s") |> (tagNumericLiteral >> Some)
                 | ILFieldInit.Int32 x  -> x |> (string >> tagNumericLiteral >> Some)
                 | ILFieldInit.Int64 x  -> ((x |> string) + "L") |> (tagNumericLiteral >> Some)
+                | ILFieldInit.UInt8 x  -> ((x |> int32 |> string) + "uy") |> (tagNumericLiteral >> Some)
                 | ILFieldInit.UInt16 x -> ((x |> int32 |> string) + "us")  |> (tagNumericLiteral >> Some)
                 | ILFieldInit.UInt32 x -> (x |> int64 |> string) + "u" |> (tagNumericLiteral >> Some)
                 | ILFieldInit.UInt64 x -> ((x |> int64 |> string) + "UL")  |> (tagNumericLiteral >> Some)


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/4065

![image](https://user-images.githubusercontent.com/873919/33794644-c9300adc-dce0-11e7-9500-90e7168754a4.png)

![image](https://user-images.githubusercontent.com/873919/33794646-d2510bd4-dce0-11e7-80af-e7d5b1566692.png)
