### PR TITLE
Make fsharpcoreunittests run on coreclr again

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -459,6 +459,10 @@ if /i "%BUILD_FCS%" == "1" (
     set NEEDS_DOTNET_CLI_TOOLS=1
 )
 
+rem Decide if Proto need building
+if NOT EXIST Proto\net40\bin\fsc.exe (
+  set BUILD_PROTO=1
+)
 
 echo Build/Tests configuration:
 echo.
@@ -658,8 +662,8 @@ set path=%~dp0Tools\dotnet20\;%path%
 
 if "%NEEDS_DOTNET_CLI_TOOLS%" == "1" (
     :: Restore projects using dotnet CLI tool 
-    echo %_dotnet20exe% restore -v:d build-everything.proj %msbuildflags% %BUILD_DIAG%
-         %_dotnet20exe% restore -v:d build-everything.proj %msbuildflags% %BUILD_DIAG%
+    echo %_dotnet20exe% restore -v:d build-everything.proj -c Proto %msbuildflags% %BUILD_DIAG%
+         %_dotnet20exe% restore -v:d build-everything.proj -c Proto %msbuildflags% %BUILD_DIAG%
 )
 
 
@@ -700,11 +704,6 @@ if "%BUILD_PROTO_WITH_CORECLR_LKG%" == "1" (
 )
 
 echo ---------------- Done with package restore, starting proto ------------------------
