### PR TITLE
Turn off unused opens diagnostic analyzer in dev15.6

### DIFF
--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -60,7 +60,9 @@ type internal Settings [<ImportingConstructor>](store: SettingsStore) =
               // See https://github.com/Microsoft/visualfsharp/pull/3238#issue-237699595
               SimplifyName = false 
               AlwaysPlaceOpensAtTopLevel = false
-              UnusedOpens = true 
+              // We have this off by default, disable until it is performant for large files
+              // See https://github.com/Microsoft/visualfsharp/issues/4488
+              UnusedOpens = false 
               UnusedDeclarations = true }
 
         store.RegisterDefault


### PR DESCRIPTION
This is a proposed patch to dev15.6. See https://github.com/Microsoft/visualfsharp/issues/4488

This diagnostic analyzer can be re-enabled once 
(a) the analyzers run in priority order, see #4341 
(b) the underlying code for unused opens is made performant, see #4488 and  fsharp/FSharp.Compiler.Service#830
(c) the underlying code for unused opens is made cancellable