### PR TITLE
Make smart the default ... always

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -33,6 +33,7 @@ open Microsoft.VisualStudio.LanguageServices.ProjectSystem
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.ComponentModelHost
+open Microsoft.CodeAnalysis.Formatting
 
 // Exposes FSharpChecker as MEF export
 [<Export(typeof<FSharpCheckerProvider>); Composition.Shared>]
@@ -372,6 +373,7 @@ type
             | WorkspaceChangeKind.SolutionCleared
             | _ -> ()
 
+        this.Workspace.Options <- this.Workspace.Options.WithChangedOption(FormattingOptions.SmartIndent, FSharpConstants.FSharpLanguageName, FormattingOptions.IndentStyle.Smart)
         this.Workspace.Options <- this.Workspace.Options.WithChangedOption(Completion.CompletionOptions.BlockForCompletionItems, FSharpConstants.FSharpLanguageName, false)
         this.Workspace.Options <- this.Workspace.Options.WithChangedOption(Shared.Options.ServiceFeatureOnOffOptions.ClosedFileDiagnostic, FSharpConstants.FSharpLanguageName, Nullable false)
         this.Workspace.WorkspaceChanged.Add(workspaceChanged)


### PR DESCRIPTION
This is really sort of a trial PR. It works, which means that @saul and @xuanduc987's excellent work for smart indenting is the default.

However, if someone chooses to turn this off, it will be turned back on if they create a new project or close/re-open VS. I have no idea how to persist options through Roslyn, and IIRC much of that infrastructure is closed off from us anyways.

I suppose this is a way of expressing my opinion that Smart indent is more valuable to F# than Block indent.