### PR TITLE
Set tailcalls to false for net sdk

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -47,6 +47,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols Condition="'$(DebugSymbols)' == '' ">true</DebugSymbols>
     <Optimize Condition="'$(Optimize)' == '' ">false</Optimize>
+    <Tailcalls Condition="'$(Tailcalls)' == '' ">false</Tailcalls>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -37,7 +37,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup>
     <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{F2A71F9B-5D33-465A-A702-920D77279786}</DefaultProjectTypeGuid>         <!-- F# project type -->
     <Prefer32Bit Condition="'$(Prefer32Bit)' == '' ">false</Prefer32Bit>
-    <Tailcalls Condition="'$(Tailcalls)' == '' ">true</Tailcalls>
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>
     <WarningLevel Condition=" '$(WarningLevel)' == '' ">3</WarningLevel>
     <WarningsAsErrors Condition="'$(WarningsAsErrors)' == '' " />
@@ -53,6 +52,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugSymbols Condition="'$(DebugSymbols)' == '' ">false</DebugSymbols>
     <Optimize Condition="'$(Optimize)' == '' ">true</Optimize>
+    <Tailcalls Condition="'$(Tailcalls)' == '' ">true</Tailcalls>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Unix' and Exists('$(MSBuildThisFileDirectory)\RunFsc.cmd')" >


### PR DESCRIPTION
Disable tailcalls by default for Debug configuration in net sdk projects.

Fixes:  4873
