### PR TITLE
[CompilerPerf] Weak ByteFile[]

### DIFF
--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -3949,12 +3949,6 @@ let rec genOpenBinaryReader infile (bf: BinaryFile) opts =
 
     ilModule, ilAssemblyRefs, pdb
   
-let mkDefault ilg = 
-    { optimizeForMemory=false 
-      pdbPath= None 
-      ilGlobals = ilg
-      stableFileHeuristic = false } 
-
 let ClosePdbReader pdb =  
 #if FX_NO_PDB_READER
     ignore pdb
@@ -3989,7 +3983,7 @@ let ilModuleReaderCache = new AgedLookup<ILModuleReaderCacheLockToken, (string *
 let ilModuleReaderCacheLock = Lock()
 
 let stableFileHeuristicApplies (filename:string) = 
-    filename.Contains("Program Files") || filename.Contains("packages/") || filename.Contains("packages\\") || filename.Contains("lib/mono")
+    filename.Contains("Reference Assemblies") || filename.Contains("packages") || filename.Contains("lib/mono")
 
 let OpenILModuleReaderAfterReadingAllBytes infile opts = 
     // Pseudo-normalize the paths.

--- a/src/absil/ilread.fsi
+++ b/src/absil/ilread.fsi
@@ -37,7 +37,9 @@ open System.IO
 type ILReaderOptions =
    { pdbPath: string option;
      ilGlobals: ILGlobals;
-     optimizeForMemory: bool  (* normally off, i.e. optimize for startup-path speed *) }
+     optimizeForMemory: bool  
+     /// Indicates that the backing file will be stable and can be re-read if the implementation wants to release in-memory resources
+     stableFileHeuristic: bool }
 
 val mkDefault :  ILGlobals -> ILReaderOptions
 

--- a/src/absil/ilread.fsi
+++ b/src/absil/ilread.fsi
@@ -41,8 +41,6 @@ type ILReaderOptions =
      /// Indicates that the backing file will be stable and can be re-read if the implementation wants to release in-memory resources
      stableFileHeuristic: bool }
 
-val mkDefault :  ILGlobals -> ILReaderOptions
-
 // The non-memory resources (i.e. the file handle) associated with 
 // the read can be recovered by calling Dispose.  Any remaining 
 // lazily-computed items in the metadata graph returned by MetadataOfILModuleReader 

--- a/src/absil/ilread.fsi
+++ b/src/absil/ilread.fsi
@@ -36,9 +36,16 @@ open System.IO
 
 type ILReaderOptions =
    { pdbPath: string option;
+
      ilGlobals: ILGlobals;
+
+     // fsc.exe does not uses optimizeForMemory (hence keeps MORE caches in AbstractIL and MORE memory mapping and MORE memory hogging)
+     // fsi.exe does use optimizeForMemory (hence keeps FEWER caches in AbstractIL and LESS memory mapping and LESS memory hogging), because its long running
+     // Visual Studio does use optimizeForMemory (hence keeps FEWER caches in AbstractIL and LESS memory mapping and LESS memory hogging), because its long running
      optimizeForMemory: bool  
+
      /// Indicates that the backing file will be stable and can be re-read if the implementation wants to release in-memory resources
+     /// Normally the same as optimizeForMemory
      stableFileHeuristic: bool }
 
 // The non-memory resources (i.e. the file handle) associated with 
@@ -56,7 +63,7 @@ val OpenILModuleReader: string -> ILReaderOptions -> ILModuleReader
 /// Open a binary reader, except first copy the entire contents of the binary into 
 /// memory, close the file and ensure any subsequent reads happen from the in-memory store. 
 /// PDB files may not be read with this option. 
