### PR TITLE
ensure all shipped binaries have a non-zero version and commit hash

### DIFF
--- a/VisualFSharp.sln
+++ b/VisualFSharp.sln
@@ -140,6 +140,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Build.UnitTests", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PEVerify", "tests\fsharpqa\testenv\src\PEVerify\PEVerify.csproj", "{B0689A4E-07D8-494D-A0C8-791CB1D74E54}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "AssemblyVersionCheck", "tests\fsharpqa\testenv\src\AssemblyVersionCheck\AssemblyVersionCheck.fsproj", "{2BE9DC57-34C1-4196-9392-A5F189E6B95A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -774,6 +776,18 @@ Global
 		{B0689A4E-07D8-494D-A0C8-791CB1D74E54}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B0689A4E-07D8-494D-A0C8-791CB1D74E54}.Release|x86.ActiveCfg = Release|Any CPU
 		{B0689A4E-07D8-494D-A0C8-791CB1D74E54}.Release|x86.Build.0 = Release|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Debug|x86.Build.0 = Debug|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Proto|Any CPU.Build.0 = Debug|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Proto|x86.ActiveCfg = Debug|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Proto|x86.Build.0 = Debug|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Release|x86.ActiveCfg = Release|Any CPU
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -838,6 +852,7 @@ Global
 		{0385564F-07B4-4264-AB8A-17C393E9140C} = {F6DAEE9A-8BE1-4C4A-BC83-09215517C7DA}
 		{400FAB03-786E-40CC-85A8-04B0C2869B14} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
 		{B0689A4E-07D8-494D-A0C8-791CB1D74E54} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
+		{2BE9DC57-34C1-4196-9392-A5F189E6B95A} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {48EDBBBE-C8EE-4E3C-8B19-97184A487B37}

--- a/build.cmd
+++ b/build.cmd
@@ -603,10 +603,7 @@ if "%RestorePackages%" == "true" (
     )
 )
 
-if "%BUILD_PROTO_WITH_CORECLR_LKG%" == "1" (
-    :: Restore the Tools directory
-    call %~dp0init-tools.cmd
-)
+call %~dp0init-tools.cmd
 
 set _dotnetcliexe=%~dp0Tools\dotnetcli\dotnet.exe
 set _dotnet20exe=%~dp0Tools\dotnet20\dotnet.exe
@@ -676,7 +673,12 @@ if "%BUILD_PHASE%" == "1" (
    @if ERRORLEVEL 1 echo Error build failed && goto :failure
 )
 
