### PR TITLE
cleanup some build warnings

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <VSCTCompile Include="MenusAndCommands.vsct">
       <XlfInput>false</XlfInput>
+      <ResourceName>Menus.ctmenu</ResourceName>
     </VSCTCompile>
     <EmbeddedResource Update="VSPackage.resx">
       <GenerateSource>true</GenerateSource>

--- a/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
+++ b/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.VisualStudio.FSharp.UIResources</RootNamespace>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #4541 as much as we currently can.

With these changes the only warnings on my machine are due to mismatched package references which is to be expected until the conversion to SDK projects is complete.