### PR TITLE
Add commit hashes to NuGet and Visual Studio packages

### DIFF
--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.props
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.props
@@ -15,6 +15,7 @@
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\coreclr\bin</OutputPath>
     <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rtm-$(BuildRevision.Trim())-0</PreReleaseSuffix>
     <PackageVersion>$(FSPackageVersion)$(PreReleaseSuffix)</PackageVersion>
-    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion)" -prop "diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)"</PackageProperties>
   </PropertyGroup>
+
+  <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
 </Project>

--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.targets
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.targets
@@ -15,8 +15,6 @@
     </ProjectReference>
   </ItemGroup>
 
-  <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />
-
   <Target Name="Build" Outputs="$(TargetPath)" DependsOnTargets="$(nugetpackfsharpcompiler)" />
   <Target Name="Rebuild"  DependsOnTargets="$(nugetpackfsharpcompiler)" />
   <Target Name="Clean"    DependsOnTargets="CleanVersionFile" />
@@ -34,7 +32,7 @@
           Outputs='$(FSharpSourcesRoot)\$(Configuration)\artifacts\$(PackageVersion)\"%(PackageNuspec.Filename)).nupkg'>
 
     <PropertyGroup>
-      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion)" -prop "diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)"</PackageProperties>
+      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion)" -prop "diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)" -prop "githeadsha=$(GitHeadSha)"</PackageProperties>
     </PropertyGroup>
 
     <MakeDir Directories="$(FSharpSourcesRoot)\..\artifacts" />

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -4,7 +4,8 @@
         <id>Microsoft.FSharp.Compiler</id>
         <description>
             .NET Core compatible version of the fsharp compiler fsc.exe.
-            Supported Platforms: - .NET Core (.netstandard1.6)
+            Supported Platforms: - .NET Core (.netstandard1.6).
+            Commit hash: $githeadsha$.
         </description>
         <language>en-US</language>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
@@ -11,6 +11,7 @@
                     .NET 4.5+           (net45)
                     netstandard1.6      (netstandard1.6)
                     netstandard2.0      (netstandard2.0)
+                Commit hash: $githeadsha$.
         </description>
         <language>en-US</language>
         <version>$version$</version>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.proj
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.proj
@@ -61,7 +61,7 @@
       <PackageVersion Condition="'@(PackageNuspec)' == 'FSharp.Core.LatestNuget.nuspec'">$(FSharpCoreLatestTargetPackageVersion)</PackageVersion>
       <PackageMajorVersion Condition="'@(PackageNuspec)' == 'FSharp.Core.LatestNuget.nuspec'">$(FSharpCoreLatestTargetMajorVersion)</PackageMajorVersion>
 
-      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
+      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "githeadsha=$(GitHeadSha)"</PackageProperties>
     </PropertyGroup>
 
     <MakeDir Directories="$(FSharpSourcesRoot)\..\artifacts\$(PackageMajorVersion)" />

--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -16,7 +16,6 @@
 "Package"="{91a04a73-4f2c-4e7c-ad38-c1a68e7da05c}"
 "ProductDetails"="#9002"
 "LogoID"="#400"
-"UseVSProductID"="1"
 @="#9001"
 
 [$RootKey$\AD7Metrics\ExpressionEvaluator\{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}\{994B45C4-E6E9-11D2-903F-00C04FA302A1}]

--- a/vsintegration/src/FSharp.Editor/Common/Constants.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Constants.fs
@@ -17,7 +17,11 @@ module internal FSharpConstants =
     [<Literal>]
     /// "BC6DD5A5-D4D6-4dab-A00D-A51242DBAF1B"
     let languageServiceGuidString = "BC6DD5A5-D4D6-4dab-A00D-A51242DBAF1B"
-    
+
+    [<Literal>]
+    /// "91a04a73-4f2c-4e7c-ad38-c1a68e7da05c"
+    let projectPackageGuidString = "91a04a73-4f2c-4e7c-ad38-c1a68e7da05c"
+
     [<Literal>]
     /// "F#"
     let FSharpLanguageName = "F#"

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="LanguageService\FSharpCheckerExtensions.fs" />
     <Compile Include="LanguageService\IProjectSite.fs" />
     <Compile Include="LanguageService\ProjectSitesAndFiles.fs" />
+    <Compile Include="LanguageService\ProvideFSharpVersionRegistrationAttribute.fs" />
     <Compile Include="LanguageService\LanguageService.fs" />
     <Compile Include="LanguageService\AssemblyContentProvider.fs" />
     <Compile Include="LanguageService\SymbolHelpers.fs" />

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -23,6 +23,7 @@ open Microsoft.FSharp.Compiler.CompileOps
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.VisualStudio
 open Microsoft.VisualStudio.Editor
+open Microsoft.VisualStudio.FSharp.Editor
 open Microsoft.VisualStudio.FSharp.Editor.SiteProvider
 open Microsoft.VisualStudio.TextManager.Interop
 open Microsoft.VisualStudio.LanguageServices
@@ -284,6 +285,7 @@ type
     [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.QuickInfoOptionPage>, "F#", null, "QuickInfo", "6009")>]
     [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.CodeFixesOptionPage>, "F#", null, "Code Fixes", "6010")>]
     [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.LanguageServicePerformanceOptionPage>, "F#", null, "Performance", "6011")>]
+    [<ProvideFSharpVersionRegistration(FSharpConstants.projectPackageGuidString, "Microsoft Visual F#")>]
     [<ProvideLanguageService(languageService = typeof<FSharpLanguageService>,
                              strLanguageName = FSharpConstants.FSharpLanguageName,
                              languageResourceID = 100,

--- a/vsintegration/src/FSharp.Editor/LanguageService/ProvideFSharpVersionRegistrationAttribute.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/ProvideFSharpVersionRegistrationAttribute.fs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.Diagnostics
+open Microsoft.VisualStudio.Shell
+
+type internal ProvideFSharpVersionRegistrationAttribute(packageGuidString:string, productName:string) =
+    inherit RegistrationAttribute()
+
+    let keyName = "InstalledProducts\\" + productName
+
+    override this.Register(context:RegistrationAttribute.RegistrationContext) =
+        // Get the version of this build.  This code is executed by CreatePkgDef.exe at build time and NOT at runtime.
+        let version = FileVersionInfo.GetVersionInfo(typeof<ProvideFSharpVersionRegistrationAttribute>.Assembly.Location)
+        use key = context.CreateKey(keyName)
+        key.SetValue("Package", Guid.Parse(packageGuidString).ToString("B"))
+        key.SetValue("PID", version.ProductVersion)
+        key.SetValue("UseInterface", false)
+        key.SetValue("UseVSProductID", false)
+
+    override this.Unregister(context:RegistrationAttribute.RegistrationContext) =
+        context.RemoveKey(keyName)


### PR DESCRIPTION
Updates the description field of our NuGet packages (FSharp.Core and Microsoft.FSharp.Compiler) to include the commit hash that produced the build.

I also shamelessly copied dotnet/roslyn#23121 to do the same for the F# entry in Help -> About.

Before:
<img width="575" alt="before" src="https://user-images.githubusercontent.com/926281/37185404-00c9db12-22f5-11e8-816b-1d9505b51b87.png">

After:
<img width="575" alt="after" src="https://user-images.githubusercontent.com/926281/37185413-05ea1972-22f5-11e8-9b37-fe3b2d69c8ad.png">