-echo ---------------- Done with build, starting assembly signing ---------------
+echo ---------------- Done with build, starting assembly version checks ---------------
+set asmvercheckpath=%~dp0tests\fsharpqa\testenv\src\AssemblyVersionCheck
+%_dotnet20exe% run -p "%asmvercheckpath%\AssemblyVersionCheck.fsproj" "%~dp0build\config\AssemblySignToolData.json" "%~dp0%BUILD_CONFIG%"
+if ERRORLEVEL 1 echo Error verifying assembly versions and commit hashes. && goto :failure
+
+echo ---------------- Done with assembly version checks, starting assembly signing ---------------
 
 if not "%SIGN_TYPE%" == "" (
     echo build\scripts\run-signtool.cmd -MSBuild %_msbuildexe% -SignType %SIGN_TYPE% -ConfigFile build\config\AssemblySignToolData.json

--- a/build/targets/AssemblyAttributes.targets
+++ b/build/targets/AssemblyAttributes.targets
@@ -1,0 +1,89 @@
+<Project>
+
+  <Import Project="GitHash.props" />
+
+  <PropertyGroup>
+    <GeneratedFSharpInternalsVisibleToFile>$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedFSharpInternalsVisibleToFile>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <InternalsVisibleTo>
+      <Visible>false</Visible>
+    </InternalsVisibleTo>
+  </ItemDefinitionGroup>
+
+  <Target Name="PrepareFSharpGenerateInternalsVisibleToFile"
+          Condition="'@(InternalsVisibleTo)' != ''">
+    <PropertyGroup>
+      <_PublicKey>002400000480000094000000060200000024000052534131000400000100010007D1FA57C4AED9F0A32E84AA0FAEFD0DE9E8FD6AEC8F87FB03766C834C99921EB23BE79AD9D5DCC1DD9AD236132102900B723CF980957FC4E177108FC607774F29E8320E92EA05ECE4E821C0A5EFE8F1645C4C0C93C1AB99285D622CAA652C1DFAD63D745D6F2DE5F17E5EAF0FC4963D261C8A12436518206DC093344D5AD293</_PublicKey>
+    </PropertyGroup>
+    <ItemGroup>
+      <_InternalsVisibleToAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+        <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' != ''">%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)</_Parameter1>
+        <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' == ''">%(InternalsVisibleTo.Identity), PublicKey=$(_PublicKey)</_Parameter1>
+      </_InternalsVisibleToAttribute>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateFSharpInternalsVisibleToFile"
+          Inputs="$(MSBuildProjectFile)"
+          Outputs="$(GeneratedFSharpInternalsVisibleToFile)"
+          DependsOnTargets="PrepareFSharpGenerateInternalsVisibleToFile;PrepareForBuild"
+          Condition="'$(Configuration)' != 'Proto' and '@(InternalsVisibleTo)' != ''"
+          BeforeTargets="CoreCompile">
+    <WriteCodeFragment AssemblyAttributes="@(_InternalsVisibleToAttribute)"
+                       Language="$(Language)"
+                       OutputFile="$(GeneratedFSharpInternalsVisibleToFile)">
+      <Output TaskParameter="OutputFile" ItemName="CompileBefore" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+  </Target>
+
+  <Target Name="GenerateAssemblyFileVersion"
+          BeforeTargets="CoreCompile"
+          Condition="'$(Configuration)' != 'Proto'">
+    <PropertyGroup>
+      <GeneratedFSharpAssemblyVersionFile>$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyAttributes$(DefaultLanguageSourceExtension)</GeneratedFSharpAssemblyVersionFile>
+      <!-- AssemblyInformationalVersionAttribute issues a by-design warning if the value passed isn't of the form #.#.#.#, but we specifically want to suppress this to allow the commit hash to be embedded. -->
+      <NoWarn Condition="'$(Language)' == 'F#'">2003;$(NoWarn)</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyCompanyAttribute">
+        <_Parameter1>Microsoft Corporation</_Parameter1>
+      </_AssemblyVersionAttributes>
+      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyCopyrightAttribute">
+        <_Parameter1>&#169; Microsoft Corporation.  All Rights Reserved.</_Parameter1>
+      </_AssemblyVersionAttributes>
+      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyDescriptionAttribute">
+        <_Parameter1>$(AssemblyName).dll</_Parameter1>
+      </_AssemblyVersionAttributes>
+      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyFileVersionAttribute">
+        <_Parameter1>$(Build_FileVersion)</_Parameter1>
+      </_AssemblyVersionAttributes>
+      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyInformationalVersionAttribute">
+        <_Parameter1>$(MicroBuildAssemblyVersion).  Commit Hash: $(GitHeadSha).</_Parameter1>
+      </_AssemblyVersionAttributes>
+      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyProductAttribute">
+        <_Parameter1>Microsoft&#174; F#</_Parameter1>
+      </_AssemblyVersionAttributes>
+      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyTitleAttribute">
+        <_Parameter1>$(AssemblyName).dll</_Parameter1>
+      </_AssemblyVersionAttributes>
+      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyVersionAttribute">
+        <_Parameter1>$(MicroBuildAssemblyVersion)</_Parameter1>
+      </_AssemblyVersionAttributes>
+    </ItemGroup>
+
+    <WriteCodeFragment AssemblyAttributes="@(_AssemblyVersionAttributes)"
+                       Language="$(Language)"
+                       OutputFile="$(GeneratedFSharpAssemblyVersionFile)">
+      <!-- For FSharp.Core, assembly version must be inserted after all Core files, as it defines F# basic types (strings) -->
+      <Output TaskParameter="OutputFile" ItemName="Compile" Condition="'$(AssemblyName)' == 'FSharp.Core' or '$(Language)' != 'F#'" />
+      <!-- For other assemblies, this must be inserted before all source files, to keep exe's EntryPoints (if any) as the last source file -->
+      <Output TaskParameter="OutputFile" ItemName="CompileBefore" Condition="'$(AssemblyName)' != 'FSharp.Core' and '$(Language)' == 'F#'" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+  </Target>
+
+</Project>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -6,8 +6,6 @@
     <RepoRoot>$(MSBuildThisFileDirectory)..\</RepoRoot>
   </PropertyGroup>
 
-  <Import Project="..\build\targets\GitHash.props" />
-
   <Choose>
     <When Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Release' ">
       <PropertyGroup>
@@ -368,89 +366,7 @@
 
   </Target>
 
-  <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
-    <GeneratedFSharpInternalsVisibleToFile>$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedFSharpInternalsVisibleToFile>
-  </PropertyGroup>
-
-  <ItemDefinitionGroup>
-    <InternalsVisibleTo>
-      <Visible>false</Visible>
-    </InternalsVisibleTo>
-  </ItemDefinitionGroup>
-
-  <Target Name="PrepareFSharpGenerateInternalsVisibleToFile"
-          Condition="'$(Configuration)' != 'Proto' and '@(InternalsVisibleTo)' != ''">
-    <PropertyGroup>
-      <_PublicKey>002400000480000094000000060200000024000052534131000400000100010007D1FA57C4AED9F0A32E84AA0FAEFD0DE9E8FD6AEC8F87FB03766C834C99921EB23BE79AD9D5DCC1DD9AD236132102900B723CF980957FC4E177108FC607774F29E8320E92EA05ECE4E821C0A5EFE8F1645C4C0C93C1AB99285D622CAA652C1DFAD63D745D6F2DE5F17E5EAF0FC4963D261C8A12436518206DC093344D5AD293</_PublicKey>
-    </PropertyGroup>
-    <ItemGroup>
-      <_InternalsVisibleToAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-        <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' != ''">%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)</_Parameter1>
-        <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' == ''">%(InternalsVisibleTo.Identity), PublicKey=$(_PublicKey)</_Parameter1>
-      </_InternalsVisibleToAttribute>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="GenerateFSharpInternalsVisibleToFile"
-          Inputs="$(MSBuildProjectFile)"
-          Outputs="$(GeneratedFSharpInternalsVisibleToFile)"
-          DependsOnTargets="PrepareFSharpGenerateInternalsVisibleToFile;PrepareForBuild"
-          Condition="'$(Configuration)' != 'Proto' and '@(InternalsVisibleTo)' != ''"
-          BeforeTargets="CoreCompile">
-    <WriteCodeFragment AssemblyAttributes="@(_InternalsVisibleToAttribute)"
-                       Language="$(Language)"
-                       OutputFile="$(GeneratedFSharpInternalsVisibleToFile)">
-      <Output TaskParameter="OutputFile" ItemName="CompileBefore" />
-      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
-    </WriteCodeFragment>
-  </Target>
-
-  <Target Name="GenerateAssemblyFileVersion"
-          BeforeTargets="CoreCompile"
-          Condition="'$(Configuration)' != 'Proto'">
-    <PropertyGroup>
-      <GeneratedFSharpAssemblyVersionFile>$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyVersion$(DefaultLanguageSourceExtension)</GeneratedFSharpAssemblyVersionFile>
-      <!-- AssemblyInformationalVersionAttribute issues a by-design warning if the value passed isn't of the form #.#.#.#, but we specifically want to suppress this to allow the commit hash to be embedded. -->
-      <NoWarn Condition="'$(Language)' == 'F#'">2003;$(NoWarn)</NoWarn>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyCompanyAttribute">
-        <_Parameter1>Microsoft Corporation</_Parameter1>
-      </_AssemblyVersionAttributes>
-      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyCopyrightAttribute">
-        <_Parameter1>&#169; Microsoft Corporation.  All Rights Reserved.</_Parameter1>
-      </_AssemblyVersionAttributes>
-      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyDescriptionAttribute">
-        <_Parameter1>$(AssemblyName).dll</_Parameter1>
-      </_AssemblyVersionAttributes>
-      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyFileVersionAttribute">
-        <_Parameter1>$(Build_FileVersion)</_Parameter1>
-      </_AssemblyVersionAttributes>
-      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyInformationalVersionAttribute">
-        <_Parameter1>$(MicroBuildAssemblyVersion).  Commit Hash: $(GitHeadSha).</_Parameter1>
-      </_AssemblyVersionAttributes>
-      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyProductAttribute">
-        <_Parameter1>Microsoft&#174; F#</_Parameter1>
-      </_AssemblyVersionAttributes>
-      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyTitleAttribute">
-        <_Parameter1>$(AssemblyName).dll</_Parameter1>
-      </_AssemblyVersionAttributes>
-      <_AssemblyVersionAttributes Include="System.Reflection.AssemblyVersionAttribute">
-        <_Parameter1>$(MicroBuildAssemblyVersion)</_Parameter1>
-      </_AssemblyVersionAttributes>
-    </ItemGroup>
-
-    <WriteCodeFragment AssemblyAttributes="@(_AssemblyVersionAttributes)"
-                       Language="$(Language)"
-                       OutputFile="$(GeneratedFSharpAssemblyVersionFile)">
-      <!-- For FSharp.Core, assembly version must be inserted after all Core files, as it defines F# basic types (strings) -->
-      <Output TaskParameter="OutputFile" ItemName="Compile" Condition="'$(AssemblyName)' == 'FSharp.Core'" />
-      <!-- For other assemblies, this must be inserted before all source files, to keep exe's EntryPoints (if any) as the last source file -->
-      <Output TaskParameter="OutputFile" ItemName="CompileBefore" Condition="'$(AssemblyName)' != 'FSharp.Core'" />
-      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
-    </WriteCodeFragment>
-  </Target>
+  <Import Project="..\build\targets\AssemblyAttributes.targets" />
 
   <UsingTask TaskName="ReplaceFileText" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
     <ParameterGroup>

--- a/tests/fsharpqa/testenv/src/AssemblyVersionCheck/AssemblyVersionCheck.fsproj
+++ b/tests/fsharpqa/testenv/src/AssemblyVersionCheck/AssemblyVersionCheck.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/fsharpqa/testenv/src/AssemblyVersionCheck/Program.fs
+++ b/tests/fsharpqa/testenv/src/AssemblyVersionCheck/Program.fs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+open System
+open System.Diagnostics
+open System.IO
+open System.Reflection
+open System.Text.RegularExpressions
+open Newtonsoft.Json.Linq
+
+module AssemblyVersionCheck =
+
+    let private versionZero = Version(0, 0, 0, 0)
+    let private commitHashPattern = new Regex(@"Commit Hash: (<developer build>)|([0-9a-fA-F]{40})", RegexOptions.Compiled)
+
+    let verifyAssemblyVersions (signToolData:string) (binariesPath:string) =
+        let json = File.ReadAllText(signToolData)
+        let jobject = JObject.Parse(json)
+
+        // could either contain things like 'net40\bin\FSharp.Core.dll' or patterns like 'net40\bin\*\FSharp.Core.resources.dll'
+        let assemblyPatterns =
+            (jobject.["sign"] :?> JArray)
+            |> Seq.map (fun a -> (a :?> JObject).["values"] :?> JArray)
+            |> Seq.map (fun a -> a :> seq<JToken>)
+            |> Seq.collect (fun t -> t)
+            |> Seq.map (fun t -> t.ToString())
+            |> Seq.filter (fun p -> p.EndsWith(".dll") || p.EndsWith(".exe")) // only check assemblies
+
+        // map the assembly patterns to actual files on disk
+        let actualAssemblies =
+            assemblyPatterns
+            |> Seq.map (fun a ->
+                if not (a.Contains("*")) then
+                    [a] // just a raw file name
+                else
+                    let parts = a.Split([|'\\'|])
+                    let mutable candidatePaths = [binariesPath]
+                    for p in parts do
+                        match p with
+                        | "*" ->
+                            // expand all candidates into multiples
+                            let expansions =
+                                candidatePaths
+                                |> List.filter Directory.Exists
+                                |> List.map (Directory.EnumerateDirectories >> Seq.toList)
+                                |> List.collect (fun x -> x)
+                            candidatePaths <- expansions
+                        | _ ->
+                            // regular path part, just append it to all candidates
+                            candidatePaths <- List.map (fun d -> Path.Combine(d, p)) candidatePaths
+                    candidatePaths)
+            |> Seq.collect (fun a -> a)
+            |> Seq.map (fun a -> Path.Combine(binariesPath, a))
+            |> Seq.filter (fun p -> File.Exists(p)) // not all test runs produce all files
+            |> Seq.toList
+
+        // verify that all assemblies have a version number other than 0.0.0.0
+        let failedVersionCheck =
+            actualAssemblies
+            |> List.filter (fun a ->
+                let assemblyVersion = AssemblyName.GetAssemblyName(a).Version
+                printfn "Checking version: %s (%A)" a assemblyVersion
+                assemblyVersion = versionZero)
+        if failedVersionCheck.Length > 0 then
+            printfn "The following assemblies had a version of %A" versionZero
+            printfn "%s\r\n" <| String.Join("\r\n", failedVersionCheck)
+
+        // verify that all assemblies have a commit hash
+        let failedCommitHash =
+            actualAssemblies
+            |> List.filter (fun a ->
+                let fileProductVersion = FileVersionInfo.GetVersionInfo(a).ProductVersion
+                printfn "Checking commit hash: %s (%s)" a fileProductVersion
+                not <| commitHashPattern.IsMatch(fileProductVersion))
+        if failedCommitHash.Length > 0 then
+            printfn "The following assemblies don't have a commit hash set"
+            printfn "%s\r\n" <| String.Join("\r\n", failedCommitHash)
+
+        // return code is the number of failures
+        failedVersionCheck.Length + failedCommitHash.Length
+
+[<EntryPoint>]
+let main argv =
+    if argv.Length <> 2 then
+        printfn "Usage: AssemblyVersionCheck.exe SignToolData.json path/to/binaries"
+        1
+    else
+        AssemblyVersionCheck.verifyAssemblyVersions argv.[0] argv.[1]

--- a/vsintegration/src/FSharp.LanguageService.Base/FSharp.LanguageService.Base.csproj
+++ b/vsintegration/src/FSharp.LanguageService.Base/FSharp.LanguageService.Base.csproj
@@ -260,4 +260,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
   <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" />
+  <Import Project="$(FSharpSourcesRoot)\..\build\targets\AssemblyAttributes.targets" />
 </Project>

--- a/vsintegration/src/FSharp.LanguageService.Base/Properties/AssemblyInfo.cs
+++ b/vsintegration/src/FSharp.LanguageService.Base/Properties/AssemblyInfo.cs
@@ -9,12 +9,7 @@ using Microsoft.VisualStudio.Shell;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("FSharp.LanguageService.Base")]
-[assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft.VisualFSharpTools")]
-[assembly: AssemblyProduct("FSharp.LanguageService.Base")]
-[assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/AssemblyInfo.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/AssemblyInfo.cs
@@ -6,11 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 /* F# additions: begin. */
-[assembly:AssemblyDescription("FSharp.ProjectSystem.Base.dll")]
-[assembly:AssemblyCompany("Microsoft Corporation")]
-[assembly:AssemblyTitle("FSharp.ProjectSystem.Base.dll")]
-[assembly:AssemblyCopyright("\x00a9 Microsoft Corporation.  All rights reserved.")]
-[assembly:AssemblyProduct("Microsoft\x00ae F#")]
 [assembly:AssemblyConfiguration("")]
 [assembly:AssemblyCulture("")]
 [assembly:ComVisible(false)]

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectSystem.Base.csproj
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectSystem.Base.csproj
@@ -293,4 +293,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
   <Import Project="$(VsSDKTargets)" />
+  <Import Project="$(FSharpSourcesRoot)\..\build\targets\AssemblyAttributes.targets" />
 </Project>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/AssemblyInfo.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/AssemblyInfo.vb
@@ -6,11 +6,6 @@ Imports System.Runtime.CompilerServices
 Imports Microsoft.VisualStudio.Shell
 
 '/* F# additions: begin. */
-<Assembly: AssemblyDescription("FSharp.ProjectSystem.Base.dll")>
-<Assembly: AssemblyCompany("Microsoft Corporation")>
-<Assembly: AssemblyTitle("FSharp.ProjectSystem.Base.dll")>
-<Assembly: AssemblyCopyright("\x00a9 Microsoft Corporation.  All rights reserved.")>
-<Assembly: AssemblyProduct("Microsoft\x00ae F#")>
 <Assembly: AssemblyConfiguration("")>
 <Assembly: AssemblyCulture("")>
 

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.PropertiesPages.vbproj
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.PropertiesPages.vbproj
@@ -382,4 +382,5 @@
   
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
   <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" />
+  <Import Project="$(FSharpSourcesRoot)\..\build\targets\AssemblyAttributes.targets" />
 </Project>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/My Project/AssemblyInfo.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/My Project/AssemblyInfo.vb
@@ -10,13 +10,6 @@ Imports System.Runtime.InteropServices
 
 ' Review the values of the assembly attributes
 
-<Assembly: AssemblyTitle("FSharp.PropertyPages.dll")> 
-<Assembly: AssemblyDescription("FSharp.PropertyPages.dll")> 
-<Assembly: AssemblyCompany("Microsoft Corporation")> 
-<Assembly: AssemblyProduct("Microsoft® F#")> 
-<Assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")> 
-<Assembly: AssemblyTrademark("")> 
-
 <Assembly: ComVisible(True)> 
 
 'The following GUID is for the ID of the typelib if this project is exposed to COM

--- a/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
+++ b/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
@@ -108,4 +108,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(FSharpSourcesRoot)\Microbuild.Settings.targets" />
+  <Import Project="$(FSharpSourcesRoot)\..\build\targets\AssemblyAttributes.targets" />
 </Project>

--- a/vsintegration/src/FSharp.UIResources/Properties/AssemblyInfo.cs
+++ b/vsintegration/src/FSharp.UIResources/Properties/AssemblyInfo.cs
@@ -8,12 +8,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("FSharp.UIResources")]
-[assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft.VisualFSharpTools")]
-[assembly: AssemblyProduct("FSharp.UIResources")]
-[assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
This fixes the issue where the few non-F# assemblies we build had version 0.0.0.0 and weren't getting the commit hash embedded.

To ensure this doesn't happen again I've also added a step to `build.cmd` that checks that all shipping assemblies (by reusing `AssemblySignToolData.json`) have a non-zero assembly version and have a commit hash set.