### PR TITLE
Add DesignTimeBuild=true  to legacy build from ProjectSystem

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ReferenceContainerNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ReferenceContainerNode.cs
@@ -371,7 +371,11 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 }
             }
 
-            BuildResult buildResult = this.ProjectMgr.Build(MsBuildTarget.ResolveAssemblyReferences);
+            var extraProperties = new KeyValuePair<string, string>[]
+            {
+                new KeyValuePair<string, string>("DesignTimeBuild", "true"),
+            }.AsEnumerable();
+            BuildResult buildResult = this.ProjectMgr.BuildWithExtraProperties(MsBuildTarget.ResolveAssemblyReferences, extraProperties);
             foreach (string referenceType in SupportedReferenceTypes)
             {
                 bool isAssemblyReference = referenceType == ProjectFileConstants.Reference;

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -1368,8 +1368,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                         // If property is not set - msbuild will resolve only primary dependencies,
                         // and compiler will be very unhappy when during processing of referenced assembly it will discover that all fundamental types should be
                         // taken from System.Runtime that is not supplied
-                        
-                        let _ = x.InvokeMsBuild("Compile", extraProperties = [KeyValuePair("_ResolveReferenceDependencies", "true")])
+                        let _ = x.InvokeMsBuild("Compile", extraProperties = [KeyValuePair("_ResolveReferenceDependencies", "true"); KeyValuePair("DesignTimeBuild", "true")])
                         sourcesAndFlagsNotifier.Notify()
                     finally
                         actuallyBuild <- true

--- a/vsintegration/tests/unittests/LegacyProjectSystem/Tests.ProjectSystem.Miscellaneous.fs
+++ b/vsintegration/tests/unittests/LegacyProjectSystem/Tests.ProjectSystem.Miscellaneous.fs
@@ -327,7 +327,7 @@ type Miscellaneous() =
             use project = TheTests.CreateProject(projFile)
             let srcFile = (Path.GetDirectoryName projFile) + "\\" + "foo.fs"
             File.AppendAllText(srcFile, "#light\nlet foo () =\n  printfn \"A\"\n") 
-            project.BuildToOutput("Build", vso) |> ignore // Build the project using vso as the output logger
+            project.BuildToOutput("Build", vso, null) |> ignore // Build the project using vso as the output logger
             let errors = List.filter (fun (s:string) -> s.Contains(expectedError)) !outputWindowPaneErrors    
             AssertEqual 1 (List.length errors)
         )        
@@ -419,7 +419,7 @@ type Miscellaneous() =
                 let vso = VsMocks.vsOutputWindowPane(outputWindowPaneErrors)
                 let srcFile = (Path.GetDirectoryName projFileName) + "\\" + "foo.fs"
                 File.AppendAllText(srcFile, "let x = 5\n") 
-                project.BuildToOutput("Build", vso) |> ignore // Build the project using vso as the output logger
+                project.BuildToOutput("Build", vso, null) |> ignore // Build the project using vso as the output logger
                 printfn "Build output:"
                 !outputWindowPaneErrors |> Seq.iter (printfn "%s")
                 let expectedRegex = new Regex("\\s*ProjectExt\\[.fsproj\\]")                

--- a/vsintegration/tests/unittests/LegacyProjectSystem/Tests.ProjectSystem.Project.fs
+++ b/vsintegration/tests/unittests/LegacyProjectSystem/Tests.ProjectSystem.Project.fs
@@ -847,7 +847,7 @@ type Project() =
             use project = TheTests.CreateProject(projFile)
             let srcFile = (Path.GetDirectoryName projFile) + "\\" + "foo.fs"
             File.AppendAllText(srcFile, "bar") ; // foo.fs will be cleaned up by parent call to DoWithTempFile
-            project.BuildToOutput("Build", vso) |> ignore // Build the project using vso as the output logger
+            project.BuildToOutput("Build", vso, null) |> ignore // Build the project using vso as the output logger
         
             let errors = List.filter (fun s -> (new Regex(expectedError)).IsMatch(s)) !outputWindowPaneErrors
         
@@ -870,7 +870,7 @@ type Project() =
             use project = TheTests.CreateProjectWithUTF8Output(projFile)
             let srcFile = (Path.GetDirectoryName projFile) + "\\" + "新規bcrogram.fs"
             File.AppendAllText(srcFile, "bar") ;            // 新規bcrogram.fs will be cleaned up by parent call to DoWithTempFile
-            project.BuildToOutput("Build", vso) |> ignore   // Build the project using vso as the output logger
+            project.BuildToOutput("Build", vso, null) |> ignore   // Build the project using vso as the output logger
 
             // The console inserts hard line breaks accumulate the output as a single line then look for the expected output.
             let output = (!outputWindowPaneErrors |> String.concat "").Replace("\r\n", "")

--- a/vsintegration/tests/unittests/LegacyProjectSystem/Tests.ProjectSystem.UpToDate.fs
+++ b/vsintegration/tests/unittests/LegacyProjectSystem/Tests.ProjectSystem.UpToDate.fs
@@ -60,7 +60,7 @@ type UpToDate() =
             File.AppendAllText(embedPath, "some embedded resource")
 
             Assert.IsFalse(config.IsUpToDate(logger, true))
