### PR TITLE
Enable Net Sdk to write project properties

### DIFF
--- a/mono/config.make
+++ b/mono/config.make
@@ -211,6 +211,12 @@ install-sdk-lib:
 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v12.0/FSharp/; \
 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v14.0/FSharp/; \
 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v15.0/FSharp/; \
+	    \
+	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.Overrides.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v/FSharp/; \
+	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.Overrides.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v11.0/FSharp/; \
+	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.Overrides.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v12.0/FSharp/; \
+	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.Overrides.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v14.0/FSharp/; \
+	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.Overrides.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v15.0/FSharp/; \
 	fi
 	@if test x-$(outsuffix) = x-net40; then \
 	    if test -e $(outdir)$(NAME).dll; then \

--- a/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
+++ b/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
@@ -17,6 +17,7 @@
       <ComponentRef Id="Compiler_Redist_Microsoft.Portable.FSharp.targets" />
       <ComponentRef Id="Compiler_Redist_Microsoft.FSharp.NetSdk.props" />
       <ComponentRef Id="Compiler_Redist_Microsoft.FSharp.NetSdk.targets" />
+      <ComponentRef Id="Compiler_Redist_Microsoft.FSharp.Overrides.NetSdk.targets" />
       <ComponentRef Id="Compiler_Redist_SupportedRuntimes.xml" />
       <ComponentRef Id="Compiler_Redist_RegistryKeys_CompilerLocation" />
 
@@ -126,6 +127,10 @@
         <File Id="Compiler_Redist_Microsoft.FSharp.NetSdk.targets" Source="$(var.BinariesDir)\net40\bin\Microsoft.FSharp.NetSdk.targets" />
       </Component>
 
+      <Component Id="Compiler_Redist_Microsoft.FSharp.Overrides.NetSdk.targets" Guid="$(fsharp.guid(Compiler_Redist_Microsoft.FSharp.Overrides.NetSdk.targets, $(var.LocaleCode)))">
+        <File Id="Compiler_Redist_Microsoft.FSharp.Overrides.NetSdk.targets" Source="$(var.BinariesDir)\net40\bin\Microsoft.FSharp.Overrides.NetSdk.targets" />
+      </Component>
+
       <Component Id="Compiler_Redist_SupportedRuntimes.xml" Guid="$(fsharp.guid(Compiler_Redist_SupportedRuntimes.xml, $(var.LocaleCode)))">
         <File Id="Compiler_Redist_SupportedRuntimes.xml" Source="$(var.FSharpTreeRoot)\vsintegration\src\SupportedRuntimes\SupportedRuntimes.xml" />
       </Component>
@@ -140,6 +145,7 @@
           <RegistryValue Name="Microsoft.Portable.FSharp.Targets" Value="[MicrosoftSDKs_FS_10.1_Framework_v4.0]Microsoft.Portable.FSharp.Targets" Type="string" />
           <RegistryValue Name="Microsoft.FSharp.NetSdk.props" Value="[MicrosoftSDKs_FS_10.1_Framework_v4.0]Microsoft.FSharp.NetSdk.props" Type="string" />
           <RegistryValue Name="Microsoft.FSharp.NetSdk.targets" Value="[MicrosoftSDKs_FS_10.1_Framework_v4.0]Microsoft.FSharpNetSdk.targets" Type="string" />
+          <RegistryValue Name="Microsoft.FSharp.Overrides.NetSdk.targets" Value="[MicrosoftSDKs_FS_10.1_Framework_v4.0]Microsoft.Overrides.FSharpNetSdk.targets" Type="string" />
         </RegistryKey>
         <RegistryKey Root="HKLM" Key="Software\Microsoft\VisualStudio\15.0\Setup\F#" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
           <RegistryValue Name="ProductDir" Value="[MicrosoftSDKs_FS_10.1_Framework_v4.0]" Type="string" />

--- a/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
@@ -7,6 +7,7 @@ folder "InstallDir:MSBuild\Microsoft\VisualStudio\v15.0\FSharp"
   file "Microsoft.FSharp.Targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.Shim.targets"
   file "Microsoft.Portable.FSharp.Targets" source="$(BinariesFolder)\setup\resources\Microsoft.Portable.FSharp.Shim.targets"
   file "Microsoft.FSharp.NetSdk.targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.NetSdk.Shim.targets"
+  file "Microsoft.FSharp.NetSdk.Overrides.targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.Overrides.NetSdk.Shim.targets"
   file "Microsoft.FSharp.NetSdk.props" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.NetSdk.Shim.props"
 
 folder "InstallDir:Common7\IDE\PublicAssemblies"

