### PR TITLE
[Complete] Make enum pattern matches print field names

### DIFF
--- a/src/fsharp/NicePrint.fs
+++ b/src/fsharp/NicePrint.fs
@@ -1923,6 +1923,8 @@ module private PrintData =
             let fields = tc.TrueInstanceFieldsAsList
             let lay fs x = (wordL (tagRecordField fs.rfield_id.idText) ^^ sepL (tagPunctuation "=")) --- (dataExprL denv x)
             leftL (tagPunctuation "{") ^^ semiListL (List.map2 lay fields xs) ^^ rightL (tagPunctuation "}")
+        | Expr.Op (TOp.ValFieldGet (RecdFieldRef.RFRef (tcref, name)), _, _, _) ->
+            (layoutTyconRef denv tcref) ^^ sepL (tagPunctuation ".") ^^ wordL (tagField name)
         | Expr.Op (TOp.Array,[_],xs,_)                 -> leftL (tagPunctuation "[|") ^^ semiListL (dataExprsL denv xs) ^^ RightL.rightBracketBar
         | _ -> wordL (tagPunctuation "?")
     and private dataExprsL denv xs = List.map (dataExprL denv) xs

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -694,8 +694,7 @@ let CompilePatternBasic
     // Note the input expression has already been evaluated and saved into a variable.
     // Hence no need for a new sequence point.
     let mbuilder = new MatchBuilder(NoSequencePointAtInvisibleBinding,exprm)
-    clausesL |> List.iteri (fun _i c -> mbuilder.AddTarget c.Target |> ignore) 
-    //clausesL |> List.iter (printfn "%A")
+    clausesL |> List.iteri (fun _i c -> mbuilder.AddTarget c.Target |> ignore)
     
     // Add the incomplete or rethrow match clause on demand, printing a 
     // warning if necessary (only if it is ever exercised) 

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -233,8 +233,6 @@ let RefuteDiscrimSet g m path discrims =
                       | _ -> 
                           raise CannotRefute) 
             
-            (* REVIEW: we could return a better enumeration literal field here if a field matches one of the enumeration cases *)
-
             match c' with 
             | None -> raise CannotRefute
             | Some c ->

--- a/tests/fsharp/typecheck/sigs/neg102.bsl
+++ b/tests/fsharp/typecheck/sigs/neg102.bsl
@@ -1,10 +1,14 @@
 
-neg102.fs(8,14,8,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'enum<EnumAB> (1)' may indicate a case not covered by the pattern(s).
+neg102.fs(9,14,9,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).
 
-neg102.fs(11,14,11,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).
+neg102.fs(12,14,12,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).
 
-neg102.fs(14,14,14,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).
+neg102.fs(15,14,15,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'EnumABC.B' may indicate a case not covered by the pattern(s).
 
-neg102.fs(20,14,20,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<EnumAB> (2)' may indicate a case not covered by the pattern(s).
+neg102.fs(18,14,18,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'EnumABC.C' may indicate a case not covered by the pattern(s).
 
-neg102.fs(24,14,24,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'Some (enum<EnumAB> (2))' may indicate a case not covered by the pattern(s).
+neg102.fs(22,14,22,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'Some (EnumABC.C)' may indicate a case not covered by the pattern(s).
+
+neg102.fs(29,14,29,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<EnumABC> (2)' may indicate a case not covered by the pattern(s).
+
+neg102.fs(34,14,34,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'Some (enum<EnumABC> (2))' may indicate a case not covered by the pattern(s).

--- a/tests/fsharp/typecheck/sigs/neg102.fs
+++ b/tests/fsharp/typecheck/sigs/neg102.fs
@@ -1,27 +1,38 @@
 module M
-type EnumAB = A = 0 | B = 1
+type EnumABC = A = 0 | B = 1 | C = 42
 type UnionAB = A | B
 
 module FS0025 =
     // All of these should emit warning FS0025 ("Incomplete pattern match....")
         
-    let f1 = function
-        | EnumAB.A -> "A"
 
-    let f2 = function
+    let f1 = function
         | UnionAB.A -> "A"
 
+    let f2 = function
+        | 42 -> "forty-two"
+
     let f3 = function
-        | 42 -> "forty-two"        
+        | EnumABC.A -> "A"
+    
+    let f4 = function
+        | EnumABC.A -> "A"
+        | EnumABC.B -> "B"
+
+    let f5 = function
+        | Some(EnumABC.A) | Some(EnumABC.B) -> "A|B"
+        | None -> "neither"
 
 module FS0104 =
     // These should emit warning FS0104 ("Enums may take values outside of known cases....")
 
     let f1 = function
-        | EnumAB.A -> "A"
-        | EnumAB.B -> "B"
+        | EnumABC.A -> "A"
+        | EnumABC.B -> "B"
+        | EnumABC.C -> "C"
 
     let f2 = function
-        | Some(EnumAB.A) -> "A"
-        | Some(EnumAB.B) -> "B"
+        | Some(EnumABC.A) -> "A"
+        | Some(EnumABC.B) -> "B"
+        | Some(EnumABC.C) -> "C"
         | None -> "none"

--- a/tests/fsharpqa/Source/Conformance/PatternMatching/Expression/W_CounterExampleWithEnum02.fs
+++ b/tests/fsharpqa/Source/Conformance/PatternMatching/Expression/W_CounterExampleWithEnum02.fs
@@ -1,11 +1,11 @@
 // #Regression #Conformance #PatternMatching 
 // Regression test for DevDiv:198999 ("Warning messages for incomplete matches involving enum types are wrong")
 //<Expects status="warning" span="(14,10-14,18)" id="FS0104">Enums may take values outside known cases\. For example, the value 'enum<T> \(2\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
-//<Expects status="warning" span="(18,10-18,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(1\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
-//<Expects status="warning" span="(21,10-21,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(1\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
-//<Expects status="warning" span="(24,10-24,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(1\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
-//<Expects status="warning" span="(27,10-27,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(1\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
-//<Expects status="warning" span="(30,10-30,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'enum<T> \(1\)' may indicate a case not covered by the pattern\(s\)\.$</Expects>
+//<Expects status="warning" span="(18,10-18,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'T.Y' may indicate a case not covered by the pattern\(s\)\.$</Expects>
+//<Expects status="warning" span="(21,10-21,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'T.Y' may indicate a case not covered by the pattern\(s\)\.$</Expects>
+//<Expects status="warning" span="(24,10-24,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'T.Y' may indicate a case not covered by the pattern\(s\)\.$</Expects>
+//<Expects status="warning" span="(27,10-27,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'T.Y' may indicate a case not covered by the pattern\(s\)\.$</Expects>
+//<Expects status="warning" span="(30,10-30,18)" id="FS0025">Incomplete pattern matches on this expression\. For example, the value 'T.Y' may indicate a case not covered by the pattern\(s\)\.$</Expects>
 
 module M
 


### PR DESCRIPTION
Proposed implementation of suggestion [#654](https://github.com/fsharp/fslang-suggestions/issues/654)

I've changed the F# incomplete pattern match warning to spit out the actual names of enum fields when possible, still falling back to the usual `enum<XYZ> 1` when necessary. With this change, this code:

```fsharp
type MyEnum = | A = 0 | B = 1 | C = 42
let f = function | A -> "foo"
```

now produces a more detailed warning:

```
warning FS0025: Incomplete pattern matches on this expression. For example, the value 'MyEnum.B' may indicate a case not covered by the pattern(s).
```

This also works when MyEnum.C is the incomplete case.