### PR TITLE
specify `15.7` as the VS version

### DIFF
--- a/build/targets/AssemblyVersions.props
+++ b/build/targets/AssemblyVersions.props
@@ -22,7 +22,7 @@
     <FSCoreVersion>4.4.3.0</FSCoreVersion>
     <FSProductVersion>10.1.1.0</FSProductVersion>
     <FSPackageVersion>10.1.4</FSPackageVersion>
-    <VSAssemblyVersion>15.6.0.0</VSAssemblyVersion>
+    <VSAssemblyVersion>15.7.0.0</VSAssemblyVersion>
     <MicroBuildAssemblyVersion Condition="'$(MicroBuildAssemblyVersion)' == ''">$(FSCoreVersion)</MicroBuildAssemblyVersion>
 
     <!-- certain delivered F# VS assemblies use a specific MicroBuildAssemblyVersion, otherwise use FSCoreVersion -->


### PR DESCRIPTION
With #4498 having been merged to `dev15.7`, the target version of Visual Studio needs to be updated.