### PR TITLE
Enum match warning

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -153,6 +153,7 @@ let GetRangeOfDiagnostic(err:PhasedDiagnostic) =
       | InterfaceNotRevealed(_, _, m) 
       | WrappedError (_, m)
       | PatternMatchCompilation.MatchIncomplete (_, _, m)
+      | PatternMatchCompilation.EnumMatchIncomplete (_, _, m)
       | PatternMatchCompilation.RuleNeverMatched m 
       | ValNotMutable(_, _, m)
       | ValNotLocal(_, _, m) 

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -354,6 +354,7 @@ let GetDiagnosticNumber(err:PhasedDiagnostic) =
       | ExtensionTyping.ProvidedTypeResolutionNoRange _
       | ExtensionTyping.ProvidedTypeResolution _ -> 103
 #endif
+      | PatternMatchCompilation.EnumMatchIncomplete _ -> 104
        (* DO NOT CHANGE THE NUMBERS *)
 
       // Strip TargetInvocationException wrappers
@@ -559,6 +560,7 @@ let MatchIncomplete2E() = DeclareResourceString("MatchIncomplete2", "%s")
 let MatchIncomplete3E() = DeclareResourceString("MatchIncomplete3", "%s")
 let MatchIncomplete4E() = DeclareResourceString("MatchIncomplete4", "")
 let RuleNeverMatchedE() = DeclareResourceString("RuleNeverMatched", "")
+let EnumMatchIncomplete1E() = DeclareResourceString("EnumMatchIncomplete1", "")
 let ValNotMutableE() = DeclareResourceString("ValNotMutable", "%s")
 let ValNotLocalE() = DeclareResourceString("ValNotLocal", "")
 let Obsolete1E() = DeclareResourceString("Obsolete1", "")
@@ -1399,6 +1401,15 @@ let OutputPhasedErrorR (os:StringBuilder) (err:PhasedDiagnostic) =
           | Some (cex, false) ->  os.Append(MatchIncomplete2E().Format cex) |> ignore
           | Some (cex, true) ->  os.Append(MatchIncomplete3E().Format cex) |> ignore
           if isComp then 
+              os.Append(MatchIncomplete4E().Format) |> ignore
+
+      | PatternMatchCompilation.EnumMatchIncomplete (isComp, cexOpt, _) ->
+          os.Append(EnumMatchIncomplete1E().Format) |> ignore
+          match cexOpt with
+          | None -> ()
+          | Some (cex, false) ->  os.Append(MatchIncomplete2E().Format cex) |> ignore
+          | Some (cex, true) ->  os.Append(MatchIncomplete3E().Format cex) |> ignore
+          if isComp then
               os.Append(MatchIncomplete4E().Format) |> ignore
 
       | PatternMatchCompilation.RuleNeverMatched _ -> os.Append(RuleNeverMatchedE().Format) |> ignore

--- a/src/fsharp/FSStrings.resx
+++ b/src/fsharp/FSStrings.resx
@@ -957,9 +957,6 @@
   <data name="FullAbstraction" xml:space="preserve">
     <value>{0}</value>
   </data>
-  <data name="EnumMatchIncomplete1" xml:space="preserve">
-    <value>Enums may take values outside known cases.</value>
-  </data>
   <data name="MatchIncomplete1" xml:space="preserve">
     <value>Incomplete pattern matches on this expression.</value>
   </data>
@@ -971,6 +968,9 @@
   </data>
   <data name="MatchIncomplete4" xml:space="preserve">
     <value> Unmatched elements will be ignored.</value>
+  </data>
+  <data name="EnumMatchIncomplete1" xml:space="preserve">
+    <value>Enums may take values outside known cases.</value>
   </data>
   <data name="RuleNeverMatched" xml:space="preserve">
     <value>This rule will never be matched</value>

--- a/src/fsharp/FSStrings.resx
+++ b/src/fsharp/FSStrings.resx
@@ -957,6 +957,9 @@
   <data name="FullAbstraction" xml:space="preserve">
     <value>{0}</value>
   </data>
