### PR TITLE
enable Microsoft.DiaSymReader* packages to be overridden during build

### DIFF
--- a/build/projects/PrepareDependencyUptake.proj
+++ b/build/projects/PrepareDependencyUptake.proj
@@ -1,0 +1,35 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <DependencyUptakeDirectory>$(MSBuildThisFileDirectory)..\..\Tools\dependencyUptake</DependencyUptakeDirectory>
+    <PackageVersionsPropsFile>$(DependencyUptakeDirectory)\PackageVersions.props</PackageVersionsPropsFile>
+    <PackagesConfigFile>$(DependencyUptakeDirectory)\packages.config</PackagesConfigFile>
+    <NuGetConfigFile>$(DependencyUptakeDirectory)\NuGet.config</NuGetConfigFile>
+  </PropertyGroup>
+
+  <Import Project="$(PackageVersionsPropsFile)" />
+
+  <!-- Prepare a dummy packages.config -->
+  <ItemGroup>
+    <PackagesConfigLines Include="&lt;packages&gt;" />
+    <PackagesConfigLines Include="  &lt;package id=&quot;Microsoft.DiaSymReader&quot; version=&quot;$(MicrosoftDiaSymReaderPackageVersion)&quot; /&gt;" />
+    <PackagesConfigLines Include="  &lt;package id=&quot;Microsoft.DiaSymReader.PortablePdb&quot; version=&quot;$(MicrosoftDiaSymReaderPortablePdbPackageVersion)&quot; /&gt;" />
+    <PackagesConfigLines Include="&lt;/packages&gt;" />
+  </ItemGroup>
+
+  <!-- Prepare a dummy NuGet.config -->
+  <ItemGroup>
+    <NuGetConfigLines Include="&lt;configuration&gt;" />
+    <NuGetConfigLines Include="  &lt;packageSources&gt;" />
+    <NuGetConfigLines Include="    &lt;clear /&gt;" />
+    <NuGetConfigLines Include="    &lt;add key=&quot;dependency-uptake&quot; value=&quot;$(PB_RestoreSource)&quot; /&gt;" />
+    <NuGetConfigLines Include="  &lt;/packageSources&gt;" />
+    <NuGetConfigLines Include="&lt;/configuration&gt;" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <WriteLinesToFile File="$(PackagesConfigFile)" Lines="@(PackagesConfigLines)" Overwrite="true" />
+    <WriteLinesToFile File="$(NuGetConfigFile)" Lines="@(NuGetConfigLines)" Overwrite="true" />
+  </Target>
+
+</Project>

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -84,6 +84,9 @@
     <MicrosoftVisualStudioThreadingVersion>15.3.23</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioValidationVersion>15.3.15</MicrosoftVisualStudioValidationVersion>
 
+    <MicrosoftDiaSymReaderPackageVersion>1.1.0</MicrosoftDiaSymReaderPackageVersion>
+    <MicrosoftDiaSymReaderPortablePdbPackageVersion>1.2.0</MicrosoftDiaSymReaderPortablePdbPackageVersion>
+
     <!-- Always qualify the IntermediateOutputPath by the TargetDotnetProfile if any exists -->
     <IntermediateOutputPath>obj\$(Configuration)\$(TargetDotnetProfile)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PortableProfileBeingReferenced)' != ''">obj\$(Configuration)\$(TargetDotnetProfile)\$(PortableProfileBeingReferenced)\</IntermediateOutputPath>
@@ -100,12 +103,16 @@
 
     <MonoPackaging Condition="'$(TargetDotnetProfile)' != 'coreclr' AND '$(OS)' == 'Unix'">true</MonoPackaging>
 
+    <DependencyUptakePackageVersionPropsFile>$(MSBuildThisFileDirectory)..\Tools\dependencyUptake\PackageVersions.props</DependencyUptakePackageVersionPropsFile>
+
     <!-- Localization -->
     <DisableLocalization Condition="'$(MonoPackaging)' == 'true'">true</DisableLocalization>
     <UpdateXlfOnBuild Condition="'$(CI)' != '1'">true</UpdateXlfOnBuild>
     <XliffTasksVersion>0.2.0-beta-000076</XliffTasksVersion>
 
   </PropertyGroup>
+
+  <Import Project="$(DependencyUptakePackageVersionPropsFile)" Condition="Exists('$(DependencyUptakePackageVersionPropsFile)')" />
 
   <!-- Default setting. Some get modified later in FSharpSource.targets -->
   <PropertyGroup>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -669,10 +669,10 @@
     <Reference Include="System.Numerics" />
     <Reference Include="ISymWrapper, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.DiaSymReader.PortablePdb">
-      <HintPath>..\..\..\packages\Microsoft.DiaSymReader.PortablePdb.1.2.0\lib\portable-net45+win8\Microsoft.DiaSymReader.PortablePdb.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.DiaSymReader.PortablePdb.$(MicrosoftDiaSymReaderPortablePdbPackageVersion)\lib\netstandard1.1\Microsoft.DiaSymReader.PortablePdb.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DiaSymReader">
-      <HintPath>..\..\..\packages\Microsoft.DiaSymReader.1.1.0\lib\portable-net45+win8\Microsoft.DiaSymReader.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.DiaSymReader.$(MicrosoftDiaSymReaderPackageVersion)\lib\netstandard1.1\Microsoft.DiaSymReader.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>


### PR DESCRIPTION
Since we're still using `packages.config`, it's not easy to pull in dynamic packages at build time, but this is manageable because there are only two packages that we might have to do this for; `Microsoft.DiaSymReader` and `Microsoft.DiaSymReader.PortablePdb`.

Since we're potentially given an MSBuild `.props` file with the new version numbers, we need to consume this from within MSBuild, hence `PrepareDependencyUptake.proj` which simply writes out an appropriate `packages.config` and `NuGet.config` which are then used to restore.

`FSharp.Compiler.Private.fsproj` is the only project that uses the `Microsoft.DiaSymReader*` packages so the hard-coded version numbers were removed from that file and replaced with the properties `$(MicrosoftDiaSymReaderPackageVersion)` and `$(MicrosoftDiaSymReaderPortablePdbPackageVersion)` whcih are specified by the potentially downloaded `PackageVersions.props` as specified by the `%PB_PackageVersionPropsUrl%` environment variable.

Once complete and verified to be correct, these same changes will be cherry-picked to `dev15.6` for the source-build efforts.