### PR TITLE
fix building in VS with PDB conversions

### DIFF
--- a/FSharp.Directory.Build.props
+++ b/FSharp.Directory.Build.props
@@ -17,8 +17,7 @@
   <PropertyGroup>
     <!-- default NuGet package restore location -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot>
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' AND '$(OS)' == 'Windows_NT'">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' AND '$(OS)' != 'Windows_NT'">$(HOME)/.nuget/packages/</NuGetPackageRoot>
+    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(MSBuildThisFileDirectory)packages</NuGetPackageRoot>
     <!-- ensure there is a trailing slash -->
     <NuGetPackageRoot Condition="!HasTrailingSlash('$(NuGetPackageRoot)') AND '$(OS)' == 'Windows_NT'">$(NuGetPackageRoot)\</NuGetPackageRoot>
     <NuGetPackageRoot Condition="!HasTrailingSlash('$(NuGetPackageRoot)') AND '$(OS)' != 'Windows_NT'">$(NuGetPackageRoot)/</NuGetPackageRoot>

--- a/build.cmd
+++ b/build.cmd
@@ -653,7 +653,7 @@ if "%NEEDS_DOTNET_CLI_TOOLS%" == "1" (
 
 set _dotnetcliexe=%~dp0Tools\dotnetcli\dotnet.exe
 set _dotnet20exe=%~dp0Tools\dotnet20\dotnet.exe
-set NUGET_PACKAGES=%~dp0Packages
+set NUGET_PACKAGES=%~dp0packages
 set path=%~dp0Tools\dotnet20\;%path%
 
 echo ----------- Done with package restore, starting dependency uptake check -------------

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.PropertiesPages.vbproj
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.PropertiesPages.vbproj
@@ -34,6 +34,7 @@
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludePkgdefInVSIXContainer>true</IncludePkgdefInVSIXContainer>
     <UsePackageTargetFallbackHack>true</UsePackageTargetFallbackHack>
+    <DisableOutputPathCopying>true</DisableOutputPathCopying>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />


### PR DESCRIPTION
There were two issues with building in Visual Studio:

1.  Converting the portable PDB to a Windows-style PDB was failing because the command-line build explicitly sets the `%NUGET_PACKAGES%` environment variable to `<repo-root>\packages`, but that variable wasn't set when `VisualFSharp.sln` was open in VS so it was falling back to the common location of `%USERPROFILE%\.nuget\packages` which doesn't work.  The fix for that is to set the fallback to `<repo-root>\packages`.
2.  The property pages project explicitly sets its `$(OutputPath)` variable which means the `HACK_CopyOutputsToTheProperLocation` target was being unnecessarily run which was resulting in incorrect PDBs and locked files.