### PR TITLE
ensure build outputs always go to `$(Configuration)\$(TargetDotnetProfile)\bin`

### DIFF
--- a/FSharp.Directory.Build.targets
+++ b/FSharp.Directory.Build.targets
@@ -1,12 +1,37 @@
 <Project>
 
   <PropertyGroup>
+    <XlfLanguages>en;$(XlfLanguages)</XlfLanguages>
     <TargetDotnetProfile Condition="$(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('netcoreapp'))">coreclr</TargetDotnetProfile>
     <TargetDotnetProfile Condition="$(TargetFramework.StartsWith('net4'))">net40</TargetDotnetProfile>
-    <OutputPath>$(RepoRoot)$(Configuration)\$(TargetDotnetProfile)\bin</OutputPath>
-    <IntermediateOutputPath>$(RepoRoot)$(Configuration)\$(TargetDotnetProfile)\obj\$(MSBuildProjectName)\</IntermediateOutputPath>
-    <XlfLanguages>en;$(XlfLanguages)</XlfLanguages>
+    <ActualOutputPath Condition="'$(Language)' != 'VB'">$(MSBuildProjectDirectory)\$(OutputPath)</ActualOutputPath>
+    <ActualOutputPath Condition="'$(Language)' == 'VB'">$(OutputPath)</ActualOutputPath>
+    <FinalOutputPath>$(RepoRoot)$(Configuration)\$(TargetDotnetProfile)\bin</FinalOutputPath>
+    <FinalIntermediateOutputPath>$(RepoRoot)$(Configuration)\$(TargetDotnetProfile)\obj</FinalIntermediateOutputPath>
   </PropertyGroup>
+
+  <Target Name="HACK_CopyOutputsToTheProperLocation"
+          AfterTargets="AfterBuild"
+          Condition="'$(DisableOutputPathCopying)' != 'true'">
+    <!--
+    Ideally we'd set <OutputPath> to `$(Configuration)\[net40|coreclr]\bin`, but the calculation of `[net40|coreclr]`
+    depends on the `$(TargetFramework)` variable which is set by the individual project files, but by the time we have
+    that value (e.g., in this file) it's too late; some targets, particularly from the VsSDK have already used the
+    values of $(OutputPath)/$(OutDir).
+
+    The fix is to not set `$(Outputpath)` and simply copy stuff there after the fact.
+    -->
+
+    <ItemGroup>
+      <OutputFilesToCopy Include="$(ActualOutputPath)**" />
+      <IntermediateFilesToCopy Include="$(IntermediateOutputPath)\**" />
+    </ItemGroup>
+
+    <Message Text="Copying build artifacts to $(FinalOutputPath)" />
+    <MakeDir Directories="$(FinalOutputPath);$(FinalIntermediateOutputPath)" />
+    <Copy SourceFiles="@(OutputFilesToCopy)" DestinationFolder="$(FinalOutputPath)" />
+    <Copy SourceFiles="@(IntermediateFilesToCopy)" DestinationFolder="$(FinalIntermediateOutputPath)" />
+  </Target>
 
   <Import Project="build\targets\AssemblyVersions.props" />
   <Import Project="build\targets\GenerateAssemblyAttributes.targets" />

--- a/setup/fsharp-setup-build.proj
+++ b/setup/fsharp-setup-build.proj
@@ -42,7 +42,7 @@
         </PropertyGroup>
         <MSBuild Projects="%(VsixProjects.ProjectPath)"
                  Targets="Build"
