### PR TITLE
[WIP] remove DiaSymReader package dependencies since they're not used

### DIFF
--- a/build/config/AssemblySignToolData.json
+++ b/build/config/AssemblySignToolData.json
@@ -63,8 +63,6 @@
     "Microsoft.Build.Framework.dll",
     "Microsoft.Build.Tasks.Core.dll",
     "Microsoft.Build.Utilities.Core.dll",
-    "Microsoft.DiaSymReader.dll",
-    "Microsoft.DiaSymReader.PortablePdb.dll",
     "Newtonsoft.Json.dll",
     "System.Collections.Immutable.dll",
     "System.Reflection.Metadata.dll",

--- a/build/projects/PrepareDependencyUptake.proj
+++ b/build/projects/PrepareDependencyUptake.proj
@@ -12,8 +12,6 @@
   <!-- Prepare a dummy packages.config -->
   <ItemGroup>
     <PackagesConfigLines Include="&lt;packages&gt;" />
-    <PackagesConfigLines Include="  &lt;package id=&quot;Microsoft.DiaSymReader&quot; version=&quot;$(MicrosoftDiaSymReaderPackageVersion)&quot; /&gt;" />
-    <PackagesConfigLines Include="  &lt;package id=&quot;Microsoft.DiaSymReader.PortablePdb&quot; version=&quot;$(MicrosoftDiaSymReaderPortablePdbPackageVersion)&quot; /&gt;" />
     <PackagesConfigLines Include="&lt;/packages&gt;" />
   </ItemGroup>
 

--- a/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -631,8 +631,6 @@
     <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="1.2.0" />
-    <PackageReference Include="Microsoft.DiaSymReader" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />

--- a/packages.config
+++ b/packages.config
@@ -17,8 +17,6 @@
   <!-- Actual dependencies of FSharp.Compiler.dll and FSharp.Core.dll -->
   <package id="System.Collections.Immutable" version="1.3.1" />
   <package id="System.Reflection.Metadata" version="1.4.2" />
-  <package id="Microsoft.DiaSymReader.PortablePdb" version="1.2.0"  />
-  <package id="Microsoft.DiaSymReader" version="1.1.0" />
   <package id="System.ValueTuple" version="4.3.1" />
   <package id="System.ValueTuple" version="4.4.0" />
   <package id="Microsoft.VisualFSharp.Msbuild.15.0" version="1.0.1" />

--- a/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
+++ b/setup/FSharp.SDK/component-groups/Compiler_Redist.wxs
@@ -28,8 +28,6 @@
       <ComponentRef Id="Compiler_Redist_Microsoft.Build.Tasks.Core.dll" />
       <ComponentRef Id="Compiler_Redist_Microsoft.Build.Utilities.Core.dll" />
 
-      <ComponentRef Id="Compiler_Redist_Microsoft.DiaSymReader.PortablePdb.dll" />
-      <ComponentRef Id="Compiler_Redist_Microsoft.DiaSymReader.dll" />
       <ComponentRef Id="Compiler_Redist_System.Reflection.Metadata.dll" />
       <ComponentRef Id="Compiler_Redist_System.Collections.Immutable.dll" />
       <ComponentRef Id="Compiler_Redist_System.ValueTuple.dll" />
@@ -182,14 +180,6 @@
 
       <Component Id="Compiler_Redist_System.Reflection.Metadata.dll" Guid="$(fsharp.guid(Compiler_Redist_System.Reflection.Metadata.dll, $(var.LocaleCode)))">
         <File Id="Compiler_Redist_System.Reflection.Metadata.dll" Source="$(var.NugetPackagesDir)\System.Reflection.Metadata.1.4.2\lib\netstandard1.1\System.Reflection.Metadata.dll" />
