### PR TITLE
Enable preferreduilang for fsi

### DIFF
--- a/src/FSharpSource.Profiles.targets
+++ b/src/FSharpSource.Profiles.targets
@@ -3,7 +3,6 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Condition="'$(TargetDotnetProfile)'=='net40'">
-    <DefineConstants>$(DefineConstants);PREFERRED_UI_LANG</DefineConstants>
     <DefineConstants>$(DefineConstants);ENABLE_MONO_SUPPORT</DefineConstants>
     <DefineConstants>$(DefineConstants);BE_SECURITY_TRANSPARENT</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_LCIDFROMCODEPAGE</DefineConstants>
@@ -15,7 +14,6 @@
   <PropertyGroup Condition="'$(TargetDotnetProfile)'=='coreclr'">
     <DefineConstants>$(DefineConstants);FX_PORTABLE_OR_NETSTANDARD</DefineConstants>
     <DefineConstants>$(DefineConstants);NETSTANDARD1_6</DefineConstants>
-    <DefineConstants>$(DefineConstants);PREFERRED_UI_LANG</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_APP_DOMAINS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_ARRAY_LONG_LENGTH</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_BEGINEND_READWRITE</DefineConstants>

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2283,9 +2283,7 @@ type TcConfigBuilder =
       mutable optSettings   : Optimizer.OptimizationSettings 
       mutable emitTailcalls : bool
       mutable deterministic : bool
-#if PREFERRED_UI_LANG
       mutable preferredUiLang: string option
-#endif
       mutable lcid          : int option
       mutable productNameForBannerText : string
       /// show the MS (c) notice, e.g. with help or fsi? 
@@ -2444,9 +2442,7 @@ type TcConfigBuilder =
           optSettings = Optimizer.OptimizationSettings.Defaults
           emitTailcalls = true
           deterministic = false
-#if PREFERRED_UI_LANG
           preferredUiLang = None
-#endif
           lcid = None
           // See bug 6071 for product banner spec
           productNameForBannerText = FSComp.SR.buildProductName(FSharpEnvironment.FSharpBannerVersion)
@@ -2910,9 +2906,7 @@ type TcConfig private (data : TcConfigBuilder, validate:bool) =
     member x.optSettings        = data.optSettings
     member x.emitTailcalls      = data.emitTailcalls
     member x.deterministic      = data.deterministic
-#if PREFERRED_UI_LANG
     member x.preferredUiLang    = data.preferredUiLang
-#endif
     member x.lcid               = data.lcid
     member x.optsOn             = data.optsOn
     member x.productNameForBannerText  = data.productNameForBannerText

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -331,9 +331,7 @@ type TcConfigBuilder =
       mutable optSettings  : Optimizer.OptimizationSettings 
       mutable emitTailcalls: bool
       mutable deterministic: bool
-#if PREFERRED_UI_LANG
       mutable preferredUiLang: string option
-#endif
       mutable lcid        : int option
       mutable productNameForBannerText: string
       mutable showBanner : bool
@@ -481,11 +479,7 @@ type TcConfig =
     member optSettings  : Optimizer.OptimizationSettings 
     member emitTailcalls: bool
     member deterministic: bool
-#if PREFERRED_UI_LANG
     member preferredUiLang: string option
-#else
-    member lcid        : int option
-#endif
     member optsOn       : bool 
     member productNameForBannerText: string
     member showBanner : bool

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -739,10 +739,8 @@ let codePageFlag (tcConfigB : TcConfigBuilder) =
                      tcConfigB.inputCodePage <- Some(n)), None,
                            Some (FSComp.SR.optsCodepage()))
 
-#if PREFERRED_UI_LANG
 let preferredUiLang (tcConfigB: TcConfigBuilder) = 
         CompilerOption("preferreduilang", tagString, OptionString (fun s -> tcConfigB.preferredUiLang <- Some(s)), None, Some(FSComp.SR.optsPreferredUiLang()))
