### PR TITLE
[WIP] Fixing error recovery for attributes

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1014,7 +1014,7 @@ let OutputPhasedErrorR (os:StringBuilder) (err:PhasedDiagnostic) =
               | Parser.TOKEN_DOWNCAST   -> getErrorString("Parser.TOKEN.DOWNCAST")
               | Parser.TOKEN_NULL   -> getErrorString("Parser.TOKEN.NULL")
               | Parser.TOKEN_RESERVED    -> getErrorString("Parser.TOKEN.RESERVED")
-              | Parser.TOKEN_MODULE | Parser.TOKEN_MODULE_COMING_SOON | Parser.TOKEN_MODULE_IS_HERE   -> getErrorString("Parser.TOKEN.MODULE")
+              | Parser.TOKEN_MODULE | Parser.TOKEN_MODULE_COMING_SOON | Parser.TOKEN_MODULE_IS_HERE | Parser.TOKEN_MODULE_ATTRIBUTE_TARGET_COMING_SOON | Parser.TOKEN_MODULE_ATTRIBUTE_TARGET_IS_HERE   -> getErrorString("Parser.TOKEN.MODULE")
               | Parser.TOKEN_AND    -> getErrorString("Parser.TOKEN.AND")
               | Parser.TOKEN_AS   -> getErrorString("Parser.TOKEN.AS")
               | Parser.TOKEN_ASSERT   -> getErrorString("Parser.TOKEN.ASSERT")

--- a/src/fsharp/LexFilter.fs
+++ b/src/fsharp/LexFilter.fs
@@ -1676,7 +1676,11 @@ type LexFilterImpl (lightSyntaxStatus:LightSyntaxStatus, compilingFsLib, lexer, 
                 
         //  module ... ~~~> CtxtModuleHead 
         |  MODULE,(_ :: _) -> 
-            insertComingSoonTokens("MODULE", MODULE_COMING_SOON, MODULE_IS_HERE)
+            match peekNextToken() with
+            | COLON ->
+                insertComingSoonTokens("MODULE", MODULE_ATTRIBUTE_TARGET_COMING_SOON, MODULE_ATTRIBUTE_TARGET_IS_HERE)
+            | _ ->
+                insertComingSoonTokens("MODULE", MODULE_COMING_SOON, MODULE_IS_HERE)
             if debug then dprintf "MODULE: entering CtxtModuleHead, awaiting EQUALS to go to CtxtSeqBlock (%a)\n" outputPos tokenStartPos
             pushCtxt tokenTup (CtxtModuleHead (tokenStartPos, token))
             hwTokenFetch(useBlockRule)

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -10499,6 +10499,10 @@ and TcAttribute canFail cenv (env: TcEnv) attrTgt (synAttr: SynAttribute)  =
     let targetIndicator           = synAttr.Target
     let isAppliedToGetterOrSetter = synAttr.AppliesToGetterAndSetter
     let mAttr                     = synAttr.Range
+
+    if tycon.IsEmpty then ([], true)
+    else
+
     let (typath, tyid) = List.frontAndBack tycon
     let tpenv = emptyUnscopedTyparEnv
 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -206,6 +206,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 
 /* for parser 'escape hatch' out of expression context without consuming the 'recover' token */
 %token TYPE_COMING_SOON TYPE_IS_HERE MODULE_COMING_SOON MODULE_IS_HERE
+%token MODULE_ATTRIBUTE_TARGET_COMING_SOON MODULE_ATTRIBUTE_TARGET_IS_HERE
 
 /* for high-precedence tyapps and apps */
 %token HIGH_PRECEDENCE_BRACK_APP   /* inserted for f[x], but not f [x] */
@@ -1368,8 +1369,8 @@ attributeList:
       { if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedLBrackLess())
         $2 }
 
-  | LBRACK_LESS  ends_coming_soon_or_recover 
-      { if not $2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedLBrackLess())
+  | LBRACK_LESS  opt_OBLOCKSEP ends_coming_soon_or_recover 
+      { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedLBrackLess())
         [] }
 
 
@@ -1402,7 +1403,7 @@ attribute:
 
 /* The target of a custom attribute */
 attributeTarget: 
-  | moduleKeyword COLON 
+  | MODULE_ATTRIBUTE_TARGET_COMING_SOON moduleKeyword COLON 
       { Some(ident("module",(rhs parseState 1))) } 
 
   | typeKeyword COLON 
@@ -4918,6 +4919,8 @@ typeKeyword:
 
 /* A 'module' keyword */
 moduleKeyword:
+  | MODULE_ATTRIBUTE_TARGET_COMING_SOON moduleKeyword { }
+  | MODULE_ATTRIBUTE_TARGET_IS_HERE { }
   | MODULE_COMING_SOON moduleKeyword { }
   | MODULE_IS_HERE { }
   | MODULE { }

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -1371,7 +1371,8 @@ attributeList:
 
   | LBRACK_LESS  opt_OBLOCKSEP ends_coming_soon_or_recover 
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedLBrackLess())
-        [] }
+        let rhsm = rhs parseState 1
+        [{ TypeName=Ast.LongIdentWithDots([], []); ArgExpr=(mkSynUnit rhsm); Target=None; AppliesToGetterAndSetter=false; Range=rhsm }] }
 
 
 /* One set of custom attributes, not including [< ... >] */

--- a/src/fsharp/service/ServiceLexing.fs
+++ b/src/fsharp/service/ServiceLexing.fs
@@ -261,7 +261,7 @@ module internal TokenClassifications =
         | IF | THEN  | ELSE | DO | DONE | LET(_) | IN (*| NAMESPACE*) | CONST
         | HIGH_PRECEDENCE_PAREN_APP | FIXED
         | HIGH_PRECEDENCE_BRACK_APP
-        | TYPE_COMING_SOON | TYPE_IS_HERE | MODULE_COMING_SOON | MODULE_IS_HERE
+        | TYPE_COMING_SOON | TYPE_IS_HERE | MODULE_COMING_SOON | MODULE_IS_HERE | MODULE_ATTRIBUTE_TARGET_COMING_SOON | MODULE_ATTRIBUTE_TARGET_IS_HERE
           -> (FSharpTokenColorKind.Keyword,FSharpTokenCharKind.Keyword,FSharpTokenTriggerClass.None)
               
         | BEGIN  


### PR DESCRIPTION
Referring to this issue: https://github.com/Microsoft/visualfsharp/issues/4130

There are some gnarly errors that occur when typing in attributes.

![attrib_error](https://user-images.githubusercontent.com/1278959/34087928-0bcde974-e35b-11e7-88ac-9130841d60d5.png)

Still WIP, but this PR will be designed to address it. I have a feeling I may be butchering stuff, but we will see. :)
