### PR TITLE
make symbols distinct, fixing #4655

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
@@ -39,7 +39,6 @@ type internal FSharpImplementInterfaceCodeFixProvider
     let queryInterfaceState appendBracketAt (pos: pos) (tokens: Tokenizer.SavedTokenInfo[]) (ast: Ast.ParsedInput) =
         asyncMaybe {
             let line = pos.Line - 1
-            let column = pos.Column
             let! iface = InterfaceStubGenerator.tryFindInterfaceDeclaration pos ast
             let endPosOfWidth =
                 tokens 


### PR DESCRIPTION
Renaming `AA` in the code below now renames correctly
```
// Learn more about F# at http://fsharp.org
// See the 'F# Tutorial' project for more help.
type AA = { IntVal: int; StringVal: string }

[<AbstractClass>]
type AbstractFoo<'T>() =
    abstract member Foo: 'T -> 'T

type C() =
    inherit AbstractFoo<AA>()
    override __.Foo(r) = { r with IntVal = 12 }
[<EntryPoint>]
let main argv = 
    printfn "%A" argv
    0 // return an integer exit code
```
