### PR TITLE
Fix #3737 - allow inheriting from FSharpFunc

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -799,9 +799,11 @@ let helpEnsureTypeHasMetadata g ty =
     if isAnyTupleTy g ty then 
         let (tupInfo, tupElemTys) = destAnyTupleTy g ty
         mkOuterCompiledTupleTy g (evalTupInfoIsStruct tupInfo) tupElemTys
+    elif isFunTy g ty then 
+        let (a,b) = destFunTy g ty
+        mkAppTy g.fastFunc_tcr [a; b]
     else ty
-
-
+ 
 //---------------------------------------------------------------------------
 // Equivalence of types up to alpha-equivalence 
 //---------------------------------------------------------------------------

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -15095,7 +15095,13 @@ module EstablishTypeDefinitionCores =
                       Some(cenv.g.system_Enum_typ) 
 
               // Allow super type to be a function type but convert back to FSharpFunc<A,B> to make sure it has metadata
-              let super = super |> Option.map (helpEnsureTypeHasMetadata cenv.g)
+              // (We don't apply the same rule to tuple types, i.e. no F#-declared inheritors of those are permitted)
+              let super = 
+                  super |> Option.map (fun ty -> 
+                     if isFunTy cenv.g ty then  
+                         let (a,b) = destFunTy cenv.g ty
+                         mkAppTy cenv.g.fastFunc_tcr [a; b] 
+                     else ty)
 
               // Publish the super type
               tycon.TypeContents.tcaug_super <- super

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -13285,6 +13285,7 @@ module MutRecBindingChecking =
                         // Phase2B: typecheck the argument to an 'inherits' call and build the new object expr for the inherit-call 
                         | Phase2AInherit (synBaseTy, arg, baseValOpt, m) ->
                             let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.Use envInstance tpenv synBaseTy
+                            let baseTy = baseTy |> helpEnsureTypeHasMetadata cenv.g
                             let inheritsExpr, tpenv = TcNewExpr cenv envInstance tpenv baseTy (Some synBaseTy.Range) true arg m
                             let envInstance = match baseValOpt with Some baseVal -> AddLocalVal cenv.tcSink scopem baseVal envInstance | None -> envInstance
                             let envNonRec   = match baseValOpt with Some baseVal -> AddLocalVal cenv.tcSink scopem baseVal envNonRec   | None -> envNonRec
@@ -15092,6 +15093,9 @@ module EstablishTypeDefinitionCores =
 
                   | SynTypeDefnSimpleRepr.Enum _ -> 
                       Some(cenv.g.system_Enum_typ) 
+
+              // Allow super type to be a function type but convert back to FSharpFunc<A,B> to make sure it has metadata
+              let super = super |> Option.map (helpEnsureTypeHasMetadata cenv.g)
 
               // Publish the super type
               tycon.TypeContents.tcaug_super <- super

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -1873,6 +1873,37 @@ module InferenceRegression4040C =
     printfn "%A" (Foo.Test 42)
 
 
