### PR TITLE
Update Jenkins to Ubuntu 16.04

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -4,7 +4,7 @@ import jobs.generation.JobReport;
 def project = GithubProject
 def branch = GithubBranchName
 
-def osList = ['Windows_NT', 'Ubuntu14.04']  //, 'OSX'], 'CentOS7.1'
+def osList = ['Windows_NT', 'Ubuntu16.04']  //, 'OSX'], 'CentOS7.1'
 
 def static getBuildJobName(def configuration, def os) {
     return configuration.toLowerCase() + '_' + os.toLowerCase()


### PR DESCRIPTION
Moving to .NET SDK project files is causing problems on Ubuntu 14.04 because of the versions of Mono and MSBuild there, which don't appear to support .NET SDK project files as fully as one might hope.

It's possible that moving to Ubuntu 16.04 will help.  At least, it's worth doing in any case

