### PR TITLE
consolidate VS package version generation

### DIFF
--- a/setup/FSharp.Setup.props
+++ b/setup/FSharp.Setup.props
@@ -10,9 +10,11 @@
         <NugetPackagesDir>$(SetupRootFolder)\..\packages</NugetPackagesDir>
     </PropertyGroup>
 
+    <Import Project="$(MSBuildThisFileDirectory)..\build\targets\AssemblyVersions.props" />
+
     <PropertyGroup>
-        <!-- This number should be kept in sync with the expected shipping version of Visual Studio. -->
-        <FSharpProductVersion>15.7</FSharpProductVersion>
+        <!-- This number should only be two parts, e.g., '15.6'. -->
+        <FSharpProductVersion>$(VSAssemblyVersion.Split('.')[0]).$(VSAssemblyVersion.Split('.')[1])</FSharpProductVersion>
         <!-- BUILD_BUILDNUMBER is passed from Microbuild. Replace by today's date and (0) if it was a local build -->
         <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd.0))</BUILD_BUILDNUMBER>
         <!-- Remove .DRAFT suffix if it exists in the build number -->


### PR DESCRIPTION
Also rewind `master` to generate package versions starting with 15.6 instead of 15.7 because `master` targets the released dev15.6.