### PR TITLE
propagate Microsoft.DiaSymReader* version overrides to NuGet packages

### DIFF
--- a/src/buildfromsource/FSharp.Compiler.nuget/FSharp.Compiler.nuget.fsproj
+++ b/src/buildfromsource/FSharp.Compiler.nuget/FSharp.Compiler.nuget.fsproj
@@ -21,12 +21,12 @@
     <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags> 
     <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rc-$(BuildRevision.Trim())-0</PreReleaseSuffix>
     <PackageVersion>4.2.0$(PreReleaseSuffix)</PackageVersion>
-    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
+    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=1.1.0" -prop "diasymreaderportablepdbversion=1.2.0"</PackageProperties>
   </PropertyGroup>
 
   <PropertyGroup>
       <NuspecFile>$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.nuget\Microsoft.FSharp.Compiler.nuspec</NuspecFile>
-      <NuspecProperties>licenseUrl=$(PackageLicenceUrl);version=$(PackageVersion);authors=$(PackageAuthors);projectUrl=$(PackageProjectUrl);tags=$(PackageTags)</NuspecProperties>
+      <NuspecProperties>licenseUrl=$(PackageLicenceUrl);version=$(PackageVersion);authors=$(PackageAuthors);projectUrl=$(PackageProjectUrl);tags=$(PackageTags);diasymreaderversion=1.1.0;diasymreaderportablepdbversion=1.2.0</NuspecProperties>
       <NuspecBasePath>$(OutputPath)/$(TargetFramework)</NuspecBasePath>
   </PropertyGroup>
 

--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.proj
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.proj
@@ -15,7 +15,7 @@
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\coreclr\bin</OutputPath>
     <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rtm-$(BuildRevision.Trim())-0</PreReleaseSuffix>
     <PackageVersion>4.2.0$(PreReleaseSuffix)</PackageVersion>
-    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
+    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion)" -prop "diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)"</PackageProperties>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetDotnetProfile)' == 'coreclr'">
@@ -57,7 +57,7 @@
           Outputs='$(FSharpSourcesRoot)\$(Configuration)\artifacts\$(PackageVersion)\"%(PackageNuspec.Filename)).nupkg'>
 
     <PropertyGroup>
-      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
+      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion)" -prop "diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)"</PackageProperties>
     </PropertyGroup>
 
     <MakeDir Directories="$(FSharpSourcesRoot)\..\artifacts" />

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -33,8 +33,8 @@
                 <dependency id="System.Threading.Thread" version="4.0.0" />
                 <dependency id="System.Threading.ThreadPool" version="4.0.10" />
                 <dependency id="System.ValueTuple" version="4.3.1" />
-                <dependency id="Microsoft.DiaSymReader.PortablePdb" version="1.2.0" />
-                <dependency id="Microsoft.DiaSymReader" version="1.1.0" />
+                <dependency id="Microsoft.DiaSymReader.PortablePdb" version="$diasymreaderportablepdbversion$" />
+                <dependency id="Microsoft.DiaSymReader" version="$diasymreaderversion$" />
             </group>
         </dependencies>
         <contentFiles>

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
@@ -32,8 +32,8 @@
                 <dependency id="System.Threading.Thread" version="4.0.0" />
                 <dependency id="System.Threading.ThreadPool" version="4.0.10" />
                 <dependency id="System.ValueTuple" version="4.3.1" />
-                <dependency id="Microsoft.DiaSymReader.PortablePdb" version="1.2.0" />
-                <dependency id="Microsoft.DiaSymReader" version="1.1.0" />
+                <dependency id="Microsoft.DiaSymReader.PortablePdb" version="$diasymreaderportablepdbversion$" />
+                <dependency id="Microsoft.DiaSymReader" version="$diasymreaderversion$" />
             </group>
         </dependencies>
     </metadata>


### PR DESCRIPTION
Locally verified that the produced NuGet package has the appropriate dependencies specified in its .nuspec file.