+  <data name="EnumMatchIncomplete1" xml:space="preserve">
+    <value>Enums may take values outside known cases.</value>
+  </data>
   <data name="MatchIncomplete1" xml:space="preserve">
     <value>Incomplete pattern matches on this expression.</value>
   </data>

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -246,9 +246,7 @@ let RefuteDiscrimSet g m path discrims =
                             match f.rfield_const, f.rfield_static with
                             | Some value, true -> Some value
                             | _, _ -> None)
-                    // enum pattern covers known values when there exist a known value such that consts does not
-                    // contain it
-                    knownValues |> Array.exists (fun ev -> not (consts.Contains ev))
+                    Array.forall (fun ev -> consts.Contains ev) knownValues
                 | _ -> false
 
             (* REVIEW: we could return a better enumeration literal field here if a field matches one of the enumeration cases *)

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -694,7 +694,8 @@ let CompilePatternBasic
                         let ignoreWithWarning = (actionOnFailure = IgnoreWithWarning)
                         let ce = ShowCounterExample g denv matchm refuted
                         match tryDestAppTy g topv.val_type, refuted with
-                        | Some tcref, [RefutedInvestigation(_, decisionTreeTests)] when tcref.IsEnumTycon ->
+                        //| Some tcref, [RefutedInvestigation(_, decisionTreeTests)] when tcref.IsEnumTycon ->
+                        | Some tcref, ds when tcref.IsEnumTycon ->
                             // Check whether or not the match handles all the defined values for the enum -- this
                             // changes what warning is emitted
                             let enumValues =
@@ -703,6 +704,9 @@ let CompilePatternBasic
                                     match f.rfield_const, f.rfield_static with
                                     | Some value, true -> Some value
                                     | _, _ -> None)
+                            let decisionTreeTests =
+                                ds |> List.collect (function | RefutedInvestigation(_,decisionTreeTests) -> decisionTreeTests
+                                                             | _ -> [])
                             let consts = Set.ofList (List.choose (function DecisionTreeTest.Const(c) -> Some c | _ -> None) decisionTreeTests)
                             if enumValues |> Seq.forall (fun c -> consts.Contains c) then
                                 warning (EnumMatchIncomplete(ignoreWithWarning, ce, matchm))

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -178,23 +178,23 @@ let RefuteDiscrimSet g m path discrims =
         | PathConj (p,_j) -> 
              go p tm
         | PathTuple (p,tys,j) -> 
-            let k, eCoversVals = mkOneKnown tm j tys
-            go p (fun _ -> mkRefTupled g m k tys, eCoversVals)
+             let k, eCoversVals = mkOneKnown tm j tys
+             go p (fun _ -> mkRefTupled g m k tys, eCoversVals)
         | PathRecd (p,tcref,tinst,j) -> 
-            let flds, eCoversVals = tcref |> actualTysOfInstanceRecdFields (mkTyconRefInst tcref tinst) |> mkOneKnown tm j
-            go p (fun _ -> Expr.Op(TOp.Recd(RecdExpr, tcref),tinst, flds,m), eCoversVals)
+             let flds, eCoversVals = tcref |> actualTysOfInstanceRecdFields (mkTyconRefInst tcref tinst) |> mkOneKnown tm j
+             go p (fun _ -> Expr.Op(TOp.Recd(RecdExpr, tcref),tinst, flds,m), eCoversVals)
 
         | PathUnionConstr (p,ucref,tinst,j) -> 
-            let flds, eCoversVals = ucref |> actualTysOfUnionCaseFields (mkTyconRefInst ucref.TyconRef tinst)|> mkOneKnown tm j
-            go p (fun _ -> Expr.Op(TOp.UnionCase(ucref),tinst, flds,m), eCoversVals)
+             let flds, eCoversVals = ucref |> actualTysOfUnionCaseFields (mkTyconRefInst ucref.TyconRef tinst)|> mkOneKnown tm j
+             go p (fun _ -> Expr.Op(TOp.UnionCase(ucref),tinst, flds,m), eCoversVals)
 
         | PathArray (p,ty,len,n) -> 