-val OpenILModuleReaderAfterReadingAllBytes: string -> ILReaderOptions -> ILModuleReader
+val OpenILModuleReader: string -> ILReaderOptions -> ILModuleReader
 
 /// Open a binary reader based on the given bytes. 
 val OpenILModuleReaderFromBytes: fileNameForDebugOutput:string -> assemblyContents: byte[] -> options: ILReaderOptions -> ILModuleReader

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
@@ -4306,6 +4306,9 @@ type internal SR private() =
     /// This expression returns a value of type '%s' but is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to use the expression as a value in the sequence then use an explicit 'yield!'.
     /// (Originally from ..\FSComp.txt:1426)
     static member implicitlyDiscardedSequenceInSequenceExpression(a0 : System.String) = (3222, GetStringFunc("implicitlyDiscardedSequenceInSequenceExpression",",,,%s,,,") a0)
+    /// The file '%s' changed on disk unexpectedly, please reload.
+    /// (Originally from ..\FSComp.txt:1427)
+    static member ilreadFileChanged(a0 : System.String) = (3223, GetStringFunc("ilreadFileChanged",",,,%s,,,") a0)
 
     /// Call this method once to validate that all known resources are valid; throws if not
     static member RunStartupValidation() =
@@ -5706,4 +5709,5 @@ type internal SR private() =
         ignore(GetString("tcTupleMemberNotNormallyUsed"))
         ignore(GetString("implicitlyDiscardedInSequenceExpression"))
         ignore(GetString("implicitlyDiscardedSequenceInSequenceExpression"))
+        ignore(GetString("ilreadFileChanged"))
         ()

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
@@ -1117,7 +1117,7 @@
     <value>The member or object constructor '{0}' is not {1}</value>
   </data>
   <data name="csMemberIsNotAccessible2" xml:space="preserve">
-    <value>The member or object constructor '{0}' is not {1}. Private members may only be accessed from within the declaring type. Protected members may only be accessed from an extending type and cannot be accessed from within inner lambda expressions, object expressions or computation expressions (such as async { }). If {0} is a protected member, consider creating a member in this type that calls it.</value>
+    <value>The member or object constructor '{0}' is not {1}. Private members may only be accessed from within the declaring type. Protected members may only be accessed from an extending type and cannot be accessed from inner lambda expressions.</value>
   </data>
   <data name="csMethodIsNotAStaticMethod" xml:space="preserve">
     <value>{0} is not a static method</value>
@@ -4308,5 +4308,8 @@
   </data>
   <data name="implicitlyDiscardedSequenceInSequenceExpression" xml:space="preserve">
     <value>This expression returns a value of type '{0}' but is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to use the expression as a value in the sequence then use an explicit 'yield!'.</value>
+  </data>
+  <data name="ilreadFileChanged" xml:space="preserve">
+    <value>The file '{0}' changed on disk unexpectedly, please reload.</value>
   </data>
 </root>

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -233,7 +233,6 @@ type TcConfigBuilder =
       mutable noFeedback: bool
       mutable stackReserveSize: int32 option
       mutable implicitIncludeDir: string
-      mutable openBinariesInMemory: bool
       mutable openDebugInformationForLaterStaticLinking: bool
       defaultFSharpBinariesDir: string
       mutable compilingFslib: bool
@@ -389,7 +388,6 @@ type TcConfig =
     member noFeedback: bool
     member stackReserveSize: int32 option
     member implicitIncludeDir: string
-    member openBinariesInMemory: bool
     member openDebugInformationForLaterStaticLinking: bool
     member fsharpBinariesDir: string
     member compilingFslib: bool

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -355,6 +355,7 @@ type TcConfigBuilder =
       mutable exename: string option 
       mutable copyFSharpCore: bool
       mutable shadowCopyReferences: bool
+      mutable stableFileHeuristic: bool
     }
 
     static member Initial: TcConfigBuilder

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -355,7 +355,6 @@ type TcConfigBuilder =
       mutable exename: string option 
       mutable copyFSharpCore: bool
       mutable shadowCopyReferences: bool
-      mutable stableFileHeuristic: bool
     }
 
     static member Initial: TcConfigBuilder
@@ -568,11 +567,8 @@ type ImportedAssembly =
 [<Sealed>] 
 type TcAssemblyResolutions = 
     member GetAssemblyResolutions: unit -> AssemblyResolution list
