### PR TITLE
Remove minimumElement and maximumElement from Set module

### DIFF
--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -813,16 +813,6 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Count")>]
         let count (set: Set<'T>) = set.Count
 
-        [<CompiledName("MinimumElement")>]
-        let minimumElement (set: Set<'T>) = set.MinimumElement
-
-        [<System.Obsolete("Renamed to MinimumElement")>]
-        [<CompiledName("MinumumElement")>]
-        let minumumElement (set: Set<'T>) = minimumElement set
-
-        [<CompiledName("MaximumElement")>]
-        let maximumElement (set: Set<'T>) = set.MaximumElement
-
         [<CompiledName("OfList")>]
         let ofList elements = Set(List.toSeq elements)
 

--- a/src/fsharp/FSharp.Core/set.fs
+++ b/src/fsharp/FSharp.Core/set.fs
@@ -813,8 +813,12 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Count")>]
         let count (set: Set<'T>) = set.Count
 
-        [<CompiledName("MinumumElement")>]
+        [<CompiledName("MinimumElement")>]
         let minimumElement (set: Set<'T>) = set.MinimumElement
+
+        [<System.Obsolete("Renamed to MinimumElement")>]
+        [<CompiledName("MinumumElement")>]
+        let minumumElement (set: Set<'T>) = minimumElement set
 
         [<CompiledName("MaximumElement")>]
         let maximumElement (set: Set<'T>) = set.MaximumElement


### PR DESCRIPTION
Fixes Microsoft/visualfsharp#4297

If you want to take this but need an RFC as it's a surface area change then I can look after that, there are definitely better ways for you to spend your time.  Also you may not want to add a minumumElement property to the F# surface area, so feel free to just close this.