### PR TITLE
include satellite assemblies in compiler packages

### DIFF
--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -65,5 +65,10 @@
         <file src="Microsoft.Portable.FSharp.Targets"           target="contentFiles\any\any"  />
         <file src="Microsoft.FSharp.NetSdk.targets"             target="contentFiles\any\any"  />
         <file src="Microsoft.FSharp.NetSdk.props"               target="contentFiles\any\any"  />
+
+        <file src="**\FSharp.Core.resources.dll"                          target="lib\netstandard1.6" />
+        <file src="**\FSharp.Compiler.Private.resources.dll"              target="lib\netstandard1.6" />
+        <file src="**\FSharp.Compiler.Interactive.Settings.resources.dll" target="lib\netstandard1.6" />
+        <file src="**\FSharp.Build.resources.dll"                         target="lib\netstandard1.6" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
@@ -57,5 +57,10 @@
         <file src="Microsoft.Portable.FSharp.Targets"           target="runtimes\any\native"  />
         <file src="Microsoft.FSharp.NetSdk.targets"             target="runtimes\any\native"  />
         <file src="Microsoft.FSharp.NetSdk.props"               target="runtimes\any\native"  />
+
+        <file src="**\FSharp.Core.resources.dll"                          target="lib\netstandard1.6" />
+        <file src="**\FSharp.Compiler.Private.resources.dll"              target="lib\netstandard1.6" />
+        <file src="**\FSharp.Compiler.Interactive.Settings.resources.dll" target="lib\netstandard1.6" />
+        <file src="**\FSharp.Build.resources.dll"                         target="lib\netstandard1.6" />
     </files>
 </package>


### PR DESCRIPTION
This should make @nguerrera's life easier when updating the dotnet CLI.

Microsoft.FSharp.Compiler.nupkg increases in size from 4.8MB to 6.1MB and the directory structure changes like so:

Old:
```
lib\netstandard1.6\
    fsi.exe
    FSharp.Core.dll
    FSharp.Compiler.Private.dll
    FSharp.Compiler.Interactive.Settings.dll
    FSharp.Build.dll
    fsc.exe
```

New:
```
lib\netstandard1.6\
    (as before)
    fr\
        FSharp.Core.resources.dll
        FSharp.Compiler.Private.resources.dll
        FSharp.Compiler.Interactive.Settings.resources.dll
        FSharp.Build.resources.dll
    (all other languages)
```

Note that no resource assemblies are included for `fsi.exe` and `fsc.exe` because none are built; all localized strings are in the other 4 assemblies.