### PR TITLE
Making +++ in name resolution lazy

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -909,7 +909,6 @@ let AddResults res1 res2 =
     | Exception (Error _),Exception (UndefinedName _ as e2) -> Exception e2
     | Exception e1,Exception _ -> Exception e1
 
-let (+++) x y = AddResults x y
 let NoResultsOrUsefulErrors = Result []
 
 /// Indicates if we only need one result or all possible results from a resolution.
@@ -944,7 +943,15 @@ let AtMostOneResult m res =
     match res with 
     | Exception err -> raze err
     | Result [] -> raze (Error(FSComp.SR.nrInvalidModuleExprType(),m))
-    | Result (res :: _) -> success res 
+    | Result (res :: _) -> success res
+
+let AtMostOneResultQuery query2 res1 =
+    match res1 with
+    | Exception _ -> AddResults res1 (query2())
+    | Result [] -> query2()
+    | _ -> res1
+
+let inline (+++) res1 query2 = AtMostOneResultQuery query2 res1
 
 //-------------------------------------------------------------------------
 // TypeNameResolutionInfo
@@ -2247,12 +2254,9 @@ let rec ResolveExprLongIdentInModuleOrNamespace (ncenv:NameResolver) nenv (typeN
                     |> CollectAtMostOneResult (fun (resInfo,typ) -> ResolveObjectConstructorPrim ncenv nenv.eDisplayEnv resInfo id.idRange ad typ) 
                     |> MapResults (fun (resInfo,item) -> (resInfo,item,[]))
 
-        match tyconSearch with
-        | Result (res :: _) -> success res
-        | _ ->
 
         // Something in a sub-namespace or sub-module 
-        let moduleSearch = 
+        let moduleSearch() = 
             match rest with
             | id2::rest2 ->
                 match mty.ModulesAndNamespacesByDemangledName.TryFind(id.idText) with
@@ -2265,7 +2269,7 @@ let rec ResolveExprLongIdentInModuleOrNamespace (ncenv:NameResolver) nenv (typeN
             | _ ->
                 NoResultsOrUsefulErrors
 
-        match tyconSearch +++ moduleSearch +++ unionSearch with
+        match tyconSearch +++ moduleSearch +++ (fun _ -> unionSearch) with
         | Result [] ->
             let suggestPossibleTypesAndNames() =
                 let types = 
@@ -2375,11 +2379,7 @@ let rec ResolveExprLongIdentPrim sink (ncenv:NameResolver) first fullyQualified 
                         let tcrefs = LookupTypeNameInEnvMaybeHaveArity fullyQualified id.idText typeNameResInfo nenv
                         ChooseTyconRefInExpr (ncenv, m, ad, nenv, id, typeNameResInfo, resInfo, tcrefs)
 
-                    match ctorSearch with
-                    | Result res when not (isNil res) -> ctorSearch
-                    | _ -> 
-
-                    let implicitOpSearch = 
+                    let implicitOpSearch() = 
                         if IsMangledOpName id.idText then 
                             success [(resInfo,Item.ImplicitOp(id, ref None),[])] 
                         else 
@@ -2458,13 +2458,13 @@ let rec ResolveExprLongIdentPrim sink (ncenv:NameResolver) first fullyQualified 
             else
               // Otherwise modules are searched first. REVIEW: modules and types should be searched together. 
               // For each module referenced by 'id', search the module as if it were an F# module and/or a .NET namespace. 
-              let moduleSearch ad = 
+              let moduleSearch ad () = 
                    ResolveLongIndentAsModuleOrNamespaceThen sink ResultCollectionSettings.AtMostOneResult ncenv.amap m fullyQualified nenv ad id rest isOpenDecl
                        (ResolveExprLongIdentInModuleOrNamespace ncenv nenv typeNameResInfo ad)
 
               // REVIEW: somewhat surprisingly, this shows up on performance traces, with tcrefs non-nil.
               // This seems strange since we would expect in the vast majority of cases tcrefs is empty here.
-              let tyconSearch ad = 
+              let tyconSearch ad () = 
                   let tcrefs = LookupTypeNameInEnvNoArity fullyQualified id.idText nenv
                   if isNil tcrefs then NoResultsOrUsefulErrors else              
                   match rest with
@@ -2476,19 +2476,7 @@ let rec ResolveExprLongIdentPrim sink (ncenv:NameResolver) first fullyQualified 
                     NoResultsOrUsefulErrors
 
               let search =
-                  let moduleSearch = moduleSearch ad 
-              
-                  match moduleSearch with
-                  | Result res when not (isNil res) -> moduleSearch
-                  | _ ->
-
-                  let tyconSearch = tyconSearch ad
-
-                  match tyconSearch with
-                  | Result res when not (isNil res) -> tyconSearch
-                  | _ ->
-
-                  let envSearch = 
+                  let envSearch () = 
                       match fullyQualified with 
                       | FullyQualified -> 
                           NoResultsOrUsefulErrors
@@ -2497,27 +2485,14 @@ let rec ResolveExprLongIdentPrim sink (ncenv:NameResolver) first fullyQualified 
                           | Some (Item.UnqualifiedType _) 
                           | None -> NoResultsOrUsefulErrors
                           | Some res -> OneSuccess (resInfo,FreshenUnqualifiedItem ncenv m res,rest)
-
-                  moduleSearch +++ tyconSearch +++ envSearch
+                  
+                  moduleSearch ad () +++ tyconSearch ad +++ envSearch
 
               let resInfo,item,rest = 
                   match AtMostOneResult m search with 
                   | Result _ as res -> ForceRaise res
                   | _ ->
-                      let innerSearch =
-                          let moduleSearch = moduleSearch AccessibleFromSomeFSharpCode
-              
-                          match moduleSearch with
-                          | Result res when not (isNil res) -> moduleSearch
-                          | _ ->
-
-                          let tyconSearch = tyconSearch AccessibleFromSomeFSharpCode
-
-                          match tyconSearch with
-                          | Result res when not (isNil res) -> tyconSearch
-                          | _ ->
-
-                          search +++ moduleSearch +++ tyconSearch
+                      let innerSearch = search +++ (moduleSearch AccessibleFromSomeFSharpCode) +++ (tyconSearch AccessibleFromSomeFSharpCode)
 
                       let suggestEverythingInScope() =
                           seq { yield! 
@@ -2583,7 +2558,7 @@ let rec ResolvePatternLongIdentInModuleOrNamespace (ncenv:NameResolver) nenv num
         success (resInfo,Item.ActivePatternCase apref,rest)
     | _ -> 
     match mty.AllValsByLogicalName.TryFind(id.idText) with
-    | Some vspec  when IsValAccessible ad (mkNestedValRef modref vspec) -> 
+    | Some vspec when IsValAccessible ad (mkNestedValRef modref vspec) -> 
         success(resInfo,Item.Value (mkNestedValRef modref vspec),rest)
     | _ ->
     let tcrefs = lazy (
@@ -2599,12 +2574,8 @@ let rec ResolvePatternLongIdentInModuleOrNamespace (ncenv:NameResolver) nenv num
         | _ ->
             NoResultsOrUsefulErrors
 
-    match tyconSearch with
-    | Result (res :: _) -> success res
-    | _ -> 
-
     // Constructor of a type? 
-    let ctorSearch = 
+    let ctorSearch() = 
         if isNil rest then
             tcrefs.Force()
             |> List.map (fun (resInfo,tcref) -> (resInfo,FreshenTycon ncenv m tcref)) 
@@ -2613,12 +2584,8 @@ let rec ResolvePatternLongIdentInModuleOrNamespace (ncenv:NameResolver) nenv num
         else
             NoResultsOrUsefulErrors
 
-    match ctorSearch with
-    | Result (res :: _) -> success res
-    | _ -> 
-
     // Something in a sub-namespace or sub-module or nested-type 
-    let moduleSearch = 
+    let moduleSearch() = 
         match rest with
         | id2::rest2 ->
             match mty.ModulesAndNamespacesByDemangledName.TryFind(id.idText) with
@@ -2666,23 +2633,23 @@ let rec ResolvePatternLongIdentPrim sink (ncenv:NameResolver) fullyQualified war
     else
         // Single identifiers in patterns 
         if isNil rest && fullyQualified <> FullyQualified then
-              // Single identifiers in patterns - bind to constructors and active patterns 
-              // For the special case of 
-              //   let C = x 
-              match nenv.ePatItems.TryFind(id.idText) with
-              | Some res when not newDef  -> FreshenUnqualifiedItem ncenv m res
-              | _ -> 
-              // Single identifiers in patterns - variable bindings 
-              if not newDef &&
-                 (warnOnUpper = WarnOnUpperCase) && 
-                 id.idText.Length >= 3 && 
-                 System.Char.ToLowerInvariant id.idText.[0] <> id.idText.[0] then 
-                warning(UpperCaseIdentifierInPattern(m))
-              Item.NewDef id
-        
+            // Single identifiers in patterns - bind to constructors and active patterns 
+            // For the special case of 
+            //   let C = x 
+            match nenv.ePatItems.TryFind(id.idText) with
+            | Some res when not newDef  -> FreshenUnqualifiedItem ncenv m res
+            | _ -> 
+            // Single identifiers in patterns - variable bindings 
+            if not newDef &&
+               (warnOnUpper = WarnOnUpperCase) && 
+               id.idText.Length >= 3 && 
+               System.Char.ToLowerInvariant id.idText.[0] <> id.idText.[0] then 
+              warning(UpperCaseIdentifierInPattern(m))
+            Item.NewDef id
+
         // Long identifiers in patterns 
         else
-            let moduleSearch ad =
+            let moduleSearch ad () =
                 ResolveLongIndentAsModuleOrNamespaceThen sink ResultCollectionSettings.AtMostOneResult ncenv.amap m fullyQualified nenv ad id rest false
                     (ResolvePatternLongIdentInModuleOrNamespace ncenv nenv numTyArgsOpt ad)
                 
@@ -2697,25 +2664,13 @@ let rec ResolvePatternLongIdentPrim sink (ncenv:NameResolver) fullyQualified war
                     NoResultsOrUsefulErrors
 
             let resInfo,res,rest =
-                let tyconResult = tyconSearch ad
-                match tyconResult with
-                | Result (res :: _) -> res
-                | _ ->
-
-                let moduleResult = moduleSearch ad
-                match moduleResult with
-                | Result (res :: _) -> res
-                | _ ->
-
-                match AtMostOneResult m (tyconResult +++ moduleResult) with 
+                match AtMostOneResult m (tyconSearch ad +++ (moduleSearch ad)) with
                 | Result _ as res -> ForceRaise res
                 | _ ->
 
-                let tyconResult = tyconSearch AccessibleFromSomeFSharpCode
-                match tyconResult with
-                | Result (res :: _) -> res
-                | _ ->
-                    ForceRaise (AtMostOneResult m (tyconResult +++ moduleSearch AccessibleFromSomeFSharpCode))
+                tyconSearch AccessibleFromSomeFSharpCode +++ (moduleSearch AccessibleFromSomeFSharpCode)
+                |> AtMostOneResult m
+                |> ForceRaise
 
             ResolutionInfo.SendEntityPathToSink(sink,ncenv,nenv,ItemOccurence.Use,ad,resInfo,ResultTyparChecker(fun () -> true))
   
@@ -2853,7 +2808,8 @@ let rec private ResolveTypeLongIdentInModuleOrNamespace sink nenv (ncenv:NameRes
                     |> HashSet
 
                 raze (UndefinedName(depth,FSComp.SR.undefinedNameType,id,suggestTypes))
-        tyconSearch +++ modulSearch
+
+        AddResults tyconSearch modulSearch
 
 /// Resolve a long identifier representing a type 
 let rec ResolveTypeLongIdentPrim sink (ncenv:NameResolver) occurence first fullyQualified m nenv ad (id:Ident) (rest: Ident list) (staticResInfo: TypeNameResolutionStaticArgsInfo) genOk =
@@ -2918,7 +2874,7 @@ let rec ResolveTypeLongIdentPrim sink (ncenv:NameResolver) occurence first fully
                     (ResolveTypeLongIdentInModuleOrNamespace sink nenv ncenv typeNameResInfo.DropStaticArgsInfo AccessibleFromSomeFSharpCode genOk)
                 |?> List.concat 
 
-            let searchSoFar = tyconSearch +++ modulSearch
+            let searchSoFar = AddResults tyconSearch modulSearch
 
             match searchSoFar with 
             | Result results -> 
@@ -2931,11 +2887,12 @@ let rec ResolveTypeLongIdentPrim sink (ncenv:NameResolver) occurence first fully
                     success(resInfo,tcref)
                 | [] -> 
                     // failing case - report nice ambiguity errors even in this case
-                    AtMostOneResult m2 ((searchSoFar +++ modulSearchFailed()) |?> (fun tcrefs -> CheckForTypeLegitimacyAndMultipleGenericTypeAmbiguities (tcrefs, typeNameResInfo, genOk, m)))
-            
+                    let r = AddResults searchSoFar (modulSearchFailed())
+                    AtMostOneResult m2 (r |?> (fun tcrefs -> CheckForTypeLegitimacyAndMultipleGenericTypeAmbiguities (tcrefs, typeNameResInfo, genOk, m)))
             | _ ->  
                 // failing case - report nice ambiguity errors even in this case
-                AtMostOneResult m2 ((searchSoFar +++ modulSearchFailed()) |?> (fun tcrefs -> CheckForTypeLegitimacyAndMultipleGenericTypeAmbiguities (tcrefs, typeNameResInfo, genOk, m)))
+                let r = AddResults searchSoFar (modulSearchFailed())
+                AtMostOneResult m2 (r |?> (fun tcrefs -> CheckForTypeLegitimacyAndMultipleGenericTypeAmbiguities (tcrefs, typeNameResInfo, genOk, m)))
 
 
 /// Resolve a long identifier representing a type and report it
@@ -2973,12 +2930,8 @@ let rec ResolveFieldInModuleOrNamespace (ncenv:NameResolver) nenv ad (resInfo:Re
             success [resInfo, FieldResolution(modref.RecdFieldRefInNestedTycon tycon id,showDeprecated), rest]
         | _ -> raze (UndefinedName(depth,FSComp.SR.undefinedNameRecordLabelOrNamespace,id,NoSuggestions))
 
-    match modulScopedFieldNames with
-    | Result (res :: _) -> success res
-    | _ -> 
-
     // search for type-qualified names, e.g. { Microsoft.FSharp.Core.Ref.contents = 1 } 
-    let tyconSearch = 
+    let tyconSearch() = 
         match rest with
         | id2::rest2 ->
             let tcrefs = LookupTypeNameInEntityMaybeHaveArity (ncenv.amap, id.idRange, ad, id.idText, TypeNameResolutionStaticArgsInfo.Indefinite, modref)
@@ -2991,12 +2944,8 @@ let rec ResolveFieldInModuleOrNamespace (ncenv:NameResolver) nenv ad (resInfo:Re
         | _ ->
             NoResultsOrUsefulErrors
 
-    match tyconSearch with
-    | Result (res :: _) -> success res
-    | _ -> 
-
     // search for names in nested modules, e.g. { Microsoft.FSharp.Core.contents = 1 } 
-    let modulSearch = 
+    let modulSearch() = 
         match rest with
         | id2::rest2 ->
             match modref.ModuleOrNamespaceType.ModulesAndNamespacesByDemangledName.TryFind(id.idText) with
@@ -3006,8 +2955,9 @@ let rec ResolveFieldInModuleOrNamespace (ncenv:NameResolver) nenv ad (resInfo:Re
                 |> OneResult
             | _ -> raze (UndefinedName(depth,FSComp.SR.undefinedNameRecordLabelOrNamespace,id,NoSuggestions))
         | _ -> raze (UndefinedName(depth,FSComp.SR.undefinedNameRecordLabelOrNamespace,id,NoSuggestions))
-
-    AtMostOneResult m (modulScopedFieldNames +++ tyconSearch +++ modulSearch)
+        
+    modulScopedFieldNames +++ tyconSearch +++ modulSearch
+    |> AtMostOneResult m
 
 /// Suggest other labels of the same record
 let SuggestOtherLabelsOfSameRecordType g (nenv:NameResolutionEnv) typ (id:Ident) (allFields:Ident list) =    
@@ -3107,7 +3057,7 @@ let ResolveFieldPrim sink (ncenv:NameResolver) nenv ad typ (mp,id:Ident) allFiel
             lookup()            
     | _ -> 
         let lid = (mp@[id])
-        let tyconSearch ad = 
+        let tyconSearch ad () = 
             match lid with 
             | tn :: id2 :: rest2 -> 
                 let m = tn.idRange
@@ -3120,37 +3070,18 @@ let ResolveFieldPrim sink (ncenv:NameResolver) nenv ad typ (mp,id:Ident) allFiel
                 tyconSearch
             | _ -> NoResultsOrUsefulErrors
 
-        let modulSearch ad =
+        let modulSearch ad () =
             match lid with
             | [] -> NoResultsOrUsefulErrors
             | id2::rest2 ->
                 ResolveLongIndentAsModuleOrNamespaceThen sink ResultCollectionSettings.AtMostOneResult ncenv.amap m OpenQualified nenv ad id2 rest2 false
                     (ResolveFieldInModuleOrNamespace ncenv nenv ad)
 
-        let search =
-            let moduleSearch1 = modulSearch ad
-        
-            match moduleSearch1 with
-            | Result (res :: _) -> success res
-            | _ -> 
+        let resInfo,item,rest = 
+            modulSearch ad () +++ tyconSearch ad +++ modulSearch AccessibleFromSomeFSharpCode +++ tyconSearch AccessibleFromSomeFSharpCode
+            |> AtMostOneResult m
+            |> ForceRaise
 
-            let tyconSearch1 = tyconSearch ad
-
-            match tyconSearch1 with
-            | Result (res :: _) -> success res
-            | _ -> 
-
-            let moduleSearch2 = modulSearch AccessibleFromSomeFSharpCode
-
-            match moduleSearch2 with
-            | Result (res :: _) -> success res
-            | _ -> 
-
-            let tyconSearch2 = tyconSearch AccessibleFromSomeFSharpCode
-
-            AtMostOneResult m (moduleSearch1 +++ tyconSearch1 +++ moduleSearch2 +++ tyconSearch2)
-
-        let resInfo,item,rest = ForceRaise search
         if not (isNil rest) then 
             errorR(Error(FSComp.SR.nrInvalidFieldLabel(),(List.head rest).idRange))
 
@@ -3169,7 +3100,6 @@ let ResolveField sink ncenv nenv ad typ (mp,id) allFields =
 /// Generate a new reference to a record field with a fresh type instantiation
 let FreshenRecdFieldRef (ncenv:NameResolver) m (rfref:RecdFieldRef) =
     Item.RecdField(RecdFieldInfo(ncenv.InstantiationGenerator m (rfref.Tycon.Typars m), rfref))
-
 
 
 /// Resolve F#/IL "." syntax in expressions (2).
@@ -3201,12 +3131,11 @@ let private ResolveExprDotLongIdent (ncenv:NameResolver) m ad nenv typ (id:Ident
                     OneSuccess (ResolutionInfo.Empty,item,rest)
                 | _ -> NoResultsOrUsefulErrors
         
-        let search = dotFieldIdSearch 
-        match AtMostOneResult m search with 
-        | Result _ as res -> ForceRaise res
-        | _ -> 
-            let adhocDotSearchAll = ResolveLongIdentInTypePrim ncenv nenv LookupKind.Expr ResolutionInfo.Empty 1 m AccessibleFromSomeFSharpCode id rest findFlag typeNameResInfo typ 
-            ForceRaise (AtMostOneResult m (search +++ adhocDotSearchAll))
+        let adhocDotSearchAll () = ResolveLongIdentInTypePrim ncenv nenv LookupKind.Expr ResolutionInfo.Empty 1 m AccessibleFromSomeFSharpCode id rest findFlag typeNameResInfo typ 
+
+        dotFieldIdSearch +++ adhocDotSearchAll
+        |> AtMostOneResult m
+        |> ForceRaise
     | _ -> 
         ForceRaise adhoctDotSearchAccessible
 


### PR DESCRIPTION
This brings the code back to original version before I started to optimize NameRes.
The only real difference to the ancient version is that `+++` is now lazy. So we don't evaluate the right hand side until we really need to.