### PR TITLE
Fixes #3222

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -351,7 +351,7 @@ this file.
 
     ============================================================
     -->
-    <Target Name="_GenerateCompileDependencyCache" DependsOnTargets="ResolveAssemblyReferences" Condition="'$(DesignTimeBuild)' == 'true'">
+    <Target Name="_GenerateCompileDependencyCache" DependsOnTargets="ResolveAssemblyReferences">
         <ItemGroup>
           <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
           <CoreCompileCache Remove="@(Compile)" />


### PR DESCRIPTION
The issue is that msbuild caches the list of files to build, in order to determine whether to perform the build, for design time builds we want it to not be so fussy, and build every time.

The Microsoft.FSharp.Targets file fixes this for DesignTime builds, however, it seems as if the DesignTime flag is not set for F# legacy project builds.

Given that the caching is essentially bug, this change to the F# targets file just ensures the hash in the cache has a different value every time.  Eventually msbuild will get fixed, but for now this is good.

If you want to manually edit the targets file and reship the nugget package for fsharp.compiler.tools.  That will be a quick resolution to the problem.  