### PR TITLE
Beautify a bit

### DIFF
--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -988,20 +988,12 @@ module UntypedParseImpl =
                 | {TypeName = LongIdentWithDots([x], _)} when x.idText = name -> Some ()
                 | _ -> None
             
-            let rec getKind isClass isInterface isStruct = 
-                function
-                | [] -> isClass, isInterface, isStruct
-                | (SynAttr "Class")::xs -> getKind true isInterface isStruct xs
-                | (SynAttr "AbstractClass")::xs -> getKind true isInterface isStruct xs
-                | (SynAttr "Interface")::xs -> getKind isClass true isStruct xs
-                | (SynAttr "Struct")::xs -> getKind isClass isInterface true xs
-                | _::xs -> getKind isClass isInterface isInterface xs
-
-            match getKind false false false synAttributes with
-            | false, false, false -> Unknown
-            | true, false, false -> Class
-            | false, true, false -> Interface
-            | false, false, true -> Struct
+            match synAttributes with
+            | [ (SynAttr "Class") ]
+            | [ (SynAttr "AbstractClass") ] -> Class
+            | [ (SynAttr "Interface") ] -> Interface
+            | [ (SynAttr "Struct") ] -> Struct
+            | [] -> Unknown
             | _ -> Invalid
 
         let GetCompletionContextForInheritSynMember ((ComponentInfo(synAttributes, _, _, _,_, _, _, _)), typeDefnKind : SynTypeDefnKind, completionPath) = 

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -988,7 +988,6 @@ module UntypedParseImpl =
                 | {TypeName = LongIdentWithDots([x], _)} when x.idText = name -> Some ()
                 | _ -> None
             
-            // This might look confusing but what's done here is quite simple
             // We're traversing the list and extract the kind of it.
             // The kind is always invalid if a synAttributes list contains multiple cases (e.g. class and interface).
             // In such cases we have an early exit.

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -988,6 +988,11 @@ module UntypedParseImpl =
                 | {TypeName = LongIdentWithDots([x], _)} when x.idText = name -> Some ()
                 | _ -> None
             
+            // This might look confusing but what's done here is quite simple
+            // We're traversing the list and extract the kind of it.
+            // The kind is always invalid if a synAttributes list contains multiple cases (e.g. class and interface).
+            // In such cases we have an early exit.
+            // Otherwise we get a valid kind or an unknown kind if none of the cases can be found.
             let rec getKind isClass isInterface isStruct = 
                 function
                 | [] -> 
@@ -998,13 +1003,13 @@ module UntypedParseImpl =
                 | (SynAttr "Class")::xs
                 | (SynAttr "AbstractClass")::xs -> 
                     if isInterface || isStruct then Invalid
-                    else getKind true isInterface isStruct xs
+                    else getKind true false false xs
                 | (SynAttr "Interface")::xs ->
                     if isStruct || isClass then Invalid
-                    else getKind isClass true isStruct xs
+                    else getKind false true false xs
                 | (SynAttr "Struct")::xs -> 
                     if isClass || isInterface then Invalid
-                    else getKind isClass isInterface true xs
+                    else getKind false false true xs
                 | _::xs -> getKind isClass isInterface isStruct xs
 
             getKind false false false synAttributes


### PR DESCRIPTION
tried cleaning this bit up after I saw it on twitter.

I could apply a `List.distinct` before to avoid any failure of the cases due to multiple occurrence of the same attributes in the list. Would this be needed or shouldn't it be the case?