### PR TITLE
[WIP] Fixed open declaration completions when there is no identifier

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -12052,11 +12052,14 @@ let TcTyconMemberSpecs cenv env containerInfo declKind tpenv (augSpfn: SynMember
 //------------------------------------------------------------------------- 
 
 let TcModuleOrNamespaceLidAndPermitAutoResolve tcSink env amap (longId : Ident list) =
-    let ad = env.eAccessRights
-    let m = longId |> List.map (fun id -> id.idRange) |> List.reduce unionRanges
-    match ResolveLongIndentAsModuleOrNamespace tcSink ResultCollectionSettings.AllResults amap m OpenQualified env.eNameResEnv ad longId true with 
-    | Result res -> Result res
-    | Exception err ->  raze err
+    if longId.IsEmpty then
+        Result []
+    else
+        let ad = env.eAccessRights
+        let m = longId |> List.map (fun id -> id.idRange) |> List.reduce unionRanges
+        match ResolveLongIndentAsModuleOrNamespace tcSink ResultCollectionSettings.AllResults amap m OpenQualified env.eNameResEnv ad longId true with 
+        | Result res -> Result res
+        | Exception err ->  raze err
 
 let TcOpenDecl tcSink (g:TcGlobals) amap m scopem env (longId : Ident list)  = 
     let modrefs = ForceRaise (TcModuleOrNamespaceLidAndPermitAutoResolve tcSink env amap longId)

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -16584,7 +16584,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv:cenv) parent typeNames scopem 
 
           return (exprfWithEscapeCheck, []), envAfter, envAfter
 
-      | SynModuleDecl.Open (LongIdentWithDots(mp, _), m) -> 
+      | SynModuleDecl.Open (_, LongIdentWithDots(mp, _), m) -> 
           let scopem = unionRanges m.EndRange scopem
           let env = TcOpenDecl cenv.tcSink cenv.g cenv.amap m scopem env mp
           return ((fun e -> e), []), env, env
@@ -16785,7 +16785,7 @@ and TcModuleOrNamespaceElementsMutRec cenv parent typeNames endm envInitial mutR
                   let decls = [MutRecShape.Module (compInfo, mutRecDefs)]
                   decls, (false, false, attrs)
 
-              | SynModuleDecl.Open (LongIdentWithDots(lid, _), m) ->  
+              | SynModuleDecl.Open (_, LongIdentWithDots(lid, _), m) ->  
                   if not openOk then errorR(Error(FSComp.SR.tcOpenFirstInMutRec(), m))
                   let decls = [ MutRecShape.Open (MutRecDataForOpen(lid, m)) ]
                   decls, (openOk, moduleAbbrevOk, attrs)

--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -1389,7 +1389,7 @@ and
     | DoExpr of SequencePointInfoForBinding * SynExpr * range:range
     | Types of SynTypeDefn list * range:range
     | Exception of SynExceptionDefn * range:range
-    | Open of longDotId:LongIdentWithDots * range:range
+    | Open of openTokenRange:range * longDotId:LongIdentWithDots * range:range
     | Attributes of SynAttributes * range:range
     | HashDirective of ParsedHashDirective * range:range
     | NamespaceFragment of SynModuleOrNamespace

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1256,8 +1256,18 @@ moduleDefn:
         [] }
 
   /* 'open' declarations */
-  | openDecl 
-      { [SynModuleDecl.Open($1, $1.Range)] }
+  | openDecl
+      { match $1 with
+        | Ast.LongIdentWithDots([], []) -> 
+            let rhsm = rhs parseState 1
+            let startPos = rhsm.End
+            let endPos = mkPos rhsm.EndLine (rhsm.EndColumn + 1)
+
+            let m = mkFileIndexRange rhsm.FileIndex startPos endPos
+            reportParseErrorAt m (FSComp.SR.parsIdentifierExpected())
+            [ SynModuleDecl.Open($1, rhsm) ]
+        | _ -> 
+            [ SynModuleDecl.Open($1, $1.Range) ] }
 
 
 /* The right-hand-side of a module abbreviation definition */ 
@@ -2354,7 +2364,8 @@ exconRepr:
   |             { None }
   | EQUALS path { Some ($2.Lid) }
 
-openDecl:  
+openDecl:
+  | OPEN      { Ast.LongIdentWithDots([], []) }
   | OPEN path { $2 }
 
 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1257,17 +1257,17 @@ moduleDefn:
 
   /* 'open' declarations */
   | openDecl
