### PR TITLE
build nuget packages after signing

### DIFF
--- a/build-everything.proj
+++ b/build-everything.proj
@@ -24,8 +24,8 @@
     <ProjectsWithCoreClr Include="src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj" />
     <ProjectsWithCoreClr Include="src/fsharp/Fsc/Fsc.fsproj" />
     <ProjectsWithCoreClr Include="src/fsharp/fsi/Fsi.fsproj" />
-    <ProjectsWithCoreClr Include="src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.proj" />
- </ItemGroup>
+    <ProjectsWithCoreClr Include="src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuget.proj" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(BUILD_VS)'=='1'">
     <ProjectsWithNet40 Include="vsintegration/fsharp-vsintegration-src-build.proj" />
@@ -45,10 +45,6 @@
 
   <ItemGroup Condition="'$(BUILD_SETUP)'=='1'">
     <SetupProjects Include="setup/fsharp-setup-build.proj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(BUILD_NUGET)'=='1'">
-    <NugetProjects Include="src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.proj" />
   </ItemGroup>
 
   <!-- +++++++++++++++++++++++ Project selection for testing +++++++++++++++++++++++++++++++ -->

--- a/build-nuget-packages.proj
+++ b/build-nuget-packages.proj
@@ -1,0 +1,21 @@
+<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+
+  <ItemGroup>
+    <PackageProjects Include="src\fsharp\FSharp.Compiler.nuget\Microsoft.FSharp.Compiler.nuget.proj" Condition="'$(BUILD_CORECLR)'=='1'" />
+    <PackageProjects Include="src\fsharp\FSharp.Core.nuget\FSharp.Core.nuget.proj" Condition="'$(BUILD_NUGET)'=='1'" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <MSBuild Projects="@(PackageProjects)" Targets="Build" BuildInParallel="true" Properties="Configuration=$(Configuration)" />
+  </Target>
+
+  <Target Name="Rebuild">
+    <MSBuild Projects="@(PackageProjects)" Targets="Rebuild" BuildInParallel="true" Properties="Configuration=$(Configuration)" />
+  </Target>
+
+  <Target Name="Clean">
+    <MSBuild Projects="@(PackageProjects)" Targets="Clean" BuildInParallel="true" Properties="Configuration=$(Configuration)" />
+  </Target>
+
+</Project>

--- a/build.cmd
+++ b/build.cmd
@@ -686,6 +686,12 @@ if not "%SIGN_TYPE%" == "" (
     if ERRORLEVEL 1 echo Error running sign tool && goto :failure
 )
 
+echo ---------------- Done with assembly signing, start package creation ---------------
+
+echo %_msbuildexe% %msbuildflags% build-nuget-packages.proj /p:Configuration=%BUILD_CONFIG%
+     %_msbuildexe% %msbuildflags% build-nuget-packages.proj /p:Configuration=%BUILD_CONFIG%
+if ERRORLEVEL 1 echo Error building NuGet packages && goto :failure
+
 if "%BUILD_SETUP%" == "1" (
     echo %_msbuildexe% %msbuildflags% setup\build-msi.proj /p:Configuration=%BUILD_CONFIG%
          %_msbuildexe% %msbuildflags% setup\build-msi.proj /p:Configuration=%BUILD_CONFIG%

--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.props
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.props
@@ -1,0 +1,20 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
+    <PreReleaseLabel>rc</PreReleaseLabel>
+    <BuildVersionFilePath Condition="'$(BuildVersionFilePath)'==''" >obj\BuildVersionFile.props</BuildVersionFilePath>
+  </PropertyGroup>
+
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.targets" />
+
+  <PropertyGroup>
+    <PackageLicenceUrl Condition="'$(PackageLicenceUrl)' == ''">https://github.com/Microsoft/visualfsharp/blob/master/License.txt</PackageLicenceUrl>
+    <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://github.com/Microsoft/visualfsharp</PackageProjectUrl>
+    <PackageAuthors    Condition="'$(PackageAuthors)' == ''"   >Microsoft and F# Software Foundation</PackageAuthors> 
+    <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags> 
+    <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\coreclr\bin</OutputPath>
+    <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rtm-$(BuildRevision.Trim())-0</PreReleaseSuffix>
+    <PackageVersion>$(FSPackageVersion)$(PreReleaseSuffix)</PackageVersion>
+    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
+  </PropertyGroup>
+</Project>

--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.targets
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.targets
@@ -1,27 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
-    <PreReleaseLabel>rc</PreReleaseLabel>
-    <BuildVersionFilePath Condition="'$(BuildVersionFilePath)'==''" >obj\BuildVersionFile.props</BuildVersionFilePath>
-  </PropertyGroup>
-
-  <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.targets" />
-
-  <PropertyGroup>
-    <PackageLicenceUrl Condition="'$(PackageLicenceUrl)' == ''">https://github.com/Microsoft/visualfsharp/blob/master/License.txt</PackageLicenceUrl>
-    <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://github.com/Microsoft/visualfsharp</PackageProjectUrl>
-    <PackageAuthors    Condition="'$(PackageAuthors)' == ''"   >Microsoft and F# Software Foundation</PackageAuthors> 
-    <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags> 
-    <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\coreclr\bin</OutputPath>
-    <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rtm-$(BuildRevision.Trim())-0</PreReleaseSuffix>
-    <PackageVersion>$(FSPackageVersion)$(PreReleaseSuffix)</PackageVersion>
-    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetDotnetProfile)' == 'coreclr'">
-    <PackageNuspec Include="Testing.FSharp.Compiler.nuspec" />
-    <PackageNuspec Include="Microsoft.FSharp.Compiler.nuspec" />
-  </ItemGroup>
 
   <ItemGroup>
     <RefMarker Include="_._"></RefMarker>

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuget.proj
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuget.proj
@@ -1,0 +1,11 @@
+<Project>
+
+  <Import Project="FSharp.Compiler.Template.nuget.props" />
+
+  <ItemGroup>
+    <PackageNuspec Include="Microsoft.FSharp.Compiler.nuspec" />
+  </ItemGroup>
+
+  <Import Project="FSharp.Compiler.Template.nuget.targets" />
+
+</Project>

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuget.proj
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuget.proj
@@ -1,0 +1,11 @@
+<Project>
+
+  <Import Project="FSharp.Compiler.Template.nuget.props" />
+
+  <ItemGroup>
+    <PackageNuspec Include="Testing.FSharp.Compiler.nuspec" />
+  </ItemGroup>
+
+  <Import Project="FSharp.Compiler.Template.nuget.targets" />
+
+</Project>


### PR DESCRIPTION
**Don't merge until the internal signed test build has completed.**

Delay building the NuGet packages until after assembly signing has occurred.

Fixes #4263.