### PR TITLE
Fix Literal values

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -1558,8 +1558,7 @@ type ILFieldDef =
     member x.WithStatic(condition) = { x with Attributes = x.Attributes |> conditionalAdd condition FieldAttributes.Static }
     member x.WithSpecialName(condition) = { x with Attributes = x.Attributes |> conditionalAdd condition (FieldAttributes.SpecialName ||| FieldAttributes.RTSpecialName) }
     member x.WithNotSerialized(condition) = { x with Attributes = x.Attributes |> conditionalAdd condition FieldAttributes.NotSerialized }
-    member x.WithLiteral(condition) = { x with Attributes = x.Attributes |> conditionalAdd condition FieldAttributes.Literal }
-    member x.WithHasDefault(condition) = { x with Attributes = x.Attributes |> conditionalAdd condition FieldAttributes.HasDefault }
+    member x.WithLiteralDefaultValue(literal) = { x with LiteralValue = literal; Attributes = x.Attributes |> conditionalAdd literal.IsSome (FieldAttributes.Literal ||| FieldAttributes.HasDefault) }
     member x.WithHasFieldMarshal(condition) = { x with Attributes = x.Attributes |> conditionalAdd condition FieldAttributes.HasFieldMarshal }
 
 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -1138,8 +1138,7 @@ type ILFieldDef =
         member WithStatic: bool -> ILFieldDef
         member WithSpecialName: bool -> ILFieldDef
         member WithNotSerialized: bool -> ILFieldDef
-        member WithLiteral: bool -> ILFieldDef
-        member WithHasDefault: bool -> ILFieldDef
+        member WithLiteralDefaultValue: ILFieldInit option -> ILFieldDef
         member WithHasFieldMarshal: bool -> ILFieldDef
 
 /// Tables of fields.  Logically equivalent to a list of fields but

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -4742,7 +4742,7 @@ and GenBindingAfterSequencePoint cenv cgbuf eenv sp (TBind(vspec,rhsExpr,_)) sta
             let ilFieldDef = mkILStaticField (fspec.Name, fty, None, None, access)
             let ilFieldDef =
                 match vref.LiteralValue with 
-                | Some konst -> { (ilFieldDef.WithHasDefault(true)).WithLiteral(true) with LiteralValue = Some(GenFieldInit m konst) }
+                | Some konst -> ilFieldDef.WithLiteralDefaultValue( Some (GenFieldInit m konst) )
                 | None  -> ilFieldDef 
               
             let ilFieldDef = 
@@ -6347,8 +6347,8 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                       { Name          = ilFieldName
                         Type          = ilPropType
                         Attributes    = enum 0
-                        Data          = None 
-                        LiteralValue  = literalValue
+                        Data          = None
+                        LiteralValue  = None
                         Offset        = ilFieldOffset
                         Marshal       = ilFieldMarshal
                         CustomAttrs   = mkILCustomAttrs (GenAttrs cenv eenv fattribs @ extraAttribs) } 
@@ -6357,8 +6357,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                         .WithStatic(isStatic)
                         .WithSpecialName(ilFieldName="value__" && tycon.IsEnumTycon)
                         .WithNotSerialized(ilNotSerialized)
-                        .WithLiteral(fspec.LiteralValue.IsSome)
-                        .WithHasDefault(literalValue.IsSome)
+                        .WithLiteralDefaultValue(literalValue)
                         .WithHasFieldMarshal(ilFieldMarshal.IsSome)
                   yield fdef
 

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -4742,7 +4742,7 @@ and GenBindingAfterSequencePoint cenv cgbuf eenv sp (TBind(vspec,rhsExpr,_)) sta
             let ilFieldDef = mkILStaticField (fspec.Name, fty, None, None, access)
             let ilFieldDef =
                 match vref.LiteralValue with 
-                | Some konst -> { ilFieldDef.WithHasDefault(true) with LiteralValue = Some(GenFieldInit m konst) }
+                | Some konst -> { (ilFieldDef.WithHasDefault(true)).WithLiteral(true) with LiteralValue = Some(GenFieldInit m konst) }
                 | None  -> ilFieldDef 
               
             let ilFieldDef = 


### PR DESCRIPTION
This PR:  https://github.com/Microsoft/visualfsharp/pull/4272

introduced a bug in code generation for literal fields.  Instead of writing them is a literal it wrote them as a value.

This issue is not in VS 2017.6 it only appears in VS2017.7 preview 1 internal builds.

The fix is to ensure that the FieldDef knows about the literal.

/cc @dsyme, @AviAvni, @jaredpar 



