### PR TITLE
add comments, fix formatting, cleanup flag

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -662,7 +662,7 @@ type internal FSharpLanguageService(package : FSharpPackage) =
             | Some (hier, _) ->
 
 
-                // Check if the file is in a CPS projct or not.
+                // Check if the file is in a CPS project or not.
                 // CPS projects don't implement IProvideProjectSite and IVSProjectHierarchy
                 // Simple explanation:
                 //    Legacy projects have IVSHierarchy and IProjectSite
@@ -671,7 +671,7 @@ type internal FSharpLanguageService(package : FSharpPackage) =
                 match hier with
                 | :? IProvideProjectSite as siteProvider when not (IsScript(filename)) ->
 
-                    // This is the path for out-of-project .fs files in legacy projects
+                    // This is the path for .fs/.fsi files in legacy projects
 
                     this.SetupProjectFile(siteProvider, this.Workspace, "SetupNewTextView")
 
@@ -682,13 +682,13 @@ type internal FSharpLanguageService(package : FSharpPackage) =
                     | null ->
                         if not (h.IsCapabilityMatch("CPS")) then
 
-                            // This is the path for out-of-project .fs files in CPS projects
+                            // This is the path when opening out-of-project .fs/.fsi files in CPS projects
 
                             let fileContents = VsTextLines.GetFileContents(textLines, textViewAdapter)
                             this.SetupStandAloneFile(filename, fileContents, this.Workspace, hier)
                     | id ->
 
-                        // This is the path for when opening in-project .fs/.fsi files in CPS projects when
+                        // This is the path when opening in-project .fs/.fsi files in CPS projects when
                         // there is already an existing DocumentId for that document in the solution (which
                         // will normally be the case)
                         //

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -160,12 +160,12 @@ type internal FSharpProjectOptionsManager
                 // compiled and #r will refer to files on disk
                 let referencedProjectFileNames = [| |] 
                 let site = ProjectSitesAndFiles.CreateProjectSiteForScript(fileName, referencedProjectFileNames, options)
-                let deps, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(Settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, tryGetOptionsForReferencedProject, site, serviceProvider, (tryGetOrCreateProjectId fileName), fileName, options.ExtraProjectInfo, Some projectOptionsTable, true)
+                let deps, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(Settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, tryGetOptionsForReferencedProject, site, serviceProvider, (tryGetOrCreateProjectId fileName), fileName, options.ExtraProjectInfo, Some projectOptionsTable)
                 let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)
                 return (deps, parsingOptions, projectOptions)
             else
                 let site = ProjectSitesAndFiles.ProjectSiteOfSingleFile(fileName)
-                let deps, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(Settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, tryGetOptionsForReferencedProject, site, serviceProvider, (tryGetOrCreateProjectId fileName), fileName, extraProjectInfo, Some projectOptionsTable, true)
+                let deps, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(Settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, tryGetOptionsForReferencedProject, site, serviceProvider, (tryGetOrCreateProjectId fileName), fileName, extraProjectInfo, Some projectOptionsTable)
                 let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)
                 return (deps, parsingOptions, projectOptions)
         }
