### PR TITLE
Fix line break character during VS-completion for open

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -172,9 +172,15 @@ module internal OpenDeclarationHelper =
         let mutable minPos = None
 
         let insert line lineStr (sourceText: SourceText) : SourceText =
-            let pos = sourceText.Lines.[line].Start
+            let ln = sourceText.Lines.[line]
+            let pos = ln.Start
             minPos <- match minPos with None -> Some pos | Some oldPos -> Some (min oldPos pos)
-            sourceText.WithChanges(TextChange(TextSpan(pos, 0), lineStr + Environment.NewLine))
+
+            // find the line break characters on the previous line to use, Environment.NewLine should not be used
+            // as it makes assumptions on the line endings in the source.
+            let lineBreak = ln.Text.ToString(TextSpan(ln.End, ln.EndIncludingLineBreak - ln.End))
+
+            sourceText.WithChanges(TextChange(TextSpan(pos, 0), lineStr + lineBreak))
 
         let getLineStr line = sourceText.Lines.[line].ToString().Trim()
         let pos = ParsedInput.adjustInsertionPoint getLineStr ctx


### PR DESCRIPTION
This removes the assumed CRLF line break under Windows when working with source files that are using Unix-style line endings (LF). Anytime an 'open' import declaration would be autocompleted through Visual Studio this would cause mismatched line endings to be applied in the source file.