### PR TITLE
Fix module name missing in XmlDocSig of value within a module.

### DIFF
--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -499,7 +499,14 @@ module internal SymbolHelpers =
         let ccuFileName = libFileOfEntityRef tcref
         let v = vref.Deref
         if v.XmlDocSig = "" && v.HasDeclaringEntity then
-            v.XmlDocSig <- XmlDocSigOfVal g (buildAccessPath vref.TopValDeclaringEntity.CompilationPathOpt) v
+            let ap = buildAccessPath vref.TopValDeclaringEntity.CompilationPathOpt
+            let path =
+                if vref.TopValDeclaringEntity.IsModule then
+                    let sep = if ap.Length > 0 then "." else ""
+                    ap + sep + vref.TopValDeclaringEntity.CompiledName
+                else
+                    ap
+            v.XmlDocSig <- XmlDocSigOfVal g path v
         Some (ccuFileName, v.XmlDocSig)                
 
     let GetXmlDocSigOfRecdFieldInfo (rfinfo:RecdFieldInfo) = 

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -3968,8 +3968,8 @@ let ``Test project28 all symbols in signature`` () =
     xmlDocSigs
       |> shouldEqual 
             [|("FSharpEntity", "M", "T:M");
-              ("FSharpMemberOrFunctionOrValue", "( |Even|Odd| )", "M:|Even|Odd|(System.Int32)");
-              ("FSharpMemberOrFunctionOrValue", "TestNumber", "M:TestNumber(System.Int32)");
+              ("FSharpMemberOrFunctionOrValue", "( |Even|Odd| )", "M:M.|Even|Odd|(System.Int32)");
+              ("FSharpMemberOrFunctionOrValue", "TestNumber", "M:M.TestNumber(System.Int32)");
               ("FSharpEntity", "DU", "T:M.DU"); 
               ("FSharpUnionCase", "A", "T:M.DU.A");
               ("FSharpField", "A", "T:M.DU.A"); 

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -55,3 +55,49 @@ match "foo" with
 
         getCaseUsages completePatternInput 7 |> Array.head |> getGroupName |> shouldEqual "|True|False|"
         getCaseUsages partialPatternInput 7 |> Array.head |> getGroupName |> shouldEqual "|String|_|"
+
+
+module XmlDocSig =
+
+    [<Test>]
+    let ``XmlDocSig of modules in namespace`` () =
+        let source = """
+namespace Ns1
+module Mod1 =
+    let val1 = 1
+    module Mod2 =
+       let func2 () = ()
+"""
+        let fileName, options = mkTestFileAndOptions source [| |]
+        let _, checkResults = parseAndCheckFile fileName source options  
+
+        let mod1 = checkResults.PartialAssemblySignature.FindEntityByPath ["Ns1"; "Mod1"] |> Option.get
+        let mod2 = checkResults.PartialAssemblySignature.FindEntityByPath ["Ns1"; "Mod1"; "Mod2"] |> Option.get
+        let mod1val1 = mod1.MembersFunctionsAndValues |> Seq.find (fun m -> m.DisplayName = "val1")
+        let mod2func2 = mod2.MembersFunctionsAndValues |> Seq.find (fun m -> m.DisplayName = "func2")
+        mod1.XmlDocSig |> shouldEqual "T:Ns1.Mod1"
+        mod2.XmlDocSig |> shouldEqual "T:Ns1.Mod1.Mod2"
+        mod1val1.XmlDocSig |> shouldEqual "P:Ns1.Mod1.val1"
+        mod2func2.XmlDocSig |> shouldEqual "M:Ns1.Mod1.Mod2.func2"
+
+    [<Test>]
+    let ``XmlDocSig of modules`` () =
+         let source = """
+module Mod1 
+let val1 = 1
+module Mod2 =
+    let func2 () = ()
+"""
+         let fileName, options = mkTestFileAndOptions source [| |]
+         let _, checkResults = parseAndCheckFile fileName source options  
+
+         let mod1 = checkResults.PartialAssemblySignature.FindEntityByPath ["Mod1"] |> Option.get
+         let mod2 = checkResults.PartialAssemblySignature.FindEntityByPath ["Mod1"; "Mod2"] |> Option.get
+         let mod1val1 = mod1.MembersFunctionsAndValues |> Seq.find (fun m -> m.DisplayName = "val1")
+         let mod2func2 = mod2.MembersFunctionsAndValues |> Seq.find (fun m -> m.DisplayName = "func2")
+         mod1.XmlDocSig |> shouldEqual "T:Mod1"
+         mod2.XmlDocSig |> shouldEqual "T:Mod1.Mod2"
+         mod1val1.XmlDocSig |> shouldEqual "P:Mod1.val1"
+         mod2func2.XmlDocSig |> shouldEqual "M:Mod1.Mod2.func2"
+
+                 


### PR DESCRIPTION
Consider the following code:
```
namespace Namespace1  
module Module1 =
  let val1 = 123
```

For `Namespace1.Module1.val1` the F# compiler service incorrectly returned the XML DocSig `P:Namespace1.val1`. This PR makes it generate the correct XML DocSig `P:Namespace1.Module1.val1`.

Generating XML documentation files was not affected by this issue, since it is handled by different code.