-
     static member SplitNonFoundationalResolutions : CompilationThreadToken * TcConfig -> AssemblyResolution list * AssemblyResolution list * UnresolvedAssemblyReference list
     static member BuildFromPriorResolutions    : CompilationThreadToken * TcConfig * AssemblyResolution list * UnresolvedAssemblyReference list -> TcAssemblyResolutions 
-    
-
 
 /// Represents a table of imported assemblies with their resolutions.
 [<Sealed>] 

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1424,3 +1424,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3220,tcTupleMemberNotNormallyUsed,"This method or property is not normally used from F# code, use an explicit tuple pattern for deconstruction instead."
 3221,implicitlyDiscardedInSequenceExpression,"This expression returns a value of type '%s' but is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to use the expression as a value in the sequence then use an explicit 'yield'."
 3222,implicitlyDiscardedSequenceInSequenceExpression,"This expression returns a value of type '%s' but is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to use the expression as a value in the sequence then use an explicit 'yield!'."
+3223,ilreadFileChanged,"The file '%s' changed on disk unexpectedly, please reload."

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1161,7 +1161,8 @@ module StaticLinker =
             let ilGlobals = mkILGlobals ILScopeRef.Local
             let opts = { ILBinaryReader.mkDefault (ilGlobals) with 
                             optimizeForMemory=tcConfig.optimizeForMemory
-                            pdbPath = None } 
+                            pdbPath = None 
+                            stableFileHeuristic = true } 
             ILBinaryReader.OpenILModuleReader mscorlib40 opts
               
         let tdefs1 = ilxMainModule.TypeDefs.AsList  |> List.filter (fun td -> not (MainModuleBuilder.injectedCompatTypes.Contains(td.Name)))

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1159,10 +1159,11 @@ module StaticLinker =
               
         let ilBinaryReader = 
             let ilGlobals = mkILGlobals ILScopeRef.Local
-            let opts = { ILBinaryReader.mkDefault (ilGlobals) with 
-                            optimizeForMemory=tcConfig.optimizeForMemory
-                            pdbPath = None 
-                            stableFileHeuristic = true } 
+            let opts : ILBinaryReader.ILReaderOptions = 
+                { ilGlobals = ilGlobals
+                  optimizeForMemory = tcConfig.optimizeForMemory
+                  pdbPath = None 
+                  stableFileHeuristic = true } 
             ILBinaryReader.OpenILModuleReader mscorlib40 opts
               
         let tdefs1 = ilxMainModule.TypeDefs.AsList  |> List.filter (fun td -> not (MainModuleBuilder.injectedCompatTypes.Contains(td.Name)))