-            let flds, eCoversVals = mkOneKnown tm n (List.replicate len ty)
-            go p (fun _ -> Expr.Op(TOp.Array,[ty], flds ,m), eCoversVals)
+             let flds, eCoversVals = mkOneKnown tm n (List.replicate len ty)
+             go p (fun _ -> Expr.Op(TOp.Array,[ty], flds ,m), eCoversVals)
 
         | PathExnConstr (p,ecref,n) -> 
-            let flds, eCoversVals = ecref |> recdFieldTysOfExnDefRef |> mkOneKnown tm n
-            go p (fun _ -> Expr.Op(TOp.ExnConstr(ecref),[], flds,m), eCoversVals)
+             let flds, eCoversVals = ecref |> recdFieldTysOfExnDefRef |> mkOneKnown tm n
+             go p (fun _ -> Expr.Op(TOp.ExnConstr(ecref),[], flds,m), eCoversVals)
 
         | PathEmpty(ty) -> tm ty
         
@@ -263,9 +263,9 @@ let RefuteDiscrimSet g m path discrims =
              | ucref2 :: _ -> 
                let flds = ucref2 |> actualTysOfUnionCaseFields (mkTyconRefInst tcref tinst) |> mkUnknowns
                Expr.Op(TOp.UnionCase(ucref2),tinst, flds,m), false
-            
+               
         | [DecisionTreeTest.ArrayLength (n,ty)] -> 
-            Expr.Op(TOp.Array,[ty], mkUnknowns (List.replicate (n+1) ty) ,m), false
+             Expr.Op(TOp.Array,[ty], mkUnknowns (List.replicate (n+1) ty) ,m), false
              
         | _ -> 
             raise CannotRefute
@@ -316,21 +316,18 @@ let rec CombineRefutations g r1 r2 =
    | _ -> r1 
 
 let ShowCounterExample g denv m refuted = 
-    try
-        let refutations = refuted |> List.collect (function RefutedWhenClause -> [] | (RefutedInvestigation(path,discrim)) -> [RefuteDiscrimSet g m path discrim])
-        let counterExample, enumCoversKnown = 
-            match refutations with 
-            | [] -> raise CannotRefute
-            | (r, eck) :: t -> 
-                if verbose then dprintf "r = %s (enumCoversKnownValue = %b)\n" (Layout.showL (exprL r)) eck
-                //List.fold (fun (rAcc, eckAcc) r ->
-                    //let rAcc, eck = CombineRefutations g rAcc r
-                    //rAcc, eckAcc || eck) (r, eck) t
-                List.fold (fun (rAcc, eckAcc) (r, eck) ->
-                    CombineRefutations g rAcc r, eckAcc || eck) (r, eck) t
-        let text = Layout.showL (NicePrint.dataExprL denv counterExample)
-        let failingWhenClause = refuted |> List.exists (function RefutedWhenClause -> true | _ -> false)
-        Some(text,failingWhenClause,enumCoversKnown)
+   try
+      let refutations = refuted |> List.collect (function RefutedWhenClause -> [] | (RefutedInvestigation(path,discrim)) -> [RefuteDiscrimSet g m path discrim])
+      let counterExample, enumCoversKnown = 
+          match refutations with 
+          | [] -> raise CannotRefute
+          | (r, eck) :: t -> 
+              if verbose then dprintf "r = %s (enumCoversKnownValue = %b)\n" (Layout.showL (exprL r)) eck
+              List.fold (fun (rAcc, eckAcc) (r, eck) ->
+                  CombineRefutations g rAcc r, eckAcc || eck) (r, eck) t
+      let text = Layout.showL (NicePrint.dataExprL denv counterExample)
+      let failingWhenClause = refuted |> List.exists (function RefutedWhenClause -> true | _ -> false)
+      Some(text,failingWhenClause,enumCoversKnown)
       
     with 
         | CannotRefute ->    
