### PR TITLE
Servicing Fix for FSC : error FS0193: Could not find file 'c:\Users\kevinr\source\r…

### DIFF
--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -1060,6 +1060,7 @@ type PEReader =
     resourcesAddr:int32
     strongnameAddr:int32
     vtableFixupsAddr:int32
+    noFileOnDisk:bool
 }
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
@@ -1537,11 +1538,25 @@ let readBlobHeapAsDouble ctxt vidx = fst (sigptrGetDouble (readBlobHeap ctxt vid
 //        (e) the start of the native resources attached to the binary if any
 // ----------------------------------------------------------------------*)
 
-let readNativeResources (pectxt: PEReader)  = 
+// noFileOnDisk indicates that the PE file was read from Memory using OpenILModuleReaderFromBytes
+// For example the assembly came from a type provider
+// In this case we eagerly read the native resources into memory
+let readNativeResources (pectxt: PEReader) = 
     [ if pectxt.nativeResourcesSize <> 0x0  && pectxt.nativeResourcesAddr <> 0x0 then 
-           let start = pectxt.anyV2P (pectxt.fileName + ": native resources", pectxt.nativeResourcesAddr)
-           yield ILNativeResource.In (pectxt.fileName, pectxt.nativeResourcesAddr, start, pectxt.nativeResourcesSize ) ]
-   
+        let start = pectxt.anyV2P (pectxt.fileName + ": native resources", pectxt.nativeResourcesAddr)
+        if pectxt.noFileOnDisk then
+#if !FX_NO_LINKEDRESOURCES
+            let unlinkedResource =
+                let linkedResource = seekReadBytes (pectxt.pefile.GetView()) start pectxt.nativeResourcesSize
+                unlinkResource pectxt.nativeResourcesAddr linkedResource
+            yield ILNativeResource.Out unlinkedResource
+#else
+            ()
+#endif
+        else
+            yield ILNativeResource.In (pectxt.fileName, pectxt.nativeResourcesAddr, start, pectxt.nativeResourcesSize ) ]
+
+
 let getDataEndPointsDelayed (pectxt: PEReader) ctxtH = 
     lazy
         let (ctxt: ILMetadataReader)  = getHole ctxtH
@@ -3688,7 +3703,7 @@ let openMetadataReader (fileName, mdfile: BinaryFile, metadataPhysLoc, peinfo, p
 // read of the AbsIL module.
 // ----------------------------------------------------------------------
 
-let openPEFileReader (fileName, pefile: BinaryFile, pdbPath) = 
+let openPEFileReader (fileName, pefile: BinaryFile, pdbPath, noFileOnDisk) = 
     let pev = pefile.GetView()
     (* MSDOS HEADER *)
     let peSignaturePhysLoc = seekReadInt32 pev 0x3c
@@ -3881,12 +3896,13 @@ let openPEFileReader (fileName, pefile: BinaryFile, pdbPath) =
           pefile=pefile
           fileName=fileName
           entryPointToken=entryPointToken
+          noFileOnDisk=noFileOnDisk
         }
     let peinfo = (subsys, (subsysMajor, subsysMinor), useHighEnthropyVA, ilOnly, only32, is32bitpreferred, only64, platform, isDll, alignVirt, alignPhys, imageBaseReal)
     (metadataPhysLoc, metadataSize, peinfo, pectxt, pev, pdb)
 
-let openPE (fileName, pefile, pdbPath, reduceMemoryUsage, ilGlobals) = 
-    let (metadataPhysLoc, _metadataSize, peinfo, pectxt, pev, pdb) = openPEFileReader (fileName, pefile, pdbPath) 
+let openPE (fileName, pefile, pdbPath, reduceMemoryUsage, ilGlobals, noFileOnDisk) = 
+    let (metadataPhysLoc, _metadataSize, peinfo, pectxt, pev, pdb) = openPEFileReader (fileName, pefile, pdbPath, noFileOnDisk) 
     let ilModule, ilAssemblyRefs = openMetadataReader (fileName, pefile, metadataPhysLoc, peinfo, pectxt, pev, Some pectxt, reduceMemoryUsage, ilGlobals)
     ilModule, ilAssemblyRefs, pdb
 
@@ -3963,7 +3979,7 @@ let tryMemoryMapWholeFile opts fileName =
 
 let OpenILModuleReaderFromBytes fileName bytes opts = 
     let pefile = ByteFile(fileName, bytes) :> BinaryFile
-    let ilModule, ilAssemblyRefs, pdb = openPE (fileName, pefile, opts.pdbPath, (opts.reduceMemoryUsage = ReduceMemoryFlag.Yes), opts.ilGlobals)
+    let ilModule, ilAssemblyRefs, pdb = openPE (fileName, pefile, opts.pdbPath, (opts.reduceMemoryUsage = ReduceMemoryFlag.Yes), opts.ilGlobals, true)
     new ILModuleReader(ilModule, ilAssemblyRefs, (fun () -> ClosePdbReader pdb))
 
 let OpenILModuleReader fileName opts = 
@@ -4011,7 +4027,7 @@ let OpenILModuleReader fileName opts =
                 // Then use the metadata blob as the long-lived memory resource.
                 let disposer, pefileEager = tryMemoryMapWholeFile opts fullPath
                 use _disposer = disposer
-                let (metadataPhysLoc, metadataSize, peinfo, pectxtEager, pevEager, _pdb) = openPEFileReader (fullPath, pefileEager, None) 
+                let (metadataPhysLoc, metadataSize, peinfo, pectxtEager, pevEager, _pdb) = openPEFileReader (fullPath, pefileEager, None, false) 
                 let mdfile = 
                     match mdfileOpt with 
                     | Some mdfile -> mdfile
@@ -4025,7 +4041,7 @@ let OpenILModuleReader fileName opts =
                 // If we are not doing metadata-only, then just go ahead and read all the bytes and hold them either strongly or weakly
                 // depending on the heuristic
                 let pefile = createByteFileChunk opts fullPath None
-                let ilModule, ilAssemblyRefs, _pdb = openPE (fullPath, pefile, None, reduceMemoryUsage, opts.ilGlobals) 
+                let ilModule, ilAssemblyRefs, _pdb = openPE (fullPath, pefile, None, reduceMemoryUsage, opts.ilGlobals, false) 
                 new ILModuleReader(ilModule, ilAssemblyRefs, ignore)
 
         if keyOk then 
@@ -4043,7 +4059,7 @@ let OpenILModuleReader fileName opts =
         //
         // We do however care about avoiding locks on files that prevent their deletion during a 
         // multi-proc build. So use memory mapping, but only for stable files.  Other files
-        // fill use an in-memory ByteFile
+        // still use an in-memory ByteFile
         let _disposer, pefile = 
             if alwaysMemoryMapFSC || stableFileHeuristicApplies fullPath then 
                 tryMemoryMapWholeFile opts fullPath
@@ -4052,7 +4068,7 @@ let OpenILModuleReader fileName opts =
                 let disposer = { new IDisposable with member __.Dispose() = () }
                 disposer, pefile
 
-        let ilModule, ilAssemblyRefs, pdb = openPE (fullPath, pefile, opts.pdbPath, reduceMemoryUsage, opts.ilGlobals)
+        let ilModule, ilAssemblyRefs, pdb = openPE (fullPath, pefile, opts.pdbPath, reduceMemoryUsage, opts.ilGlobals, false)
         let ilModuleReader = new ILModuleReader(ilModule, ilAssemblyRefs, (fun () -> ClosePdbReader pdb))
 
         // Readers with PDB reader disposal logic don't go in the cache.  Note the PDB reader is only used in static linking.

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -4064,7 +4064,7 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
                       reduceMemoryUsage = tcConfig.reduceMemoryUsage
                       pdbPath = None 
                       metadataOnly = MetadataOnlyFlag.Yes
-                      tryGetMetadataSnapshot = tcConfig.tryGetMetadataSnapshot }                       
+                      tryGetMetadataSnapshot = tcConfig.tryGetMetadataSnapshot }
                 let reader = OpenILModuleReaderFromBytes fileName bytes opts
                 reader.ILModuleDef, reader.ILAssemblyRefs
 


### PR DESCRIPTION
Cherry pick this fix from master, for release in the servicing train.

Fix FSC : error FS0193: Could not find file 'c:\Users\kevinr\source\r…epos\Library2\Library2\tmpB4E3.dll (#4800)