### PR TITLE
Typecheck method args even though it's not resolved

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -9454,16 +9454,7 @@ and TcMethodApplication
 
         let uniquelyResolved = 
             let csenv = MakeConstraintSolverEnv ContextInfo.NoContext cenv.css mMethExpr denv
-            let res = UnifyUniqueOverloading csenv callerArgCounts methodName ad preArgumentTypeCheckingCalledMethGroup returnTy
-
-            match res with
-            |   ErrorResult _ -> 
-                match afterResolution with
-                | AfterResolution.DoNothing -> ()
-                | AfterResolution.RecordResolution(_, _, _, onFailure) -> onFailure()
-            |   _ -> ()
-
-            res |> CommitOperationResult
+            UnifyUniqueOverloading csenv callerArgCounts methodName ad preArgumentTypeCheckingCalledMethGroup returnTy
 
         uniquelyResolved, preArgumentTypeCheckingCalledMethGroup
 
@@ -9496,7 +9487,7 @@ and TcMethodApplication
                         else
                             [domainTy]
                     [argTys], returnTy
-                        
+                         
             let lambdaVarsAndExprs = curriedArgTys |> List.mapiSquared (fun i j ty -> mkCompGenLocal mMethExpr ("arg"+string i+string j) ty)
             let unnamedCurriedCallerArgs = lambdaVarsAndExprs |> List.mapSquared (fun (_, e) -> CallerArg(tyOfExpr cenv.g e, e.Range, false, e))
             let namedCurriedCallerArgs = lambdaVarsAndExprs |> List.map (fun _ -> [])
@@ -9529,6 +9520,16 @@ and TcMethodApplication
 
     let preArgumentTypeCheckingCalledMethGroup = 
        preArgumentTypeCheckingCalledMethGroup |> List.map (fun cmeth -> (cmeth.Method, cmeth.CalledTyArgs, cmeth.AssociatedPropertyInfo, cmeth.UsesParamArrayConversion))
+    
+    let uniquelyResolved =
+        match uniquelyResolved with
+        | ErrorResult _ -> 
+            match afterResolution with
+            | AfterResolution.DoNothing -> ()
+            | AfterResolution.RecordResolution(_, _, _, onFailure) -> onFailure()
+        | _ -> ()
+
+        uniquelyResolved |> CommitOperationResult
     
     // STEP 3. Resolve overloading 
     /// Select the called method that's the result of overload resolution

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -211,6 +211,26 @@ is not compatible with type
     'int []'    
 .
 
+neg20.fs(183,29,183,34): typecheck error FS0001: This expression was expected to have type
+    'int'    
+but here has type
+    'obj'    
+
+neg20.fs(183,29,183,34): typecheck error FS0001: This expression was expected to have type
+    'int'    
+but here has type
+    'obj'    
+
+neg20.fs(183,35,183,40): typecheck error FS0001: This expression was expected to have type
+    'int'    
+but here has type
+    'obj'    
+
+neg20.fs(183,35,183,40): typecheck error FS0001: This expression was expected to have type
+    'int'    
+but here has type
+    'obj'    
+
 neg20.fs(183,14,183,41): typecheck error FS0001: This expression was expected to have type
     'unit'    
 but here has type
@@ -247,6 +267,26 @@ neg20.fs(188,14,188,31): typecheck error FS0041: Possible overload: 'static memb
 is not compatible with type
     'string []'    
 .
+
+neg20.fs(189,29,189,34): typecheck error FS0001: This expression was expected to have type
+    'string'    
+but here has type
+    'obj'    
+
+neg20.fs(189,29,189,34): typecheck error FS0001: This expression was expected to have type
+    'string'    
+but here has type
+    'obj'    
+
+neg20.fs(189,35,189,40): typecheck error FS0001: This expression was expected to have type
+    'string'    
+but here has type
+    'obj'    
+
+neg20.fs(189,35,189,40): typecheck error FS0001: This expression was expected to have type
+    'string'    
+but here has type
+    'obj'    
 
 neg20.fs(189,14,189,41): typecheck error FS0001: This expression was expected to have type
     'unit'    

--- a/tests/fsharp/typecheck/sigs/neg67.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg67.vsbsl
@@ -18,6 +18,6 @@ neg67.fsx(42,35,42,36): parse error FS0010: Unexpected symbol '}' in definition.
 neg67.fsx(41,9,41,14): typecheck error FS0001: This expression was expected to have type
     'unit'    
 but here has type
-    'Async<'a>'    
+    'Async<unit>'    
 
 neg67.fsx(30,1,41,37): typecheck error FS0003: This value is not a function and cannot be applied.

--- a/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/unittests/Tests.LanguageService.Completion.fs
@@ -1029,7 +1029,35 @@ for i in 0..a."]
         for (code, marker) in useCases do
             let code = prologue @ [code]
             AssertCtrlSpaceCompleteContains code marker [] ["field1"; "field2"]
+            
+    [<Test>]
+    [<Category("Records")>]
+    member public this.``Records.InferByFieldsInPriorMethodArguments``() =
+        
+        let prologue = 
+            [
+                "type T() ="
+                "    new (left: float32, top: float32) = T()"
+                "    new (left: float32, top: float32, width: float32, height: float32) = T()"
+                ""
+                "type Rect ="
+                "    { Left: float32"
+                "      Top: float32"
+                "      Width: float32"
+                "      Height: float32 }"
+            ]
 
+        let useCases = 
+            [ 
+              "let toT(original) = T(original.Left, (* MARKER*)original.)", "(* MARKER*)original.", ["Left"; "Top"; "Width"; "Height"]
+              "let toT(original) = T(original.Left, original.Height, (* MARKER*)original.)", "(* MARKER*)original.", ["Left"; "Top"; "Width"; "Height"]
+              "let toT(original) = T(original.Left, original.Height, original.Width, (* MARKER*)original.)", "(* MARKER*)original.", ["Left"; "Top"; "Width"; "Height"]
+              "let toT(original) = T(original.Left, original.Height, (* MARKER*)original., original.Width)", "(* MARKER*)original.", ["Left"; "Top"; "Width"; "Height"]
+            ]
+            
+        for (code, marker, should) in useCases do
+            let code = prologue @ [code]
+            AssertCtrlSpaceCompleteContains code marker should []
 
     [<Test>]
     member this.``Completion.DetectInterfaces``() = 


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/4098

The bug 

1. We are at 
```fsharp
module DataCentricPrograms

open System.Drawing

type Rect =
    { Left: float32
      Top: float32
      Width: float32
      Height: float32 }

let toRectangleF(original) =
    RectangleF(original.Left, original.Top, original.<caret>)
```
2. `RectangleF` has three constructors: with no params, with two params and with four params.
3. Typechecker tries to find a suitable one based on number of provided arguments (3), fails _and early return without typeckecking the args expressions_. The latter causes `original` type inference loose, which is based on `Left` and `Top` record fields. This causes loosing name resolution environment for `original` as of `Rect` type ===> no its fields names in completion.

It worked for `RectangleF(original.Left, original.<caret>)` and `RectangleF(original.Left, original.Top, original.Width, original.<caret>)` because typechecker successfully finds 2 and 4 params overloads.

So the fix is to always typeckeck arguments even though number of args does not match any of overloads.

@dsyme please, review.

![image](https://user-images.githubusercontent.com/873919/33805957-9b2d383e-ddd1-11e7-862b-81e82fff4b3d.png)