@@ -701,24 +698,25 @@ let CompilePatternBasic
     // Add the incomplete or rethrow match clause on demand, printing a 
     // warning if necessary (only if it is ever exercised) 
     let incompleteMatchClauseOnce = ref None
-    let getIncompleteMatchClause refuted = 
+    let getIncompleteMatchClause (refuted) = 
         // This is lazy because emit a 
         // warning when the lazy thunk gets evaluated 
         match !incompleteMatchClauseOnce with 
         | None -> 
-                (* Emit the incomplete match warning *)
-                if warnOnIncomplete then
-                    match actionOnFailure with
-                    | ThrowIncompleteMatchException | IgnoreWithWarning ->
-                        let ignoreWithWarning = (actionOnFailure = IgnoreWithWarning)
-                        match ShowCounterExample g denv matchm refuted with
-                        | Some(text,failingWhenClause,true) ->
-                            warning (EnumMatchIncomplete(ignoreWithWarning, Some(text,failingWhenClause), matchm))
-                        | Some(text,failingWhenClause,false) ->
-                            warning (MatchIncomplete(ignoreWithWarning, Some(text,failingWhenClause), matchm))
-                        | None ->
-                            warning (MatchIncomplete(ignoreWithWarning, None, matchm))
-                    | _ -> ()
+                (* Emit the incomplete match warning *)               
+                if warnOnIncomplete then 
+                   match actionOnFailure with 
+                   | ThrowIncompleteMatchException | IgnoreWithWarning ->
+                       let ignoreWithWarning = (actionOnFailure = IgnoreWithWarning)
+                       match ShowCounterExample g denv matchm refuted with
+                       | Some(text,failingWhenClause,true) ->
+                           warning (EnumMatchIncomplete(ignoreWithWarning, Some(text,failingWhenClause), matchm))
+                       | Some(text,failingWhenClause,false) ->
+                           warning (MatchIncomplete(ignoreWithWarning, Some(text,failingWhenClause), matchm))
+                       | None ->
+                           warning (MatchIncomplete(ignoreWithWarning, None, matchm))
+                   | _ -> 
+                        ()
                         
                 let throwExpr =
                     match actionOnFailure with

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -692,24 +692,16 @@ let CompilePatternBasic
         match !incompleteMatchClauseOnce with 
         | None -> 
                 (* Emit the incomplete match warning *)
-                if warnOnIncomplete then 
-                    //let mkIncompleteMatchExn = if isEnum then EnumMatchIncomplete else MatchIncomplete
-                    
+                if warnOnIncomplete then
                     match actionOnFailure with
-                    | ThrowIncompleteMatchException ->
+                    | ThrowIncompleteMatchException | IgnoreWithWarning ->
+                        let ignoreWithWarning = (actionOnFailure = IgnoreWithWarning)
                         let ce = ShowCounterExample g denv matchm refuted
                         if isEnumTy g topv.val_type then
-                            warning (EnumMatchIncomplete(false, ce, matchm))
+                            warning (EnumMatchIncomplete(ignoreWithWarning, ce, matchm))
                         else
-                            warning (MatchIncomplete(false, ce, matchm))
-                    | IgnoreWithWarning ->
-                        let ce = ShowCounterExample g denv matchm refuted
-                        if isEnumTy g topv.val_type then
-                            warning (EnumMatchIncomplete(true, ce, matchm))
-                        else
-                            warning (MatchIncomplete(true, ce, matchm))
-                    | _ ->
-                        ()
+                            warning (MatchIncomplete(ignoreWithWarning, ce, matchm))
+                    | _ -> ()
                         
                 let throwExpr =
                     match actionOnFailure with

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -691,11 +691,9 @@ let CompilePatternBasic
                 if warnOnIncomplete then
                     match actionOnFailure with
                     | ThrowIncompleteMatchException | IgnoreWithWarning ->
