### PR TITLE
combine support for `PB_PackageVersionPropsUrl` and `DotNetPackageVersionPropsPath`

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -664,6 +664,9 @@ if not "%PB_PackageVersionPropsUrl%" == "" (
     :: restore dependencies
     %_nugetexe% restore !dependencyUptakeDir!\packages.config -PackagesDirectory packages -ConfigFile !dependencyUptakeDir!\NuGet.config
     if ERRORLEVEL 1 echo Error restoring dependency uptake packages && goto :failure
+
+    :: set DotNetPackageVersionPropsPath
+    set DotNetPackageVersionPropsPath=!dependencyUptakeDir!\PackageVersions.props
 )
 
 set _fsiexe="packages\FSharp.Compiler.Tools.4.1.27\tools\fsi.exe"

--- a/build/targets/PackageVersions.props
+++ b/build/targets/PackageVersions.props
@@ -58,10 +58,6 @@
   </PropertyGroup>
 
   <!-- dependency uptake version overrides -->
-  <PropertyGroup>
-    <DependencyUptakePackageVersionPropsFile>$(MSBuildThisFileDirectory)..\..\Tools\dependencyUptake\PackageVersions.props</DependencyUptakePackageVersionPropsFile>
-  </PropertyGroup>
-
-  <Import Project="$(DependencyUptakePackageVersionPropsFile)" Condition="Exists('$(DependencyUptakePackageVersionPropsFile)')" />
+  <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != '' AND Exists('$(DotNetPackageVersionPropsPath)')" />
 
 </Project>


### PR DESCRIPTION
This is essentially a port of #4674 to `master`.

Following other repos' pattern of downloading `PB_PackageVersionPropsUrl` and directly setting `DotNetPackageVersionPropsPath` to simplify the logic.