### PR TITLE
build portable PDBs from SDK projects and convert to Windows PDBs after build

### DIFF
--- a/FSharp.Directory.Build.props
+++ b/FSharp.Directory.Build.props
@@ -46,7 +46,7 @@
 
   <!-- other -->
   <PropertyGroup>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <MicroBuildAssemblyFileLanguage>fs</MicroBuildAssemblyFileLanguage>
     <UseStandardResourceNames>false</UseStandardResourceNames>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/FSharp.Directory.Build.targets
+++ b/FSharp.Directory.Build.targets
@@ -34,6 +34,7 @@
   </Target>
 
   <Import Project="build\targets\AssemblyVersions.props" />
+  <Import Project="build\targets\ConvertPortablePdbs.targets" />
   <Import Project="build\targets\GenerateAssemblyAttributes.targets" />
   <Import Project="build\targets\GenerateInternalsVisibleTo.targets" />
 

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -17,6 +17,7 @@
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="myget.org roslyn tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="myget.org roslyn" value="https://dotnet.myget.org/F/roslyn-for-vs-for-mac/api/v3/index.json" />
+    <add key="myget.org symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
   </packageSources>
 
 </configuration>

--- a/build/targets/ConvertPortablePdbs.targets
+++ b/build/targets/ConvertPortablePdbs.targets
@@ -1,0 +1,20 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbPackageVersion)" />
+  </ItemGroup>
+
+  <Target Name="ConvertPortablePdbs"
+          AfterTargets="AfterBuild"
+          Condition="Exists('$(TargetPath)') AND ('$(DebugType)' == 'portable' OR '$(DebugType)' == 'embedded')">
+    <PropertyGroup>
+      <ConvertedPdbsDirectory>$(FinalOutputPath)\ConvertedPdbs</ConvertedPdbsDirectory>
+      <PdbConverterExe>$(NuGetPackageRoot)Microsoft.DiaSymReader.Pdb2Pdb\$(MicrosoftDiaSymReaderPdb2PdbPackageVersion)\tools\Pdb2Pdb.exe</PdbConverterExe>
+      <PdbConverterArgs>"$(TargetPath)" /out "$(ConvertedPdbsDirectory)\$(TargetName).pdb" /verbose /srcsvrvar SRC_INDEX=public</PdbConverterArgs>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(ConvertedPdbsDirectory)" />
+    <Exec Command='"$(PdbConverterExe)" $(PdbConverterArgs)' />
+  </Target>
+
+</Project>

--- a/build/targets/PackageVersions.props
+++ b/build/targets/PackageVersions.props
@@ -48,6 +48,7 @@
 
     <!-- other packages -->
     <MicrosoftCompositionPackageVersion>1.0.30</MicrosoftCompositionPackageVersion>
+    <MicrosoftDiaSymReaderPdb2PdbPackageVersion>1.1.0-roslyn-62714-01</MicrosoftDiaSymReaderPdb2PdbPackageVersion>
     <MicrosoftMSXMLPackageVersion>8.0.0-alpha</MicrosoftMSXMLPackageVersion>
     <MicrosoftVisualFSharpMSBuild150PackageVersion>1.0.1</MicrosoftVisualFSharpMSBuild150PackageVersion>
     <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>


### PR DESCRIPTION
Follow-up to #4521 and #4524.