### PR TITLE
Override ToString in FSharpSymbolUse

### DIFF
--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2302,4 +2302,4 @@ type FSharpSymbolUse(g:TcGlobals, denv: DisplayEnv, symbol:FSharpSymbol, itemOcc
     member __.Range = Range.toZ range
     member __.RangeAlternate = range
 
-    override __.ToString() = sprintf "%A, %A, %A" symbol itemOcc range 
+    override __.ToString() = sprintf "%O, %O, %O" symbol itemOcc range 

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2302,3 +2302,4 @@ type FSharpSymbolUse(g:TcGlobals, denv: DisplayEnv, symbol:FSharpSymbol, itemOcc
     member __.Range = Range.toZ range
     member __.RangeAlternate = range
 
+    override __.ToString() = sprintf "%A, %A, %A" symbol itemOcc range 


### PR DESCRIPTION
I find this override useful when looking at `GetAllUsesOfAllSymbolsInFile` results.