### PR TITLE
[WIP] Add call to FSharp.Editor bits in the legacy project system

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -107,11 +107,6 @@
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>
     </ProjectReference>
-    <!-- <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.LanguageService\FSharp.LanguageService.fsproj">
-      <Name>FSharp.LanguageService</Name>
-      <Project>{ee85aab7-cda0-4c4e-bda0-a64ccc413e3f}</Project>
-      <Private>True</Private>
-    </ProjectReference> -->
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.LanguageService.Base\FSharp.LanguageService.Base.csproj">
       <Name>FSharp.LanguageService.Base</Name>
       <Project>{1c5c163c-37ea-4a3c-8ccc-0d34b74bf8ef}</Project>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -107,6 +107,11 @@
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>
     </ProjectReference>
+    <!-- <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.LanguageService\FSharp.LanguageService.fsproj">
+      <Name>FSharp.LanguageService</Name>
+      <Project>{ee85aab7-cda0-4c4e-bda0-a64ccc413e3f}</Project>
+      <Private>True</Private>
+    </ProjectReference> -->
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.LanguageService.Base\FSharp.LanguageService.Base.csproj">
       <Name>FSharp.LanguageService.Base</Name>
       <Project>{1c5c163c-37ea-4a3c-8ccc-0d34b74bf8ef}</Project>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -28,19 +28,6 @@
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludePkgdefInVSIXContainer>true</IncludePkgdefInVSIXContainer>
   </PropertyGroup>
-  <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
-  <Import Project="$(VsSDKTargets)" />
-  <Import Project="$(FSharpSourcesRoot)\..\vsintegration\vsintegration.targets" />
-  <Target Name="GatherBinariesToBeSigned" AfterTargets="CopyFilesToOutputDirectory">
-    <ItemGroup>
-      <BinariesToBeSigned Include="$(OutDir)$(AssemblyName).dll" />
-      <BinariesToBeSigned Include="$(OutDir)**\$(AssemblyName).resources.dll" />
-      <FilesToSign Include="@(BinariesToBeSigned)">
-        <Authenticode>Microsoft</Authenticode>
-        <StrongName>StrongName</StrongName>
-      </FilesToSign>
-    </ItemGroup>
-  </Target>
   <ItemGroup>
     <InternalsVisibleTo Include="FSharp.ProjectSystem.FSharp" />
     <InternalsVisibleTo Include="VisualFSharp.UnitTests" />
@@ -148,7 +135,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UIAutomationTypes" />
-    <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="WindowsBase" />
     <Reference Include="System" />
     <Reference Include="PresentationCore" />

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -28,6 +28,19 @@
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludePkgdefInVSIXContainer>true</IncludePkgdefInVSIXContainer>
   </PropertyGroup>
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
+  <Import Project="$(VsSDKTargets)" />
+  <Import Project="$(FSharpSourcesRoot)\..\vsintegration\vsintegration.targets" />
+  <Target Name="GatherBinariesToBeSigned" AfterTargets="CopyFilesToOutputDirectory">
+    <ItemGroup>
+      <BinariesToBeSigned Include="$(OutDir)$(AssemblyName).dll" />
+      <BinariesToBeSigned Include="$(OutDir)**\$(AssemblyName).resources.dll" />
+      <FilesToSign Include="@(BinariesToBeSigned)">
+        <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
   <ItemGroup>
     <InternalsVisibleTo Include="FSharp.ProjectSystem.FSharp" />
     <InternalsVisibleTo Include="VisualFSharp.UnitTests" />
@@ -135,6 +148,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UIAutomationTypes" />
+    <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="WindowsBase" />
     <Reference Include="System" />
     <Reference Include="PresentationCore" />

--- a/vsintegration/src/FSharp.LanguageService/LanguageServiceConstants.fs
+++ b/vsintegration/src/FSharp.LanguageService/LanguageServiceConstants.fs
@@ -8,3 +8,7 @@ module internal LanguageServiceConstants =
     /// "F#"
     [<Literal>]
     let FSharpLanguageName = "F#"
+        
+    [<Literal>]
+    /// "F# Language Service"
+    let FSharpLanguageServiceCallbackName = "F# Language Service"

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -87,7 +87,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
 //////////////////////
 
     // An IProjectSite object with hot-swappable inner implementation
-    type internal DynamicProjectSite(origInnerImpl : Microsoft.VisualStudio.FSharp.LanguageService.IProjectSite) =
+    type internal DynamicProjectSite(origInnerImpl : Microsoft.VisualStudio.FSharp.Editor.IProjectSite) =
 
         let mutable inner = origInnerImpl
 
@@ -95,7 +95,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
             inner <- newInner
 
         // This interface is thread-safe, assuming "inner" is thread-safe
