### PR TITLE
Fix deadlock when invoking QuickInfo command. #4710

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/Vs.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Vs.fs
@@ -88,5 +88,4 @@ module internal ServiceProviderExtensions =
 
         member sp.TextManager = sp.GetService<SVsTextManager, IVsTextManager>()
         member sp.RunningDocumentTable = sp.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable>()
-        member sp.XmlService = sp.GetService<SVsXMLMemberIndexService, IVsXMLMemberIndexService>()
-        member sp.DTE = sp.GetService<SDTE, EnvDTE.DTE>()
+        member sp.XMLMemberIndexService = sp.GetService<SVsXMLMemberIndexService, IVsXMLMemberIndexService>()

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -53,8 +53,7 @@ type internal FSharpCompletionProvider
     
     let checker = checkerProvider.Checker
 
-    let xmlMemberIndexService = serviceProvider.GetService(typeof<IVsXMLMemberIndexService>) :?> IVsXMLMemberIndexService
-    let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(xmlMemberIndexService, serviceProvider.DTE)
+    let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(serviceProvider.XMLMemberIndexService)
         
     static let noCommitOnSpaceRules = 
         // These are important.  They make sure we don't _commit_ autocompletion when people don't expect them to.  Some examples:

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -29,8 +29,7 @@ type internal FSharpSignatureHelpProvider
     ) =
 
     static let userOpName = "SignatureHelpProvider"
-    let xmlMemberIndexService = serviceProvider.GetService(typeof<IVsXMLMemberIndexService>) :?> IVsXMLMemberIndexService
-    let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(xmlMemberIndexService, serviceProvider.DTE)
+    let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(serviceProvider.XMLMemberIndexService)
 
     static let oneColAfter (lp: LinePosition) = LinePosition(lp.Line,lp.Character+1)
     static let oneColBefore (lp: LinePosition) = LinePosition(lp.Line,max 0 (lp.Character-1))

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -160,7 +160,6 @@ module private FSharpQuickInfo =
 type internal FSharpAsyncQuickInfoSource
     (
         xmlMemberIndexService: IVsXMLMemberIndexService,
-        dte: EnvDTE.DTE,
         checkerProvider:FSharpCheckerProvider,
         projectInfoManager:FSharpProjectOptionsManager,
         gotoDefinitionService:FSharpGoToDefinitionService,
@@ -193,7 +192,7 @@ type internal FSharpAsyncQuickInfoSource
             | false -> Task.FromResult<QuickInfoItem>(null)
             | true ->
                 let triggerPoint = triggerPoint.GetValueOrDefault()
-                let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(xmlMemberIndexService, dte)
+                let documentationBuilder = XmlDocumentation.CreateDocumentationBuilder(xmlMemberIndexService)
                 asyncMaybe {
                     let document = textBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges()
                     let! symbolUse, sigQuickInfo, targetQuickInfo = FSharpQuickInfo.getQuickInfo(checkerProvider.Checker, projectInfoManager, document, triggerPoint.Position, cancellationToken)
@@ -264,4 +263,4 @@ type internal FSharpAsyncQuickInfoSourceProvider
     ) =
     interface IAsyncQuickInfoSourceProvider with
         override __.TryCreateQuickInfoSource(textBuffer:ITextBuffer) : IAsyncQuickInfoSource =
-            new FSharpAsyncQuickInfoSource(serviceProvider.XmlService, serviceProvider.DTE, checkerProvider, projectInfoManager, gotoDefinitionService, textBuffer) :> IAsyncQuickInfoSource
+            new FSharpAsyncQuickInfoSource(serviceProvider.XMLMemberIndexService, checkerProvider, projectInfoManager, gotoDefinitionService, textBuffer) :> IAsyncQuickInfoSource


### PR DESCRIPTION
I really have no idea what's going on here, but this fixes #4710 

Edit - explanation from the discussion below:

> This code is deadlocking because it violates the VS threading rules. GetQuickInfoItemAsync is called from a background thread whereas GetService() has a strict STA thread requirement.


This PR moves `GetService` call out of the `GetQuickInfoItemAsync` method so it will be called on the UI thread.


