### PR TITLE
Allow to build LexBuffer from array without copying.

### DIFF
--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -145,7 +145,6 @@ namespace Internal.Utilities.Text.Lexing
                 buffer <- repl
 
 
-        // A full type signature is required on this method because it is used at more specific types within its own scope
         static member FromFunction (f : 'Char[] * int * int -> int) : LexBuffer<'Char> = 
             let extension= Array.zeroCreate 4096
             let filler (lexBuffer: LexBuffer<'Char>) =
@@ -155,7 +154,6 @@ namespace Internal.Utilities.Text.Lexing
                  lexBuffer.BufferMaxScanLength <- lexBuffer.BufferScanLength + n
             new LexBuffer<'Char>(filler)
               
-        // A full type signature is required on this method because it is used at more specific types within its own scope
         // Important: This method takes ownership of the array
         static member FromArrayNoCopy (buffer: 'Char[]) : LexBuffer<'Char> = 
             let lexBuffer = new LexBuffer<'Char>(fun _ -> ())
@@ -163,7 +161,6 @@ namespace Internal.Utilities.Text.Lexing
             lexBuffer.BufferMaxScanLength <- buffer.Length
             lexBuffer
 
-        // A full type signature is required on this method because it is used at more specific types within its own scope
         // Important: this method does copy the array
         static member FromArray (s: 'Char[]) : LexBuffer<'Char> = 
             let buffer = Array.copy s 

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -156,14 +156,21 @@ namespace Internal.Utilities.Text.Lexing
             new LexBuffer<'Char>(filler)
               
         // A full type signature is required on this method because it is used at more specific types within its own scope
-        static member FromArray (s: 'Char[]) : LexBuffer<'Char> = 
+        // Important: This method takes ownership of the array
+        static member FromArrayNoCopy (buffer: 'Char[]) : LexBuffer<'Char> = 
             let lexBuffer = new LexBuffer<'Char>(fun _ -> ())
-            let buffer = Array.copy s 
             lexBuffer.Buffer <- buffer;
             lexBuffer.BufferMaxScanLength <- buffer.Length;
             lexBuffer
 
-        static member FromChars (arr:char[]) = LexBuffer.FromArray arr 
+        // A full type signature is required on this method because it is used at more specific types within its own scope
+        // Important: this method does copy the array
+        static member FromArray (s: 'Char[]) : LexBuffer<'Char> = 
+            let buffer = Array.copy s 
+            LexBuffer<'Char>.FromArrayNoCopy buffer
+
+        // Important: This method takes ownership of the array
+        static member FromChars (arr:char[]) = LexBuffer.FromArrayNoCopy arr 
 
     module GenericImplFragments = 
         let startInterpret(lexBuffer:LexBuffer<char>)= 

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -159,8 +159,8 @@ namespace Internal.Utilities.Text.Lexing
         // Important: This method takes ownership of the array
         static member FromArrayNoCopy (buffer: 'Char[]) : LexBuffer<'Char> = 
             let lexBuffer = new LexBuffer<'Char>(fun _ -> ())
-            lexBuffer.Buffer <- buffer;
-            lexBuffer.BufferMaxScanLength <- buffer.Length;
+            lexBuffer.Buffer <- buffer
+            lexBuffer.BufferMaxScanLength <- buffer.Length
             lexBuffer
 
         // A full type signature is required on this method because it is used at more specific types within its own scope

--- a/src/utils/prim-lexing.fsi
+++ b/src/utils/prim-lexing.fsi
@@ -65,6 +65,7 @@ type internal LexBuffer<'Char> =
     member IsPastEndOfStream: bool with get,set
 
     /// Create a lex buffer suitable for Unicode lexing that reads characters from the given array.
+    /// Important: does take ownership of the array.
     static member FromChars: char[] -> LexBuffer<char>
     /// Create a lex buffer that reads character or byte inputs by using the given function.
     static member FromFunction: ('Char[] * int * int -> int) -> LexBuffer<'Char>


### PR DESCRIPTION
All usages of FromChars seem to be taking a throw away array that caller don't keep a reference, usages found:

src\fsharp\lex.fsl(155)
src\fsharp\UnicodeLexing.fs(18)
src\fsharp\UnicodeLexing.fs(68)
src\fsharp\FSharp.Compiler.Private\lex.fs(154)
tests\FSharp.Compiler.UnitTests\HashIfExpression.fs(71)