### PR TITLE
[roslyn update needed] set diagnostic analyzer priorities

### DIFF
--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -104,6 +104,8 @@ type internal FSharpDocumentDiagnosticAnalyzer() =
             return results
         }
 
+    override __.Priority = 10 // Default = 50
+
     override this.SupportedDiagnostics = RoslynHelpers.SupportedDiagnostics()
 
     override this.AnalyzeSyntaxAsync(document: Document, cancellationToken: CancellationToken): Task<ImmutableArray<Diagnostic>> =

--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -42,7 +42,7 @@ type internal SimplifyNameDiagnosticAnalyzer() =
             customTags = DiagnosticCustomTags.Unnecessary)
 
     static member LongIdentPropertyKey = "FullName"
-    
+    override __.Priority = 100 // Default = 50
     override __.SupportedDiagnostics = ImmutableArray.Create Descriptor
     override this.AnalyzeSyntaxAsync(_, _) = Task.FromResult ImmutableArray<Diagnostic>.Empty
 

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
@@ -94,6 +94,8 @@ type internal UnusedDeclarationsAnalyzer() =
         //#endif
         unusedRanges
 
+    override __.Priority = 80 // Default = 50
+
     override __.SupportedDiagnostics = ImmutableArray.Create Descriptor
     
     override __.AnalyzeSyntaxAsync(_, _) = Task.FromResult ImmutableArray<Diagnostic>.Empty

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
@@ -35,6 +35,7 @@ type internal UnusedOpensDiagnosticAnalyzer() =
             isEnabledByDefault = true, 
             customTags = DiagnosticCustomTags.Unnecessary)
 
+    override __.Priority = 90 // Default = 50
     override __.SupportedDiagnostics = ImmutableArray.Create Descriptor
     override this.AnalyzeSyntaxAsync(_, _) = Task.FromResult ImmutableArray<Diagnostic>.Empty
 


### PR DESCRIPTION
Sets document diagnostic analyzer error priorities.

Can be integrated when https://github.com/dotnet/roslyn/pull/24673 is available in Roslyn

**NOTE: Should NOT be integrated into the nightly update branch until we know we can rely on the binaries above being available**

* After this the error-messages appear in about 2 seconds after a small edit **regardless** of whether of "SimplifyName" is on by default
* Prior to this change error-messages appeared in about 5-6 seconds if "SimplifyName" is on by default
* Prior to this change error-messages appeared in about 2 seconds if "SimplifyName" is off by default
* I used Elmish.WPF as the test case, editing the last line of ViewModel.fs

This doesn't yet turn SimplifyName on by default