-      { match $1 with
-        | Some longDotId -> [ SynModuleDecl.Open(longDotId, longDotId.Range) ]
+      { let rhsm = rhs parseState 1
+        match $1 with
+        | Some longDotId -> [ SynModuleDecl.Open(rhsm, longDotId, unionRanges rhsm longDotId.Range) ]
         | _ -> 
-            let rhsm = rhs parseState 1
             let startPos = rhsm.End
             let endPos = mkPos rhsm.EndLine (rhsm.EndColumn + 1)
 
             let m = mkFileIndexRange rhsm.FileIndex startPos endPos
             reportParseErrorAt m (FSComp.SR.parsIdentifierExpected())
 
-            [ SynModuleDecl.Open(Ast.LongIdentWithDots([], []), rhsm) ] }
+            [ SynModuleDecl.Open(rhsm, LongIdentWithDots([], []), rhsm) ] }
 
 
 /* The right-hand-side of a module abbreviation definition */ 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1258,7 +1258,7 @@ moduleDefn:
   /* 'open' declarations */
   | openDecl
       { match $1 with
-        | Some lid -> [ SynModuleDecl.Open(lid, lid.Range) ]
+        | Some longDotId -> [ SynModuleDecl.Open(longDotId, longDotId.Range) ]
         | _ -> 
             let rhsm = rhs parseState 1
             let startPos = rhsm.End

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -286,7 +286,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <Ast.SynExceptionDefn> exconDefn
 %type <Ast.SynExceptionDefnRepr> exconCore
 %type <Ast.SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
-%type <Ast.LongIdentWithDots> openDecl
+%type <Ast.LongIdentWithDots option> openDecl
 %type <Ast.LongIdentWithDots> path
 %type <Ast.LongIdentWithDots> pathOp
 /*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
@@ -1258,16 +1258,16 @@ moduleDefn:
   /* 'open' declarations */
   | openDecl
       { match $1 with
-        | Ast.LongIdentWithDots([], []) -> 
+        | Some lid -> [ SynModuleDecl.Open(lid, lid.Range) ]
+        | _ -> 
             let rhsm = rhs parseState 1
             let startPos = rhsm.End
             let endPos = mkPos rhsm.EndLine (rhsm.EndColumn + 1)
 
             let m = mkFileIndexRange rhsm.FileIndex startPos endPos
             reportParseErrorAt m (FSComp.SR.parsIdentifierExpected())
-            [ SynModuleDecl.Open($1, rhsm) ]
-        | _ -> 
-            [ SynModuleDecl.Open($1, $1.Range) ] }
+
+            [ SynModuleDecl.Open(Ast.LongIdentWithDots([], []), rhsm) ] }
 
 
 /* The right-hand-side of a module abbreviation definition */ 
@@ -2365,8 +2365,8 @@ exconRepr:
   | EQUALS path { Some ($2.Lid) }
 
 openDecl:
-  | OPEN      { Ast.LongIdentWithDots([], []) }
-  | OPEN path { $2 }
+  | OPEN      { None }
+  | OPEN path { Some $2 }
 
 
 /*-------------------------------------------------------------------------*/

--- a/src/fsharp/vs/ServiceAssemblyContent.fs
+++ b/src/fsharp/vs/ServiceAssemblyContent.fs
@@ -877,7 +877,7 @@ module ParsedInput =
                 | SynModuleDecl.DoExpr (_, _, r)
                 | SynModuleDecl.Types (_, r)
                 | SynModuleDecl.Exception (_, r)
-                | SynModuleDecl.Open (_, r)
+                | SynModuleDecl.Open (_, _, r)
                 | SynModuleDecl.HashDirective (_, r) -> Some r
                 | _ -> None
                 |> Option.map (fun r -> r.StartColumn)
@@ -922,7 +922,7 @@ module ParsedInput =
                     let moduleBodyIdentation = getMinColumn decls |> Option.defaultValue (range.StartColumn + 4)
                     doRange NestedModule fullIdent range.StartLine moduleBodyIdentation
                     List.iter (walkSynModuleDecl fullIdent) decls
-            | SynModuleDecl.Open (_, range) -> doRange OpenDeclaration [] range.EndLine (range.StartColumn - 5)
+            | SynModuleDecl.Open (_, _, range) -> doRange OpenDeclaration [] range.EndLine (range.StartColumn - 5)
             | SynModuleDecl.HashDirective (_, range) -> doRange HashDirective [] range.EndLine range.StartColumn
             | _ -> ()
 

