### PR TITLE
fix a mistake in FSharp.Compiler.Unittests project file

### DIFF
--- a/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.Unittests.fsproj
+++ b/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.Unittests.fsproj
@@ -60,10 +60,9 @@
       <Name>FSharp.Compiler.Private</Name>
       <Project>{2e4d67b4-522d-4cf7-97e4-ba940f0b18f3}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\FSharp.Core\FSharp.Core.fsproj">
+    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
+      <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>
-      <Project>{ded3bbd7-53f4-428a-8c9f-27968e768605}</Project>
-      <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />


### PR DESCRIPTION
The project reference was wrong.  Not entirely sure how this is building, I assume it was using an incorrect FSHarp.Core and it didn't matter