### PR TITLE
use VS version as base for insertion packages

### DIFF
--- a/setup/FSharp.Setup.props
+++ b/setup/FSharp.Setup.props
@@ -11,7 +11,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <FSharpProductVersion>10.1</FSharpProductVersion>
+        <!-- This number should be kept in sync with the expected shipping version of Visual Studio. -->
+        <FSharpProductVersion>15.7</FSharpProductVersion>
         <!-- BUILD_BUILDNUMBER is passed from Microbuild. Replace by today's date and (0) if it was a local build -->
         <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd.0))</BUILD_BUILDNUMBER>
         <!-- Remove .DRAFT suffix if it exists in the build number -->


### PR DESCRIPTION
It was recently discovered that the packages inserted into the official Visual Studio build are all prefixed with `10.1` as per #4112.  During the course of normal VS branch merges this can cause a state where a VS branch might actually attempt to 'downgrade' (see below) the F# package version which would cause the install builder to choose the incorrect 'newer' version.

The fix is to use the Visual Studio version numbers as the prefix for the insertion packages.  FSharp.Core is still versioned as 4.x, fsc is still versioned as 10.x, the language service VSIX is still versioned as 15.x, and now the internal installer packages are 15.x.

**downgrade**: If the `10.1` prefix is not changed, the `dev15.6` branch might produce an insertion package with the version `10.1.20180307.0` and the previous day's `dev15.7` branch produced `10.1.20180306.0`.  Technically, the build from `dev15.7` appears to be 'older' than the `dev15.6` build, even though that's not necessarily the case.  As soon as the `dev15.7` branch is in lockdown, `master` will change this value to `15.8` to prepare for the next release.