### PR TITLE
Fix for:  Error dialog when deleting files from F# projects #319

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -359,6 +359,7 @@ type
     override this.Initialize() = 
         base.Initialize()
 
+
         let workspaceChanged (args:WorkspaceChangeEventArgs) =
             match args.Kind with
             | WorkspaceChangeKind.ProjectAdded     -> this.OnProjectAdded(args.ProjectId)
@@ -585,12 +586,13 @@ type
                 match hier with
                 | :? IProvideProjectSite as siteProvider when not (IsScript(filename)) ->
                     this.SetupProjectFile(siteProvider, this.Workspace, "SetupNewTextView")
-                | _ when not (IsScript(filename)) ->
+                | h when not (IsScript(filename)) ->
                     let docId = this.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filename).FirstOrDefault()
                     match docId with
                     | null ->
-                        let fileContents = VsTextLines.GetFileContents(textLines, textViewAdapter)
-                        this.SetupStandAloneFile(filename, fileContents, this.Workspace, hier)
+                        if not (h.IsCapabilityMatch("CPS")) then
+                            let fileContents = VsTextLines.GetFileContents(textLines, textViewAdapter)
+                            this.SetupStandAloneFile(filename, fileContents, this.Workspace, hier)
                     | id ->
                         projectInfoManager.UpdateProjectInfoWithProjectId(id.ProjectId, "SetupNewTextView", invalidateConfig=true)
                 | _ ->


### PR DESCRIPTION
Fixes dotnet/project-system#3195 (comment)

When deleting a file for a newly created F# project causes a Watson, and VS crashes and restarts.

The error happens because VS is in the process of loading and instantiating project, and at the same time starts the editor.  Our implementation of SetupNewTextView, queries the workspace to see if the project contains this document.  Unfortunately since the project is not yet fully instantiated, the workspace doesn't have information about the document.  The document will be added to the workspace and project as the project load proceeds normally, and workspace events will cause us to wire up intellisense correctly.

We need to ensure that we still enable the miscellaneous files behavior for loose F# documents.

The fix is to verify that hierarchy retrieved from the running document table for the document has the capability "CPS".  I.e. is a cps project.

If the document is associated with a CPS project we can be sure that necessary workspace events are on their way, and we can leave SetupNewTextView without doing any intellisense wireup, because it will be handled in the workspace events.

@brettfo, @Pilchie --- this fixes an AV does it meet the bar for 15.6

Will, brett, we need to try this out to make sure there are no other holes.

Kevin