### PR TITLE
Fix error logging in brace matching code

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1521,6 +1521,12 @@ module internal Parser =
 
     let matchBraces(source, fileName, options: FSharpParsingOptions, userOpName: string) =
         Trace.TraceInformation("FCS: {0}.{1} ({2})", userOpName, "matchBraces", fileName)
+
+        // Make sure there is an ErrorLogger installed whenever we do stuff that might record errors, even if we ultimately ignore the errors
+        let delayedLogger = CapturingErrorLogger("matchBraces")
+        use _unwindEL = PushErrorLoggerPhaseUntilUnwind (fun _ -> delayedLogger)
+        use _unwindBP = PushThreadBuildPhaseUntilUnwind BuildPhase.Parse
+        
         let matchingBraces = new ResizeArray<_>()
         Lexhelp.usingLexbufForParsing(UnicodeLexing.StringAsLexbuf(addNewLine source), fileName) (fun lexbuf ->
             let errHandler = ErrorHandler(false, fileName, options.ErrorSeverityOptions, source)
@@ -1554,6 +1560,8 @@ module internal Parser =
     let parseFile(source, fileName, options: FSharpParsingOptions, userOpName: string) =
         Trace.TraceInformation("FCS: {0}.{1} ({2})", userOpName, "parseFile", fileName)
         let errHandler = new ErrorHandler(true, fileName, options.ErrorSeverityOptions, source)
+        use unwindEL = PushErrorLoggerPhaseUntilUnwind (fun _oldLogger -> errHandler.ErrorLogger)
+        use unwindBP = PushThreadBuildPhaseUntilUnwind BuildPhase.Parse
 
         let parseResult =
             Lexhelp.usingLexbufForParsing(UnicodeLexing.StringAsLexbuf(addNewLine source), fileName) (fun lexbuf ->

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1554,8 +1554,6 @@ module internal Parser =
     let parseFile(source, fileName, options: FSharpParsingOptions, userOpName: string) =
         Trace.TraceInformation("FCS: {0}.{1} ({2})", userOpName, "parseFile", fileName)
         let errHandler = new ErrorHandler(true, fileName, options.ErrorSeverityOptions, source)
-        use unwindEL = PushErrorLoggerPhaseUntilUnwind (fun _oldLogger -> errHandler.ErrorLogger)
-        use unwindBP = PushThreadBuildPhaseUntilUnwind BuildPhase.Parse
 
         let parseResult =
             Lexhelp.usingLexbufForParsing(UnicodeLexing.StringAsLexbuf(addNewLine source), fileName) (fun lexbuf ->


### PR DESCRIPTION
Update: fixed #3795

-- Old PR text --

Potentially fixes #3795

As per [this comment](https://github.com/Microsoft/visualfsharp/issues/3795#issuecomment-342207509) by @dsyme I was curious if the code could just be removed. I actually have no clue why or why not this would or would not work.  But:

* Assertion is no longer present
* In a small test project things seemed to work
* In VF# things seemed to work
* Setting breakpoints in VF# seemed the same

I tried to run tests locally but my machine got a BSOD so I'll just let CI do that instead.