### PR TITLE
Fix icon for FSharp.Core nuget package

### DIFF
--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.4.1.xxx.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.4.1.xxx.nuspec
@@ -23,6 +23,7 @@
         <authors>$authors$</authors>
         <licenseUrl>$licenseUrl$</licenseUrl>
         <projectUrl>$projectUrl$</projectUrl>
+        <iconUrl>http://fsharp.org/img/logo.png</iconUrl>
         <tags>$tags$</tags>
         <dependencies>
             <group targetFramework="net20">

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
@@ -18,6 +18,7 @@
         <authors>$authors$</authors>
         <licenseUrl>$licenseUrl$</licenseUrl>
         <projectUrl>$projectUrl$</projectUrl>
+        <iconUrl>http://fsharp.org/img/logo.png</iconUrl>
         <tags>$tags$</tags>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <dependencies>


### PR DESCRIPTION
Ensure that nuget package carries the FSSF logo.