### PR TITLE
Fix #4714 (save completion data for at least as long as the completion session)

### DIFF
--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -185,7 +185,7 @@ type internal FSharpCompletionProvider
 
                 let key = completionItem.DisplayText
                 let cacheItem = CacheItem(key, declarationItem)
-                let policy = CacheItemPolicy(SlidingExpiration=DefaultTuning.PerDocumentSavedDataSlidingWindow)
+                let policy = CacheItemPolicy(SlidingExpiration=DefaultTuning.PerCompletionSessionSlidingWindow)
                 declarationItemsCache.Set(cacheItem, policy)
                 results.Add(completionItem))
 

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -212,7 +212,6 @@ type internal FSharpCompletionProvider
             let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)
             (documentId, document.FilePath, defines)
 
-        declarationItemsData.Clear()
         FSharpCompletionProvider.ShouldTriggerCompletionAux(sourceText, caretPosition, trigger.Kind, getInfo)
         
     override this.ProvideCompletionsAsync(context: Completion.CompletionContext) =

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -21,6 +21,7 @@ open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open System.Runtime.Caching
+open System.Collections.Concurrent
 
 type internal FSharpCompletionProvider
     (
@@ -34,8 +35,9 @@ type internal FSharpCompletionProvider
     inherit CompletionProvider()
 
     static let userOpName = "CompletionProvider"
-    // Save the backing data in a memory cache held in a sliding window
-    static let declarationItemsCache = new MemoryCache("FSharp.Editor." + userOpName)
+    // Save the backing data in a cache, we need to save for at least the length of the completion session
+    // See https://github.com/Microsoft/visualfsharp/issues/4714
+    static let declarationItemsData = new ConcurrentDictionary<string, FSharpDeclarationListItem>()
     static let [<Literal>] NameInCodePropName = "NameInCode"
     static let [<Literal>] FullNamePropName = "FullName"
     static let [<Literal>] IsExtensionMemberPropName = "IsExtensionMember"
@@ -139,6 +141,7 @@ type internal FSharpCompletionProvider
 
             let maxHints = if mruItems.Values.Count = 0 then 0 else Seq.max mruItems.Values
 
+            declarationItemsData.Clear()
             sortedDeclItems |> Array.iteri (fun number declarationItem ->
                 let glyph = Tokenizer.FSharpGlyphToRoslynGlyph (declarationItem.Glyph, declarationItem.Accessibility)
                 let name =
@@ -184,9 +187,7 @@ type internal FSharpCompletionProvider
                 let completionItem = completionItem.WithSortText(sortText)
 
                 let key = completionItem.DisplayText
-                let cacheItem = CacheItem(key, declarationItem)
-                let policy = CacheItemPolicy(SlidingExpiration=DefaultTuning.PerCompletionSessionSlidingWindow)
-                declarationItemsCache.Set(cacheItem, policy)
+                declarationItemsData.Add(key, declarationItem)
                 results.Add(completionItem))
 
             if results.Count > 0 && not declarations.IsForType && not declarations.IsError && List.isEmpty partialName.QualifyingIdents then
@@ -211,8 +212,9 @@ type internal FSharpCompletionProvider
             let defines = projectInfoManager.GetCompilationDefinesForEditingDocument(document)
             (documentId, document.FilePath, defines)
 
+        declarationItemsData.Clear()
         FSharpCompletionProvider.ShouldTriggerCompletionAux(sourceText, caretPosition, trigger.Kind, getInfo)
-    
+        
     override this.ProvideCompletionsAsync(context: Completion.CompletionContext) =
         asyncMaybe {
             let document = context.Document
@@ -228,13 +230,14 @@ type internal FSharpCompletionProvider
             let! results = 
                 FSharpCompletionProvider.ProvideCompletionsAsyncAux(checker, sourceText, context.Position, projectOptions, 
                                                                     document.FilePath, textVersion.GetHashCode(), getAllSymbols)
+            
             context.AddItems(results)
         } |> Async.Ignore |> RoslynHelpers.StartAsyncUnitAsTask context.CancellationToken
         
     override this.GetDescriptionAsync(_: Document, completionItem: Completion.CompletionItem, cancellationToken: CancellationToken): Task<CompletionDescription> =
         async {
-            match declarationItemsCache.Get(completionItem.DisplayText) with
-            | :? FSharpDeclarationListItem as declarationItem -> 
+            match declarationItemsData.TryGetValue(completionItem.DisplayText) with
+            | true, declarationItem -> 
                 let! description = declarationItem.StructuredDescriptionTextAsync
                 let documentation = List()
                 let collector = RoslynHelpers.CollectTaggedText documentation

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -187,7 +187,7 @@ type internal FSharpCompletionProvider
                 let completionItem = completionItem.WithSortText(sortText)
 
                 let key = completionItem.DisplayText
-                declarationItemsData.Add(key, declarationItem)
+                declarationItemsData.TryAdd(key, declarationItem) |> ignore
                 results.Add(completionItem))
 
             if results.Count > 0 && not declarations.IsForType && not declarations.IsError && List.isEmpty partialName.QualifyingIdents then

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -18,6 +18,7 @@ module DefaultTuning =
     /// How long is the per-document data saved before it is eligible for eviction from the cache? 10 seconds.
     /// Re-tokenizing is fast so we don't need to save this data long.
     let PerDocumentSavedDataSlidingWindow = TimeSpan(0,0,10)(* seconds *)
+    let PerCompletionSessionSlidingWindow = TimeSpan(0,2,0)(* minutes *)
 
 // CLIMutable to make the record work also as a view model
 [<CLIMutable>]

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -18,7 +18,6 @@ module DefaultTuning =
     /// How long is the per-document data saved before it is eligible for eviction from the cache? 10 seconds.
     /// Re-tokenizing is fast so we don't need to save this data long.
     let PerDocumentSavedDataSlidingWindow = TimeSpan(0,0,10)(* seconds *)
-    let PerCompletionSessionSlidingWindow = TimeSpan(0,2,0)(* minutes *)
 
 // CLIMutable to make the record work also as a view model
 [<CLIMutable>]


### PR DESCRIPTION
#4714 is quite a bad bug where descriptions in VS completions timeout after 10 seconds. Mea culpa

I'm not quite sure of the right fix for this - @majocha decribes some potential fixes in the bug - I suggest we at least increase the expiration time to 2 minutes as a starting point.