-                        printfn "%A" refuted
                         let ignoreWithWarning = (actionOnFailure = IgnoreWithWarning)
                         let ce = ShowCounterExample g denv matchm refuted
                         match tryDestAppTy g topv.val_type, refuted with
-                        //| Some tcref, [RefutedInvestigation(_, decisionTreeTests)] when tcref.IsEnumTycon ->
                         | Some tcref, ds when tcref.IsEnumTycon ->
                             // Check whether or not the match handles all the defined values for the enum -- this
                             // changes what warning is emitted

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -691,6 +691,7 @@ let CompilePatternBasic
                 if warnOnIncomplete then
                     match actionOnFailure with
                     | ThrowIncompleteMatchException | IgnoreWithWarning ->
+                        printfn "%A" refuted
                         let ignoreWithWarning = (actionOnFailure = IgnoreWithWarning)
                         let ce = ShowCounterExample g denv matchm refuted
                         match tryDestAppTy g topv.val_type, refuted with

--- a/src/fsharp/PatternMatchCompilation.fsi
+++ b/src/fsharp/PatternMatchCompilation.fsi
@@ -67,3 +67,4 @@ val internal CompilePattern :
 
 exception internal MatchIncomplete of bool * (string * bool) option * range
 exception internal RuleNeverMatched of range
+exception internal EnumMatchIncomplete of bool * (string * bool) option * range

--- a/src/fsharp/xlf/FSStrings.cs.xlf
+++ b/src/fsharp/xlf/FSStrings.cs.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.cs.xlf
+++ b/src/fsharp/xlf/FSStrings.cs.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.cs.xlf
+++ b/src/fsharp/xlf/FSStrings.cs.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Nespárované prvky se budou ignorovat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Pro toto pravidlo nebude nikdy existovat shoda.</target>

--- a/src/fsharp/xlf/FSStrings.de.xlf
+++ b/src/fsharp/xlf/FSStrings.de.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Nicht zugeordnete Elemente werden ignoriert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Für diese Regel wird niemals eine Übereinstimmung gefunden.</target>

--- a/src/fsharp/xlf/FSStrings.de.xlf
+++ b/src/fsharp/xlf/FSStrings.de.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.de.xlf
+++ b/src/fsharp/xlf/FSStrings.de.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.en.xlf
+++ b/src/fsharp/xlf/FSStrings.en.xlf
@@ -1421,6 +1421,7 @@
         <source> Unmatched elements will be ignored.</source>
         <target state="new"> Unmatched elements will be ignored.</target>
         <note />
+      </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
         <target state="new">Enums may take values outside known cases.</target>

--- a/src/fsharp/xlf/FSStrings.en.xlf
+++ b/src/fsharp/xlf/FSStrings.en.xlf
@@ -1422,8 +1422,8 @@
         <target state="new"> Unmatched elements will be ignored.</target>
         <note />
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="new">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.en.xlf
+++ b/src/fsharp/xlf/FSStrings.en.xlf
@@ -1421,6 +1421,10 @@
         <source> Unmatched elements will be ignored.</source>
         <target state="new"> Unmatched elements will be ignored.</target>
         <note />
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="new">Enums may take values outside known cases.</value>
+        <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>

--- a/src/fsharp/xlf/FSStrings.es.xlf
+++ b/src/fsharp/xlf/FSStrings.es.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Los elementos que no coinciden se omitirán.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Nunca se buscarán coincidencias con esta regla.</target>

--- a/src/fsharp/xlf/FSStrings.es.xlf
+++ b/src/fsharp/xlf/FSStrings.es.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.es.xlf
+++ b/src/fsharp/xlf/FSStrings.es.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.fr.xlf
+++ b/src/fsharp/xlf/FSStrings.fr.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Les éléments non appariés seront ignorés.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Cette règle n'aura aucune correspondance</target>

