### PR TITLE
remove Newtonsoft.Json code base

### DIFF
--- a/vsintegration/src/FSharp.Editor/Common/AssemblyInfo.fs
+++ b/vsintegration/src/FSharp.Editor/Common/AssemblyInfo.fs
@@ -6,7 +6,6 @@ open Microsoft.VisualStudio.Shell
 
 [<assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\FSharp.Editor.dll")>]
 [<assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\FSharp.UIResources.dll")>]
-[<assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Newtonsoft.Json.dll")>]
 
 do()
 


### PR DESCRIPTION
This is the cause of a bunch of Watson failures in previews because we removed our direct dependency on `Newtonsoft.Json.dll` opting to instead use the version that ships with Visual Studio.  If a user installed an earlier preview of 15.7 when `Newtonsoft` was included then upgraded to a newer preview, that file will have been removed, but the `ProvideCodeBase` attribute was still getting applied.

(I had previously misstated that the 'fix' was to drop the hive to force `devenv.exe.config` to get regenerated, but that is incorrect.  The 'fix' was to manually drop the codeBase entry from the config file for the F# version of Newtonsoft.Json.)