### PR TITLE
Do not check assembly symbols equality by DefinitionRange and name

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1337,7 +1337,7 @@ let tyconRefDefnEq g (eref1:EntityRef) (eref2: EntityRef) =
     tyconRefEq g eref1 eref2 || 
 
     // Signature items considered equal to implementation items
-    eref1.DefinitionRange <> Range.rangeStartup &&
+    eref1.DefinitionRange <> Range.rangeStartup && eref1.DefinitionRange <> Range.range0 && eref1.DefinitionRange <> Range.rangeCmdArgs &&
     (eref1.DefinitionRange = eref2.DefinitionRange || eref1.SigRange = eref2.SigRange) &&
     eref1.LogicalName = eref2.LogicalName
 
@@ -1348,7 +1348,7 @@ let valRefDefnEq g (vref1:ValRef) (vref2: ValRef) =
     valRefEq g vref1 vref2 ||
 
     // Signature items considered equal to implementation items
-    vref1.DefinitionRange <> Range.rangeStartup &&
+    vref1.DefinitionRange <> Range.rangeStartup && vref1.DefinitionRange <> Range.range0 && vref1.DefinitionRange <> Range.rangeCmdArgs &&
     (vref1.DefinitionRange = vref2.DefinitionRange || vref1.SigRange = vref2.SigRange) && 
     vref1.LogicalName = vref2.LogicalName
 

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -1334,19 +1334,23 @@ let tyconRefDefnHash (_g: TcGlobals) (eref1:EntityRef) =
     hash eref1.LogicalName 
 
 let tyconRefDefnEq g (eref1:EntityRef) (eref2: EntityRef) =
-    tyconRefEq g eref1 eref2 
-    // Signature items considered equal to implementation items
-    || ((eref1.DefinitionRange = eref2.DefinitionRange || eref1.SigRange = eref2.SigRange) &&
-        (eref1.LogicalName = eref2.LogicalName))
+    tyconRefEq g eref1 eref2 || 
 
-let valRefDefnHash (_g: TcGlobals) (vref1:ValRef)=
+    // Signature items considered equal to implementation items
+    eref1.DefinitionRange <> Range.rangeStartup &&
+    (eref1.DefinitionRange = eref2.DefinitionRange || eref1.SigRange = eref2.SigRange) &&
+    eref1.LogicalName = eref2.LogicalName
+
+let valRefDefnHash (_g: TcGlobals) (vref1:ValRef) =
     hash vref1.DisplayName
 
 let valRefDefnEq g (vref1:ValRef) (vref2: ValRef) =
-    valRefEq g vref1 vref2 
+    valRefEq g vref1 vref2 ||
+
     // Signature items considered equal to implementation items
-    || ((vref1.DefinitionRange = vref2.DefinitionRange || vref1.SigRange = vref2.SigRange)) && 
-        (vref1.LogicalName = vref2.LogicalName)
+    vref1.DefinitionRange <> Range.rangeStartup &&
+    (vref1.DefinitionRange = vref2.DefinitionRange || vref1.SigRange = vref2.SigRange) && 
+    vref1.LogicalName = vref2.LogicalName
 
 let unionCaseRefDefnEq g (uc1:UnionCaseRef) (uc2: UnionCaseRef) =
     uc1.CaseName = uc2.CaseName && tyconRefDefnEq g uc1.TyconRef uc2.TyconRef

--- a/tests/service/CSharpProjectAnalysis.fs
+++ b/tests/service/CSharpProjectAnalysis.fs
@@ -146,3 +146,47 @@ let _ = CSharpClass(0)
         Seq.exists (fun (mfv : FSharpMemberOrFunctionOrValue) -> mfv.IsEffectivelySameAs ctor) members |> should be True
     | None -> failwith "Expected Some for DeclaringEntity"
 
+let getEntitiesUses source =
+    let csharpAssembly = PathRelativeToTestAssembly "CSharp_Analysis.dll"
+    let results, _ = getProjectReferences(source, [csharpAssembly], None, None)
+    results.GetAllUsesOfAllSymbols()
+    |> Async.RunSynchronously
+    |> Seq.choose (fun su ->
+        match su.Symbol with
+        | :? FSharpEntity as entity -> Some entity
+        | _ -> None)
+    |> List.ofSeq
+
+[<Test>]
+let ``Different types with the same short name equality check`` () =
+    let source = """
+module CtorTest
+
+let (s1: System.String) = null
+let (s2: FSharp.Compiler.Service.Tests.String) = null
+"""
+
+    let stringSymbols =
+        getEntitiesUses source
+        |> List.filter (fun entity -> entity.LogicalName = "String")
+
+    match stringSymbols with
+    | e1 :: e2 :: [] -> e1.IsEffectivelySameAs(e2) |> should be False
+    | _ -> sprintf "Expecting two symbols, got %A" stringSymbols |> failwith
+
+[<Test>]
+let ``Different namespaces with the same short name equality check`` () =
+    let source = """
+module CtorTest
+
+open System.Linq
+open FSharp.Compiler.Service.Tests.Linq
+"""
+
+    let stringSymbols =
+        getEntitiesUses source
+        |> List.filter (fun entity -> entity.LogicalName = "Linq")
+
+    match stringSymbols with
+    | e1 :: e2 :: [] -> e1.IsEffectivelySameAs(e2) |> should be False
+    | _ -> sprintf "Expecting two symbols, got %A" stringSymbols |> failwith

--- a/tests/service/CSharpProjectAnalysis.fs
+++ b/tests/service/CSharpProjectAnalysis.fs
@@ -158,6 +158,9 @@ let getEntitiesUses source =
     |> List.ofSeq
 
 [<Test>]
+#if NETCOREAPP2_0
+[<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
+#endif
 let ``Different types with the same short name equality check`` () =
     let source = """
 module CtorTest
@@ -175,6 +178,9 @@ let (s2: FSharp.Compiler.Service.Tests.String) = null
     | _ -> sprintf "Expecting two symbols, got %A" stringSymbols |> failwith
 
 [<Test>]
+#if NETCOREAPP2_0
+[<Ignore("SKIPPED: need to check if these tests can be enabled for .NET Core testing of FSharp.Compiler.Service")>]
+#endif
 let ``Different namespaces with the same short name equality check`` () =
     let source = """
 module CtorTest

--- a/tests/service/data/CSharp_Analysis/CSharpClass.cs
+++ b/tests/service/data/CSharp_Analysis/CSharpClass.cs
@@ -126,4 +126,14 @@ namespace FSharp.Compiler.Service.Tests
         }
     }
 
+    public class String
+    {
+    }
+
+    namespace Linq
+    {
+        public class DummyClass
+        {
+        }
+    }
 }


### PR DESCRIPTION
Currently, assembly symbols have `startup` definition range and are considered equal when `LogicalName` equals.
We should not check this range for assembly symbols, as a proper check is done just before.
Fixes #4658.