### PR TITLE
Wrong Nuget package version following version # update

### DIFF
--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -79,6 +79,8 @@
     <!-- Frozen FSharp.Core package being built with this build -->
     <FSharpCore41TargetPackageVersion>4.1.19</FSharpCore41TargetPackageVersion>
     <FSharpCore41TargetMajorVersion>4.1</FSharpCore41TargetMajorVersion>
+    <FSharpCoreLatestTargetPackageVersion>4.3.0</FSharpCoreLatestTargetPackageVersion>
+    <FSharpCoreLatestTargetMajorVersion>4.3</FSharpCoreLatestTargetMajorVersion>
 
     <!-- Frozen FSharp.Core package -->
     <FSharpCoreFrozenPortablePackageVersion>10.1.0</FSharpCoreFrozenPortablePackageVersion>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -54,7 +54,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(FSharpCoreImplicitPackageVersion)' == '' ">
-    <FSharpCoreImplicitPackageVersion>4.2.*</FSharpCoreImplicitPackageVersion>
+    <FSharpCoreImplicitPackageVersion>4.3.*</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(DisableImplicitSystemValueTupleReference)' != 'true' ">

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.proj
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.proj
@@ -58,8 +58,8 @@
       <PackageVersion Condition="'@(PackageNuspec)' == 'FSharp.Core.4.1.xxx.nuspec'">$(FSharpCore41TargetPackageVersion)</PackageVersion>
       <PackageMajorVersion Condition="'@(PackageNuspec)' == 'FSharp.Core.4.1.xxx.nuspec'">$(FSharpCore41TargetMajorVersion)</PackageMajorVersion>
 
-      <PackageVersion Condition="'@(PackageNuspec)' == 'FSharp.Core.LatestNuget.nuspec'">$(FSharpCoreFrozenPortableTargetPackageVersion)</PackageVersion>
-      <PackageMajorVersion Condition="'@(PackageNuspec)' == 'FSharp.Core.LatestNuget.nuspec'">$(FSharpCoreFrozenPortableTargetMajorVersion)</PackageMajorVersion>
+      <PackageVersion Condition="'@(PackageNuspec)' == 'FSharp.Core.LatestNuget.nuspec'">$(FSharpCoreLatestTargetPackageVersion)</PackageVersion>
+      <PackageMajorVersion Condition="'@(PackageNuspec)' == 'FSharp.Core.LatestNuget.nuspec'">$(FSharpCoreLatestTargetMajorVersion)</PackageMajorVersion>
 
       <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
     </PropertyGroup>


### PR DESCRIPTION
I messed up, I got the package version number wrong for the FSharp.Core nugget package.  It should be 4.3.0 not 10.1.1
 
Also update FSharp.Core reference to 4.3