-#endif
 
 let utf8OutputFlag (tcConfigB: TcConfigBuilder) = 
         CompilerOption("utf8output", tagNone, OptionUnit (fun () -> tcConfigB.utf8output <- true), None,
@@ -771,9 +769,7 @@ let advancedFlagsBoth tcConfigB =
     [
         yield codePageFlag tcConfigB
         yield utf8OutputFlag tcConfigB
-#if PREFERRED_UI_LANG
         yield preferredUiLang tcConfigB
-#endif
         yield fullPathsFlag tcConfigB
         yield libFlag tcConfigB
         yield CompilerOption("simpleresolution", 
@@ -849,11 +845,7 @@ let testFlag tcConfigB =
 let vsSpecificFlags (tcConfigB: TcConfigBuilder) = 
   [ CompilerOption("vserrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.VSErrors), None, None)
     CompilerOption("validate-type-providers", tagNone, OptionUnit (id), None, None)  // preserved for compatibility's sake, no longer has any effect
-#if PREFERRED_UI_LANG
     CompilerOption("LCID", tagInt, OptionInt (fun _n -> ()), None, None)
-#else
-    CompilerOption("LCID", tagInt, OptionInt (fun n -> tcConfigB.lcid <- Some(n)), None, None)
-#endif
     CompilerOption("flaterrors", tagNone, OptionUnit (fun () -> tcConfigB.flatErrors <- true), None, None) 
     CompilerOption("sqmsessionguid", tagNone, OptionString (fun s -> tcConfigB.sqmSessionGuid <- try System.Guid(s) |> Some  with e -> None), None, None)
     CompilerOption("gccerrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.GccErrors), None, None) 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1635,7 +1635,6 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, openBinarie
     let directoryBuildingFrom = Directory.GetCurrentDirectory()
     let setProcessThreadLocals tcConfigB =
                     tcConfigB.openBinariesInMemory <- openBinariesInMemory
-#if PREFERRED_UI_LANG
                     match tcConfigB.preferredUiLang with
 #if FX_RESHAPED_GLOBALIZATION
                     | Some s -> System.Globalization.CultureInfo.CurrentUICulture <- new System.Globalization.CultureInfo(s)
@@ -1643,11 +1642,6 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, openBinarie
                     | Some s -> Thread.CurrentThread.CurrentUICulture <- new System.Globalization.CultureInfo(s)
 #endif
                     | None -> ()
-#else
-                    match tcConfigB.lcid with
-                    | Some n -> Thread.CurrentThread.CurrentUICulture <- new CultureInfo(n)
-                    | None -> ()
-#endif
                     if tcConfigB.utf8output then 
                         Console.OutputEncoding <- Encoding.UTF8
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2419,19 +2419,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     // We later switch to doing interaction-by-interaction processing on the "event loop" thread.
     let ctokStartup = AssumeCompilationThreadWithoutEvidence ()
 
-#if FX_LCIDFROMCODEPAGE
-
-    // See Bug 735819 
-    let lcidFromCodePage = 
-        if (Console.OutputEncoding.CodePage <> 65001) &&
-           (Console.OutputEncoding.CodePage <> Thread.CurrentThread.CurrentUICulture.TextInfo.OEMCodePage) &&
-           (Console.OutputEncoding.CodePage <> Thread.CurrentThread.CurrentUICulture.TextInfo.ANSICodePage) then
-                Thread.CurrentThread.CurrentUICulture <- new CultureInfo("en-US")
-                Some 1033
-        else
-            None
-#endif
-
     let timeReporter = FsiTimeReporter(outWriter)
 
 #if !FX_RESHAPED_CONSOLE
@@ -2495,9 +2482,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     let fsiConsolePrompt = FsiConsolePrompt(fsiOptions, fsiConsoleOutput)
 
     do
-#if FX_LCIDFROMCODEPAGE
-      ignore lcidFromCodePage
-#endif
       match tcConfigB.preferredUiLang with
 #if FX_RESHAPED_GLOBALIZATION
       | Some s -> System.Globalization.CultureInfo.CurrentUICulture <- new System.Globalization.CultureInfo(s)

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2494,9 +2494,20 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     let fsiOptions       = FsiCommandLineOptions(fsi, argv, tcConfigB, fsiConsoleOutput)
     let fsiConsolePrompt = FsiConsolePrompt(fsiOptions, fsiConsoleOutput)
 
-    // Check if we have a codepage from the console
-#if FX_LCIDFROMCODEPAGE
     do
+#if PREFERRED_UI_LANG
+#if FX_LCIDFROMCODEPAGE
+      ignore lcidFromCodePage
+#endif
+      match tcConfigB.preferredUiLang with
+#if FX_RESHAPED_GLOBALIZATION
+      | Some s -> System.Globalization.CultureInfo.CurrentUICulture <- new System.Globalization.CultureInfo(s)
+#else
+      | Some s -> Thread.CurrentThread.CurrentUICulture <- new System.Globalization.CultureInfo(s)
+#endif
+      | None -> ()
+#else
+#if FX_LCIDFROMCODEPAGE
       match fsiOptions.FsiLCID with
       | Some _ -> ()
       | None -> tcConfigB.lcid <- lcidFromCodePage
@@ -2504,8 +2515,9 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     // Set the ui culture
     do 
       match fsiOptions.FsiLCID with
-      | Some(n) -> Thread.CurrentThread.CurrentUICulture <- new CultureInfo(n)
+      | Some n -> Thread.CurrentThread.CurrentUICulture <- new CultureInfo(n)
       | None -> ()
+#endif
 #endif
 
 #if !FX_NO_SERVERCODEPAGES

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2495,7 +2495,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     let fsiConsolePrompt = FsiConsolePrompt(fsiOptions, fsiConsoleOutput)
 
     do
-#if PREFERRED_UI_LANG
 #if FX_LCIDFROMCODEPAGE
       ignore lcidFromCodePage
 #endif
@@ -2506,19 +2505,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
       | Some s -> Thread.CurrentThread.CurrentUICulture <- new System.Globalization.CultureInfo(s)
 #endif
       | None -> ()
-#else
-#if FX_LCIDFROMCODEPAGE
-      match fsiOptions.FsiLCID with
-      | Some _ -> ()
-      | None -> tcConfigB.lcid <- lcidFromCodePage
-
-    // Set the ui culture
-    do 
-      match fsiOptions.FsiLCID with
-      | Some n -> Thread.CurrentThread.CurrentUICulture <- new CultureInfo(n)
-      | None -> ()
-#endif
-#endif
 
 #if !FX_NO_SERVERCODEPAGES
     do 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
@@ -3277,16 +3277,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 
                 projectInstance.SetProperty("UTFOutput", "true");
 
-#if FX_PREFERRED_UI_LANG
                 // The CoreCLR build of FSC will use the CultureName since lcid doesn't apply very well
                 // so that the errors reported by fsc.exe are in the right locale
                 projectInstance.SetProperty("PREFERREDUILANG", System.Threading.Thread.CurrentThread.CurrentUICulture.Name);
-#else
-                // When building, we need to set the flags for the fsc.exe that we spawned
-                // so that the errors reported by fsc.exe are in the right locale
-                projectInstance.SetProperty("LCID", System.Threading.Thread.CurrentThread.CurrentUICulture.LCID.ToString());
-#endif
-
                 this.BuildProject.ProjectCollection.HostServices.SetNodeAffinity(projectInstance.FullPath, NodeAffinity.InProc);
                 BuildRequestData requestData = new BuildRequestData(projectInstance, targetsToBuild, this.BuildProject.ProjectCollection.HostServices, BuildRequestDataFlags.ReplaceExistingProjectInstance);
                 submission = BuildManager.DefaultBuildManager.PendBuildRequest(requestData);

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectSystem.Base.csproj
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectSystem.Base.csproj
@@ -22,7 +22,6 @@
     <DefineConstants>$(DefineConstants);CODE_ANALYSIS</DefineConstants>
     <AsmmetaDependsOnMSBuildInVS>true</AsmmetaDependsOnMSBuildInVS>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <DefineConstants>$(DefineConstants);FX_PREFERRED_UI_LANG</DefineConstants>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Enable the preferreduilang switch for fsi.exe.

````
fsi.exe --preferreduilang:de-DE

Microsoft (R) F# Interactive, Version 4.1
Copyright (c) Microsoft Corporation. Alle Rechte vorbehalten.

Um Hilfe zu erhalten, geben Sie "#help;;" ein.

> #quit;;
````