-      </Component>
-
-      <Component Id="Compiler_Redist_Microsoft.DiaSymReader.PortablePdb.dll" Guid="$(fsharp.guid(Compiler_Redist_Microsoft.DiaSymReader.PortablePdb.dll, $(var.LocaleCode)))">
-        <File Id="Compiler_Redist_Microsoft.DiaSymReader.PortablePdb.dll" Source="$(var.NugetPackagesDir)\Microsoft.DiaSymReader.PortablePdb.1.2.0\lib\netstandard1.1\Microsoft.DiaSymReader.PortablePdb.dll" />
-      </Component>
-
-      <Component Id="Compiler_Redist_Microsoft.DiaSymReader.dll" Guid="$(fsharp.guid(Compiler_Redist_Microsoft.DiaSymReader.dll, $(var.LocaleCode)))">
-        <File Id="Compiler_Redist_Microsoft.DiaSymReader.dll" Source="$(var.NugetPackagesDir)\Microsoft.DiaSymReader.1.1.0\lib\netstandard1.1\Microsoft.DiaSymReader.dll" />
       </Component>
 
       <Component Id="Compiler_Redist_System.ValueTuple.dll" Guid="$(fsharp.guid(Compiler_Redist_System.ValueTuple.dll, $(var.LocaleCode)))">

--- a/setup/packages.config
+++ b/setup/packages.config
@@ -2,8 +2,6 @@
 <packages>
   <package id="System.Collections.Immutable" version="1.3.1" />
   <package id="System.Reflection.Metadata" version="1.4.2" />
-  <package id="Microsoft.DiaSymReader.PortablePdb" version="1.2.0"  />
-  <package id="Microsoft.DiaSymReader" version="1.1.0" />
   <package id="FsSrGen" version="2.0.0" targetFramework="net46" />
   <package id="MicroBuild.Core" version="0.2.0" />
   <package id="MicroBuild.Core.Sentinel" version="1.0.0" />

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -94,9 +94,6 @@
     <MicrosoftVisualStudioThreadingVersion>15.3.23</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioValidationVersion>15.3.15</MicrosoftVisualStudioValidationVersion>
 
-    <MicrosoftDiaSymReaderPackageVersion>1.1.0</MicrosoftDiaSymReaderPackageVersion>
-    <MicrosoftDiaSymReaderPortablePdbPackageVersion>1.2.0</MicrosoftDiaSymReaderPortablePdbPackageVersion>
-
     <!-- Frozen FSharp.Core package being built with this build -->
     <FSharpCore41TargetPackageVersion>4.1.19</FSharpCore41TargetPackageVersion>
     <FSharpCore41TargetMajorVersion>4.1</FSharpCore41TargetMajorVersion>

--- a/src/buildfromsource/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -638,8 +638,6 @@
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(SystemThreadingTasksParallelPackageVersion)" />
     <PackageReference Include="System.Threading.Thread" Version="$(SystemThreadingThreadPackageVersion)" />
     <PackageReference Include="System.Threading.ThreadPool" Version="$(SystemThreadingThreadPoolPackageVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbPackageVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderPackageVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTuplePackageVersion)" />
   </ItemGroup>
 

--- a/src/buildfromsource/FSharp.Compiler.nuget/FSharp.Compiler.nuget.fsproj
+++ b/src/buildfromsource/FSharp.Compiler.nuget/FSharp.Compiler.nuget.fsproj
@@ -21,12 +21,12 @@
     <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags> 
     <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rc-$(BuildRevision.Trim())-0</PreReleaseSuffix>
     <PackageVersion>10.1.1$(PreReleaseSuffix)</PackageVersion>
-    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion)" -prop "diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)"</PackageProperties>
+    <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
   </PropertyGroup>
 
   <PropertyGroup>
       <NuspecFile>$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.nuget\Microsoft.FSharp.Compiler.nuspec</NuspecFile>
-      <NuspecProperties>licenseUrl=$(PackageLicenceUrl);version=$(PackageVersion);authors=$(PackageAuthors);projectUrl=$(PackageProjectUrl);tags=$(PackageTags);diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion);diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)</NuspecProperties>
+      <NuspecProperties>licenseUrl=$(PackageLicenceUrl);version=$(PackageVersion);authors=$(PackageAuthors);projectUrl=$(PackageProjectUrl);tags=$(PackageTags)</NuspecProperties>
       <NuspecBasePath>$(OutputPath)/$(TargetFramework)</NuspecBasePath>
   </PropertyGroup>
 

