### PR TITLE
fix resource name, for FCS

### DIFF
--- a/fcs/FSharp.Compiler.Service.netstandard/FSharp.Compiler.Service.netstandard.fsproj
+++ b/fcs/FSharp.Compiler.Service.netstandard/FSharp.Compiler.Service.netstandard.fsproj
@@ -81,6 +81,7 @@
     </FsSrGen>
     <EmbeddedResource Include="$(FSharpSourcesRoot)/fsharp/FSStrings.resx">
       <Link>FSStrings.resx</Link>
+      <LogicalName>FSStrings.resources</LogicalName>
     </EmbeddedResource>
     <FsYacc Include="$(FSharpSourcesRoot)\absil\ilpars.fsy">
       <OtherFlags>--module Microsoft.FSharp.Compiler.AbstractIL.Internal.AsciiParser --open Microsoft.FSharp.Compiler.AbstractIL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>


### PR DESCRIPTION
otherwise instead of expected `FSStrings.resources` will use `FSharp.Compiler.Service.netstandard.FSStrings.resources`

ref #4150 