-        interface Microsoft.VisualStudio.FSharp.LanguageService.IProjectSite with
+        interface Microsoft.VisualStudio.FSharp.Editor.IProjectSite with
             member __.Description = inner.Description
             member __.CompilationSourceFiles = inner.CompilationSourceFiles
             member __.CompilationOptions = inner.CompilationOptions
@@ -128,7 +128,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
         // This member is thread-safe
         member x.GetProjectSite() =
             Debug.Assert(state <> ProjectSiteOptionLifetimeState.Opening, "ProjectSite is not available")
-            projectSite.Value :> Microsoft.VisualStudio.FSharp.LanguageService.IProjectSite
+            projectSite.Value :> Microsoft.VisualStudio.FSharp.Editor.IProjectSite
 
         // This member is thread-safe
         member x.TryGetProjectSite() =
@@ -136,7 +136,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
             | ProjectSiteOptionLifetimeState.Opening, _ 
             | ProjectSiteOptionLifetimeState.Closed, _ -> None
             | _, None ->  None
-            | _, Some x ->  Some(x :> Microsoft.VisualStudio.FSharp.LanguageService.IProjectSite)
+            | _, Some x ->  Some(x :> Microsoft.VisualStudio.FSharp.Editor.IProjectSite)
 
         member x.Open(site) =
             Debug.Assert((state = ProjectSiteOptionLifetimeState.Opening), "Called Open, but not in Opening state")
@@ -159,7 +159,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
         static member ExploreFolderInWindows = 1635u
 
     type internal Notifier() =
-        let notificationsDict = new System.Collections.Generic.Dictionary<string,Microsoft.VisualStudio.FSharp.LanguageService.AdviseProjectSiteChanges>()
+        let notificationsDict = new System.Collections.Generic.Dictionary<string,Microsoft.VisualStudio.FSharp.Editor.AdviseProjectSiteChanges>()
         member this.Notify() =
             for kvp in notificationsDict do
                 kvp.Value.Invoke()
@@ -1446,7 +1446,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
             // Returns an IProjectSite that references "this" to get its information
             member private x.CreateRunningProjectSite() =
                 let creationTime = System.DateTime.UtcNow
