### PR TITLE
Dev15.6  -- Fix multi-targetting / F# IDE

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -226,13 +226,20 @@ type internal FSharpProjectOptionsManager
 
     [<Export>]
     /// This handles commandline change notifications from the Dotnet Project-system
+    /// Prior to VS 15.7 path contained path to project file, post 15.7 contains target binpath
+    /// binpath is more accurate because a project file can have multiple in memory projects based on configuration
     member this.HandleCommandLineChanges(path:string, sources:ImmutableArray<CommandLineSourceFile>, references:ImmutableArray<CommandLineReference>, options:ImmutableArray<string>) =
         let fullPath p =
             if Path.IsPathRooted(p) then p
             else Path.Combine(Path.GetDirectoryName(path), p)
         let sourcePaths = sources |> Seq.map(fun s -> fullPath s.Path) |> Seq.toArray
         let referencePaths = references |> Seq.map(fun r -> fullPath r.Reference) |> Seq.toArray
-        let projectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(path, projectDisplayNameOf path)
+        let result, project = workspace.ProjectTracker.TryGetProjectByBinPath(path)
+        let projectId =
+            if result then
+                project.Id
+            else
+                workspace.ProjectTracker.GetOrCreateProjectIdForPath(path, projectDisplayNameOf path)
         projectOptionsTable.SetOptionsWithProjectId(projectId, sourcePaths, referencePaths, options.ToArray())
         this.UpdateProjectInfoWithProjectId(projectId, "HandleCommandLineChanges", invalidateConfig=true)
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -234,12 +234,10 @@ type internal FSharpProjectOptionsManager
             else Path.Combine(Path.GetDirectoryName(path), p)
         let sourcePaths = sources |> Seq.map(fun s -> fullPath s.Path) |> Seq.toArray
         let referencePaths = references |> Seq.map(fun r -> fullPath r.Reference) |> Seq.toArray
-        let result, project = workspace.ProjectTracker.TryGetProjectByBinPath(path)
         let projectId =
-            if result then
-                project.Id
-            else
-                workspace.ProjectTracker.GetOrCreateProjectIdForPath(path, projectDisplayNameOf path)
+            match workspace.ProjectTracker.TryGetProjectByBinPath(path) with
+            | true, project -> project.Id
+            | false, _ -> workspace.ProjectTracker.GetOrCreateProjectIdForPath(path, projectDisplayNameOf path)
         projectOptionsTable.SetOptionsWithProjectId(projectId, sourcePaths, referencePaths, options.ToArray())
         this.UpdateProjectInfoWithProjectId(projectId, "HandleCommandLineChanges", invalidateConfig=true)
 


### PR DESCRIPTION
Multi-targeting doesn't work correctly in the F# IDE.

__Relies on this Project System PR:   https://github.com/dotnet/project-system/pull/3198__

The reason is the IDE doesn't know how to identify the correct cached references and source files. Currently it uses the project file name, this is insufficient because in a multi-targeting project there is in fact an in memory project for each target framework.
The project tracker can identify the correct in memory project using the binpath of the project output file. In the project system the context object also identifies the binpath for the project being "design-time" built.

This change modifies the CommandLine notification to send the binpath rather than the project path.

The code can handle the existing behavior of the CommandLine  If the binpath doesn't find a project, it then tries the project file name.  And behaves the same as before.

Kevin




