### PR TITLE
Fix AdvancedOptions

### DIFF
--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -48,6 +48,7 @@ type CodeLensOptions =
     UseColors: bool
     Prefix : string }
 
+[<CLIMutable>]
 type AdvancedOptions =
     { IsBlockStructureEnabled: bool 
       IsOutliningEnabled: bool }

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -14,7 +14,7 @@ module DefaultTuning =
     let SimplifyNameInitialDelay = 2000 (* milliseconds *)
     let SimplifyNameEachItemDelay = 0 (* milliseconds *)
 
-// CLIMutable to make the record work also as a view model
+// CLIMutable attribute is required if we want to use the record also as a view model bound to XAML options page
 [<CLIMutable>]
 type IntelliSenseOptions =
   { ShowAfterCharIsTyped: bool


### PR DESCRIPTION
`[<CLIMutable>]` got removed somehow, causing PresentationFramework exception when opening to Advanced Options page.