### PR TITLE
Set serializable bit for all serializable types

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -3747,8 +3747,8 @@ and GenClosureTypeDefs cenv (tref:ILTypeRef, ilGenParams, attrs, ilCloFreeVars, 
       Properties = emptyILProperties
       Methods= mkILMethods mdefs 
       MethodImpls= mkILMethodImpls mimpls 
-      IsSerializable= cenv.g.attrib_SerializableAttribute.IsSome
-      IsComInterop= false    
+      IsSerializable=true
+      IsComInterop= false
       IsSpecialName= true
       NestedTypes=emptyILTypeDefs
       Encoding= ILDefaultPInvokeEncoding.Auto
@@ -3803,8 +3803,8 @@ and GenLambdaClosure cenv (cgbuf:CodeGenBuffer) eenv isLocalTypeFunc selfv expr 
                       Properties = emptyILProperties
                       Methods= mkILMethods ilContractMeths 
                       MethodImpls= emptyILMethodImpls 
-                      IsSerializable= cenv.g.attrib_SerializableAttribute.IsSome 
-                      IsComInterop=false    
+                      IsSerializable=true
+                      IsComInterop=false
                       IsSpecialName= true
                       NestedTypes=emptyILTypeDefs
                       Encoding= ILDefaultPInvokeEncoding.Auto
@@ -6563,9 +6563,8 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
         let ilFields = mkILFields ilFieldDefs
         
         let tdef, tdefDiscards = 
-           let isSerializable = (TryFindFSharpBoolAttribute cenv.g cenv.g.attrib_AutoSerializableAttribute tycon.Attribs <> Some(false)) 
-                             && cenv.g.attrib_SerializableAttribute.IsSome
-                                       
+           let isSerializable = (TryFindFSharpBoolAttribute cenv.g cenv.g.attrib_AutoSerializableAttribute tycon.Attribs <> Some(false))
+
            match tycon.TypeReprInfo with 
            | TILObjectRepr _ ->
                let td = tycon.ILTyconRawMetadata
@@ -6817,11 +6816,10 @@ and GenExnDef cenv mgbuf eenv m (exnc:Tycon) =
             else
                 []
 
-        
         let serializationRelatedMembers =
-            // do not emit serialization related members if target framework lacks SerializableAttribute or SerializationInfo
-          match cenv.g.attrib_SerializableAttribute, cenv.g.iltyp_SerializationInfo, cenv.g.iltyp_StreamingContext with 
-          | Some _,  Some serializationInfoType, Some streamingContextType -> 
+          // do not emit serialization related members if target framework lacks SerializationInfo or StreamingContext
+          match cenv.g.iltyp_SerializationInfo, cenv.g.iltyp_StreamingContext with 
+          | Some serializationInfoType, Some streamingContextType -> 
             let ilCtorDefForSerialziation = 
                 mkILCtor(ILMemberAccess.Family,
                         [mkILParamNamed("info", serializationInfoType);mkILParamNamed("context",streamingContextType)],
@@ -6880,7 +6878,7 @@ and GenExnDef cenv mgbuf eenv m (exnc:Tycon) =
              emptyILEvents,
              mkILCustomAttrs [mkCompilationMappingAttr cenv.g (int SourceConstructFlags.Exception)],
              ILTypeInit.BeforeField)
-        let tdef = { tdef with IsSerializable = cenv.g.attrib_SerializableAttribute.IsSome }
+        let tdef = { tdef with IsSerializable = true }
         mgbuf.AddTypeDef(tref, tdef, false, false, None)
 
 

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -1005,7 +1005,6 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
   member val attrib_ProjectionParameterAttribute           = mk_MFCore_attrib "ProjectionParameterAttribute"
   member val attrib_CustomOperationAttribute               = mk_MFCore_attrib "CustomOperationAttribute"
   member val attrib_NonSerializedAttribute                 = tryFindSysAttrib "System.NonSerializedAttribute"
-  member val attrib_SerializableAttribute                 = tryFindSysAttrib "System.SerializableAttribute"
   
   member val attrib_AutoSerializableAttribute              = mk_MFCore_attrib "AutoSerializableAttribute"
   member val attrib_RequireQualifiedAccessAttribute        = mk_MFCore_attrib "RequireQualifiedAccessAttribute"

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1968,12 +1968,10 @@ let main2b (tcImportsCapture,dynamicAssemblyCreator) (Args (ctok, tcConfig: TcCo
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.IlxGen
     let ilxGenerator = CreateIlxAssemblyGenerator (tcConfig, tcImports, tcGlobals, (LightweightTcValForUsingInBuildMethodCall tcGlobals), generatedCcu)
 
-    // Check if System.SerializableAttribute exists in mscorlib.dll, 
-    // so that make sure the compiler only emits "serializable" bit into IL metadata when it is available.
-    // Note that SerializableAttribute may be relocated in the future but now resides in mscorlib.
     let codegenResults = GenerateIlxCode ((if Option.isSome dynamicAssemblyCreator then IlReflectBackend else IlWriteBackend), Option.isSome dynamicAssemblyCreator, false, tcConfig, topAttrs, optimizedImpls, generatedCcu.AssemblyName, ilxGenerator)
     let casApplied = new Dictionary<Stamp, bool>()
     let securityAttrs, topAssemblyAttrs = topAttrs.assemblyAttrs |> List.partition (fun a -> TypeChecker.IsSecurityAttribute tcGlobals (tcImports.GetImportMap()) casApplied a rangeStartup)
+
     // remove any security attributes from the top-level assembly attribute list
     let topAttrs = {topAttrs with assemblyAttrs=topAssemblyAttrs}
     let permissionSets = ilxGenerator.CreatePermissionSets securityAttrs


### PR DESCRIPTION
Fixes:  #4207 

C# uses a pseudo custom attribute serializableattribute to tell the compiler to set the serializable bit for managed types.

F# doesn't ...  
By default F# marks managed types as serializable unless the type is decorated with SerializeableAuto(false)  attribute.

The F# compiler used the presence of serializable attribute in the targetframework to determine whether there was any point setting the serializable bit.  Given that the Managed assemblies are now usable across multiple platforms that may or may not support serialization.  This PR modifies the compiler to always set the serialization bit, regardless of the compilation target profile.

With this change it should be possible to serialize / de-serialize libraries F# types compiled targeting netstandard 1.6 when used with an app targeting netstandard 2.0 + or net45+

A consequence of this change is that FSharp.Core for netstandard1.6 built with an updated compiler will obviously contain serializable types.

The change consists of a few small changes ..

Where serializable was determined by the presence of the serializable attribute in the target framework they now just use true.

* The decision to set the serializable bit is now solely based on the absence of the AutoSerializationAttribute with the false parameter.

* The code that emits serialization helpers are emitted based on the presences of SerializationInfo and SerializationContext.  They are present in netstandard1.0, netcoreapp1.0, net45 and all subsequent frameworks.