-
-rem Decide if Proto need building
-if NOT EXIST Proto\net40\bin\fsc.exe (
-  set BUILD_PROTO=1
-)
 
 rem Build Proto
 if "%BUILD_PROTO%" == "1" (
@@ -1004,6 +1003,18 @@ if "%TEST_NET40_COREUNIT_SUITE%" == "1" (
     echo "!NUNIT3_CONSOLE!" --verbose --framework:V4.0 --result:"!XMLFILE!;format=nunit3" !OUTPUTARG! !ERRORARG! --work:"!FSCBINPATH!" "!FSCBINPATH!\FSharp.Build.UnitTests.dll" !WHERE_ARG_NUNIT!
          "!NUNIT3_CONSOLE!" --verbose --framework:V4.0 --result:"!XMLFILE!;format=nunit3" !OUTPUTARG! !ERRORARG! --work:"!FSCBINPATH!" "!FSCBINPATH!\FSharp.Build.UnitTests.dll" !WHERE_ARG_NUNIT!
 
+
+    if errorlevel 1 (
+        echo -----------------------------------------------------------------
+        type "!OUTPUTFILE!"
+        echo -----------------------------------------------------------------
+        type "!ERRORFILE!"
+        echo -----------------------------------------------------------------
+        echo Error: Running tests net40-coreunit failed, see logs above -- FAILED
+        echo -----------------------------------------------------------------
+        goto :failure
+    )
+
     echo "!NUNIT3_CONSOLE!" --verbose --framework:V4.0 --result:"!XMLFILE!;format=nunit3" !OUTPUTARG! !ERRORARG! --work:"!FSCBINPATH!" "!FSCBINPATH!\FSharp.Core.UnitTests.dll" !WHERE_ARG_NUNIT!
          "!NUNIT3_CONSOLE!" --verbose --framework:V4.0 --result:"!XMLFILE!;format=nunit3" !OUTPUTARG! !ERRORARG! --work:"!FSCBINPATH!" "!FSCBINPATH!\FSharp.Core.UnitTests.dll" !WHERE_ARG_NUNIT!
 
@@ -1030,10 +1041,17 @@ if "%TEST_CORECLR_COREUNIT_SUITE%" == "1" (
     echo "%_dotnetcliexe%" "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Build.UnitTests\FSharp.Build.UnitTests.dll" !WHERE_ARG_NUNIT!
          "%_dotnetcliexe%" "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Build.UnitTests\FSharp.Build.UnitTests.dll" !WHERE_ARG_NUNIT!
 
+    if errorlevel 1 (
+        echo -----------------------------------------------------------------
+        echo Error: Running tests coreclr-coreunit failed, see logs above-- FAILED
+        echo -----------------------------------------------------------------
+        goto :failure
+    )
+
     echo "%_dotnetcliexe%" "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Core.UnitTests\FSharp.Core.UnitTests.dll" !WHERE_ARG_NUNIT!
          "%_dotnetcliexe%" "%~dp0tests\testbin\!BUILD_CONFIG!\coreclr\FSharp.Core.UnitTests\FSharp.Core.UnitTests.dll" !WHERE_ARG_NUNIT!
 
-    if ERRORLEVEL 1 (
+    if errorlevel 1 (
         echo -----------------------------------------------------------------
         echo Error: Running tests coreclr-coreunit failed, see logs above-- FAILED
         echo -----------------------------------------------------------------

--- a/packages.config
+++ b/packages.config
@@ -27,7 +27,7 @@
   <package id="Microsoft.Build.Tasks.Core" version="14.3.0" />
 
   <!-- Testing -->
-  <package id="FsCheck" version="2.6.2" />
+  <package id="FsCheck" version="3.0.0-alpha3" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
   <package id="NUnit.Console" version="3.0.0" targetFramework="net45" />
   <package id="NUnitLite" version="3.5.0" targetFramework="net45" />

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -50,8 +50,8 @@
 
   <PropertyGroup>
     <NugetLocalPackagesDir>$(FSharpSourcesRoot)\..\packages</NugetLocalPackagesDir>
-    <FsCheckVersion>2.6.2</FsCheckVersion>
-    <FsCheckFullVersion>2.6.2.0</FsCheckFullVersion>
+    <FsCheckVersion>3.0.0-alpha3</FsCheckVersion>
+    <FsCheckFullVersion>3.0.0.0</FsCheckFullVersion>
     <FsCheckLibDir>$(FSharpSourcesRoot)\..\packages\FsCheck.$(FsCheckVersion)\lib\</FsCheckLibDir>
   </PropertyGroup>
 

--- a/tests/FSharp.Build.UnitTests/NuGet.Config
+++ b/tests/FSharp.Build.UnitTests/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+    <add key="DependencyVersion" value="Highest" />
+  </solution>
+  <packageSources>  
+    <add key="artifacts" value="../../artifacts" />
+  </packageSources>
+</configuration>

--- a/tests/FSharp.Build.UnitTests/project.json
+++ b/tests/FSharp.Build.UnitTests/project.json
@@ -11,6 +11,7 @@
     "Microsoft.Build": "15.1.548",
     "Microsoft.Build.Framework": "15.1.548",
     "Microsoft.Build.Tasks.Core": "15.1.548",
+    "Testing.FSharp.Core": "4.2.4",
     "Microsoft.Build.Utilities.Core": "15.1.548"
   },
   "runtimes": {

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.Unittests.fsproj
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.Unittests.fsproj
@@ -49,7 +49,7 @@
     <Reference Include="FsCheck, Version=$(FsCheckFullVersion)" Condition=" '$(TargetDotnetProfile)' != 'portable47' ">
       <SpecificVersion>true</SpecificVersion>
       <Private>True</Private>
-      <HintPath Condition="'$(TargetDotnetProfile)' == 'net40'">$(FsCheckLibDir)\net45\FsCheck.dll</HintPath>
+      <HintPath Condition="'$(TargetDotnetProfile)' == 'net40'">$(FsCheckLibDir)\net452\FsCheck.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
         <HintPath>..\..\..\packages\System.ValueTuple.4.3.1\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>

--- a/tests/FSharp.Core.UnitTests/NuGet.Config
+++ b/tests/FSharp.Core.UnitTests/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+    <add key="DependencyVersion" value="Highest" />
+  </solution>
+  <packageSources>  
+    <add key="artifacts" value="../../artifacts" />
+  </packageSources>
+</configuration>

--- a/tests/FSharp.Core.UnitTests/project.json
+++ b/tests/FSharp.Core.UnitTests/project.json
@@ -9,7 +9,8 @@
     "nunit": "3.5.0",
     "nunitlite": "3.5.0",
     "System.ValueTuple": "4.3.1",
-    "FsCheck": "2.6.2",
+    "FsCheck": "3.0.0-alpha3",
+    "Testing.FSharp.Core": "4.2.4",
     "Microsoft.FSharp.TupleSample": "1.0.0-alpha-161112"
   },
   "runtimes": {


### PR DESCRIPTION
The FSharpCoreUnitests stopped working on coreclr a while back.  I don't actually know when.  Anyway this gets them running again.

1.   The FSharpCoreUnit tests were published with the wrong version of fsharp.core, that failed to run successfully.  Used the TestFSharp.Nuget package built during the build and restored from the archive folder.

2.  Updates FsCheck to the latest release.

3.  build ci_part3 was broken if you didn't have proto already built, the build fails to find the target file during the restore phase.