--- a/src/fsharp/vs/ServiceParseTreeWalk.fs
+++ b/src/fsharp/vs/ServiceParseTreeWalk.fs
@@ -169,7 +169,7 @@ module internal AstTraversal =
                 | SynModuleDecl.DoExpr(_sequencePointInfoForBinding, synExpr, _range) -> traverseSynExpr path synExpr  
                 | SynModuleDecl.Types(synTypeDefnList, _range) -> synTypeDefnList |> List.map (fun x -> dive x x.Range (traverseSynTypeDefn path)) |> pick decl
                 | SynModuleDecl.Exception(_synExceptionDefn, _range) -> None
-                | SynModuleDecl.Open(_longIdent, _range) -> None
+                | SynModuleDecl.Open(_openTokenRange, _longIdent, _range) -> None
                 | SynModuleDecl.Attributes(_synAttributes, _range) -> None
                 | SynModuleDecl.HashDirective(_parsedHashDirective, range) -> visitor.VisitHashDirective range
                 | SynModuleDecl.NamespaceFragment(synModuleOrNamespace) -> traverseSynModuleOrNamespace path synModuleOrNamespace

--- a/src/fsharp/vs/ServiceStructure.fs
+++ b/src/fsharp/vs/ServiceStructure.fs
@@ -569,7 +569,7 @@ module Structure =
             |> List.choose selectRanges
             |> acc.AddRange
 
