### PR TITLE
Add support for UnmanagedType.LPUTF8Str (fix for #4359)

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -1130,6 +1130,7 @@ type ILNativeType =
     | LPSTR
     | LPWSTR
     | LPTSTR
+    | LPUTF8STR
     | ByValStr
     | TBSTR
     | LPSTRUCT

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -756,6 +756,7 @@ type ILNativeType =
     | LPSTR
     | LPWSTR
     | LPTSTR
+    | LPUTF8STR
     | ByValStr
     | TBSTR
     | LPSTRUCT

--- a/src/absil/ilbinary.fs
+++ b/src/absil/ilbinary.fs
@@ -838,6 +838,7 @@ let nt_ARRAY       = 0x2Auy
 let nt_LPSTRUCT    = 0x2Buy
 let nt_CUSTOMMARSHALER = 0x2Cuy
 let nt_ERROR       = 0x2Duy
+let nt_LPUTF8STR   = 0x30uy
 let nt_MAX = 0x50uy
 
 // From c:/clrenv.i386/Crt/Inc/i386/hs.h
@@ -894,6 +895,7 @@ let ILNativeTypeMap =
         nt_LPSTR , ILNativeType.LPSTR
         nt_LPWSTR , ILNativeType.LPWSTR
         nt_LPTSTR, ILNativeType.LPTSTR
+        nt_LPUTF8STR, ILNativeType.LPUTF8STR
         nt_IUNKNOWN , (* COM interop *) ILNativeType.IUnknown
         nt_IDISPATCH , (* COM interop *) ILNativeType.IDispatch
         nt_BYVALSTR , ILNativeType.ByValStr

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -4969,7 +4969,8 @@ and GenMarshal cenv attribs =
                error(Error(FSComp.SR.ilCustomMarshallersCannotBeUsedInFSharp(),m))
                (* ILNativeType.Custom of bytes * string * string * bytes (* GUID,nativeTypeName,custMarshallerName,cookieString *) *)
                //ILNativeType.Error  
-            | 0x2D -> ILNativeType.Error  
+            | 0x2D -> ILNativeType.Error
+            | 0x30 -> ILNativeType.LPUTF8STR
             | _ -> ILNativeType.Empty
         Some(decodeUnmanagedType unmanagedType), otherAttribs
     | Some (Attrib(_,_,_,_,_,_,m))  -> 


### PR DESCRIPTION
This is a minimal fix for #4359 which adds support for UnmanagedType.LPUTF8Str.