### PR TITLE
Remove duplicate illex.fsl include

### DIFF
--- a/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -278,10 +278,6 @@
     <Compile Include="$(FSharpSourcesRoot)/ilx/EraseUnions.fs">
       <Link>ILXErase/EraseUnions.fs</Link>
     </Compile>
-    <FsLex Include="$(FSharpSourcesRoot)\absil\illex.fsl">
-      <OtherFlags>--unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
-      <Link>AbsIL/illex.fsl</Link>
-    </FsLex>
     <FsLex Include="$(FSharpSourcesRoot)\fsharp\lex.fsl">
       <OtherFlags>--unicode --lexlib Internal.Utilities.Text.Lexing</OtherFlags>
       <Link>ParserAndUntypedAST/lex.fsl</Link>


### PR DESCRIPTION
While looking at https://github.com/Microsoft/visualfsharp/issues/4608, I've found that `illex.fsl` is included twice in FSharp.Compiler.Service project (FSharp.Compiler.Private doesn't have the second include).