-        let collectOpens = getConsecutiveModuleDecls (function SynModuleDecl.Open (_, r) -> Some r | _ -> None) Scope.Open
+        let collectOpens = getConsecutiveModuleDecls (function SynModuleDecl.Open (_, _, r) -> Some r | _ -> None) Scope.Open
 
         let collectHashDirectives =
              getConsecutiveModuleDecls(

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -1262,12 +1262,12 @@ module UntypedParseImpl =
                     member __.VisitModuleDecl(defaultTraverse, decl) =
                         match decl with
                         // this path is when there are no identifiers
-                        | SynModuleDecl.Open(LongIdentWithDots([], _), m) ->
-                            if pos.Column > m.StartColumn && (pos.Column > m.EndColumn || pos.Line <> m.EndLine) then
+                        | SynModuleDecl.Open(openTokenM, LongIdentWithDots([], _), _) ->
+                            if pos.Column > openTokenM.StartColumn && (pos.Column > openTokenM.EndColumn || pos.Line <> openTokenM.EndLine) then
                                 Some CompletionContext.OpenDeclaration
                             else
                                 None
-                        | SynModuleDecl.Open(_, m) -> 
+                        | SynModuleDecl.Open(_, _, m) -> 
                             // in theory, this means we're "in an open"
                             // in practice, because the parse tree/walkers do not handle attributes well yet, need extra check below to ensure not e.g. $here$
                             //     open System

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -1267,7 +1267,7 @@ module UntypedParseImpl =
                                 Some CompletionContext.OpenDeclaration
                             else
                                 None
-                        | SynModuleDecl.Open(_, _, m) -> 
+                        | SynModuleDecl.Open(_, longDotId, _) -> 
                             // in theory, this means we're "in an open"
                             // in practice, because the parse tree/walkers do not handle attributes well yet, need extra check below to ensure not e.g. $here$
                             //     open System
@@ -1275,7 +1275,7 @@ module UntypedParseImpl =
                             //     let f() = ()
                             // inside an attribute on the next item
                             let pos = mkPos pos.Line (pos.Column - 1) // -1 because for e.g. "open System." the dot does not show up in the parse tree
-                            if rangeContainsPos m pos then  
+                            if rangeContainsPos longDotId.Range pos then  
                                 Some CompletionContext.OpenDeclaration
                             else
                                 None

--- a/src/fsharp/vs/ServiceUntypedParse.fs
+++ b/src/fsharp/vs/ServiceUntypedParse.fs
@@ -1261,6 +1261,12 @@ module UntypedParseImpl =
 
                     member __.VisitModuleDecl(defaultTraverse, decl) =
                         match decl with
+                        // this path is when there are no identifiers
+                        | SynModuleDecl.Open(LongIdentWithDots([], _), m) ->
+                            if pos.Column > m.StartColumn && (pos.Column > m.EndColumn || pos.Line <> m.EndLine) then
+                                Some CompletionContext.OpenDeclaration
+                            else
+                                None
                         | SynModuleDecl.Open(_, m) -> 
                             // in theory, this means we're "in an open"
                             // in practice, because the parse tree/walkers do not handle attributes well yet, need extra check below to ensure not e.g. $here$

--- a/tests/service/InteractiveCheckerTests.fs
+++ b/tests/service/InteractiveCheckerTests.fs
@@ -41,7 +41,7 @@ let internal identsAndRanges (input: Ast.ParsedInput) =
         | Ast.SynModuleDecl.Let(_, _, _) -> failwith "Not implemented yet"
         | Ast.SynModuleDecl.DoExpr(_, _, _range) -> failwith "Not implemented yet"
         | Ast.SynModuleDecl.Exception(_, _range) -> failwith "Not implemented yet"
-        | Ast.SynModuleDecl.Open(longIdentWithDots, range) -> [ identAndRange (longIdentWithDotsToString longIdentWithDots) range ]
+        | Ast.SynModuleDecl.Open(_, longIdentWithDots, range) -> [ identAndRange (longIdentWithDotsToString longIdentWithDots) range ]
         | Ast.SynModuleDecl.Attributes(_attrs, _range) -> failwith "Not implemented yet"
         | Ast.SynModuleDecl.HashDirective(_, _range) -> failwith "Not implemented yet"
         | Ast.SynModuleDecl.NamespaceFragment(moduleOrNamespace) -> extractFromModuleOrNamespace moduleOrNamespace

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -565,6 +565,44 @@ module M2 =
 """
     VerifyCompletionList(fileContents, "    Ext", ["Extensions"; "ExtraTopLevelOperators"], [])
 
+[<Test>]
+let ``Provide namespace/module completions on an empty identifier for an open delcaration`` =
+    let fileContents = """
+open 
+"""
+    VerifyCompletionList(fileContents, "open ", ["System"], ["abs"])
+
+[<Test>]
+let ``Don't provide namespace/module completions on an empty identifier for an open delcaration, but position is at the end position of the open token`` =
+    let fileContents = """
+open 
+"""
+    VerifyCompletionList(fileContents, "open", ["abs"], [])
+
+[<Test>]
+let ``Don't provide namespace/module completions on an empty identifier for an open delcaration on the next line, but at the same column as the start position of the open token`` =
+    let fileContents = """
+open 
+ 
+"""
+    VerifyCompletionList(fileContents, "open \r\n", ["abs"], [])
+
+[<Test>]
+let ``Provide namespace/module completions on an empty identifier for an open delcaration on the next line`` =
+    let fileContents = """
+open 
+ 
+"""
+    VerifyCompletionList(fileContents, "open \r\n ", ["System"], ["abs"])
+
+[<Test>]
+let ``Provide namespace/module completions on an identifier for an open delcaration`` =
+    let fileContents = """
+open S
+"""
+    VerifyCompletionList(fileContents, "open S", ["System"], ["abs"])
+
+
 #if EXE
 ShouldDisplaySystemNamespace()
 #endif

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -573,14 +573,14 @@ open
     VerifyCompletionList(fileContents, "open ", ["System"], ["abs"])
 
 [<Test>]
-let ``Don't provide namespace/module completions on an empty identifier for an open delcaration, but position is at the end position of the open token`` =
+let ``Don't provide namespace/module completions on an empty identifier for an open delcaration; position is at the end position of the OPEN token`` =
     let fileContents = """
 open 
 """
     VerifyCompletionList(fileContents, "open", ["abs"], [])
 
 [<Test>]
-let ``Don't provide namespace/module completions on an empty identifier for an open delcaration on the next line, but at the same column as the start position of the open token`` =
+let ``Don't provide namespace/module completions on an empty identifier for an open delcaration on the next line; position is at the start column of the OPEN token`` =
     let fileContents = """
 open 
  


### PR DESCRIPTION
Referring to this issue: https://github.com/Microsoft/visualfsharp/issues/4078

We are getting all symbols when we do completions for open delcarations that do not have an identifier. The reason is because the parser is giving us nothing useful at this specific point.

This fix modifies the parser slightly to give us something to work with. It also gives us a different error message if there is no identifier, "Identifier expected". This is what C# does as well.

#

This needs a bit of discussion. 

In `pars.fsy`, I'm not entirely sure this is a good idea returning: 
```[ SynModuleDecl.Open(Ast.LongIdentWithDots([], []), rhsm) ]```. 

 ```rhsm``` is the range of the OPEN token. Normally the range that is passed to ```SynModuleDecl.Open``` is the entire range of ```Ast.LongIdentWithDots``` when there is an identifier. 

This could be a little confusing. Perhaps there is a better way to represent this kind of thing. I need the range of the OPEN token when there is no identifier in order have completions that result in compilable code.

#

Also, need to add a little more tests.