### PR TITLE
[Experiment] Compound open statement

### DIFF
--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -288,7 +288,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <Ast.SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
 %type <Ast.LongIdentWithDots list> openDecl
 %type <Ast.LongIdentWithDots> path
-%type <Ast.Ident list> commaSeparatedPaths
+%type <Ast.LongIdentWithDots list> commaSeparatedPaths
 %type <Ast.LongIdentWithDots list> multiPath
 %type <Ast.LongIdentWithDots> pathOp
 /*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
@@ -4729,13 +4729,13 @@ path:
        let (LongIdentWithDots(lid,dotms)) = $1 in LongIdentWithDots(lid, dotms @ [rhs parseState 2])  } 
 
 commaSeparatedPaths:
-  | ident { [$1] }
-  | ident COMMA commaSeparatedPaths { $1 :: $3 }
+  | path { [$1] }
+  | path COMMA commaSeparatedPaths { $1 :: $3 }
 
 multiPath:
   | path DOT LPAREN commaSeparatedPaths rparen
     { let (LongIdentWithDots(lid,dotms)) = $1
-      List.map (fun p -> LongIdentWithDots(lid @ [p], dotms @ [rhs parseState 2])) $4 }
+      List.map (fun (p: LongIdentWithDots) -> LongIdentWithDots(lid @ p.Lid, dotms @ [rhs parseState 2])) $4 }
     
 /* An operator name, with surrounnding parentheses */
 opName: 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -286,8 +286,10 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <Ast.SynExceptionDefn> exconDefn
 %type <Ast.SynExceptionDefnRepr> exconCore
 %type <Ast.SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
-%type <Ast.LongIdentWithDots> openDecl
+%type <Ast.LongIdentWithDots list> openDecl
 %type <Ast.LongIdentWithDots> path
+%type <Ast.Ident list> commaSeparatedPaths
+%type <Ast.LongIdentWithDots list> multiPath
 %type <Ast.LongIdentWithDots> pathOp
 /*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
 %type <range * range option * bool     * Ast.SynType list * range list * range> typeArgsActual
@@ -721,8 +723,10 @@ moduleSpfns:
      { (* silent recovery *) $3 }
 
   | moduleSpfn  opt_topSeparators 
-     { [$1] } 
+     { [$1] }
 
+  | OPEN multiPath opt_topSeparators moduleSpfns 
+      { (List.map (fun (p: Ast.LongIdentWithDots) -> SynModuleSigDecl.Open(p.Lid, p.Range)) $2) @ $4 }
 
 moduleSpfn: 
   | hashDirective 
@@ -1257,8 +1261,7 @@ moduleDefn:
 
   /* 'open' declarations */
   | openDecl 
-      { [SynModuleDecl.Open($1, $1.Range)] }
-
+      { List.map (fun p -> SynModuleDecl.Open(p, p.Range)) $1 }
 
 /* The right-hand-side of a module abbreviation definition */ 
 /* This occurs on the right of a module abbreviation (#light encloses the r.h.s. with OBLOCKBEGIN/OBLOCKEND) */
@@ -2355,8 +2358,8 @@ exconRepr:
   | EQUALS path { Some ($2.Lid) }
 
 openDecl:  
-  | OPEN path { $2 }
-
+  | OPEN path { [$2] }
+  | OPEN multiPath { $2 }
 
 /*-------------------------------------------------------------------------*/
 /* F# Definitions and Expressions  */
@@ -4725,7 +4728,15 @@ path:
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedNameAfterToken())
        let (LongIdentWithDots(lid,dotms)) = $1 in LongIdentWithDots(lid, dotms @ [rhs parseState 2])  } 
 
+commaSeparatedPaths:
+  | ident { [$1] }
+  | ident COMMA commaSeparatedPaths { $1 :: $3 }
 
+multiPath:
+  | path DOT LPAREN commaSeparatedPaths rparen
+    { let (LongIdentWithDots(lid,dotms)) = $1
+      List.map (fun p -> LongIdentWithDots(lid @ [p], dotms @ [rhs parseState 2])) $4 }
+    
 /* An operator name, with surrounnding parentheses */
 opName: 
   | LPAREN operatorName rparen  

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -4731,6 +4731,13 @@ path:
 commaSeparatedPaths:
   | path { [$1] }
   | path COMMA commaSeparatedPaths { $1 :: $3 }