--- a/src/fsharp/xlf/FSStrings.fr.xlf
+++ b/src/fsharp/xlf/FSStrings.fr.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.fr.xlf
+++ b/src/fsharp/xlf/FSStrings.fr.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.it.xlf
+++ b/src/fsharp/xlf/FSStrings.it.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Gli elementi senza corrispondenza verranno ignorati.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Questa regola non avrà mai alcuna corrispondenza</target>

--- a/src/fsharp/xlf/FSStrings.it.xlf
+++ b/src/fsharp/xlf/FSStrings.it.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.it.xlf
+++ b/src/fsharp/xlf/FSStrings.it.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.ja.xlf
+++ b/src/fsharp/xlf/FSStrings.ja.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.ja.xlf
+++ b/src/fsharp/xlf/FSStrings.ja.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.ja.xlf
+++ b/src/fsharp/xlf/FSStrings.ja.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> 一致しない要素は無視されます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">この規則には一致しません</target>

--- a/src/fsharp/xlf/FSStrings.ko.xlf
+++ b/src/fsharp/xlf/FSStrings.ko.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.ko.xlf
+++ b/src/fsharp/xlf/FSStrings.ko.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.ko.xlf
+++ b/src/fsharp/xlf/FSStrings.ko.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> 일치하지 않는 요소는 무시됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">이 규칙은 일치시킬 수 없습니다.</target>

--- a/src/fsharp/xlf/FSStrings.pl.xlf
+++ b/src/fsharp/xlf/FSStrings.pl.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.pl.xlf
+++ b/src/fsharp/xlf/FSStrings.pl.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.pl.xlf
+++ b/src/fsharp/xlf/FSStrings.pl.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Niedopasowane elementy zostaną zignorowane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Ta reguła nigdy nie zostanie dopasowana</target>

--- a/src/fsharp/xlf/FSStrings.pt-BR.xlf
+++ b/src/fsharp/xlf/FSStrings.pt-BR.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.pt-BR.xlf
+++ b/src/fsharp/xlf/FSStrings.pt-BR.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.pt-BR.xlf
+++ b/src/fsharp/xlf/FSStrings.pt-BR.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Elementos incompatíveis serão ignorados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Esta regra nunca será correspondida</target>

--- a/src/fsharp/xlf/FSStrings.ru.xlf
+++ b/src/fsharp/xlf/FSStrings.ru.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Элементы без соответствий будут проигнорированы.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Данное правило никогда не будет сопоставлено</target>

--- a/src/fsharp/xlf/FSStrings.ru.xlf
+++ b/src/fsharp/xlf/FSStrings.ru.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.ru.xlf
+++ b/src/fsharp/xlf/FSStrings.ru.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.tr.xlf
+++ b/src/fsharp/xlf/FSStrings.tr.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> Eşleşmeyen öğeler yok sayılacak.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">Bu kural hiçbir zaman eşleştirilmeyecek</target>

--- a/src/fsharp/xlf/FSStrings.tr.xlf
+++ b/src/fsharp/xlf/FSStrings.tr.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.tr.xlf
+++ b/src/fsharp/xlf/FSStrings.tr.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSStrings.zh-Hans.xlf
@@ -1424,7 +1424,7 @@
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSStrings.zh-Hans.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSStrings.zh-Hans.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> 将忽略不匹配的元素。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">从不与此规则匹配</target>

--- a/src/fsharp/xlf/FSStrings.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSStrings.zh-Hant.xlf
@@ -1422,9 +1422,9 @@
         <target state="translated"> 無對應的項目將會被忽略。</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumMatchIncomplete1">
+     <trans-unit id="EnumMatchIncomplete1">
         <source>Enums may take values outside known cases.</source>
-        <target state="translated">Enums may take values outside known cases.</target>
+        <target state="new">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSStrings.zh-Hant.xlf
@@ -1423,8 +1423,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumMatchIncomplete1">
-        <source>Enums may take values outside known cases.</value>
-        <target state="translated">Enums may take values outside known cases.</value>
+        <source>Enums may take values outside known cases.</source>
+        <target state="translated">Enums may take values outside known cases.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuleNeverMatched">

