### PR TITLE
remove old CopyAndSubstituteText build task and targets

### DIFF
--- a/src/buildfromsource/BuildFromSource.targets
+++ b/src/buildfromsource/BuildFromSource.targets
@@ -37,21 +37,6 @@
   <Import Project="..\FSharpSource.Profiles.targets" />
   <Import Project="$(BuildVersionFilePath)" Condition="Exists('$(BuildVersionFilePath)')" />
 
-  <Target Name="CopyAndSubstituteTextFiles" 
-          BeforeTargets="Compile"
-          Inputs="@(CopyAndSubstituteText)"
-          Outputs="@(CopyAndSubstituteText->'$(OutDir)%(TargetFilename)')"
-          Condition="'$(DesignTimeBuild)' != 'true'">
-
-    <ItemGroup>
-      <FileTextMap Include="%(CopyAndSubstituteText.TargetFilename)">
-        <FileText>$([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText("%(CopyAndSubstituteText.FullPath)")), "%(CopyAndSubstituteText.Pattern1)", "%(CopyAndSubstituteText.Replacement1)"))</FileText>
-        <FileText Condition = "'$(CurrentPattern2)' != ''">$([System.Text.RegularExpressions.Regex]::Replace($(FileText), "%(CopyAndSubstituteText.Pattern2)", "%(CopyAndSubstituteText.Replacement2)"))</FileText>
-      </FileTextMap>
-    </ItemGroup>
-    <WriteLinesToFile File="$(OutDir)%(FileTextMap.Identity)" Lines="%(FileTextMap.FileText)" Overwrite="true" />
-  </Target>
-
   <ItemGroup>
     <AvailableItemName Include="FsLex">
       <Visible>false</Visible>

--- a/src/buildfromsource/FSharp.Build/FSharp.Build.fsproj
+++ b/src/buildfromsource/FSharp.Build/FSharp.Build.fsproj
@@ -26,31 +26,11 @@
     <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\FSharpEmbedResXSource.fs" />
     <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\WriteCodeFragment.fs" />
     <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\CreateFSharpManifestResourceName.fs" />
-    <CopyAndSubstituteText Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.Targets">
-        <TargetFilename>Microsoft.FSharp.Targets</TargetFilename>
-        <Pattern1>{BuildSuffix}</Pattern1>
-        <Replacement1></Replacement1>
-    </CopyAndSubstituteText>
-    <CopyAndSubstituteText Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.Portable.FSharp.Targets">
-      <TargetFilename>Microsoft.Portable.FSharp.Targets</TargetFilename>
-      <Pattern1>{BuildSuffix}</Pattern1>
-      <Replacement1></Replacement1>
-    </CopyAndSubstituteText>
-    <CopyAndSubstituteText Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.NetSdk.props">
-        <TargetFilename>Microsoft.FSharp.NetSdk.props</TargetFilename>
-        <Pattern1>{BuildSuffix}</Pattern1>
-        <Replacement1></Replacement1>
-    </CopyAndSubstituteText>
-    <CopyAndSubstituteText Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.NetSdk.targets">
-        <TargetFilename>Microsoft.FSharp.NetSdk.targets</TargetFilename>
-        <Pattern1>{BuildSuffix}</Pattern1>
-        <Replacement1></Replacement1>
-    </CopyAndSubstituteText>
-    <CopyAndSubstituteText Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.Overrides.NetSdk.targets">
-        <TargetFilename>Microsoft.FSharp.Overrides.NetSdk.targets</TargetFilename>
-        <Pattern1>{BuildSuffix}</Pattern1>
-        <Replacement1></Replacement1>
-    </CopyAndSubstituteText>
+    <None Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.Targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.Portable.FSharp.Targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.NetSdk.props" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(FSharpSourcesRoot)\fsharp\FSharp.Build\Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The pattern `{BuildSuffix}` is no longer present in the targets files so this is useless.