### PR TITLE
Fix IndexOutOfRangeException in check for providing completion

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -85,10 +85,9 @@ type internal FSharpCompletionProvider
         else
             let triggerPosition = caretPosition - 1
             let triggerChar = sourceText.[triggerPosition]
-            let prevChar = sourceText.[triggerPosition - 1]
-            
+
             // do not trigger completion if it's not single dot, i.e. range expression
-            if not Settings.IntelliSense.ShowAfterCharIsTyped && prevChar = '.' then
+            if not Settings.IntelliSense.ShowAfterCharIsTyped && triggerPosition > 0 && sourceText.[triggerPosition - 1] = '.' then
                 false
             else
                 let documentId, filePath, defines = getInfo()

--- a/vsintegration/tests/unittests/CompletionProviderTests.fs
+++ b/vsintegration/tests/unittests/CompletionProviderTests.fs
@@ -274,6 +274,18 @@ xVal**y
         Assert.IsTrue(triggered, "Completion should trigger after typing an identifier that follows a mathematical operation")
 
 [<Test>]
+let ShouldTriggerCompletionAtStartOfFileWithInsertion =
+    let fileContents = """
+l"""
+
+    let marker = "l"
+    let caretPosition = fileContents.IndexOf(marker) + marker.Length
+    let documentId = DocumentId.CreateNewId(ProjectId.CreateNewId())
+    let getInfo() = documentId, filePath, []
+    let triggered = FSharpCompletionProvider.ShouldTriggerCompletionAux(SourceText.From(fileContents), caretPosition, CompletionTriggerKind.Insertion, getInfo)
+    Assert.IsTrue(triggered, "Completion should trigger after typing an Insertion character at the top of the file, e.g. a function definition in a new script file.")
+
+[<Test>]
 let ShouldDisplayTypeMembers() =
     let fileContents = """
 type T1() =


### PR DESCRIPTION
Fixes #4115 

It seems a check on `triggerPosition` was removed here: https://github.com/Microsoft/visualfsharp/commit/1e6f253d6ce899a1bb8bbace0d0883f1a207c74f#diff-d788d4b29ac0cab7497b91c678517720

This was also after any 15.4 merges, hence why it's not seen until 15.5.