### PR TITLE
An alternative implementation for 'Make ErrorStrings properties instead of evaluating them in .cctor'

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -509,16 +509,16 @@ namespace Microsoft.FSharp.Core
 
     module LanguagePrimitives =  
 
-        module (* internal *) ErrorStrings =
+        type (* internal *) ErrorStrings =
             // inline functions cannot call GetString, so we must make these bits public
-            let AddressOpNotFirstClassString = SR.GetString(SR.addressOpNotFirstClass)
-            let NoNegateMinValueString = SR.GetString(SR.noNegateMinValue)
+            static member AddressOpNotFirstClassString with get () = SR.GetString(SR.addressOpNotFirstClass)
+            static member NoNegateMinValueString with get () = SR.GetString(SR.noNegateMinValue)
             // needs to be public to be visible from inline function 'average' and others
-            let InputSequenceEmptyString = SR.GetString(SR.inputSequenceEmpty) 
+            static member InputSequenceEmptyString with get () = SR.GetString(SR.inputSequenceEmpty) 
             // needs to be public to be visible from inline function 'average' and others
-            let InputArrayEmptyString = SR.GetString(SR.arrayWasEmpty) 
+            static member InputArrayEmptyString with get () = System.Console.WriteLine("Hello"); SR.GetString(SR.arrayWasEmpty) 
             // needs to be public to be visible from inline function 'average' and others
-            let InputMustBeNonNegativeString = SR.GetString(SR.inputMustBeNonNegative)
+            static member InputMustBeNonNegativeString with get () = SR.GetString(SR.inputMustBeNonNegative)
             
         [<CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")>]  // nested module OK              
         module IntrinsicOperators =        

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -985,23 +985,23 @@ namespace Microsoft.FSharp.Core
         val inline DivideByInt< ^T >  : x:^T -> y:int -> ^T when ^T : (static member DivideByInt : ^T * int -> ^T) 
 
         /// <summary>For compiler use only</summary>
-        module (* internal *) ErrorStrings = 
+        [<Class>]
+        type (* internal *) ErrorStrings = 
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val InputSequenceEmptyString : string
+            static member InputSequenceEmptyString : string with get
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val InputArrayEmptyString : string
+            static member InputArrayEmptyString : string with get
         
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val AddressOpNotFirstClassString : string
+            static member AddressOpNotFirstClassString : string with get
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val NoNegateMinValueString : string
+            static member NoNegateMinValueString : string with get
                 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val InputMustBeNonNegativeString : string
-                
+            static member InputMustBeNonNegativeString : string with get
 
         //-------------------------------------------------------------------------
 


### PR DESCRIPTION
This is intended to achieve the same result as the @vbfox  PR: #4482.

The approach is rather straightforward:  in order to ensure that existing inlined code still works, create a type with member properties rather than a module with fields.

This presents a type to the existing inlined code with compatible metadata.  And yet the F# compiler no longer adds the static member properties to the .cctor.