@@ -175,7 +175,7 @@ type internal FSharpProjectOptionsManager
         projectOptionsTable.AddOrUpdateProject(projectId, (fun isRefresh ->
             let extraProjectInfo = Some(box workspace)
             let tryGetOptionsForReferencedProject f = f |> tryGetOrCreateProjectId |> Option.bind this.TryGetOptionsForProject |> Option.map(fun (_, _, projectOptions) -> projectOptions)
-            let referencedProjects, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(Settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, tryGetOptionsForReferencedProject, site, serviceProvider, (tryGetOrCreateProjectId (site.ProjectFileName)), site.ProjectFileName, extraProjectInfo,  Some projectOptionsTable, true)
+            let referencedProjects, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(Settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, tryGetOptionsForReferencedProject, site, serviceProvider, (tryGetOrCreateProjectId (site.ProjectFileName)), site.ProjectFileName, extraProjectInfo,  Some projectOptionsTable)
             if invalidateConfig then checkerProvider.Checker.InvalidateConfiguration(projectOptions, startBackgroundCompileIfAlreadySeen = not isRefresh, userOpName = userOpName + ".UpdateProjectInfo")
             let referencedProjectIds = referencedProjects |> Array.choose tryGetOrCreateProjectId
             let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -206,18 +206,18 @@ type internal FSharpProjectOptionsManager
             match singleFileProjectTable.TryGetValue(projectId) with
             | true, (loadTime, _, _) ->
                 try
-                let fileName = document.FilePath
-                let! cancellationToken = Async.CancellationToken
-                let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                // NOTE: we don't use FCS cross-project references from scripts to projects.  The projects must have been
-                // compiled and #r will refer to files on disk.
-                let tryGetOrCreateProjectId _ = None 
-                let! _referencedProjectFileNames, parsingOptions, projectOptions = this.ComputeSingleFileOptions (tryGetOrCreateProjectId, fileName, loadTime, sourceText.ToString())
-                this.AddOrUpdateSingleFileProject(projectId, (loadTime, parsingOptions, projectOptions))
-                return Some (parsingOptions, None, projectOptions)
+                    let fileName = document.FilePath
+                    let! cancellationToken = Async.CancellationToken
+                    let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
+                    // NOTE: we don't use FCS cross-project references from scripts to projects.  The projects must have been
+                    // compiled and #r will refer to files on disk.
+                    let tryGetOrCreateProjectId _ = None 
+                    let! _referencedProjectFileNames, parsingOptions, projectOptions = this.ComputeSingleFileOptions (tryGetOrCreateProjectId, fileName, loadTime, sourceText.ToString())
+                    this.AddOrUpdateSingleFileProject(projectId, (loadTime, parsingOptions, projectOptions))
+                    return Some (parsingOptions, None, projectOptions)
                 with ex -> 
-                Assert.Exception(ex)
-                return None
+                    Assert.Exception(ex)
+                    return None
             | _ -> return this.TryGetOptionsForProject(projectId)
         }
 
@@ -658,26 +658,51 @@ type internal FSharpLanguageService(package : FSharpPackage) =
         | (VSConstants.S_OK, textLines) ->
             let filename = VsTextLines.GetFilename textLines
 
-            // CPS projects don't implement IProvideProjectSite and IVSProjectHierarchy
-            // Simple explanation:
-            //    Legacy projects have IVSHierarchy and IPRojectSite
-            //    CPS Projects and loose script files don't
             match VsRunningDocumentTable.FindDocumentWithoutLocking(package.RunningDocumentTable,filename) with
             | Some (hier, _) ->
+
+
+                // Check if the file is in a CPS projct or not.
+                // CPS projects don't implement IProvideProjectSite and IVSProjectHierarchy
+                // Simple explanation:
+                //    Legacy projects have IVSHierarchy and IProjectSite
+                //    CPS Projects, out-of-project file and script files don't
+
                 match hier with
                 | :? IProvideProjectSite as siteProvider when not (IsScript(filename)) ->
+
+                    // This is the path for out-of-project .fs files in legacy projects
+
                     this.SetupProjectFile(siteProvider, this.Workspace, "SetupNewTextView")
+
                 | h when not (IsScript(filename)) ->
+                    
                     let docId = this.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filename).FirstOrDefault()
                     match docId with
                     | null ->
                         if not (h.IsCapabilityMatch("CPS")) then
+
+                            // This is the path for out-of-project .fs files in CPS projects
+
                             let fileContents = VsTextLines.GetFileContents(textLines, textViewAdapter)
                             this.SetupStandAloneFile(filename, fileContents, this.Workspace, hier)
                     | id ->
+
+                        // This is the path for when opening in-project .fs/.fsi files in CPS projects when
+                        // there is already an existing DocumentId for that document in the solution (which
+                        // will normally be the case)
+                        //
+                        // However, it is not clear this call to UpdateProjectInfoWithProjectId is needed, and it seems
+                        // harmful as it will cause a complete recheck of the project every time a view for a file in the
+                        // project is freshly opened.
+
                         projectInfoManager.UpdateProjectInfoWithProjectId(id.ProjectId, "SetupNewTextView", invalidateConfig=true)
                 | _ ->
+
+                    // This is the path for both in-project and out-of-project .fsx files
+
                     let fileContents = VsTextLines.GetFileContents(textLines, textViewAdapter)
                     this.SetupStandAloneFile(filename, fileContents, this.Workspace, hier)
+
             | _ -> ()
         | _ -> ()


### PR DESCRIPTION
`useUniqueStamp` stems from the time when `ProjectSitesAndFiles.fs` was shared between `FSharp.Editor` and `FSharp.LanguageService`. For `FSharp.Editor` this is always true, (and for the legacy `FSharp.LanguageService` this was always false). So the meaning of the flag was "are we using the unique stamping facility at all". 

Since we no longer share ProjectSitesAndFiles.fs we can remove this flag