+  | path DOT LPAREN commaSeparatedPaths rparen
+  { let (LongIdentWithDots(lid,dotms)) = $1
+    List.map (fun (p: LongIdentWithDots) -> LongIdentWithDots(lid @ p.Lid, dotms @ [rhs parseState 2])) $4 }
+  | path DOT LPAREN commaSeparatedPaths rparen COMMA commaSeparatedPaths
+  { let (LongIdentWithDots(lid,dotms)) = $1
+    let subpaths = List.map (fun (p: LongIdentWithDots) -> LongIdentWithDots(lid @ p.Lid, dotms @ [rhs parseState 2])) $4
+    List.append subpaths $7 }
 
 multiPath:
   | path DOT LPAREN commaSeparatedPaths rparen

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -288,7 +288,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <Ast.SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
 %type <Ast.LongIdentWithDots list> openDecl
 %type <Ast.LongIdentWithDots> path
-%type <Ast.LongIdentWithDots list> commaSeparatedPaths
+%type <Ast.LongIdentWithDots option list> commaSeparatedPaths
 %type <Ast.LongIdentWithDots list> multiPath
 %type <Ast.LongIdentWithDots> pathOp
 /*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
@@ -4729,13 +4729,15 @@ path:
        let (LongIdentWithDots(lid,dotms)) = $1 in LongIdentWithDots(lid, dotms @ [rhs parseState 2])  } 
 
 commaSeparatedPaths:
-  | path { [$1] }
-  | path COMMA commaSeparatedPaths { $1 :: $3 }
+  | path { [Some $1] }
+  | path COMMA commaSeparatedPaths { Some $1 :: $3 }
+  | UNDERSCORE { [None] }
+  | UNDERSCORE COMMA commaSeparatedPaths { None :: $3 }
 
 multiPath:
   | path DOT LPAREN commaSeparatedPaths rparen
-    { let (LongIdentWithDots(lid,dotms)) = $1
-      List.map (fun (p: LongIdentWithDots) -> LongIdentWithDots(lid @ p.Lid, dotms @ [rhs parseState 2])) $4 }
+    { let (LongIdentWithDots(lid,dotms)) = $1      
+      List.map (function None -> $1 | Some(LongIdentWithDots(lid',_)) -> LongIdentWithDots(lid @ lid', dotms @ [rhs parseState 2])) $4 }
     
 /* An operator name, with surrounnding parentheses */
 opName: 

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -288,7 +288,7 @@ let rangeOfLongIdent(lid:LongIdent) =
 %type <Ast.SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
 %type <Ast.LongIdentWithDots list> openDecl
 %type <Ast.LongIdentWithDots> path
-%type <Ast.LongIdentWithDots option list> commaSeparatedPaths
+%type <Ast.LongIdentWithDots list> commaSeparatedPaths
 %type <Ast.LongIdentWithDots list> multiPath
 %type <Ast.LongIdentWithDots> pathOp
 /*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
@@ -4729,15 +4729,13 @@ path:
        let (LongIdentWithDots(lid,dotms)) = $1 in LongIdentWithDots(lid, dotms @ [rhs parseState 2])  } 
 
 commaSeparatedPaths:
-  | path { [Some $1] }
-  | path COMMA commaSeparatedPaths { Some $1 :: $3 }
-  | UNDERSCORE { [None] }
-  | UNDERSCORE COMMA commaSeparatedPaths { None :: $3 }
+  | path { [$1] }
+  | path COMMA commaSeparatedPaths { $1 :: $3 }
 
 multiPath:
   | path DOT LPAREN commaSeparatedPaths rparen
-    { let (LongIdentWithDots(lid,dotms)) = $1      
-      List.map (function None -> $1 | Some(LongIdentWithDots(lid',_)) -> LongIdentWithDots(lid @ lid', dotms @ [rhs parseState 2])) $4 }
+    { let (LongIdentWithDots(lid,dotms)) = $1
+      List.map (fun (p: LongIdentWithDots) -> LongIdentWithDots(lid @ p.Lid, dotms @ [rhs parseState 2])) $4 }
     
 /* An operator name, with surrounnding parentheses */
 opName: 


### PR DESCRIPTION
Here is a patch to the parser to allow compound open statements.

This is how it works:

```
Microsoft (R) F# Interactive version 10.1.0 for F# 4.1
Copyright (c) Microsoft Corporation. All Rights Reserved.

For help type #help;;

> open System.(_, Collections.Generic, Text);;
> Console.WriteLine(ASCIIEncoding().BodyName);;
us-ascii
val it : unit = ()
```

With this change, namespaces with the same prefix can be grouped together, and a special case for `_` is there for importing the base namespace as well.

For example, `open System.(_, Collections.Generic, Text)` expands into
```F#
open System
open System.Collections.Generic
open System.Text
```

I'm open to suggestions and other modifications.

Thanks to @lambdageek for helping me to craft this patch.
