### PR TITLE
include satellite assemblies in FSharp.Core packages

### DIFF
--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
@@ -62,5 +62,8 @@
         <file src="net40\bin\FSharp.Core.optdata"        target="lib\net45" />
         <file src="net40\bin\FSharp.Core.xml"            target="lib\net45" />
 
+        <!-- resources -->
+        <file src="coreclr\bin\**\FSharp.Core.resources.dll" target="lib\netstandard1.6" />
+        <file src="net40\bin\**\FSharp.Core.resources.dll"   target="lib\net45" />
     </files>
 </package>


### PR DESCRIPTION
A followup to #4210 to add `FSharp.Core.resources.dll` to the FSharp.Core packages.  Total package size goes from 2.07MB to 2.3MB.