### PR TITLE
use the official build number (if provided) to version the compiler package

### DIFF
--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -47,18 +47,20 @@
     Given $(BUILD_BUILDNUMBER) = '20161225.1'
     Given $(MicroBuildAssemblyVersion) = '15.4.1.0'
 
-    Then $(BuildTimeStamp_Day) = 161225
+    Then $(BuildTimeStamp_Date) = 161225
     Then $(BuildTimeStamp_Number) = 01
     Then $(BuildTimeStamp) = 16122501
     Then $(MicroBuildAssemblyVersion_WithoutRevision) = 15.4.1
     Then $(VsixPackageVersion) = 15.4.1.16122501
+    Then $(NuGetPackageVersionSuffix) = 161225-01
 
     -->
-    <BuildTimeStamp_Day>$(BUILD_BUILDNUMBER.Split('.')[0].Substring(2))</BuildTimeStamp_Day>
+    <BuildTimeStamp_Date>$(BUILD_BUILDNUMBER.Split('.')[0].Substring(2))</BuildTimeStamp_Date>
     <BuildTimeStamp_Number>$(BUILD_BUILDNUMBER.Split('.')[1].PadLeft(2, '0'))</BuildTimeStamp_Number>
-    <BuildTimeStamp>$(BuildTimeStamp_Day)$(BuildTimeStamp_Number)</BuildTimeStamp>
+    <BuildTimeStamp>$(BuildTimeStamp_Date)$(BuildTimeStamp_Number)</BuildTimeStamp>
     <MicroBuildAssemblyVersion_WithoutRevision>$(MicroBuildAssemblyVersion.Substring(0, $(MicroBuildAssemblyVersion.LastIndexOf('.'))))</MicroBuildAssemblyVersion_WithoutRevision>
     <VsixPackageVersion>$(MicroBuildAssemblyVersion_WithoutRevision).$(BuildTimeStamp)</VsixPackageVersion>
+    <NuGetPackageVersionSuffix>$(BuildTimeStamp_Date)-$(BuildTimeStamp_Number)</NuGetPackageVersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.proj
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.nuget.proj
@@ -13,7 +13,7 @@
     <PackageAuthors    Condition="'$(PackageAuthors)' == ''"   >Microsoft and F# Software Foundation</PackageAuthors> 
     <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags> 
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\coreclr\bin</OutputPath>
-    <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rtm-$(BuildRevision.Trim())-0</PreReleaseSuffix>
+    <PreReleaseSuffix Condition="'$(PreRelease)' != 'false'">-rtm-$(NuGetPackageVersionSuffix)</PreReleaseSuffix>
     <PackageVersion>4.2.0$(PreReleaseSuffix)</PackageVersion>
     <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion)" -prop "diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)"</PackageProperties>
   </PropertyGroup>


### PR DESCRIPTION
Currently the compiler package version always has a suffix of `-0`.  This change uses the full build number passed in from the signed build definition and uses the proper build suffix; `-00` for local developer builds, `-01`, etc. for signed builds.  This will make it easier for internal employees to map from the packages published on [NuGet.org](https://www.nuget.org/packages/Microsoft.FSharp.Compiler) and the internal build that produced them.

E.g.,
Old: `4.2.0-rtm-180217-0` -> New: `4.2.0-rtm-180217-01`.