--- a/src/buildfromsource/targets/PackageVersions.props
+++ b/src/buildfromsource/targets/PackageVersions.props
@@ -26,8 +26,6 @@
     <MicrosoftBuildFrameworkPackageVersion>15.1.548</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>15.1.548</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.1.548</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftDiaSymReaderPackageVersion>1.1.0</MicrosoftDiaSymReaderPackageVersion>
-    <MicrosoftDiaSymReaderPortablePdbPackageVersion>1.2.0</MicrosoftDiaSymReaderPortablePdbPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>4.3.0</MicrosoftWin32RegistryPackageVersion>
 
   </PropertyGroup>

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1926,8 +1926,6 @@ let SystemAssemblies () =
       yield "System.Threading.Timer"
 
       yield "FSharp.Compiler.Interactive.Settings"
-      yield "Microsoft.DiaSymReader"
-      yield "Microsoft.DiaSymReader.PortablePdb"
       yield "Microsoft.Win32.Registry"
       yield "System.Diagnostics.Tracing"
       yield "System.Globalization.Calendars"

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -29,8 +29,6 @@
       <BuiltProjectOutputGroupKeyOutput Include="$(FSharpSourcesRoot)\..\$(Configuration)\net40\bin\Microsoft.Build.Engine.dll" />
       <BuiltProjectOutputGroupKeyOutput Include="$(FSharpSourcesRoot)\..\$(Configuration)\net40\bin\Microsoft.Build.Utilities.Core.dll" />
       <BuiltProjectOutputGroupKeyOutput Include="$(FSharpSourcesRoot)\..\$(Configuration)\net40\bin\Microsoft.Build.Tasks.Core.dll" />
-      <BuiltProjectOutputGroupKeyOutput Include="$(FSharpSourcesRoot)\..\$(Configuration)\net40\bin\Microsoft.DiaSymReader.PortablePdb.dll" />
-      <BuiltProjectOutputGroupKeyOutput Include="$(FSharpSourcesRoot)\..\$(Configuration)\net40\bin\Microsoft.DiaSymReader.dll" />
       <BuiltProjectOutputGroupKeyOutput Include="$(FSharpSourcesRoot)\..\$(Configuration)\net40\bin\System.Reflection.Metadata.dll" />
       <BuiltProjectOutputGroupKeyOutput Include="$(FSharpSourcesRoot)\..\$(Configuration)\net40\bin\System.Collections.Immutable.dll" />
       <BuiltProjectOutputGroupKeyOutput Include="$(FSharpSourcesRoot)\..\$(Configuration)\net40\bin\System.ValueTuple.dll" />
@@ -670,12 +668,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="ISymWrapper, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.DiaSymReader.PortablePdb">
-      <HintPath>..\..\..\packages\Microsoft.DiaSymReader.PortablePdb.$(MicrosoftDiaSymReaderPortablePdbPackageVersion)\lib\netstandard1.1\Microsoft.DiaSymReader.PortablePdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.DiaSymReader">
-      <HintPath>..\..\..\packages\Microsoft.DiaSymReader.$(MicrosoftDiaSymReaderPackageVersion)\lib\netstandard1.1\Microsoft.DiaSymReader.dll</HintPath>
-    </Reference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.netcore.nuspec
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.netcore.nuspec
@@ -31,8 +31,6 @@
                 <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
                 <dependency id="System.Threading.Thread" version="4.0.0" />
                 <dependency id="System.Threading.ThreadPool" version="4.0.10" />
-                <dependency id="Microsoft.DiaSymReader.PortablePdb" version="1.2.0" />
-                <dependency id="Microsoft.DiaSymReader" version="1.1.0" />
                 <dependency id="System.ValueTuple" version="4.4.0" />
             </group>
         </dependencies>

