### PR TITLE
ensure all resources assemblies get shipped

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Vsix.Resources/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Vsix.Resources/Files.swr
@@ -10,9 +10,11 @@ folder "InstallDir:Common7\IDE\PublicAssemblies\$(LocaleParentCulture)"
 folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp\$(LocaleParentCulture)"
   file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.Compiler.Private.resources.dll" vs.file.ngen=yes
   file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.Core.resources.dll" vs.file.ngen=yes
+  file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.Editor.resources.dll" vs.file.ngen=yes
   file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.LanguageService.Base.resources.dll" vs.file.ngen=yes
   file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.LanguageService.resources.dll" vs.file.ngen=yes
   file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.ProjectSystem.Base.resources.dll" vs.file.ngen=yes
   file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.ProjectSystem.FSharp.resources.dll" vs.file.ngen=yes
   file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.ProjectSystem.PropertyPages.resources.dll" vs.file.ngen=yes
+  file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.UIResources.resources.dll" vs.file.ngen=yes
   file source="$(BinariesFolder)\net40\bin\$(LocaleParentCulture)\FSharp.VS.FSI.resources.dll" vs.file.ngen=yes


### PR DESCRIPTION
The resources for `FSharp.Editor.dll` and `FSharp.UIResources.dll` weren't getting shipped; this fixes that.

(I'm not sure if they were ever getting shipped to begin with.)