### PR TITLE
fix 4604 - assembly level attributes aren't returned by FCS

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2322,9 +2322,6 @@ type TcConfigBuilder =
       isInvalidationSupported : bool
 
       /// used to log sqm data
-      mutable sqmSessionGuid : System.Guid option
-      mutable sqmNumOfSourceFiles : int
-      sqmSessionStartedTime : int64
 
       /// if true - every expression in quotations will be augmented with full debug info (filename, location in file)
       mutable emitDebugInfoInQuotations : bool
@@ -2472,9 +2469,6 @@ type TcConfigBuilder =
           noDebugData = false
           isInteractive = false
           isInvalidationSupported = false
-          sqmSessionGuid = None
-          sqmNumOfSourceFiles = 0
-          sqmSessionStartedTime = System.DateTime.UtcNow.Ticks
           emitDebugInfoInQuotations = false
           exename = None
           copyFSharpCore = CopyFSharpCoreFlag.No
@@ -2943,9 +2937,6 @@ type TcConfig private (data : TcConfigBuilder, validate:bool) =
     member x.isInteractive = data.isInteractive
     member x.isInvalidationSupported = data.isInvalidationSupported
     member x.emitDebugInfoInQuotations = data.emitDebugInfoInQuotations
-    member x.sqmSessionGuid = data.sqmSessionGuid
-    member x.sqmNumOfSourceFiles = data.sqmNumOfSourceFiles
-    member x.sqmSessionStartedTime = data.sqmSessionStartedTime
     member x.copyFSharpCore = data.copyFSharpCore
     member x.shadowCopyReferences = data.shadowCopyReferences
     member x.tryGetMetadataSnapshot = data.tryGetMetadataSnapshot

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -355,9 +355,6 @@ type TcConfigBuilder =
       /// If true, indicates all type checking and code generation is in the context of fsi.exe
       isInteractive: bool 
       isInvalidationSupported: bool 
-      mutable sqmSessionGuid: System.Guid option
-      mutable sqmNumOfSourceFiles: int
-      sqmSessionStartedTime: int64
       mutable emitDebugInfoInQuotations: bool
       mutable exename: string option 
       mutable copyFSharpCore: CopyFSharpCoreFlag
@@ -524,9 +521,6 @@ type TcConfig =
     /// File system query based on TcConfig settings
     member MakePathAbsolute: string -> string
 
-    member sqmSessionGuid: System.Guid option
-    member sqmNumOfSourceFiles: int
-    member sqmSessionStartedTime: int64
     member copyFSharpCore: CopyFSharpCoreFlag
     member shadowCopyReferences: bool
     static member Create: TcConfigBuilder * validate: bool -> TcConfig

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -145,7 +145,7 @@ type IRawFSharpAssemblyData =
     abstract GetInternalsVisibleToAttributes: ILGlobals  -> string list
     ///  The raw IL module definition in the assembly, if any. This is not present for cross-project references
     /// in the language service
-    abstract TryGetRawILModule: unit -> ILModuleDef option
+    abstract ILModuleDef: unit -> ILModuleDef option
     abstract HasAnyFSharpSignatureDataAttribute: bool
     abstract HasMatchingFSharpSignatureDataAttribute: ILGlobals -> bool
     ///  The raw F# signature data in the assembly, if any

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -145,7 +145,7 @@ type IRawFSharpAssemblyData =
     abstract GetInternalsVisibleToAttributes: ILGlobals  -> string list
     ///  The raw IL module definition in the assembly, if any. This is not present for cross-project references
     /// in the language service
