### PR TITLE
Fixed referencing netstandard projects in legacy projects

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectReferenceNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectReferenceNode.cs
@@ -805,6 +805,12 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 return FrameworkCompatibility.Ok;
             }
 
+            if (String.Compare(otherFrameworkName.Identifier, ".NETStandard", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                // we always allow references to projects that are targeted to the ".NETStandard" family
+                return FrameworkCompatibility.Ok;
+            }
+
             var myFrameworkName = GetProjectTargetFrameworkName(thisProject);
             if (String.Compare(otherFrameworkName.Identifier, myFrameworkName.Identifier, StringComparison.OrdinalIgnoreCase) == 0)
             {


### PR DESCRIPTION
This fixes: https://github.com/Microsoft/visualfsharp/issues/2461

You should be able to add .NETStandard project references in legacy projects now. This is important for the short term.