### PR TITLE
Remove allocation from logblock

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -595,12 +595,10 @@ namespace Microsoft.FSharp.Core
                 //assert not(TypeInfo<'T>.TypeInfo = TypeNullnessSemantics_NullTrueValue)
                 notnullPrim(isinstPrim<'T>(source)) 
 
-            let Dispose<'T when 'T :> IDisposable >(resource:'T) =
-                if typeof<'T>.IsValueType then resource.Dispose()
-                else 
-                    match box resource with  
-                    | null -> () 
-                    | _ -> resource.Dispose() 
+            let Dispose<'T when 'T :> IDisposable >(resource:'T) = 
+                match box resource with 
+                | null -> ()
+                | _ -> resource.Dispose()
 
             let FailInit() : unit = raise (InvalidOperationException(SR.GetString(SR.checkInit)))
 

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -595,10 +595,12 @@ namespace Microsoft.FSharp.Core
                 //assert not(TypeInfo<'T>.TypeInfo = TypeNullnessSemantics_NullTrueValue)
                 notnullPrim(isinstPrim<'T>(source)) 
 
-            let Dispose<'T when 'T :> IDisposable >(resource:'T) = 
-                match box resource with 
-                | null -> ()
-                | _ -> resource.Dispose()
+            let Dispose<'T when 'T :> IDisposable >(resource:'T) =
+                if typeof<'T>.IsValueType then resource.Dispose()
+                else 
+                    match box resource with  
+                    | null -> () 
+                    | _ -> resource.Dispose() 
 
             let FailInit() : unit = raise (InvalidOperationException(SR.GetString(SR.checkInit)))
 

--- a/src/fsharp/Logger.fs
+++ b/src/fsharp/Logger.fs
@@ -40,8 +40,13 @@ module Logger =
 
     let LogBlockStop(functionId) = FSharpCompilerEventSource.Instance.BlockStop(functionId)
 
+    [<Struct>]
+    type LogBlockDisposable =
+        val functionId: LogCompilerFunctionId
+        new(id: LogCompilerFunctionId) = { functionId = id }
+        interface IDisposable with
+            member this.Dispose() = FSharpCompilerEventSource.Instance.BlockStop(this.functionId)
+
     let LogBlock(functionId) =
         FSharpCompilerEventSource.Instance.BlockStart(functionId)
-        { new IDisposable with
-            member __.Dispose() =
-                FSharpCompilerEventSource.Instance.BlockStop(functionId) }
+        new LogBlockDisposable (functionId)

--- a/src/fsharp/Logger.fsi
+++ b/src/fsharp/Logger.fsi
@@ -18,4 +18,10 @@ module internal Logger =
 
     val LogBlockStop : LogCompilerFunctionId -> unit
 
-    val LogBlock : LogCompilerFunctionId -> IDisposable
+    [<Struct>]
+    type LogBlockDisposable =
+        val functionId: LogCompilerFunctionId
+        interface IDisposable
+        new : LogCompilerFunctionId -> LogBlockDisposable
+
+    val LogBlock : LogCompilerFunctionId -> LogBlockDisposable

--- a/vsintegration/src/FSharp.Editor/Common/Logger.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Logger.fs
@@ -42,9 +42,14 @@ module Logger =
 
     let LogBlockStop(functionId) = FSharpEditorEventSource.Instance.BlockStop(functionId)
 
+    [<Struct>]
+    type LogBlockDisposable =
+        val functionId: LogEditorFunctionId
+        new(id: LogEditorFunctionId) = { functionId = id }
+        interface IDisposable with
+            member this.Dispose() = FSharpEditorEventSource.Instance.BlockStop(this.functionId)
+
     let LogBlock(functionId) =
         FSharpEditorEventSource.Instance.BlockStart(functionId)
-        { new IDisposable with
-            member __.Dispose() =
-                FSharpEditorEventSource.Instance.BlockStop(functionId) }
+        new LogBlockDisposable (functionId)
     

--- a/vsintegration/src/FSharp.Editor/Common/Logger.fsi
+++ b/vsintegration/src/FSharp.Editor/Common/Logger.fsi
@@ -20,4 +20,10 @@ module internal Logger =
 
     val LogBlockStop : LogEditorFunctionId -> unit
 
-    val LogBlock : LogEditorFunctionId -> IDisposable
+    [<Struct>]
+    type LogBlockDisposable =
+        val functionId: LogEditorFunctionId
+        interface IDisposable
+        new : LogEditorFunctionId -> LogBlockDisposable
+
+    val LogBlock : LogEditorFunctionId -> LogBlockDisposable

--- a/vsintegration/src/FSharp.Editor/Common/Pervasive.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Pervasive.fs
@@ -65,11 +65,9 @@ type MaybeBuilder () =
     member __.Using (resource: ('T :> System.IDisposable), body: _ -> _ option): _ option =
         try body resource
         finally
-            if typeof<'T>.IsValueType then resource.Dispose()
-            else
-                match box resource with 
-                | null -> ()
-                | _ -> resource.Dispose()
+            match box resource with 
+            | null -> ()
+            | _ -> resource.Dispose()
 
     // (unit -> bool) * M<'T> -> M<'T>
     [<DebuggerStepThrough>]
@@ -149,11 +147,9 @@ type AsyncMaybeBuilder () =
     member __.Using (resource : ('T :> IDisposable), body : _ -> Async<_ option>) : Async<_ option> =
         try body resource
         finally
-            if typeof<'T>.IsValueType then resource.Dispose()
-            else
-                match box resource with 
-                | null -> ()
-                | _ -> resource.Dispose()
+            match box resource with 
+            | null -> ()
+            | _ -> resource.Dispose()
         
     [<DebuggerStepThrough>]
     member x.While (guard, body : Async<_ option>) : Async<_ option> =

--- a/vsintegration/src/FSharp.Editor/Common/Pervasive.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Pervasive.fs
@@ -145,7 +145,11 @@ type AsyncMaybeBuilder () =
     [<DebuggerStepThrough>]
     member __.Using (resource : ('T :> IDisposable), body : _ -> Async<_ option>) : Async<_ option> =
         try body resource
-        finally if not (isNull resource) then resource.Dispose ()
+        finally
+            match box resource with 
+            | null -> ()
+            | _ -> resource.Dispose()
+        
 
     [<DebuggerStepThrough>]
     member x.While (guard, body : Async<_ option>) : Async<_ option> =


### PR DESCRIPTION
LogBlock used _use on a new object to defer the Log Stop message until the function being logged completed.

Because of the AsyncMaybe computation, it couldn't use struct.

This change fixes AsyncMaybe to allow structs with disposable in using blocks and uses a struct to mage the dispose.

It should be noted that box on a value type generates a new object ... thus handily eliminating the benefit of using a struct.   We now test if the type is a valuetype and only box on the object codepath.

I note that in Intrisics, dispose is declared like this:
https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/FSharp.Core/prim-types.fs#L598

````
     match box resource with 
     | null -> ()
     | _ -> resource.Dispose()
````

Which will alloc for value types, therefore logging on Async Computation will still allocate an object, should I make a similar change there?