-    abstract ILModuleDef: unit -> ILModuleDef option
+    abstract TryGetILModuleDef: unit -> ILModuleDef option
     abstract HasAnyFSharpSignatureDataAttribute: bool
     abstract HasMatchingFSharpSignatureDataAttribute: ILGlobals -> bool
     ///  The raw F# signature data in the assembly, if any

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -851,16 +851,16 @@ let testFlag tcConfigB =
 let vsSpecificFlags (tcConfigB: TcConfigBuilder) = 
   [ CompilerOption("vserrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.VSErrors), None, None)
     CompilerOption("validate-type-providers", tagNone, OptionUnit (id), None, None)  // preserved for compatibility's sake, no longer has any effect
-    CompilerOption("LCID", tagInt, OptionInt (fun _n -> ()), None, None)
+    CompilerOption("LCID", tagInt, OptionInt ignore, None, None)
     CompilerOption("flaterrors", tagNone, OptionUnit (fun () -> tcConfigB.flatErrors <- true), None, None) 
-    CompilerOption("sqmsessionguid", tagNone, OptionString (fun s -> tcConfigB.sqmSessionGuid <- try System.Guid(s) |> Some  with e -> None), None, None)
+    CompilerOption("sqmsessionguid", tagNone, OptionString ignore, None, None)
     CompilerOption("gccerrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.GccErrors), None, None) 
     CompilerOption("exename", tagNone, OptionString (fun s -> tcConfigB.exename <- Some(s)), None, None)
     CompilerOption("maxerrors", tagInt, OptionInt (fun n -> tcConfigB.maxErrors <- n), None, None) ]
 
 let internalFlags (tcConfigB:TcConfigBuilder) =
   [
-    CompilerOption("stamps", tagNone, OptionUnit (fun () -> ()), Some(InternalCommandLineOption("--stamps", rangeCmdArgs)), None)
+    CompilerOption("stamps", tagNone, OptionUnit ignore, Some(InternalCommandLineOption("--stamps", rangeCmdArgs)), None)
     CompilerOption("ranges", tagNone, OptionSet Tastops.DebugPrint.layoutRanges, Some(InternalCommandLineOption("--ranges", rangeCmdArgs)), None)  
     CompilerOption("terms" , tagNone, OptionUnit (fun () -> tcConfigB.showTerms <- true), Some(InternalCommandLineOption("--terms", rangeCmdArgs)), None)
     CompilerOption("termsfile" , tagNone, OptionUnit (fun () -> tcConfigB.writeTermsToFiles <- true), Some(InternalCommandLineOption("--termsfile", rangeCmdArgs)), None)

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1341,7 +1341,7 @@ module StaticLinker =
                       | ResolvedCcu ccu -> Some ccu
                       | UnresolvedCcu(_ccuName) -> None
 
-                  let modul = dllInfo.RawMetadata.TryGetRawILModule().Value
+                  let modul = dllInfo.RawMetadata.TryGetILModuleDef().Value
                   yield (ccu, dllInfo.ILScopeRef, modul), (ilAssemRef.Name, provAssemStaticLinkInfo)
               | None -> () ]
 
@@ -1967,7 +1967,7 @@ let main2a(Args (ctok, tcConfig, tcImports, frameworkTcImports: TcImports, tcGlo
     let metadataVersion = 
         match tcConfig.metadataVersion with
         | Some v -> v
-        | _ -> match (frameworkTcImports.DllTable.TryFind tcConfig.primaryAssembly.Name) with | Some ib -> ib.RawMetadata.TryGetRawILModule().Value.MetadataVersion | _ -> ""
+        | _ -> match (frameworkTcImports.DllTable.TryFind tcConfig.primaryAssembly.Name) with | Some ib -> ib.RawMetadata.TryGetILModuleDef().Value.MetadataVersion | _ -> ""
     let optimizedImpls, optimizationData, _ = ApplyAllOptimizations (tcConfig, tcGlobals, (LightweightTcValForUsingInBuildMethodCall tcGlobals), outfile, importMap, false, optEnv0, generatedCcu, typedImplFiles)
 
     AbortOnError(errorLogger, exiter)

--- a/src/fsharp/import.fs
+++ b/src/fsharp/import.fs
@@ -552,10 +552,10 @@ let ImportILAssemblyTypeForwarders (amap, m, exportedTypes:ILExportedTypesAndFor
   
 
 /// Import an IL assembly as a new TAST CCU
-let ImportILAssembly(amap:(unit -> ImportMap),m,auxModuleLoader,sref,sourceDir,filename,ilModule:ILModuleDef,invalidateCcu:IEvent<string>) = 
+let ImportILAssembly(amap:(unit -> ImportMap), m, auxModuleLoader, ilScopeRef, sourceDir, filename, ilModule:ILModuleDef, invalidateCcu:IEvent<string>) = 
         invalidateCcu |> ignore
         let aref =   
-            match sref with 
+            match ilScopeRef with 
             | ILScopeRef.Assembly aref -> aref 
             | _ -> error(InternalError("ImportILAssembly: cannot reference .NET netmodules directly, reference the containing assembly instead",m))
         let nm = aref.Name
@@ -568,13 +568,14 @@ let ImportILAssembly(amap:(unit -> ImportMap),m,auxModuleLoader,sref,sourceDir,f
             IsProviderGenerated = false
             ImportProvidedType = (fun ty -> ImportProvidedType (amap()) m ty)
 #endif
-            QualifiedName= Some sref.QualifiedName
-            Contents = NewCcuContents sref m nm mty 
-            ILScopeRef = sref
+            QualifiedName= Some ilScopeRef.QualifiedName
+            Contents = NewCcuContents ilScopeRef m nm mty 
+            ILScopeRef = ilScopeRef
             Stamp = newStamp()
             SourceCodeDirectory = sourceDir  // note: not an accurate value, but IL assemblies don't give us this information in any attributes. 
             FileName = filename
             MemberSignatureEquality= (fun ty1 ty2 -> Tastops.typeEquivAux EraseAll (amap()).g ty1 ty2)
+            TryGetILModuleDef = (fun () -> Some ilModule)
             TypeForwarders = 
                (match ilModule.Manifest with 
                 | None -> Map.empty

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1153,7 +1153,7 @@ type RawFSharpAssemblyDataBackedByLanguageService (tcConfig, tcGlobals, tcState:
     interface IRawFSharpAssemblyData with 
         member __.GetAutoOpenAttributes(_ilg) = autoOpenAttrs
         member __.GetInternalsVisibleToAttributes(_ilg) =  ivtAttrs
-        member __.ILModuleDef() = None
+        member __.TryGetILModuleDef() = None
         member __.GetRawFSharpSignatureData(_m, _ilShortAssemName, _filename) = sigData
         member __.GetRawFSharpOptimizationData(_m, _ilShortAssemName, _filename) = [ ]
         member __.GetRawTypeForwarders() = mkILExportedTypes []  // TODO: cross-project references with type forwarders

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1153,7 +1153,7 @@ type RawFSharpAssemblyDataBackedByLanguageService (tcConfig, tcGlobals, tcState:
     interface IRawFSharpAssemblyData with 
         member __.GetAutoOpenAttributes(_ilg) = autoOpenAttrs
         member __.GetInternalsVisibleToAttributes(_ilg) =  ivtAttrs
-        member __.TryGetRawILModule() = None
+        member __.ILModuleDef() = None
         member __.GetRawFSharpSignatureData(_m, _ilShortAssemName, _filename) = sigData
         member __.GetRawFSharpOptimizationData(_m, _ilShortAssemName, _filename) = [ ]
         member __.GetRawTypeForwarders() = mkILExportedTypes []  // TODO: cross-project references with type forwarders

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2173,11 +2173,22 @@ and FSharpAssemblySignature private (cenv, topAttribs: TypeChecker.TopAttribs op
         loop mtyp |> makeReadOnlyCollection
 
     member __.Attributes =
-        match topAttribs with
-        | None -> makeReadOnlyCollection []
-        | Some tA ->
-            tA.assemblyAttrs
-            |> List.map (fun a -> FSharpAttribute(cenv, AttribInfo.FSAttribInfo(cenv.g, a))) |> makeReadOnlyCollection
+        [ match optViewedCcu with 
+          | Some ccu -> 
+              if ccu.IsFSharp then
+                  for a in ccu.Contents.Attribs do 
+                      yield FSharpAttribute(cenv, FSAttribInfo (cenv.g, a))
+              else
+                  match ccu.TryGetILModuleDef() with 
+                  | None -> ()
+                  | Some ilModule -> 
+                      for a in AttribInfosOfIL cenv.g cenv.amap cenv.thisCcu.ILScopeRef range0 ilModule.CustomAttrs do
+                          yield FSharpAttribute(cenv, a)
+          | None -> 
+              match topAttribs with
+              | None -> ()
+              | Some tA -> for a in tA.assemblyAttrs do yield FSharpAttribute(cenv, AttribInfo.FSAttribInfo(cenv.g, a)) ]
+        |> makeReadOnlyCollection
 
     member __.FindEntityByPath path =
         let inline findNested name = function

--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -2175,15 +2175,18 @@ and FSharpAssemblySignature private (cenv, topAttribs: TypeChecker.TopAttribs op
     member __.Attributes =
         [ match optViewedCcu with 
           | Some ccu -> 
-              if ccu.IsFSharp then
-                  for a in ccu.Contents.Attribs do 
-                      yield FSharpAttribute(cenv, FSAttribInfo (cenv.g, a))
-              else
-                  match ccu.TryGetILModuleDef() with 
-                  | None -> ()
-                  | Some ilModule -> 
-                      for a in AttribInfosOfIL cenv.g cenv.amap cenv.thisCcu.ILScopeRef range0 ilModule.CustomAttrs do
-                          yield FSharpAttribute(cenv, a)
+                match ccu.TryGetILModuleDef() with 
+                | Some ilModule -> 
+                    match ilModule.Manifest with 
+                    | None -> ()
+                    | Some manifest -> 
+                        for a in AttribInfosOfIL cenv.g cenv.amap cenv.thisCcu.ILScopeRef range0 manifest.CustomAttrs do
+                            yield FSharpAttribute(cenv, a)
+                | None -> 
+                    // If no module is available, then look in the CCU contents. 
+                    if ccu.IsFSharp then
+                        for a in ccu.Contents.Attribs do 
+                            yield FSharpAttribute(cenv, FSAttribInfo (cenv.g, a))
           | None -> 
               match topAttribs with
               | None -> ()

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -3695,6 +3695,10 @@ and
       
       /// A helper function used to link method signatures using type equality. This is effectively a forward call to the type equality 
       /// logic in tastops.fs
+      TryGetILModuleDef: (unit -> ILModuleDef option) 
+      
+      /// A helper function used to link method signatures using type equality. This is effectively a forward call to the type equality 
+      /// logic in tastops.fs
       MemberSignatureEquality : (TType -> TType -> bool) 
       
       /// The table of .NET CLI type forwarders for this assembly
@@ -3764,6 +3768,9 @@ and CcuThunk =
 
     /// Holds the filename for the DLL, if any 
     member ccu.FileName            = ccu.Deref.FileName
+
+    /// Try to get the .NET Assembly, if known.  May not be present for `IsFSharp` for in-memory cross-project references
+    member ccu.TryGetILModuleDef()  = ccu.Deref.TryGetILModuleDef()
 
 #if !NO_EXTENSIONTYPING
     /// Is the CCu an EST injected assembly

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -4726,13 +4726,17 @@ let ``Test project37 typeof and arrays in attribute constructor arguments`` () =
     |> Seq.map (fun a -> a.AttributeType.CompiledName)
     |> Array.ofSeq |> shouldEqual [| "AttrTestAttribute"; "AttrTest2Attribute" |]
 
-    for a in wholeProjectResults.ProjectContext.GetReferencedAssemblies() do
-        if a.SimpleName = "mscorlib" then 
-            // check we get some attributes on mscorlib, we don't check which ones
-            shouldEqual (a.Contents.Attributes.Count > 0) true
-        if a.SimpleName = "FSharp.Core" then 
-            // check we get some attributes on mscorlib, we don't check which ones
-            shouldEqual (a.Contents.Attributes.Count > 0) true
+    wholeProjectResults.ProjectContext.GetReferencedAssemblies() 
+    |> Seq.find (fun a -> a.SimpleName = "mscorlib")
+    |> fun a -> 
+        printfn "Attributes found in mscorlib: %A" a.Contents.Attributes
+        shouldEqual (a.Contents.Attributes.Count > 0) true
+
+    wholeProjectResults.ProjectContext.GetReferencedAssemblies() 
+    |> Seq.find (fun a -> a.SimpleName = "FSharp.Core")
+    |> fun a -> 
+        printfn "Attributes found in FSharp.Core: %A" a.Contents.Attributes
+        shouldEqual (a.Contents.Attributes.Count > 0) true
 
 //-----------------------------------------------------------
 

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -4726,6 +4726,14 @@ let ``Test project37 typeof and arrays in attribute constructor arguments`` () =
     |> Seq.map (fun a -> a.AttributeType.CompiledName)
     |> Array.ofSeq |> shouldEqual [| "AttrTestAttribute"; "AttrTest2Attribute" |]
 
+    for a in wholeProjectResults.ProjectContext.GetReferencedAssemblies() do
+        if a.SimpleName = "mscorlib" then 
+            // check we get some attributes on mscorlib, we don't check which ones
+            shouldEqual (a.Contents.Attributes.Count > 0) true
+        if a.SimpleName = "FSharp.Core" then 
+            // check we get some attributes on mscorlib, we don't check which ones
+            shouldEqual (a.Contents.Attributes.Count > 0) true
+
 //-----------------------------------------------------------
 
 


### PR DESCRIPTION
Fixes #4604 = assembly level attributes aren't returned by FCS

Needed for FCS <-> Roslyn bridge being developed by @nosami, and in turn needed by the the Xamarin Android designer.


