### PR TITLE
Rename pdbPath to pdbDirPath in assembly reading

### DIFF
--- a/src/absil/ilread.fsi
+++ b/src/absil/ilread.fsi
@@ -44,7 +44,7 @@ type internal MetadataOnlyFlag = Yes | No
 type internal ReduceMemoryFlag = Yes | No
 
 type internal ILReaderOptions =
-   { pdbPath: string option
+   { pdbDirPath: string option
 
      ilGlobals: ILGlobals
 

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1164,7 +1164,7 @@ module StaticLinker =
                   reduceMemoryUsage = tcConfig.reduceMemoryUsage
                   metadataOnly = MetadataOnlyFlag.No
                   tryGetMetadataSnapshot = (fun _ -> None)
-                  pdbPath = None  } 
+                  pdbDirPath = None  } 
             ILBinaryReader.OpenILModuleReader mscorlib40 opts
               
         let tdefs1 = ilxMainModule.TypeDefs.AsList  |> List.filter (fun td -> not (MainModuleBuilder.injectedCompatTypes.Contains(td.Name)))
@@ -1250,7 +1250,7 @@ module StaticLinker =
 
                                 let fileName = dllInfo.FileName
                                 let modul = 
-                                    let pdbPathOption = 
+                                    let pdbDirPathOption = 
                                         // We open the pdb file if one exists parallel to the binary we 
                                         // are reading, so that --standalone will preserve debug information. 
                                         if tcConfig.openDebugInformationForLaterStaticLinking then 
@@ -1268,7 +1268,7 @@ module StaticLinker =
                                         { ilGlobals = ilGlobals
                                           metadataOnly = MetadataOnlyFlag.No // turn this off here as we need the actual IL code
                                           reduceMemoryUsage = tcConfig.reduceMemoryUsage
-                                          pdbPath = pdbPathOption
+                                          pdbDirPath = pdbDirPathOption
                                           tryGetMetadataSnapshot = (fun _ -> None) } 
 
                                     let reader = ILBinaryReader.OpenILModuleReader dllInfo.FileName opts


### PR DESCRIPTION
`ILReaderOptions` actually keeps pdb directory path, not pdb path (see code below). I renamed it so it doesn't look confusing.
@TIHan Probably the whole logic around reading pdb files should be checked in `openPEFileReader` and friends.
https://github.com/Microsoft/visualfsharp/blob/3e71220c8db4c17986ab81925d4c5a18ee3e5339/src/fsharp/CompileOps.fs#L4141-L4143