### PR TITLE
Fix QuickInfo links underline style

### DIFF
--- a/vsintegration/src/FSharp.UIResources/HyperlinkStyles.xaml
+++ b/vsintegration/src/FSharp.UIResources/HyperlinkStyles.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <SolidColorBrush x:Key="inherited_brush" Color="{Binding Path=Foreground.Color, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=TextBlock}}" />
-    <SolidColorBrush x:Key="inherited_semi_brush" Opacity="0.28" Color="{Binding Path=Foreground.Color, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=TextBlock}}" />
+    <SolidColorBrush x:Key="inherited_brush" Color="{Binding Path=Foreground.Color, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Underline}}" />
+    <SolidColorBrush x:Key="inherited_semi_brush" Opacity="0.28" Color="{Binding Path=Foreground.Color, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Underline}}" />
     <DashStyle x:Key="dash_dashstyle" Dashes="5 5"/>
     <DashStyle x:Key="dot_dashstyle" Dashes="1 5"/>
     <Pen x:Key="dot_pen" DashStyle="{StaticResource dot_dashstyle}" Brush="{StaticResource inherited_brush}"/>
@@ -20,23 +20,23 @@
     <TextDecorationCollection x:Key="full_deco">
         <TextDecoration PenOffset="1" Pen="{StaticResource mouseover_pen}" />
     </TextDecorationCollection>
-    <Style x:Key="base_sourcelink" TargetType="TextBlock" >
+    <Style x:Key="base_sourcelink" TargetType="Underline" >
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="TextDecorations" Value="{StaticResource full_deco}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
-    <Style x:Key="solid_underline" TargetType="TextBlock" BasedOn="{StaticResource base_sourcelink}">
+    <Style x:Key="solid_underline" TargetType="Underline" BasedOn="{StaticResource base_sourcelink}">
         <Setter Property="TextDecorations" Value="{StaticResource solid_deco}"/>
     </Style>
-    <Style x:Key="dash_underline" TargetType="TextBlock" BasedOn="{StaticResource base_sourcelink}">
+    <Style x:Key="dash_underline" TargetType="Underline" BasedOn="{StaticResource base_sourcelink}">
         <Setter Property="TextDecorations" Value="{StaticResource dash_deco}"/>
     </Style>
-    <Style x:Key="dot_underline" TargetType="TextBlock" BasedOn="{StaticResource base_sourcelink}">
+    <Style x:Key="dot_underline" TargetType="Underline" BasedOn="{StaticResource base_sourcelink}">
         <Setter Property="TextDecorations" Value="{StaticResource dot_deco}"/>
     </Style>
-    <Style x:Key="no_underline" TargetType="TextBlock" BasedOn="{StaticResource base_sourcelink}">
+    <Style x:Key="no_underline" TargetType="Underline" BasedOn="{StaticResource base_sourcelink}">
         <Setter Property="TextDecorations" Value="{x:Null}"/>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
This solves #4684, restoring previous look of Quickinfo navigable links.