### PR TITLE
ensure that Newtonsoft.Json.dll is included in the language service VSIX packages

### DIFF
--- a/vsintegration/Vsix/Directory.Build.targets
+++ b/vsintegration/Vsix/Directory.Build.targets
@@ -2,6 +2,16 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
+  <Target Name="AddFilesToVsixContainer"
+          BeforeTargets="CreateVsixContainer"
+          Condition="'@(VsixAdditionalFile)' != ''">
+    <ItemGroup>
+      <VSIXSourceItem Include="%(VsixAdditionalFile.Identity)">
+        <VSIXSubPath>%(VsixAdditionalFile.Path)</VSIXSubPath>
+      </VSIXSourceItem>
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6">
       <Visible>False</Visible>

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -192,4 +192,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <VsixAdditionalFile Include="$(NugetPackageRoot)Newtonsoft.Json\$(NewtonsoftJsonPackageVersion)\lib\net45\Newtonsoft.Json.dll" Path="" />
+  </ItemGroup>
+
 </Project>

--- a/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
+++ b/vsintegration/Vsix/VisualFSharpOpenSource/VisualFSharpOpenSource.csproj
@@ -216,4 +216,8 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <VsixAdditionalFile Include="$(NugetPackageRoot)Newtonsoft.Json\$(NewtonsoftJsonPackageVersion)\lib\net45\Newtonsoft.Json.dll" Path="" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Follow up to #4464.

When the VSIX packages were converted to be SDK-style projects in #4417 `Newtonsoft.Json.dll` stopped getting added to `VisualFSharpFull.vsix`/`VisualFSharpOpenSource.vsix` due to shortcomings in the VSSDK.

The fix is to manually add that file to the `<VSIXSourceItem>` item group right before the VSIX container is created.