### PR TITLE
Reduced allocation by reading from a stream into an array for ILResource

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -8,6 +8,7 @@ module Microsoft.FSharp.Compiler.AbstractIL.IL
 
 
 open System
+open System.IO
 open System.Collections
 open System.Collections.Generic
 open System.Collections.Concurrent
@@ -1986,11 +1987,7 @@ type ILResource =
     member r.GetBytes() = 
         match r.Location with
         | ILResourceLocation.LocalIn (file, start, len) -> 
-            let bytes = Array.zeroCreate len
-            use fileStream = FileSystem.FileStreamReadShim(file)
-            fileStream.Position <- int64 start
-            fileStream.Read(bytes, 0, len) |> ignore
-            bytes
+            File.ReadBinaryChunk(file, start, len)
         | ILResourceLocation.LocalOut bytes -> bytes
         | _ -> failwith "GetBytes"
 

--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -1986,7 +1986,11 @@ type ILResource =
     member r.GetBytes() = 
         match r.Location with
         | ILResourceLocation.LocalIn (file, start, len) -> 
-            FileSystem.ReadAllBytesShim(file).[start .. start + len - 1]
+            let bytes = Array.zeroCreate len
+            use fileStream = FileSystem.FileStreamReadShim(file)
+            fileStream.Position <- int64 start
+            fileStream.Read(bytes, 0, len) |> ignore
+            bytes
         | ILResourceLocation.LocalOut bytes -> bytes
         | _ -> failwith "GetBytes"
 

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -1291,7 +1291,7 @@ module Shim =
         static member ReadBinaryChunk (fileName, start, len) = 
             use stream = FileSystem.FileStreamReadShim fileName
             stream.Seek(int64 start, SeekOrigin.Begin) |> ignore
-            let buffer = Array.zeroCreate  len 
+            let buffer = Array.zeroCreate len 
             let mutable n = 0
             while n < len do 
                 n <- n + stream.Read(buffer, n, len-n)

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -149,7 +149,7 @@ type IRawFSharpAssemblyData =
     abstract HasAnyFSharpSignatureDataAttribute: bool
     abstract HasMatchingFSharpSignatureDataAttribute: ILGlobals -> bool
     ///  The raw F# signature data in the assembly, if any
-    abstract GetRawFSharpSignatureData: range * ilShortAssemName: string * fileName: string -> (string * byte[]) list
+    abstract GetRawFSharpSignatureData: range * ilShortAssemName: string * fileName: string -> (string * (unit -> byte[])) list
     ///  The raw F# optimization data in the assembly, if any
     abstract GetRawFSharpOptimizationData: range * ilShortAssemName: string * fileName: string -> (string * (unit -> byte[])) list
     ///  The table of type forwarders in the assembly

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1172,8 +1172,7 @@ type RawFSharpAssemblyDataBackedByLanguageService (tcConfig, tcGlobals, tcState:
         let _sigDataAttributes, sigDataResources = Driver.EncodeInterfaceData(tcConfig, tcGlobals, exportRemapping, generatedCcu, outfile, true)
         [ for r in sigDataResources  do
             let ccuName = GetSignatureDataResourceName r
-            let bytes = r.GetBytes()
-            yield (ccuName, bytes) ]
+            yield (ccuName, (fun () -> r.GetBytes())) ]
 
     let autoOpenAttrs = topAttrs.assemblyAttrs |> List.choose (List.singleton >> TryFindFSharpStringAttribute tcGlobals tcGlobals.attrib_AutoOpenAttribute)
     let ivtAttrs = topAttrs.assemblyAttrs |> List.choose (List.singleton >> TryFindFSharpStringAttribute tcGlobals tcGlobals.attrib_InternalsVisibleToAttribute)


### PR DESCRIPTION
This reduces allocation on LOH for getting the bytes from an ILResource. We could probably go further when allocating the byte array, but this is an easy win.

A little bit of stats here when opening VisualFSharp.sln.

The image below is without the changes. It shows 2.2% of all allocations was spent on reading all bytes from a file in ILResource, and putting those in the LOH. With the changes, this issue goes away.
![alloc_reduction1](https://user-images.githubusercontent.com/1278959/38388341-d891efea-38cf-11e8-9f04-77a7e7d1ff5f.png)

GC Time Paused without change: **33-35%**
GC Time Paused with changes: **26-29%**
