### PR TITLE
Debugger View for lists

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -3043,29 +3043,34 @@ namespace Microsoft.FSharp.Collections
     // List (debug view)
     //-------------------------------------------------------------------------
 
-    and 
+    and
        ListDebugView<'T>(l:list<'T>) =
 
-           let ListDebugViewMaxLength = 50
-           let rec count l n = 
-               match l with 
-               | [] -> n 
-               | _::t -> if n > ListDebugViewMaxLength then n else count t (n+1) 
+           let ListDebugViewMaxLength = 50                          // default displayed Max Length
+           let ListDebugViewMaxFullLength = 5000                    // display only when FullList opened (5000 is a super big display used to cut-off an infinite list or undebuggably huge one)
+           let rec count l n max =
+               match l with
+               | [] -> n
+               | _::t -> if n > max then n else count t (n+1) max
 
-           [<DebuggerBrowsable(DebuggerBrowsableState.RootHidden)>]
-           member x.Items =
-               let n = count l 0 
-               let items = zeroCreate n 
+           let items length =
+               let items = zeroCreate length
                let rec copy (items: 'T[]) l i = 
                    match l with
                    | [] -> () 
                    | h::t -> 
-                       if i < n then 
+                       if i < length then 
                            SetArray items i h
                            copy items t (i+1)
 
                copy items l 0
                items
+
+           [<DebuggerBrowsable(DebuggerBrowsableState.RootHidden)>]
+           member x.Items = items (count l 0 ListDebugViewMaxLength)
+
+           [<DebuggerBrowsable(DebuggerBrowsableState.Collapsed)>]
+           member x._FullList = items (count l 0 ListDebugViewMaxFullLength)
 
     type ResizeArray<'T> = System.Collections.Generic.List<'T>
 


### PR DESCRIPTION
Fixes #4398 VS debugging view for lists restricts the view to 50 elements 

whilst debugging something I came across this.  Even using the Raw node didn't allow me to see more than 50 items, which was super vexing.  I really wanted to see more of the list.

This fix adds an additional collapsed node _FullList next to Raw View, if a developer opens _FullList then it will display the complete list.

The watchpoint and intellisense for this looks like:

![image](https://user-images.githubusercontent.com/5175830/36708630-bc9a5116-1b28-11e8-8913-14d85844dc44.png)

**Note:  _FullList is constrained to 5000 elements to ensure that the debugger doesn't hang if the list is a never ending list, or perhaps un-debugably huge.**