-                 Properties="Configuration=$(Configuration);IsLangPack=%(VsixProjects.IsLangPack);FSharpPackageVersion=$(FSharpPackageVersion);OutputPath=$(VsixBuildLocation);$(CustomProps)" />
+                 Properties="Configuration=$(Configuration);IsLangPack=%(VsixProjects.IsLangPack);FSharpPackageVersion=$(FSharpPackageVersion);OutputPath=$(VsixBuildLocation);DisableOutputPathCopying=true;$(CustomProps)" />
         <MSBuild Projects="%(SwixSetupProjects.ProjectPath)"
                  Targets="Build"
                  Properties="LocaleCode=%(SwixSetupProjects.LocaleCode);LocaleId=%(SwixSetupProjects.LocaleId);LocaleParentId=%(SwixSetupProjects.LocaleParentId);LocaleParentCulture=%(SwixSetupProjects.LocaleParentCulture);LocaleSpecificCulture=%(SwixSetupProjects.LocaleSpecificCulture);IsLangPack=%(SwixSetupProjects.IsLangPack);FSharpPackageVersion=$(FSharpPackageVersion);$(CustomProps)"/>

--- a/vsintegration/Directory.Build.targets
+++ b/vsintegration/Directory.Build.targets
@@ -11,11 +11,6 @@
     <PackageTargetFallback>net462</PackageTargetFallback>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(CreateVsixContainer)' == 'true'">
-    <!-- Ensure VSIX packages end up in the proper location. -->
-    <OutDir>$(OutputPath)\</OutDir>
-  </PropertyGroup>
-
   <ImportGroup Condition="'$(ImportVsSDK)' == 'true'">
     <Import Project="$(NuGetPackageRoot)Microsoft.VSSDK.BuildTools\$(MicrosoftVSSDKBuildToolsPackageVersion)\build\Microsoft.VsSDK.BuildTools.props" />
     <Import Project="$(NugetPackageRoot)Microsoft.VSSDK.BuildTools\$(MicrosoftVSSDKBuildToolsPackageVersion)\build\Microsoft.VsSDK.BuildTools.targets" />

--- a/vsintegration/Templates.Directory.Build.targets
+++ b/vsintegration/Templates.Directory.Build.targets
@@ -2,10 +2,6 @@
 
   <Import Project="Directory.Build.targets" />
 
-  <PropertyGroup>
-    <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\$(TargetDotnetProfile)\bin\$(TemplateCategory)\$(AssemblyName)</OutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- everything under the `Template` directory is not to be considered part of the project -->
     <Compile Remove="**\Template\**" />
@@ -14,9 +10,5 @@
   </ItemGroup>
 
   <Target Name="CoreCompile" />
-
-  <Target Name="CopyFilesToOutputDirectory" AfterTargets="CoreCompile">
-    <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="@(TemplateFiles->'$(OutputPath)\%(Filename)%(Extension)')" />
-  </Target>
 
 </Project>

--- a/vsintegration/tests/unittests/MockTypeProviders/Directory.Build.props
+++ b/vsintegration/tests/unittests/MockTypeProviders/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- empty to prevent directory crawling -->
+</Project>

--- a/vsintegration/tests/unittests/MockTypeProviders/Directory.Build.targets
+++ b/vsintegration/tests/unittests/MockTypeProviders/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- empty to prevent directory crawling -->
+</Project>


### PR DESCRIPTION
Different build targets copy their outputs at different times during the build which means `$(OutputPath)` will only really be honored if it's set in the top-level `FSharp.Directory.Build.props`, but we need to consume the `$(TargetFramework)` variable to properly set this, and `$(TargetFramework)` is set in the individual project files, which means we can only have a meaningful value of `$(OutputPath)` in `FSharp.Directory.Build.targets`, but that doesn't work for certain VS projects (notably those consuming the VsSDK) because they've already captured the value of `$(OutputPath)` before we have a chance to properly set it.

The fix is to manually copy the build artifacts after the `AfterBuild` target has executed.

This is a hack and is temporary until I've upgraded the rest of our project files to the SDK, at which point it's trivial to move our output directories away from `$(Configuration)\net40\bin` and to a cleaner, and more importantly, supported by the dotnet CI system value of `artifacts\$(Configuration)\$(AssemblyName)\$(TargetFramework)\bin`.