### PR TITLE
Enable --debug:full on coreclr

### DIFF
--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -470,7 +470,13 @@ let SetDebugSwitch (tcConfigB : TcConfigBuilder) (dtype : string option) (s : Op
        | "portable" ->  tcConfigB.portablePDB <- true;  tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- true; tcConfigB.ignoreSymbolStoreSequencePoints <- true
        | "pdbonly" ->   tcConfigB.portablePDB <- false; tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- false
        | "embedded" ->  tcConfigB.portablePDB <- true;  tcConfigB.embeddedPDB <- true;  tcConfigB.jitTracking <- true; tcConfigB.ignoreSymbolStoreSequencePoints <- true
+#if FX_NO_PDB_WRITER
+       // When building on the coreclr, full means portable
+       | "full" ->      tcConfigB.portablePDB <- true; tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- true
+#else
        | "full" ->      tcConfigB.portablePDB <- false; tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- true
+#endif
+
        | _ -> error(Error(FSComp.SR.optsUnrecognizedDebugType(s), rangeCmdArgs))
     | None ->           tcConfigB.portablePDB <- false; tcConfigB.embeddedPDB <- false; tcConfigB.jitTracking <- s = OptionSwitch.On;
     tcConfigB.debuginfo <- s = OptionSwitch.On


### PR DESCRIPTION
The coreclr F# does not generate a pdb file when a developer specified --debug:full

On the desktop --debug:full generates a windows format pdb.

With this PR --debug:full will generate a portable format pdb file from the coreclr version of the compiler.

**It should be noted that:** we cannot generate windows format pdbs on non windows machines, the libraries that support generation and use of windows pdb are windows only.


The recommended approach for developers is to use 
````
<DebugType>portable</DebugType>
````
in project files, as this will produce the same result, with the desktop and coreclr F# compiler.  However, with this PR the result of **<DebugType>full</DebugType>** will be less surprising than before.


Kevin
