### PR TITLE
product Windows-style PDBs from SDK projects

### DIFF
--- a/FSharp.Directory.Build.props
+++ b/FSharp.Directory.Build.props
@@ -46,6 +46,7 @@
 
   <!-- other -->
   <PropertyGroup>
+    <DebugType>full</DebugType>
     <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
     <UseStandardResourceNames>false</UseStandardResourceNames>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
The public symbol server doesn't yet support portable PDBs so we're instead producing Windows-style PDBs that can be properly archived.