+module TestInheritFunc = 
+    type Foo() =
+        inherit FSharpFunc<int,int>()
+        override __.Invoke(a:int) = a + 1
+
+    check "cnwcki1" ((Foo() |> box |> unbox<int -> int> ) 5) 6
+
+module TestInheritFuncGeneric = 
+    type Foo<'T,'U>() =
+        inherit FSharpFunc<'T,'T>()
+        override __.Invoke(a:'T) = a
+
+    check "cnwcki2" ((Foo<int,int>() |> box |> unbox<int -> int> ) 5) 5
+
+
+module TestInheritFunc2 = 
+    type Foo() =
+        inherit OptimizedClosures.FSharpFunc<int,int,int>()
+        override f.Invoke(a:int) = (fun u -> f.Invoke(a,u))
+        override __.Invoke(a:int,b:int) = a + b + 1
+
+    check "cnwcki3" ((Foo() |> box |> unbox<int -> int -> int> ) 5 6) 12
+
+module TestInheritFunc3 = 
+    type Foo() =
+        inherit OptimizedClosures.FSharpFunc<int,int,int,int>()
+        override f.Invoke(t) = (fun u v -> f.Invoke(t,u,v))
+        override __.Invoke(a:int,b:int,c:int) = a + b + c + 1
+
+    check "cnwcki4" ((Foo() |> box |> unbox<int -> int -> int -> int> ) 5 6 7) 19
+
 
 #if TESTS_AS_APP
 let RUN() = !failures

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -1904,6 +1904,17 @@ module TestInheritFunc3 =
 
     check "cnwcki4" ((Foo() |> box |> unbox<int -> int -> int -> int> ) 5 6 7) 19
 
+module TestConverter =
+    open System
+
+    let fromConverter (f: Converter<'T1,'X>) = FSharp.Core.FSharpFunc.FromConverter f
+    let implicitConv (f: Converter<'T1,'X>) = FSharp.Core.FSharpFunc.op_Implicit f
+    let toConverter (f: 'T1 -> 'X) = FSharp.Core.FSharpFunc.ToConverter f
+    let toConverter2 (f: FSharpFunc<'T1, 'X>) = FSharp.Core.FSharpFunc.ToConverter f
+
+    test "cenwceoiwe1" ((id |> toConverter |> fromConverter) 6 = 6)
+    test "cenwceoiwe2" ((id |> toConverter |> fromConverter |> toConverter2 |> implicitConv) 6 = 6)
+
 
 #if TESTS_AS_APP
 let RUN() = !failures

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -1904,6 +1904,8 @@ module TestInheritFunc3 =
 
     check "cnwcki4" ((Foo() |> box |> unbox<int -> int -> int -> int> ) 5 6 7) 19
 
+#if !NETCOREAPP1_0
+
 module TestConverter =
     open System
 
@@ -1914,6 +1916,7 @@ module TestConverter =
 
     test "cenwceoiwe1" ((id |> toConverter |> fromConverter) 6 = 6)
     test "cenwceoiwe2" ((id |> toConverter |> fromConverter |> toConverter2 |> implicitConv) 6 = 6)
+#endif
 
 
 #if TESTS_AS_APP

--- a/tests/fsharpqa/Source/Diagnostics/General/E_AreYouMissingAnArgumentToAFunction01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/General/E_AreYouMissingAnArgumentToAFunction01.fs
@@ -1,8 +1,8 @@
 // #Regression #Diagnostics 
 // Regression test for FSHARP1.0:2804
 // Make sure we don't emit ?. (notice that the error message changed a bit since the bug was opened)
-//<Expects status="error" span="(6,32-6,33)" id="FS0001">This expression was expected to have type.$</Expects>
-//<Expects status="error" span="(6,35-6,37)" id="FS0001">This expression was expected to have type.$</Expects>
+//<Expects status="error" span="(7,32-7,33)" id="FS0001">This expression was expected to have type.$</Expects>
+//<Expects status="error" span="(7,35-7,37)" id="FS0001">This expression was expected to have type.$</Expects>
 
 let f (x : int list)  = int32 (x>>32)
 

--- a/tests/fsharpqa/Source/Diagnostics/General/E_AreYouMissingAnArgumentToAFunction01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/General/E_AreYouMissingAnArgumentToAFunction01.fs
@@ -1,8 +1,8 @@
 // #Regression #Diagnostics 
 // Regression test for FSHARP1.0:2804
 // Make sure we don't emit ?. (notice that the error message changed a bit since the bug was opened)
-//<Expects status="error" span="(7,32-7,33)" id="FS0001">This expression was expected to have type.$</Expects>
-//<Expects status="error" span="(7,35-7,37)" id="FS0001">This expression was expected to have type.$</Expects>
+//<Expects status="error" span="(7,32-7,33)" id="FS0001">This expression was expected to have type</Expects>
+//<Expects status="error" span="(7,35-7,37)" id="FS0001">This expression was expected to have type</Expects>
 
 let f (x : int list)  = int32 (x>>32)
 

--- a/tests/fsharpqa/Source/Diagnostics/General/E_AreYouMissingAnArgumentToAFunction01.fs
+++ b/tests/fsharpqa/Source/Diagnostics/General/E_AreYouMissingAnArgumentToAFunction01.fs
@@ -1,7 +1,8 @@
 // #Regression #Diagnostics 
 // Regression test for FSHARP1.0:2804
 // Make sure we don't emit ?. (notice that the error message changed a bit since the bug was opened)
-//<Expects status="error" span="(6,32-6,37)" id="FS0001">Expecting a type supporting the operator 'op_Explicit' but given a function type\. You may be missing an argument to a function\.$</Expects>
+//<Expects status="error" span="(6,32-6,33)" id="FS0001">This expression was expected to have type.$</Expects>
+//<Expects status="error" span="(6,35-6,37)" id="FS0001">This expression was expected to have type.$</Expects>
 
 let f (x : int list)  = int32 (x>>32)
 


### PR DESCRIPTION
Fix #3737 - allow inheriting from FSharpFunc

A crucial piece of Xamarin tooling (the CIL interpreter in Xamarin LivePlayer) relies on being able to extend FSharpFunc.  Without this, even basic uses of LivePlay can't work on F# code.

I've discussed this with @praeclarum and it's a reasonable usage scenario for creating inheritance-based implementations of `FSharpFunc` in F# user code

