### PR TITLE
Add manifests for product construction

### DIFF
--- a/PublishToBlob.proj
+++ b/PublishToBlob.proj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
     <!-- This version should be kept in sync with `packages.config` -->
-    <FeedTasksPackageVersion>1.0.0-prerelease-02219-01</FeedTasksPackageVersion>
+    <FeedTasksPackageVersion>2.1.0-prerelease-02419-02</FeedTasksPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)packages\$(FeedTasksPackage).$(FeedTasksPackageVersion)\build\$(FeedTasksPackage).targets" />
@@ -24,12 +24,23 @@
     <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
                     AccountKey="$(AccountKey)"
                     ItemsToPush="@(NuGetPackages)"
-                    Overwrite="$(PublishOverwrite)" />
+                    Overwrite="$(PublishOverwrite)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestCommit="$(ManifestCommit)"
+                    ManifestName="fsharp"
+                    SkipCreateManifest="false" />
+
     <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
                     AccountKey="$(AccountKey)"
                     ItemsToPush="@(OtherAssets)"
                     PublishFlatContainer="true"
-                    Overwrite="$(PublishOverwrite)" />
+                    Overwrite="$(PublishOverwrite)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestCommit="$(ManifestCommit)"
+                    ManifestName="fsharp"
+                    SkipCreateManifest="false" />
   </Target>
 
 </Project>

--- a/packages.config
+++ b/packages.config
@@ -12,7 +12,7 @@
   <package id="MicroBuild.Core.Sentinel" version="1.0.0" />
 
   <!-- For the internal orchestrated build.  This version should be kept in sync with `PublishToBlob.proj` -->
-  <package id="Microsoft.DotNet.Build.Tasks.Feed" version="1.0.0-prerelease-02219-01" />
+  <package id="Microsoft.DotNet.Build.Tasks.Feed" version="2.1.0-prerelease-02419-02" />
 
   <!-- Actual dependencies of FSharp.Compiler.dll and FSharp.Core.dll -->
   <package id="System.Collections.Immutable" version="1.3.1" />


### PR DESCRIPTION
Will set up the input parameters (commit/build id, etc.) as part of the build definition.