### PR TITLE
Reduce comparisons for GenericEqualityERFast

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -1575,15 +1575,15 @@ namespace Microsoft.FSharp.Core
                   when 'T : nativeint  = (# "ceq" x y : bool #)
                   when 'T : unativeint  = (# "ceq" x y : bool #)
                   when 'T : float = 
-                    if not (# "ceq" x x : bool #) && not (# "ceq" y y : bool #) then
+                    if (# "ceq" x y : bool #) then
                         true
                     else
-                        (# "ceq" x y : bool #)
+                        not (# "ceq" x x : bool #) && not (# "ceq" y y : bool #)
                   when 'T : float32 =
-                    if not (# "ceq" x x : bool #) && not (# "ceq" y y : bool #) then
+                    if (# "ceq" x y : bool #) then
                         true
                     else
-                        (# "ceq" x y : bool #)
+                        not (# "ceq" x x : bool #) && not (# "ceq" y y : bool #)
                   when 'T : char    = (# "ceq" x y : bool #)
                   when 'T : string  = System.String.Equals((# "" x : string #),(# "" y : string #))
                   when 'T : decimal     = System.Decimal.op_Equality((# "" x:decimal #), (# "" y:decimal #))


### PR DESCRIPTION
This changes the evaluation a bit:

x = y <> NaN was 2 comparisons. now 1 comparison
x <> y and both not NaN was 2. now still 2 comparisons
x = NaN and y <> NaN was 2. now 1 comparison
x <> NaN and y = NaN was 3. now 1 comparison
x = y = NaN was 2 comparisons. now 3 comparioson.

So in all cases but the last we are now faster or same. The last one is a bit slower but probably not that often seen.