### PR TITLE
Fix FCS problem with duplicate  ByteFile

### DIFF
--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -6,7 +6,7 @@
   <Import Project="..\netfx.props" />
   <PropertyGroup>
     <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);44;</NoWarn>
+    <NoWarn>$(NoWarn);44;75;</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>

--- a/fcs/README.md
+++ b/fcs/README.md
@@ -60,9 +60,9 @@ which does things like:
 Yu can push the packages if you have permissions, either automatically using ``build Release`` or manually
 
     set APIKEY=...
-    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.22.0.1.nupkg %APIKEY% -Source https://nuget.org 
-    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.MSBuild.v12.22.0.1.nupkg %APIKEY%  -Source https://nuget.org
-    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.ProjectCracker.22.0.1.nupkg %APIKEY%  -Source https://nuget.org
+    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.22.0.2.nupkg %APIKEY% -Source https://nuget.org 
+    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.MSBuild.v12.22.0.2.nupkg %APIKEY%  -Source https://nuget.org
+    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.ProjectCracker.22.0.2.nupkg %APIKEY%  -Source https://nuget.org
     
 
 ### Use of Paket and FAKE

--- a/fcs/README.md
+++ b/fcs/README.md
@@ -60,9 +60,9 @@ which does things like:
 Yu can push the packages if you have permissions, either automatically using ``build Release`` or manually
 
     set APIKEY=...
-    .nuget\nuget.exe push release\fcs\FSharp.Compiler.Service.21.0.1.nupkg %APIKEY% -Source https://nuget.org 
-    .nuget\nuget.exe push release\fcs\FSharp.Compiler.Service.MSBuild.v12.21.0.1.nupkg %APIKEY%  -Source https://nuget.org
-    .nuget\nuget.exe push release\fcs\FSharp.Compiler.Service.ProjectCracker.21.0.1.nupkg %APIKEY%  -Source https://nuget.org
+    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.22.0.1.nupkg %APIKEY% -Source https://nuget.org 
+    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.MSBuild.v12.22.0.1.nupkg %APIKEY%  -Source https://nuget.org
+    ..\fsharp\.nuget\nuget.exe push %HOMEDRIVE%%HOMEPATH%\Downloads\FSharp.Compiler.Service.ProjectCracker.22.0.1.nupkg %APIKEY%  -Source https://nuget.org
     
 
 ### Use of Paket and FAKE

--- a/fcs/RELEASE_NOTES.md
+++ b/fcs/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 22.0.2
+  * Use correct version number in DLLs (needed until https://github.com/Microsoft/visualfsharp/issues/3113 is fixed)
+
+#### 22.0.1
+  * Integrate visualfsharp master
+  * Includes recent memory usage reduction work for ByteFile and ILAttributes
+
 #### 21.0.1
   * Use new .NET SDK project files
   * FSharp.Compiler.Service nuget now uses net45 and netstandard2.0

--- a/fcs/fcs.props
+++ b/fcs/fcs.props
@@ -3,7 +3,12 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
 
+<<<<<<< HEAD
     <VersionPrefix>21.0.1</VersionPrefix>
+=======
+    <VersionPrefix>22.0.2</VersionPrefix>
+    <OtherFlags>--version:$(VersionPrefix)</OtherFlags>
+>>>>>>> 4c1e73e3d... use explicit version flag until https://github.com/Microsoft/visualfsharp/issues/3113 is fixed
     <!-- FSharp.Compiler.Tools is currently only used to get a working FSI.EXE to execute some scripts during the build -->
     <!-- The LKG FSI.EXE requires MSBuild 15 to be installed, which is painful -->
     <FsiToolPath>$(FSharpSourcesRoot)\..\packages\FSharp.Compiler.Tools.4.1.27\tools</FsiToolPath>

--- a/fcs/fcs.props
+++ b/fcs/fcs.props
@@ -3,12 +3,8 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
 
-<<<<<<< HEAD
-    <VersionPrefix>21.0.1</VersionPrefix>
-=======
     <VersionPrefix>22.0.2</VersionPrefix>
     <OtherFlags>--version:$(VersionPrefix)</OtherFlags>
->>>>>>> 4c1e73e3d... use explicit version flag until https://github.com/Microsoft/visualfsharp/issues/3113 is fixed
     <!-- FSharp.Compiler.Tools is currently only used to get a working FSI.EXE to execute some scripts during the build -->
     <!-- The LKG FSI.EXE requires MSBuild 15 to be installed, which is painful -->
     <FsiToolPath>$(FSharpSourcesRoot)\..\packages\FSharp.Compiler.Tools.4.1.27\tools</FsiToolPath>

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -359,11 +359,11 @@ type WeakByteFile(fileName: string, chunk: (int * int) option) =
     member __.FileName = fileName
 
     /// Get the bytes for the file
-    member this.Get() =
+    member __.Get() =
         let mutable tg = null
         if not (weakBytes.TryGetTarget(&tg)) then 
             if FileSystem.GetLastWriteTimeShim(fileName) <> fileStamp then 
-               errorR (Error (FSComp.SR.ilreadFileChanged fileName, range0))
+                error (Error (FSComp.SR.ilreadFileChanged fileName, range0))
 
             let bytes = 
                 match chunk with 
@@ -373,6 +373,7 @@ type WeakByteFile(fileName: string, chunk: (int * int) option) =
             tg <- bytes
 
             weakBytes.SetTarget tg
+
         tg
 
     interface BinaryFile with

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -37,7 +37,7 @@ let _ = if checking then dprintn "warning : ILBinaryReader.checking is on"
 let noStableFileHeuristic = try (System.Environment.GetEnvironmentVariable("FSharp_NoStableFileHeuristic") <> null) with _ -> false
 let alwaysMemoryMapFSC = try (System.Environment.GetEnvironmentVariable("FSharp_AlwaysMemoryMapCommandLineCompiler") <> null) with _ -> false
 let stronglyHeldReaderCacheSizeDefault = 30
-let stronglyHeldReaderCacheSize = try match System.Environment.GetEnvironmentVariable("FSharp_StronglyHeldBinaryReaderCacheSize") with null -> stronglyHeldReaderCacheSizeDefault | s -> int32 s with _ -> stronglyHeldReaderCacheSizeDefault
+let stronglyHeldReaderCacheSize = try (match System.Environment.GetEnvironmentVariable("FSharp_StronglyHeldBinaryReaderCacheSize") with null -> stronglyHeldReaderCacheSizeDefault | s -> int32 s) with _ -> stronglyHeldReaderCacheSizeDefault
 
 let singleOfBits (x:int32) = System.BitConverter.ToSingle(System.BitConverter.GetBytes(x), 0)
 let doubleOfBits (x:int64) = System.BitConverter.Int64BitsToDouble(x)


### PR DESCRIPTION
We had a report that too many duplicate ByteFile objects are still being created when FCS is used (e.g. in Ionide and Rider), despite #4586

This is because the default FCS configuration for reading memory is to use a ByteFile for the metadata section of metadata-only binaries.  This can be a WeakByteFile to reduce memory usage.

Also the strongly-held cache was set to zero - now that binary readers are more memory efficient and release resources by default we can increase this to a non-zero default.

The screen shot that convinced me this is a problem is from @AviAvni below

![image](https://user-images.githubusercontent.com/7204669/37974737-86c1f86e-31d5-11e8-9017-a2fd6c42814c.png)