--- a/src/fsharp/xlf/FSStrings.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSStrings.zh-Hant.xlf
@@ -1422,6 +1422,11 @@
         <target state="translated"> 無對應的項目將會被忽略。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumMatchIncomplete1">
+        <source>Enums may take values outside known cases.</value>
+        <target state="translated">Enums may take values outside known cases.</value>
+        <note />
+      </trans-unit>
       <trans-unit id="RuleNeverMatched">
         <source>This rule will never be matched</source>
         <target state="translated">這個規則絕不會比對到</target>

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2162,6 +2162,9 @@ module TypecheckTests =
     [<Test>] 
     let ``type check neg101`` () = singleNegTest (testConfig "typecheck/sigs") "neg101"
 
+    [<Test>]
+    let ``type check neg102`` () = singleNegTest (testConfig "typecheck/sigs") "neg102"
+
     [<Test>] 
     let ``type check neg_byref_1`` () = singleNegTest (testConfig "typecheck/sigs") "neg_byref_1"
 

--- a/tests/fsharp/typecheck/sigs/neg102.bsl
+++ b/tests/fsharp/typecheck/sigs/neg102.bsl
@@ -1,10 +1,10 @@
 
-\Users\jwostenberg\Code\FSharp\visualfsharp\tests\fsharp\typecheck\sigs\neg102.fs(8,14,8,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'enum<EnumAB> (1)' may indicate a case not covered by the pattern(s).
+neg102.fs(8,14,8,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'enum<EnumAB> (1)' may indicate a case not covered by the pattern(s).
 
-\Users\jwostenberg\Code\FSharp\visualfsharp\tests\fsharp\typecheck\sigs\neg102.fs(11,14,11,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).
+neg102.fs(11,14,11,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).
 
-\Users\jwostenberg\Code\FSharp\visualfsharp\tests\fsharp\typecheck\sigs\neg102.fs(14,14,14,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).
+neg102.fs(14,14,14,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).
 
-typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<EnumAB> (2)' may indicate a case not covered by the pattern(s).
+neg102.fs(20,14,20,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<EnumAB> (2)' may indicate a case not covered by the pattern(s).
 
-typecheck error FS0104: Enums may take values outside known cases. For example, the value 'Some (enum<EnumAB> (2))' may indicate a case not covered by the pattern(s).
+neg102.fs(24,14,24,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'Some (enum<EnumAB> (2))' may indicate a case not covered by the pattern(s).

--- a/tests/fsharp/typecheck/sigs/neg102.bsl
+++ b/tests/fsharp/typecheck/sigs/neg102.bsl
@@ -1,10 +1,10 @@
 
-neg102.fs(7,14,7,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'enum<EnumAB> (1)' may indicate a case not covered by the pattern(s).
+\Users\jwostenberg\Code\FSharp\visualfsharp\tests\fsharp\typecheck\sigs\neg102.fs(8,14,8,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'enum<EnumAB> (1)' may indicate a case not covered by the pattern(s).
 
-neg102.fs(10,14,10,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).
+\Users\jwostenberg\Code\FSharp\visualfsharp\tests\fsharp\typecheck\sigs\neg102.fs(11,14,11,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).
 
-neg102.fs(13,14,13,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).
+\Users\jwostenberg\Code\FSharp\visualfsharp\tests\fsharp\typecheck\sigs\neg102.fs(14,14,14,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).
 
 typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<EnumAB> (2)' may indicate a case not covered by the pattern(s).
 
-
+typecheck error FS0104: Enums may take values outside known cases. For example, the value 'Some (enum<EnumAB> (2))' may indicate a case not covered by the pattern(s).

--- a/tests/fsharp/typecheck/sigs/neg102.bsl
+++ b/tests/fsharp/typecheck/sigs/neg102.bsl
@@ -1,0 +1,10 @@
+
+neg102.fs(7,14,7,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'enum<EnumAB> (1)' may indicate a case not covered by the pattern(s).
+
+neg102.fs(10,14,10,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).
+
+neg102.fs(13,14,13,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).
+
+typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<EnumAB> (2)' may indicate a case not covered by the pattern(s).
+
+

--- a/tests/fsharp/typecheck/sigs/neg102.fs
+++ b/tests/fsharp/typecheck/sigs/neg102.fs
@@ -1,0 +1,20 @@
+module M
+type EnumAB = A = 0 | B = 1
+type UnionAB = A | B
+
+module FS0025 =
+    // All of these should emit warning FS0025 ("Incomplete pattern match....")
+    let f1 = function
+        | EnumAB.A -> "A"
+
+    let f2 = function
+        | UnionAB.A -> "A"
+
+    let f3 = function
+        | 42 -> "forty-two"        
+
+module FS0104 =
+    // These should emit warning FS0104 ("Enums may take values outside of known cases....")
+    let f1 = function
+        | EnumAB.A -> "A"
+        | EnumAB.B -> "B"

--- a/tests/fsharp/typecheck/sigs/neg102.fs
+++ b/tests/fsharp/typecheck/sigs/neg102.fs
@@ -4,6 +4,7 @@ type UnionAB = A | B
 
 module FS0025 =
     // All of these should emit warning FS0025 ("Incomplete pattern match....")
+        
     let f1 = function
         | EnumAB.A -> "A"
 
@@ -15,6 +16,12 @@ module FS0025 =
 
 module FS0104 =
     // These should emit warning FS0104 ("Enums may take values outside of known cases....")
+
     let f1 = function
         | EnumAB.A -> "A"
         | EnumAB.B -> "B"
+
+    let f2 = function
+        | Some(EnumAB.A) -> "A"
+        | Some(EnumAB.B) -> "B"
+        | None -> "none"

--- a/tests/fsharpqa/Source/Conformance/PatternMatching/Expression/W_CounterExampleWithEnum02.fs
+++ b/tests/fsharpqa/Source/Conformance/PatternMatching/Expression/W_CounterExampleWithEnum02.fs
@@ -1,6 +1,6 @@
 // #Regression #Conformance #PatternMatching 
 // Regression test for DevDiv:198999 ("Warning messages for incomplete matches involving enum types are wrong")
-//<Expects status="warning" span="(14,10-14,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(2\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
+//<Expects status="warning" span="(14,10-14,18)" id="FS0104">Enums may take values outside known cases\. For example, the value 'enum<T> \(2\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
 //<Expects status="warning" span="(18,10-18,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(1\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
 //<Expects status="warning" span="(21,10-21,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(1\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
 //<Expects status="warning" span="(24,10-24,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(1\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>

--- a/tests/fsharpqa/Source/Conformance/PatternMatching/Simple/E_namedLiberal01.fs
+++ b/tests/fsharpqa/Source/Conformance/PatternMatching/Simple/E_namedLiberal01.fs
@@ -1,8 +1,7 @@
 // #Regression #Conformance #PatternMatching 
-// Match warning when using enum for incomplete match.
-// (Even if you use every possible value.
+// Match warning when covering all defined values of an enum
 
-//<Expects status="warning" id="FS0025">Incomplete pattern matches on this expression</Expects>
+//<Expects status="warning" id="FS0104">Enums may take values outside known cases.</Expects>
 
 
 open System


### PR DESCRIPTION
First attempt at fslang-suggestions [#652](https://github.com/fsharp/fslang-suggestions/issues/652). It seems to work correctly so far, but tests will be coming soon.

One question -- this can't possibly be the first piece of code to grab all the defined enum values from a Tycon; is there a function that does this already? Currently this fix just looks through all the enum type's static fields (see PatternMatchCompilation.fs changes)