### PR TITLE
Fixed .NET SDK style project slowness in the editor

### DIFF
--- a/tests/projects/stress/Templates/netstandard_fsproj.template
+++ b/tests/projects/stress/Templates/netstandard_fsproj.template
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+[FILES]
+  </ItemGroup>
+  <ItemGroup>
+[PROJECTREFERENCES]
+  </ItemGroup>
+  <ItemGroup>
+[PACKAGEREFERENCES]
+  </ItemGroup>
+</Project>

--- a/tests/projects/stress/perf.fsx
+++ b/tests/projects/stress/perf.fsx
@@ -105,6 +105,30 @@ module FSharpProject =
 
         safeWrite path text
 
+    let writeNetStandard path (project : Project) =
+
+        let files =
+            let printFileReference = sprintf "    <Compile Include=\"%s\" />"
+            project.Files |> List.map printFileReference |> String.concat "\n"
+
+        for f in project.Files do 
+            let filePath = Path.Combine(Path.GetDirectoryName(path),f)
+            let fileContents = sprintf "module %s\n\nlet x = 1" (Path.GetFileNameWithoutExtension(f))
+            safeWrite filePath fileContents
+         
+        let references =
+            let printProjectReference (r : ProjectRef) =
+                sprintf "    <ProjectReference Include=\"%s\" />" r.RelativePath
+            project.References |> List.map printProjectReference |> String.concat "\n"
+
+        let text =
+            File.ReadAllText(Path.Combine(__SOURCE_DIRECTORY__,@"Templates\netstandard_fsproj.template"))
+                .Replace("[FILES]", files)
+                .Replace("[PROJECTREFERENCES]", references)
+                .Replace("[PACKAGEREFERENCES]", String.Empty)
+
+        safeWrite path text
+
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module CSharpProject =
 
@@ -132,6 +156,30 @@ module CSharpProject =
                 .Replace("[FILES]", files)
                 .Replace("[REFERENCES]", references)
                 .Replace("[BINARYREFERENCES]", binaryReferences)
+
+        safeWrite path text
+
+    let writeNetStandard path (project : Project) =
+
+        let files =
+            let printFileReference = sprintf "    <Compile Include=\"%s\" />"
+            project.Files |> List.map printFileReference |> String.concat "\n"
+
+        for f in project.Files do 
+            let filePath = Path.Combine(Path.GetDirectoryName(path),f)
+            let fileContents = sprintf "module %s\n\nlet x = 1" (Path.GetFileNameWithoutExtension(f))
+            safeWrite filePath fileContents
+         
+        let references =
+            let printProjectReference (r : ProjectRef) =
+                sprintf "    <ProjectReference Include=\"%s\" />" r.RelativePath
+            project.References |> List.map printProjectReference |> String.concat "\n"
+
+        let text =
+            File.ReadAllText(Path.Combine(__SOURCE_DIRECTORY__,@"Templates\netstandard_fsproj.template"))
+                .Replace("[FILES]", files)
+                .Replace("[PROJECTREFERENCES]", references)
+                .Replace("[PACKAGEREFERENCES]", String.Empty)
 
         safeWrite path text
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -427,7 +427,6 @@ type internal FSharpLanguageService(package : FSharpPackage) =
     member private this.OnProjectAdded(projectId:ProjectId) = projectInfoManager.UpdateProjectInfoWithProjectId(projectId, "OnProjectAdded", invalidateConfig=true)
     member private this.OnProjectReloaded(projectId:ProjectId) = projectInfoManager.UpdateProjectInfoWithProjectId(projectId, "OnProjectReloaded", invalidateConfig=true)
     member private this.OnDocumentAdded(projectId:ProjectId, documentId:DocumentId) = projectInfoManager.UpdateDocumentInfoWithProjectId(projectId, documentId, "OnDocumentAdded", invalidateConfig=true)
-    member private this.OnDocumentChanged(projectId:ProjectId, documentId:DocumentId) = projectInfoManager.UpdateDocumentInfoWithProjectId(projectId, documentId, "OnDocumentChanged", invalidateConfig=false)
     member private this.OnDocumentReloaded(projectId:ProjectId, documentId:DocumentId) = projectInfoManager.UpdateDocumentInfoWithProjectId(projectId, documentId, "OnDocumentReloaded", invalidateConfig=true)
 
     override this.Initialize() = 
@@ -439,7 +438,6 @@ type internal FSharpLanguageService(package : FSharpPackage) =
             | WorkspaceChangeKind.ProjectAdded     -> this.OnProjectAdded(args.ProjectId)
             | WorkspaceChangeKind.ProjectReloaded  -> this.OnProjectReloaded(args.ProjectId)
             | WorkspaceChangeKind.DocumentAdded    -> this.OnDocumentAdded(args.ProjectId, args.DocumentId)
-            | WorkspaceChangeKind.DocumentChanged  -> this.OnDocumentChanged(args.ProjectId, args.DocumentId)
             | WorkspaceChangeKind.DocumentReloaded -> this.OnDocumentReloaded(args.ProjectId, args.DocumentId)
             | WorkspaceChangeKind.DocumentRemoved
             | WorkspaceChangeKind.ProjectRemoved
@@ -686,17 +684,7 @@ type internal FSharpLanguageService(package : FSharpPackage) =
 
                             let fileContents = VsTextLines.GetFileContents(textLines, textViewAdapter)
                             this.SetupStandAloneFile(filename, fileContents, this.Workspace, hier)
-                    | id ->
-
-                        // This is the path when opening in-project .fs/.fsi files in CPS projects when
-                        // there is already an existing DocumentId for that document in the solution (which
-                        // will normally be the case)
-                        //
-                        // However, it is not clear this call to UpdateProjectInfoWithProjectId is needed, and it seems
-                        // harmful as it will cause a complete recheck of the project every time a view for a file in the
-                        // project is freshly opened.
-
-                        projectInfoManager.UpdateProjectInfoWithProjectId(id.ProjectId, "SetupNewTextView", invalidateConfig=true)
+                    | _ -> ()
                 | _ ->
 
                     // This is the path for both in-project and out-of-project .fsx files


### PR DESCRIPTION
This was something; took quite a bit of time tracking down, but now it's starting to make sense.

**Edited**

We changed the approach on how we fix this problem. Essentially, we are removing calls to `UpdateProjectInfo` on document opened/changed.

Test Plan

- New .NET SDK style project, measure time to first semantic highlighting
- Edit document in .NET SDK style project, time to semantic highlighting and autocomplete
- Generate large .NET SDK style solutions under `tests/projects/stress` and check load time and first semantic highlighting
- Check script in .NET SDK style project with `Include=None`.
- Check script in legacy project with `Include=None`
- Check script with same cases as above, but with `Include=Compile`
- Check script in no project without any project loaded
- Check out of project `.fs` file without a project loaded
- Check out of project `.fs` file where a project loaded .net sdk / legacy
- Check out of project `.fsx` script file where a project loaded .net sdk / legacy
- Close and re-open `SortedMap.fs` in Spreads, time to semantic highlighting after re-open.
- Close and re-open huge generated .NET SDK style `.fs` file, time to semantic highlighting after re-open.
- Add file in .NET SDK style project, check semantic highlighting
- Remove file in .NET SDK style project, check semantic highlighting