--- a/setup/resources/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
+++ b/setup/resources/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(MSBuildProgramFiles32)\Microsoft SDKs\F#\4.1\Framework\v4.0\Microsoft.FSharp.Overrides.NetSdk.targets" />
+
+</Project>

--- a/setup/resources/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
+++ b/setup/resources/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(MSBuildProgramFiles32)\Microsoft SDKs\F#\4.1\Framework\v4.0\Microsoft.FSharp.Overrides.NetSdk.targets" />
+  <Import Project="$(MSBuildProgramFiles32)\Microsoft SDKs\F#\10.1\Framework\v4.0\Microsoft.FSharp.Overrides.NetSdk.targets" />
 
 </Project>

--- a/src/buildfromsource/FSharp.Build/FSharp.Build.fsproj
+++ b/src/buildfromsource/FSharp.Build/FSharp.Build.fsproj
@@ -46,6 +46,11 @@
         <Pattern1>{BuildSuffix}</Pattern1>
         <Replacement1></Replacement1>
     </CopyAndSubstituteText>
+    <CopyAndSubstituteText Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.Overrides.NetSdk.targets">
+        <TargetFilename>Microsoft.FSharp.Overrides.NetSdk.targets</TargetFilename>
+        <Pattern1>{BuildSuffix}</Pattern1>
+        <Replacement1></Replacement1>
+    </CopyAndSubstituteText>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
+++ b/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
@@ -51,6 +51,9 @@
     <None Include="..\FSharp.Build\Microsoft.FSharp.NetSdk.targets" CopyToOutputDirectory="PreserveNewest">
       <Link>Microsoft.FSharp.NetSdk.targets</Link>
     </None>
+    <None Include="..\FSharp.Build\Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest">
+      <Link>Microsoft.FSharp.Overrides.NetSdk.targets</Link>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -37,6 +37,7 @@
     <None Include="Microsoft.Portable.FSharp.Targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Microsoft.FSharp.NetSdk.props" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Microsoft.FSharp.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetDotnetProfile)' != 'coreclr'">

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Overrides.NetSdk.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Overrides.NetSdk.targets
@@ -1,0 +1,36 @@
+<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
+
+<!--
+***********************************************************************************************
+Microsoft.FSharp.Overrides.NetSdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Target Name="CoreGenerateAssemblyInfo"
+          Condition="'$(Language)'=='F#'"
+          DependsOnTargets="CreateGeneratedAssemblyInfoInputsCacheFile"
+          Inputs="$(GeneratedAssemblyInfoInputsCacheFile)"
+          Outputs="$(GeneratedAssemblyInfoFile)">
+    <ItemGroup>
+      <!-- Ensure the generated assemblyinfo file is not already part of the Compile sources, as a workaround for https://github.com/dotnet/sdk/issues/114 -->
+      <Compile Remove="$(GeneratedAssemblyInfoFile)" />
+    </ItemGroup>
+
+    <WriteCodeFragment AssemblyAttributes="@(AssemblyAttribute)" Language="$(Language)" OutputFile="$(GeneratedAssemblyInfoFile)">
+      <Output TaskParameter="OutputFile" ItemName="CompileBefore" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+  </Target>
+
+</Project>

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -41,8 +41,9 @@
             <files include="any\any\default.win32manifest"                       buildAction="Content" copyToOutput="true" flatten="false"  />
             <files include="any\any\Microsoft.FSharp.Targets"                    buildAction="Content" copyToOutput="true" flatten="false"  />
             <files include="any\any\Microsoft.Portable.FSharp.targets"           buildAction="Content" copyToOutput="true" flatten="false"  />
-            <files include="any\any\Microsoft.FSharp.NetSdk.targets"             buildAction="Content" copyToOutput="true" flatten="false"  />
             <files include="any\any\Microsoft.FSharp.NetSdk.props"               buildAction="Content" copyToOutput="true" flatten="false"  />
+            <files include="any\any\Microsoft.FSharp.NetSdk.targets"             buildAction="Content" copyToOutput="true" flatten="false"  />
+            <files include="any\any\Microsoft.FSharp.Overrides.NetSdk.targets"   buildAction="Content" copyToOutput="true" flatten="false"  />
         </contentFiles>
     </metadata>
     <files>