@@ -1650,7 +1651,7 @@ let main0(ctok, argv, legacyReferenceResolver, bannerAlreadyPrinted, openBinarie
 
     let optimizeForMemory = false // optimizeForMemory - fsc.exe can use as much memory as it likes to try to compile as fast as possible
 
-    let tcConfigB = TcConfigBuilder.CreateNew(legacyReferenceResolver, DefaultFSharpBinariesDir, optimizeForMemory, directoryBuildingFrom, isInteractive=false, isInvalidationSupported=false, defaultCopyFSharpCore=defaultCopyFSharpCore)
+    let tcConfigB = TcConfigBuilder.CreateNew(legacyReferenceResolver, DefaultFSharpBinariesDir, optimizeForMemory=optimizeForMemory, implicitIncludeDir=directoryBuildingFrom, isInteractive=false, isInvalidationSupported=false, defaultCopyFSharpCore=defaultCopyFSharpCore)
     // Preset: --optimize+ -g --tailcalls+ (see 4505)
     SetOptimizeSwitch tcConfigB OptionSwitch.On
     SetDebugSwitch    tcConfigB None OptionSwitch.Off
@@ -1840,7 +1841,7 @@ let main1(Args (ctok, tcGlobals, tcImports: TcImports, frameworkTcImports, gener
 // set up typecheck for given AST without parsing any command line parameters
 let main1OfAst (ctok, legacyReferenceResolver, openBinariesInMemory, assemblyName, target, outfile, pdbFile, dllReferences, noframework, exiter, errorLoggerProvider: ErrorLoggerProvider, inputs : ParsedInput list) =
 
-    let tcConfigB = TcConfigBuilder.CreateNew(legacyReferenceResolver, DefaultFSharpBinariesDir, (*optimizeForMemory*) false, Directory.GetCurrentDirectory(), isInteractive=false, isInvalidationSupported=false, defaultCopyFSharpCore=false)
+    let tcConfigB = TcConfigBuilder.CreateNew(legacyReferenceResolver, DefaultFSharpBinariesDir, optimizeForMemory=false, implicitIncludeDir=Directory.GetCurrentDirectory(), isInteractive=false, isInvalidationSupported=false, defaultCopyFSharpCore=false)
     tcConfigB.openBinariesInMemory <- openBinariesInMemory
     tcConfigB.framework <- not noframework 
     // Preset: --optimize+ -g --tailcalls+ (see 4505)

--- a/src/fsharp/fsc.fsi
+++ b/src/fsharp/fsc.fsi
@@ -32,7 +32,7 @@ val typecheckAndCompile :
     argv : string[] * 
     legacyReferenceResolver: ReferenceResolver.Resolver * 
     bannerAlreadyPrinted : bool * 
-    openBinariesInMemory: bool * 
+    optimizeForMemory: bool * 
     defaultCopyFSharpCore: bool * 
     exiter : Exiter *
     loggerProvider: ErrorLoggerProvider *
@@ -45,7 +45,7 @@ val mainCompile :
     argv: string[] * 
     legacyReferenceResolver: ReferenceResolver.Resolver * 
     bannerAlreadyPrinted: bool * 
-    openBinariesInMemory: bool * 
+    optimizeForMemory: bool * 
     defaultCopyFSharpCore: bool * 
     exiter: Exiter * 
     loggerProvider: ErrorLoggerProvider * 
@@ -56,7 +56,7 @@ val mainCompile :
 val compileOfAst : 
     ctok: CompilationThreadToken *
     legacyReferenceResolver: ReferenceResolver.Resolver * 
-    openBinariesInMemory: bool * 
+    optimizeForMemory: bool * 
     assemblyName:string * 
     target:CompilerTarget * 
     targetDll:string * 

--- a/src/fsharp/fscmain.fs
+++ b/src/fsharp/fscmain.fs
@@ -55,7 +55,7 @@ module Driver =
             MSBuildReferenceResolver.Resolver
 #endif
 
-        mainCompile (ctok, argv, legacyReferenceResolver, (*bannerAlreadyPrinted*)false, (*openBinariesInMemory*)false, (*defaultCopyFSharpCore*)true, quitProcessExiter, ConsoleLoggerProvider(), None, None)
+        mainCompile (ctok, argv, legacyReferenceResolver, (*bannerAlreadyPrinted*)false, (*optimizeForMemory*)false, (*defaultCopyFSharpCore*)true, quitProcessExiter, ConsoleLoggerProvider(), None, None)
         0 
 
 [<EntryPoint>]

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1726,10 +1726,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
                 // see also fsc.fs:runFromCommandLineToImportingAssemblies(), as there are many similarities to where the PS creates a tcConfigB
                 let tcConfigB = TcConfigBuilder.CreateNew(legacyReferenceResolver, defaultFSharpBinariesDir, implicitIncludeDir=projectDirectory, optimizeForMemory=true, isInteractive=false, isInvalidationSupported=true, defaultCopyFSharpCore=false) 
 
-                // The following uses more memory but means we don't take read-exclusions on the DLLs we reference 
-                // Could detect well-known assemblies--ie System.dll--and open them with read-locks 
-                tcConfigB.openBinariesInMemory <- true
-
                 tcConfigB.resolutionEnvironment <- (ReferenceResolver.ResolutionEnvironment.EditingOrCompilation true)
 
                 tcConfigB.conditionalCompilationDefines <- 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -2202,7 +2202,7 @@ module CompileHelpers =
         let errors, errorLogger, loggerProvider = mkCompilationErorHandlers()
         let result = 
             tryCompile errorLogger (fun exiter -> 
-                mainCompile (ctok, argv, legacyReferenceResolver, (*bannerAlreadyPrinted*)true, (*openBinariesInMemory*)true, (*defaultCopyFSharpCore*)false, exiter, loggerProvider, tcImportsCapture, dynamicAssemblyCreator) )
+                mainCompile (ctok, argv, legacyReferenceResolver, (*bannerAlreadyPrinted*)true, (*optimizeForMemory*)true, (*defaultCopyFSharpCore*)false, exiter, loggerProvider, tcImportsCapture, dynamicAssemblyCreator) )
     
         errors.ToArray(), result
 
@@ -2215,7 +2215,7 @@ module CompileHelpers =
     
         let result = 
             tryCompile errorLogger (fun exiter -> 
-                compileOfAst (ctok, legacyReferenceResolver, (*openBinariesInMemory=*)true, assemblyName, target, outFile, pdbFile, dependencies, noframework, exiter, loggerProvider, asts, tcImportsCapture, dynamicAssemblyCreator))
+                compileOfAst (ctok, legacyReferenceResolver, (*optimizeForMemory=*)true, assemblyName, target, outFile, pdbFile, dependencies, noframework, exiter, loggerProvider, asts, tcImportsCapture, dynamicAssemblyCreator))
 
         errors.ToArray(), result
 

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">Tento výraz vrátí hodnotu typu {0}, ale implicitně se zahodí. Zvažte vytvoření vazby mezi výsledkem a názvem pomocí klíčového slova let, např. let výsledek = výraz. Pokud jste chtěli výraz použít jako hodnotu v sekvenci, použijte explicitní klíčové slovo yield!.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">Dieser Ausdruck gibt einen Wert des Typs "{0}" zurück, wird aber implizit verworfen. Verwenden Sie ggf. "let", um das Ergebnis an einen Namen zu binden. Beispiel: "let Ergebnis = Ausdruck". Falls Sie den Ausdruck als Wert in der Sequenz einsetzen möchten, verwenden Sie explizit "yield!".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -6982,6 +6982,11 @@
         <target state="new">This expression returns a value of type '{0}' but is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to use the expression as a value in the sequence then use an explicit 'yield!'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">Esta expresión devuelve un valor de tipo “{0}”, pero se descarta de forma implícita. Considere el uso de “let” para enlazar el resultado a un nombre; por ejemplo, “let result = expression”. Si su intención es utilizar la expresión como un valor en la secuencia, utilice “yield” de forma explícita.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">Cette expression retourne une valeur de type '{0}', mais est implicitement ignorée. Utilisez 'let' pour lier le résultat à un nom, par ex. 'let result = expression'. Si vous voulez utiliser l'expression comme valeur dans la séquence, utilisez un 'yield!' explicite.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">Questa espressione restituisce un valore di tipo '{0}' ma viene rimossa in modo implicito. Provare a usare 'let' per eseguire il binding del risultato a un nome, ad esempio 'let risultato = espressione'. Se si intende usare l'espressione come valore nella sequenza, usare l'operando 'yield!' esplicito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">この式は型 '{0}' の値を返しますが、暗黙的に破棄されます。'let' を使用して結果を名前にバインドすることを検討してください。例: 'let result = expression'。式をシーケンス内で値として使用する場合は、明示的に 'yield!' を使用してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">이 식은 '{0}' 형식의 값을 반환하지만 암시적으로 삭제됩니다. 'let'을 사용하여 결과를 이름에 바인딩하세요(예: 'let result = expression'). 식을 시퀀스의 값으로 사용하려면 명시적 'yield!'를 사용하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">To wyrażenie zwraca wartość typu „{0}”, ale jest niejawnie odrzucane. Rozważ użycie instrukcji „let” do powiązania wyniku z nazwą, np. „let wynik = wyrażenie”. Jeśli chcesz użyć tego wyrażenia jako wartości w sekwencji, użyj jawnej instrukcji „yield!”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">Essa expressão retorna um valor de tipo '{0}', mas é descartada de forma implícita. Considere o uso de 'let' para associar o resultado a um nome, por exemplo, 'let result = expression'. Se você pretende usar a expressão como um valor na sequência, use um “yield!” explícito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">Это выражение возвращает значение типа "{0}", но оно неявно отбрасывается. Чтобы привязать результат к какому-то имени, используйте "let", например: "let &lt;результат&gt; = &lt;выражение&gt;". Если вы собирались использовать выражение как значение в последовательности, используйте в явном виде "yield!".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">Bu ifade '{0}' türünde bir değer döndürür ancak örtük olarak atılır. Sonucu bir ada bağlamak için 'let' kullanabilirsiniz, örn. 'let sonuc = ifade'. İfadeyi dizide bir değer olarak kullanmayı amaçladıysanız açık bir 'yield!' kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">此表达式返回类型为“{0}”的值，但被隐式放弃。请考虑使用 "let" 将结果绑定到名称，例如 "let result = expression"。如果要使用该表达式作为序列中的值，则使用显式 "yield!"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -6982,6 +6982,11 @@
         <target state="translated">此運算式會傳回類型為 '{0}' 的值，但會被間接捨棄。請考慮使用 'let' 將結果繫結到名稱。例如 'let result = expression'。若您想要在序列中，以值的形式使用運算式，請直接使用 'yield!'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ilreadFileChanged">
+        <source>The file '{0}' changed on disk unexpectedly, please reload.</source>
+        <target state="new">The file '{0}' changed on disk unexpectedly, please reload.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/vsintegration.targets
+++ b/vsintegration/vsintegration.targets
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="RestoreVsIntegrationPackages" BeforeTargets="Build" Condition="'$(RestorePackages)' == ''">
-    <Exec Command=".\.nuget\NuGet.exe restore vsintegration\packages.config -PackagesDirectory packages -ConfigFile .\NuGet.Config" WorkingDirectory="$(FSharpSourcesRoot)\.." />
-  </Target>
-</Project>


### PR DESCRIPTION
This is a possible solution to the "ByteFile" memory usage problem discussed [here](https://github.com/Microsoft/visualfsharp/pull/4429#issuecomment-372662705) and [here](https://github.com/Microsoft/visualfsharp/issues/4258)

### Background

ByteFile accounts for something like 25% of F# memory usage in Visual Studio and long running FCS applications (we have to revalidate that this is still the case, but we expect it to be)


@vbfox says:

> From my measurements ByteFile is the single thing that make VS OOM for our team.
> Both the compiler directly and via type providers maintain them in memory, and having a dll with some bitmap resources of a few dozen MB can trash VS memory very fast.
> And from what I saw in the code only the tables (types, methods, ...) are used and not the IL or the resources or any other.

ByteFile objects come from DLL references - we read the whole DLL into memory. The memory gets collected if you move on to a new project or the builder for the project is otherwise collected.  But while the project is being edited the memory is held strongly.  

The memory held by `byte[]` is not very intrusive for GC, but is a killer when the memory reaches max address space, which affects Visual Studio in particular (most other F# editing tools use 64-bit address spaces)

### Proposed Solution

The solution here is to hold the ByteFile memory weakly for stable DLLs.  Stable DLLs can be whatever we choose them to be, but I have chosen them in this PR to be:

* Stable DLL = DLLs whose full path name contains "packages" or "Reference Assemblies" or "lib/mono"

The prototype does what it says on the tin: it holds the bytes weakly, resurrects them if they are needed and have been collected, and complains if the file has been written to under its feet.

The PR is carefully written to hold the contents strongly over  operations in ilread.fs that eagerly read data chunks.  It does this by converting the WeakByteFile into a ByteFile for the duration of an operation.

The prototype should only change the behaviour of FCS, Visual Studio and F# Interactive.  It doesn't apply to fsc.exe which generally uses memory mapping for these binary files.

Done:

* [x] Get it green
* [x] Validate via a memory dump that we have reduced active byte[] usage

