### PR TITLE
always emit the local scope's start offset

### DIFF
--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -423,22 +423,15 @@ let generatePortablePdb (embedAllSource:bool) (embedSourceList:string list) (sou
                 list.ToArray() |> Array.sortWith<PdbMethodScope> scopeSorter
 
             collectScopes scope |> Seq.iter(fun s ->
-                                    if s.Children.Length = 0 then
-                                        metadata.AddLocalScope(MetadataTokens.MethodDefinitionHandle(minfo.MethToken),
-                                                               Unchecked.defaultof<ImportScopeHandle>,
-                                                               nextHandle lastLocalVariableHandle,
-                                                               Unchecked.defaultof<LocalConstantHandle>,
-                                                               0, s.EndOffset - s.StartOffset ) |>ignore
-                                    else
-                                        metadata.AddLocalScope(MetadataTokens.MethodDefinitionHandle(minfo.MethToken),
-                                                               Unchecked.defaultof<ImportScopeHandle>,
-                                                               nextHandle lastLocalVariableHandle,
-                                                               Unchecked.defaultof<LocalConstantHandle>,
-                                                               s.StartOffset, s.EndOffset - s.StartOffset) |>ignore
+                                   metadata.AddLocalScope(MetadataTokens.MethodDefinitionHandle(minfo.MethToken),
+                                                          Unchecked.defaultof<ImportScopeHandle>,
+                                                          nextHandle lastLocalVariableHandle,
+                                                          Unchecked.defaultof<LocalConstantHandle>,
+                                                          s.StartOffset, s.EndOffset - s.StartOffset ) |>ignore
 
-                                    for localVariable in s.Locals do
-                                        lastLocalVariableHandle <- metadata.AddLocalVariable(LocalVariableAttributes.None, localVariable.Index, metadata.GetOrAddString(localVariable.Name))
-                                    )
+                                   for localVariable in s.Locals do
+                                       lastLocalVariableHandle <- metadata.AddLocalVariable(LocalVariableAttributes.None, localVariable.Index, metadata.GetOrAddString(localVariable.Name))
+                                   )
 
         match minfo.RootScope with
         | None -> ()


### PR DESCRIPTION
When recursively gathering the scopes we weren't writing the correct start offset.

Fixes #4523