-                { new Microsoft.VisualStudio.FSharp.LanguageService.IProjectSite with
+                { new Microsoft.VisualStudio.FSharp.Editor.IProjectSite with
 
                     member __.CompilationSourceFiles = x.CompilationSourceFiles
                     member __.CompilationOptions = x.CompilationOptions
@@ -1471,7 +1471,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     member __.TargetFrameworkMoniker = x.GetTargetFrameworkMoniker()
                     member __.ProjectGuid = x.GetProjectGuid()
                     member __.LoadTime = creationTime
-                    member __.ProjectProvider = Some (x :> Microsoft.VisualStudio.FSharp.LanguageService.IProvideProjectSite)
+                    member __.ProjectProvider = Some (x :> Microsoft.VisualStudio.FSharp.Editor.IProvideProjectSite)
 
                 }
 
@@ -1490,7 +1490,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                 let creationTime = DateTime.UtcNow
 
                 // This object is thread-safe
-                { new Microsoft.VisualStudio.FSharp.LanguageService.IProjectSite with
+                { new Microsoft.VisualStudio.FSharp.Editor.IProjectSite with
                     member __.Description = description
                     member __.CompilationSourceFiles = sourceFiles
                     member __.CompilationOptions = options
@@ -1507,11 +1507,11 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     member __.TargetFrameworkMoniker = targetFrameworkMoniker
                     member __.ProjectGuid = x.GetProjectGuid()
                     member __.LoadTime = creationTime
-                    member __.ProjectProvider = Some (x :> Microsoft.VisualStudio.FSharp.LanguageService.IProvideProjectSite)
+                    member __.ProjectProvider = Some (x :> Microsoft.VisualStudio.FSharp.Editor.IProvideProjectSite)
                 }
 
             // let the language service ask us questions
-            interface Microsoft.VisualStudio.FSharp.LanguageService.IProvideProjectSite with
+            interface Microsoft.VisualStudio.FSharp.Editor.IProvideProjectSite with
                 member x.GetProjectSite() = 
                     match projectSite.State with
                     | ProjectSiteOptionLifetimeState.Opening ->

--- a/vsintegration/tests/Salsa/FSharpLanguageServiceTestable.fs
+++ b/vsintegration/tests/Salsa/FSharpLanguageServiceTestable.fs
@@ -18,7 +18,6 @@ open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.VisualStudio.FSharp.LanguageService
 open Microsoft.VisualStudio.FSharp.LanguageService.SiteProvider
-open Microsoft.VisualStudio.FSharp.Editor
 
 type internal FSharpLanguageServiceTestable() as this =
     static let colorizerGuid = new Guid("{A2976312-7D71-4BB4-A5F8-66A08EBF46C8}") // Guid for colorized user data on IVsTextBuffer
@@ -149,9 +148,9 @@ type internal FSharpLanguageServiceTestable() as this =
             match hier with 
             | :? Microsoft.VisualStudio.FSharp.LanguageService.IProvideProjectSite as siteProvider ->
                 let site = siteProvider.GetProjectSite()
-                site.AdviseProjectSiteChanges(FSharpConstants.FSharpLanguageServiceCallbackName, 
+                site.AdviseProjectSiteChanges(LanguageServiceConstants.FSharpLanguageServiceCallbackName, 
                                               new Microsoft.VisualStudio.FSharp.LanguageService.AdviseProjectSiteChanges(fun () -> this.OnProjectSettingsChanged(site))) 
-                site.AdviseProjectSiteCleaned(FSharpConstants.FSharpLanguageServiceCallbackName, 
+                site.AdviseProjectSiteCleaned(LanguageServiceConstants.FSharpLanguageServiceCallbackName, 
                                               new Microsoft.VisualStudio.FSharp.LanguageService.AdviseProjectSiteChanges(fun () -> this.OnProjectCleaned(site))) 
             | _ -> 
                 // This can happen when the file is in a solution folder or in, say, a C# project.

--- a/vsintegration/tests/unittests/TestLib.ProjectSystem.fs
+++ b/vsintegration/tests/unittests/TestLib.ProjectSystem.fs
@@ -18,6 +18,7 @@ open Microsoft.Win32
 
 open Microsoft.VisualStudio
 open Microsoft.VisualStudio.FSharp.ProjectSystem
+open Microsoft.VisualStudio.FSharp.Editor
 open Microsoft.VisualStudio.Shell.Interop
 
 open Microsoft.Build.Execution
@@ -366,10 +367,10 @@ type TheTests() =
         () 
 
     member internal this.EnsureCausesNotification(project, code) =
-        let ipsf = project :> Microsoft.VisualStudio.FSharp.LanguageService.IProvideProjectSite
+        let ipsf = project :> IProvideProjectSite
         let ips = ipsf.GetProjectSite()
         let changed = ref false
-        let handle = ips.AdviseProjectSiteChanges("EnsureCausesNotificationTest", new Microsoft.VisualStudio.FSharp.LanguageService.AdviseProjectSiteChanges(fun () -> changed := true))
+        let handle = ips.AdviseProjectSiteChanges("EnsureCausesNotificationTest", new AdviseProjectSiteChanges(fun () -> changed := true))
         code()
         AssertEqual true (!changed)
     static member MsBuildCompileItems(project : Microsoft.Build.Evaluation.Project) =

--- a/vsintegration/tests/unittests/Tests.ProjectSystem.Miscellaneous.fs
+++ b/vsintegration/tests/unittests/Tests.ProjectSystem.Miscellaneous.fs
@@ -15,6 +15,7 @@ open Microsoft.VisualStudio
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.FSharp.ProjectSystem
+open Microsoft.VisualStudio.FSharp.Editor
 
 // Internal unittest namespaces
 open NUnit.Framework
@@ -498,7 +499,7 @@ type Miscellaneous() =
             // Now the project system is in a state where ComputeSourcesAndFlags will fail.
             // Our goal is to at least be able to open individual source files and treat them like 'files outside a project' with regards to intellisense, etc.
             // Also, if the user does 'Build', he will get an error which will help diagnose the problem.
-            let ipps = project :> Microsoft.VisualStudio.FSharp.LanguageService.IProvideProjectSite
+            let ipps = project :> IProvideProjectSite
             let ips = ipps.GetProjectSite()
             let expected = [| |] // Ideal behavior is [|"foo.fs";"bar.fs"|], and we could choose to improve this in the future.  For now we are just happy to now throw/crash.
             let actual = ips.CompilationSourceFiles


### PR DESCRIPTION
#4108 wasn't complete, apparently.

* The legacy project system was still calling into the FSharp.LanguageService version of ProjectSitesAndFiles.fs via fully-qualified name
* Parts of the project system tests were doing this as well

These are now updated to call into the correct things, thus ensuring that F# source files from .NET Framework-based projects aren't rendered as plaintext.

.NET Core SDK-based projects and VisualFSharp.sln all seem to load and work with these changes.

I did notice, while testing, that automatic restore for .NET Core SDK-based projects wasn't happening.

**TODO**

- [ ] Find any further usage of FSharp.LanguageService.ProjectSitesAndFiles in the tests and replace then with the FSharp.Editor version
- [ ] Potentially add a test to see that once a file is opened, the lang service is initialized