--- a/src/fsharp/FSharp.Compiler.Private/project.json
+++ b/src/fsharp/FSharp.Compiler.Private/project.json
@@ -17,8 +17,6 @@
     "System.Threading.Tasks.Parallel": "4.3.0",
     "System.Threading.Thread": "4.3.0",
     "System.Threading.ThreadPool": "4.3.0",
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
-    "Microsoft.DiaSymReader": "1.1.0",
     "System.ValueTuple": "4.4.0"
   },
   "runtimes": {

--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.targets
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.targets
@@ -35,7 +35,7 @@
       <!-- can't have &lt; and &gt; which happens when building locally -->
       <NormalizedGitHeadSha>$(GitHeadSha)</NormalizedGitHeadSha>
       <NormalizedGitHeadSha Condition="'$(NormalizedGitHeadSha)' == '&lt;developer build&gt;'">[developer build]</NormalizedGitHeadSha>
-      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "diasymreaderversion=$(MicrosoftDiaSymReaderPackageVersion)" -prop "diasymreaderportablepdbversion=$(MicrosoftDiaSymReaderPortablePdbPackageVersion)" -prop "githeadsha=$(NormalizedGitHeadSha)"</PackageProperties>
+      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "githeadsha=$(NormalizedGitHeadSha)"</PackageProperties>
     </PropertyGroup>
 
     <MakeDir Directories="$(FSharpSourcesRoot)\..\artifacts" />

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -34,8 +34,6 @@
                 <dependency id="System.Threading.Thread" version="4.0.0" />
                 <dependency id="System.Threading.ThreadPool" version="4.0.10" />
                 <dependency id="System.ValueTuple" version="4.4.0" />
-                <dependency id="Microsoft.DiaSymReader.PortablePdb" version="$diasymreaderportablepdbversion$" />
-                <dependency id="Microsoft.DiaSymReader" version="$diasymreaderversion$" />
             </group>
         </dependencies>
         <contentFiles>

--- a/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Testing.FSharp.Compiler.nuspec
@@ -32,8 +32,6 @@
                 <dependency id="System.Threading.Thread" version="4.0.0" />
                 <dependency id="System.Threading.ThreadPool" version="4.0.10" />
                 <dependency id="System.ValueTuple" version="4.4.0" />
-                <dependency id="Microsoft.DiaSymReader.PortablePdb" version="$diasymreaderportablepdbversion$" />
-                <dependency id="Microsoft.DiaSymReader" version="$diasymreaderversion$" />
             </group>
         </dependencies>
     </metadata>

--- a/src/fsharp/Fsc-proto/Fsc-proto.fsproj
+++ b/src/fsharp/Fsc-proto/Fsc-proto.fsproj
@@ -454,12 +454,6 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="ISymWrapper, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.DiaSymReader.PortablePdb">
-      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.DiaSymReader.PortablePdb.1.2.0\lib\portable-net45+win8\Microsoft.DiaSymReader.PortablePdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.DiaSymReader">
-      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.DiaSymReader.1.1.0\lib\portable-net45+win8\Microsoft.DiaSymReader.dll</HintPath>
-    </Reference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>$(FSharpSourcesRoot)\..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>

--- a/vsintegration/Utils/LanguageServiceProfiling/Options.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Options.fs
@@ -211,8 +211,6 @@ let FCS (repositoryDir: string) : Options =
             @"--define:COMPILER_SERVICE_DLL"; "--define:NO_STRONG_NAMES"; "--define:TRACE";
             @"--doc:..\..\..\bin\v4.5\FSharp.Compiler.Service.xml"; "--optimize-";
             @"--platform:anycpu";
-            @"-r:" + (repositoryDir </> @"packages\Microsoft.DiaSymReader\lib\net20\Microsoft.DiaSymReader.dll");
-            @"-r:" + (repositoryDir </> @"packages\Microsoft.DiaSymReader.PortablePdb\lib\net45\Microsoft.DiaSymReader.PortablePdb.dll");
             @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll";
             @"-r:" + (repositoryDir </> @"packages\System.Collections.Immutable\lib\netstandard1.0\System.Collections.Immutable.dll");
             @"-r:" + (repositoryDir </> @"packages\FSharp.Core\lib\net40\FSharp.Core.dll");


### PR DESCRIPTION
It was recently discovered that we're not actually using the `Microsoft.DiaSymReader` and `Microsoft.DiaSymReader.PortablePdb` packages.  I've verified both `buildfromsource.cmd` and `buildfromsource.sh` locally, so this is to test CI.  Next step will be to test a full build.