### PR TITLE
get latest mono in CI

### DIFF
--- a/fcs/cibuild.sh
+++ b/fcs/cibuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # note: expects to run from top directory
-#./mono/latest-mono-stable.sh
+./mono/latest-mono-stable.sh
 ./build.sh NuGet

--- a/mono/cibuild.sh
+++ b/mono/cibuild.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # note: expects to run from top directory
-#./mono/latest-mono-stable.sh 
-make Configuration=$@ 
-#sudo make install Configuration=$@ 
+./mono/latest-mono-stable.sh
+make Configuration=$@
+#sudo make install Configuration=$@
 #./mono/test-mono.sh

--- a/mono/test-mono.sh
+++ b/mono/test-mono.sh
@@ -2,6 +2,7 @@
 # Run some a variation of the tests/fsharp suite
 # Run the FSharp.Core.UnitTests suite
 
+# note: expects to run from top directory
 (cd tests/projects; ./build.sh) &&
 (cd tests/fsharp/core; ./run-opt.sh) 
 # This currently takes too long in travis


### PR DESCRIPTION
#4392 allows us to get the latest stable Mono prior to build+testing