-            project.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
+            project.Build(configNameDebug, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(config.IsUpToDate(logger, true))
 
             // None items should not affect up-to-date (unless captured by well-known items, e.g. App.config)
@@ -112,7 +112,7 @@ type UpToDate() =
 
             project.SetConfiguration(config.ConfigCanonicalName);
             Assert.IsFalse(config.IsUpToDate(logger, true))
-            project.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
+            project.Build(configNameDebug, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(config.IsUpToDate(logger, true))
 
             for path in [verPath; keyPath] do
@@ -147,7 +147,7 @@ type UpToDate() =
             File.AppendAllText(absFilePath, "printfn \"hello\"")
 
             Assert.IsFalse(config.IsUpToDate(logger, true))
-            project.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
+            project.Build(configNameDebug, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(config.IsUpToDate(logger, true))
 
             // touch proj file
@@ -178,7 +178,7 @@ type UpToDate() =
             let config1 = project1.ConfigProvider.GetProjectConfiguration(configNameDebug)
 
             Assert.IsFalse(config1.IsUpToDate(logger, true))
-            project1.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
+            project1.Build(configNameDebug, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(config1.IsUpToDate(logger, true))
 
             let output1 = Path.Combine(project1.ProjectFolder, "bin\\debug", project1.OutputFileName)
@@ -197,7 +197,7 @@ type UpToDate() =
                 let startTime = DateTime.UtcNow
 
                 Assert.IsFalse(config2.IsUpToDate(logger, true))
-                project2.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
+                project2.Build(configNameDebug, output, "Build", null) |> AssertBuildSuccessful
                 Assert.IsTrue(config2.IsUpToDate(logger, true))
 
                 // reference is updated
@@ -241,7 +241,7 @@ type UpToDate() =
             File.AppendAllText(appConfigPath, """<?xml version="1.0" encoding="utf-8" ?><configuration></configuration>""")
 
             Assert.IsFalse(config.IsUpToDate(logger, true))
-            project.Build(configNameDebug, output, "Build") |> AssertBuildSuccessful
+            project.Build(configNameDebug, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(config.IsUpToDate(logger, true))
 
             let startTime = DateTime.UtcNow
@@ -290,25 +290,25 @@ type UpToDate() =
             Assert.IsFalse(debugConfigAnyCPU.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigAnyCPU.IsUpToDate(logger, true))
 
-            project.Build(configNameDebugx86, output, "Build") |> AssertBuildSuccessful
+            project.Build(configNameDebugx86, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(debugConfigx86.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigx86.IsUpToDate(logger, true))
             Assert.IsFalse(debugConfigAnyCPU.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigAnyCPU.IsUpToDate(logger, true))
 
-            project.Build(configNameReleasex86, output, "Build") |> AssertBuildSuccessful
+            project.Build(configNameReleasex86, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(debugConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(releaseConfigx86.IsUpToDate(logger, true))
             Assert.IsFalse(debugConfigAnyCPU.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigAnyCPU.IsUpToDate(logger, true))
 
-            project.Build(configNameDebugAnyCPU, output, "Build") |> AssertBuildSuccessful
+            project.Build(configNameDebugAnyCPU, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(debugConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(releaseConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(debugConfigAnyCPU.IsUpToDate(logger, true))
             Assert.IsFalse(releaseConfigAnyCPU.IsUpToDate(logger, true))
 
-            project.Build(configNameReleaseAnyCPU, output, "Build") |> AssertBuildSuccessful
+            project.Build(configNameReleaseAnyCPU, output, "Build", null) |> AssertBuildSuccessful
             Assert.IsTrue(debugConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(releaseConfigx86.IsUpToDate(logger, true))
             Assert.IsTrue(debugConfigAnyCPU.IsUpToDate(logger, true))

--- a/vsintegration/tests/unittests/TestLib.ProjectSystem.fs
+++ b/vsintegration/tests/unittests/TestLib.ProjectSystem.fs
@@ -657,7 +657,7 @@ module LanguageServiceExtension =
                                 failwith "tried to build not-yet-created project"
                             else
                                 let target = if target <> null then target else "Build"
-                                projInfo.Project.BuildToOutput(target,vsOutputWindowPane) |> ignore   // force build through project system for code coverage
+                                projInfo.Project.BuildToOutput(target,vsOutputWindowPane, null) |> ignore   // force build through project system for code coverage
                                 hooks.BuildHook(projFileName, target, vsOutputWindowPane)      // use MSBuild to build and also return MainAssembly value
 
                         member x.GetMainOutputAssemblyHook baseName = hooks.GetMainOutputAssemblyHook baseName 


### PR DESCRIPTION
This replaces:  PR #4395.

Fixes: #3222 

The project system wasn't setting the DesignTimeBuild flag when running design time builds.  This PR addresses that issue.

