### PR TITLE
Add support for easy DesignTime Assembly Packing

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -77,7 +77,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackageFSharpDesignTimeTools</TargetsForTfmSpecificContentInPackage> 
   </PropertyGroup> 
 
-  <Target Name="PackageFSharpDesignTimeTools">
+  <Target Name="PackageFSharpDesignTimeTools" DependsOnTargets="_GetFrameworkAssemblyReferences">
     <PropertyGroup>
       <FSharpDesignTimeProtocol Condition = " '$(FSharpDesignTimeProtocol)' == '' ">fsharp41</FSharpDesignTimeProtocol>
       <FSharpToolsDirectory Condition = " '$(FSharpToolsDirectory)' == '' ">tools</FSharpToolsDirectory>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -87,10 +87,17 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Error Text="The 'FSharpDesignTimeProtocol'  property can be only 'fsharp41'" Condition="'$(FSharpDesignTimeProtocol)' != 'fsharp41'" />
 
     <ItemGroup>
-      <TfmSpecificPackageFile Include="@(_ResolvedProjectReferencePaths)" Condition="'%(_ResolvedProjectReferencePaths.IsFSharpDesignTimeProvider)' == 'true'">
-        <PackagePath>$(FSharpToolsDirectory)/$(FSharpToolsProtocol)/%(_ResolvedProjectReferencePaths.NearestTargetFramework)/%(_ResolvedProjectReferencePaths.FileName)%(_ResolvedProjectReferencePaths.Extension)</PackagePath>
+      <_ResolvedProjectOutputFiles
+          Include="%(_ResolvedProjectReferencePaths.RootDir)%(_ResolvedProjectReferencePaths.Directory)/**/*" 
+          Exclude="%(_ResolvedProjectReferencePaths.RootDir)%(_ResolvedProjectReferencePaths.Directory)/**/FSharp.Core.dll;%(_ResolvedProjectReferencePaths.RootDir)%(_ResolvedProjectReferencePaths.Directory)/**/System.ValueTuple.dll" 
+          Condition="'%(_ResolvedProjectReferencePaths.IsFSharpDesignTimeProvider)' == 'true'">
+        <NearestTargetFramework>%(_ResolvedProjectReferencePaths.NearestTargetFramework)</NearestTargetFramework>
+      </_ResolvedProjectOutputFiles>
+
+      <TfmSpecificPackageFile Include="@(_ResolvedProjectOutputFiles)">
+         <PackagePath>$(FSharpToolsDirectory)/$(FSharpDesignTimeProtocol)/%(_ResolvedProjectOutputFiles.NearestTargetFramework)/%(_ResolvedProjectOutputFiles.FileName)%(_ResolvedProjectOutputFiles.Extension)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>
-`
+
 </Project>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -73,4 +73,24 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreImplicitPackageVersion)"  Condition=" '$(DisableImplicitFSharpCoreReference)' != 'true' "></PackageReference>
   </ItemGroup>
 
+  <PropertyGroup> 
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackageFSharpDesignTimeTools</TargetsForTfmSpecificContentInPackage> 
+  </PropertyGroup> 
+
+  <Target Name="PackageFSharpDesignTimeTools">
+    <PropertyGroup>
+      <FSharpDesignTimeProtocol Condition = " '$(FSharpDesignTimeProtocol)' == '' ">fsharp41</FSharpDesignTimeProtocol>
+      <FSharpToolsDirectory Condition = " '$(FSharpToolsDirectory)' == '' ">tools</FSharpToolsDirectory>
+    </PropertyGroup>
+
+    <Error Text="'$(FSharpToolsDirectory)' is an invalid value for 'FSharpToolsDirectory' valid values are 'typeproviders' and 'tools'." Condition="'$(FSharpToolsDirectory)' != 'typeproviders' and '$(FSharpToolsDirectory)' != 'tools'" />
+    <Error Text="The 'FSharpDesignTimeProtocol'  property can be only 'fsharp41'" Condition="'$(FSharpDesignTimeProtocol)' != 'fsharp41'" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(_ResolvedProjectReferencePaths)" Condition="'%(_ResolvedProjectReferencePaths.IsFSharpDesignTimeProvider)' == 'true'">
+        <PackagePath>$(FSharpToolsDirectory)/$(FSharpToolsProtocol)/%(_ResolvedProjectReferencePaths.NearestTargetFramework)/%(_ResolvedProjectReferencePaths.FileName)%(_ResolvedProjectReferencePaths.Extension)</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
+`
 </Project>


### PR DESCRIPTION
Type providers may be split into two portions a runtime helpers library and a design time library to run in the compiler/fcs/fsi etc ...

This PR makes dotnet pack easier.

Example projects:

This Example consists of a runtime project a design time project
The design time project is a project reference it is tagged with:
```
      <IsFSharpDesignTimeProvider>true</IsFSharpDesignTimeProvider>
      <PrivateAssets>all</PrivateAssets>
```

Private Assets, stops the build and nuget from making the DesignTime assembly a dependency of the package.

The package layout conforms to :  https://github.com/Microsoft/visualfsharp/pull/3864

However, nuget doesn't make make specific target runtimes subdirectories of the TargetFramework, so neither does this.  nugget uses the runtime branch for runtime specific probing.

I propose revising the current probing logic to stop probing for x86 and x64.

Additionally:
*   DesignTime Assemblies will cover extensions other than TypeProviders moving forward.
*   'typeproviders' causes nuget packaging warnings

The default here is to place designtime assemblies below tool.   To place them below typeproviders\
use:
````
<FSharpToolsDirectory>typeproviders</<FSharpToolsDirectory>
````

````
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
  </PropertyGroup>

  <ItemGroup>
    <Compile Include="BasicProvider.Runtime.fs" />
  </ItemGroup>

  <ItemGroup>
    <ProjectReference Include="..\BasicProvider.DesignTime\BasicProvider.DesignTime.fsproj">
      <IsFSharpDesignTimeProvider>true</IsFSharpDesignTimeProvider>
      <PrivateAssets>all</PrivateAssets>
    </ProjectReference>
  </ItemGroup>

</Project>


````





