### PR TITLE
normalize VSIX package versions with VS insertion item package versions

### DIFF
--- a/build/targets/AssemblyVersions.props
+++ b/build/targets/AssemblyVersions.props
@@ -39,16 +39,14 @@
     Then $(BuildTimeStamp_Date) = 161225
     Then $(BuildTimeStamp_Number) = 01
     Then $(BuildTimeStamp) = 16122501
-    Then $(MicroBuildAssemblyVersion_WithoutRevision) = 15.4.1
-    Then $(VsixPackageVersion) = 15.4.1.16122501
+    Then $(VsixPackageVersion) = 15.4.20161225.1
     Then $(NuGetPackageVersionSuffix) = 161225-01
 
     -->
     <BuildTimeStamp_Date>$(BUILD_BUILDNUMBER.Split('.')[0].Substring(2))</BuildTimeStamp_Date>
     <BuildTimeStamp_Number>$(BUILD_BUILDNUMBER.Split('.')[1].PadLeft(2, '0'))</BuildTimeStamp_Number>
     <BuildTimeStamp>$(BuildTimeStamp_Date)$(BuildTimeStamp_Number)</BuildTimeStamp>
-    <MicroBuildAssemblyVersion_WithoutRevision>$(MicroBuildAssemblyVersion.Substring(0, $(MicroBuildAssemblyVersion.LastIndexOf('.'))))</MicroBuildAssemblyVersion_WithoutRevision>
-    <VsixPackageVersion>$(MicroBuildAssemblyVersion_WithoutRevision).$(BuildTimeStamp)</VsixPackageVersion>
+    <VsixPackageVersion>$(VSAssemblyVersion.Split('.')[0]).$(VSAssemblyVersion.Split('.')[1]).$(BUILD_BUILDNUMBER)</VsixPackageVersion>
     <NuGetPackageVersionSuffix>$(BuildTimeStamp_Date)-$(BuildTimeStamp_Number)</NuGetPackageVersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
Consolidating `$(FSharpPackageVersion)` from `setup\FSharp.Setup.props` and `$(VsixPackageVersion)` from `build\targets\AssemblyVersions.props`.  Since version numbers need to increase between builds of Visual Studio, `$(VsixPackageVersion)` had to go up instead of `$(FSharpPackageVersion)` going down.