@@ -63,8 +64,9 @@
         <file src="default.win32manifest"                       target="contentFiles\any\any"  />
         <file src="Microsoft.FSharp.Targets"                    target="contentFiles\any\any"  />
         <file src="Microsoft.Portable.FSharp.Targets"           target="contentFiles\any\any"  />
-        <file src="Microsoft.FSharp.NetSdk.targets"             target="contentFiles\any\any"  />
         <file src="Microsoft.FSharp.NetSdk.props"               target="contentFiles\any\any"  />
+        <file src="Microsoft.FSharp.NetSdk.targets"             target="contentFiles\any\any"  />
+        <file src="Microsoft.FSharp.Overrides.NetSdk.targets"   target="contentFiles\any\any"  />
 
         <file src="**\FSharp.Core.resources.dll"                          target="lib\netstandard1.6" />
         <file src="**\FSharp.Compiler.Private.resources.dll"              target="lib\netstandard1.6" />

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
@@ -55,8 +55,8 @@
         <file src="default.win32manifest"                       target="runtimes\any\native"  />
         <file src="Microsoft.FSharp.Targets"                    target="runtimes\any\native"  />
         <file src="Microsoft.Portable.FSharp.Targets"           target="runtimes\any\native"  />
-        <file src="Microsoft.FSharp.NetSdk.targets"             target="runtimes\any\native"  />
         <file src="Microsoft.FSharp.NetSdk.props"               target="runtimes\any\native"  />
+        <file src="Microsoft.FSharp.Overrides.NetSdk.targets"   target="runtimes\any\native"  />
 
         <file src="**\FSharp.Core.resources.dll"                          target="lib\netstandard1.6" />
         <file src="**\FSharp.Compiler.Private.resources.dll"              target="lib\netstandard1.6" />

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
@@ -56,7 +56,7 @@
         <file src="Microsoft.FSharp.Targets"                    target="runtimes\any\native"  />
         <file src="Microsoft.Portable.FSharp.Targets"           target="runtimes\any\native"  />
         <file src="Microsoft.FSharp.NetSdk.props"               target="runtimes\any\native"  />
-        <file src="Microsoft.FSharp.\NetSdk.targets"            target="runtimes\any\native"  />
+        <file src="Microsoft.FSharp.NetSdk.targets"             target="runtimes\any\native"  />
         <file src="Microsoft.FSharp.Overrides.NetSdk.targets"   target="runtimes\any\native"  />
 
         <file src="**\FSharp.Core.resources.dll"                          target="lib\netstandard1.6" />

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
@@ -56,6 +56,7 @@
         <file src="Microsoft.FSharp.Targets"                    target="runtimes\any\native"  />
         <file src="Microsoft.Portable.FSharp.Targets"           target="runtimes\any\native"  />
         <file src="Microsoft.FSharp.NetSdk.props"               target="runtimes\any\native"  />
+        <file src="Microsoft.FSharp.\NetSdk.targets"            target="runtimes\any\native"  />
         <file src="Microsoft.FSharp.Overrides.NetSdk.targets"   target="runtimes\any\native"  />
 
         <file src="**\FSharp.Core.resources.dll"                          target="lib\netstandard1.6" />

--- a/vsintegration/update-vsintegration.cmd
+++ b/vsintegration/update-vsintegration.cmd
@@ -226,6 +226,7 @@ if "!BIN_AVAILABLE!" == "true" (
     CALL :backupAndOrCopy Microsoft.Portable.FSharp.Targets "%COMPILERSDKPATH%"
     CALL :backupAndOrCopy Microsoft.FSharp.NetSdk.props "%COMPILERSDKPATH%"
     CALL :backupAndOrCopy Microsoft.FSharp.NetSdk.targets "%COMPILERSDKPATH%"
+    CALL :backupAndOrCopy Microsoft.FSharp.Overrides.NetSdk.targets "%COMPILERSDKPATH%"
 
     rem Special casing for SupportedRuntimes.xml, it has a different source directory, it's always there
     set SOURCEDIR="%TOPDIR%\vsintegration\src\SupportedRuntimes"


### PR DESCRIPTION
Fixes:  #3113

This requires a Net Sdk fix:  https://github.com/dotnet/sdk/pull/2021

Adds a new target file to handle the overrides.  This was necessary, because the FSharp.NetSdk target files occurs before the NetSdk targets are defined.

Once the infra is done, the fix is trivial, just override CoreGenerateAssemblyInfo and run it for F# files only.  Include the output in CompileBefore.

The remainder is just deployment nonsense.

Kevin

/cc @nguerrera, @enricosada, @TIHan @dsyme  