### PR TITLE
Fix source control diff view

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -580,7 +580,8 @@ type
         let outliningManagerService = this.Package.ComponentModel.GetService<IOutliningManagerService>()
         let wpfTextView = this.EditorAdaptersFactoryService.GetWpfTextView(textView)
         let outliningManager = outliningManagerService.GetOutliningManager(wpfTextView)
-        outliningManager.Enabled <- Settings.Advanced.IsOutliningEnabled
+        if not (isNull outliningManager) then
+            outliningManager.Enabled <- Settings.Advanced.IsOutliningEnabled
 
         match textView.GetBuffer() with
         | (VSConstants.S_OK, textLines) ->


### PR DESCRIPTION
#4507 highlighted an issue where an `outliningManager` might not exist for a `wpfTextView` - one such case is when using the diff viewer in VS.