### PR TITLE
Add a test where generative TP DLL has native resources

### DIFF
--- a/tests/fsharp/TypeProviderTests.fs
+++ b/tests/fsharp/TypeProviderTests.fs
@@ -36,7 +36,9 @@ let diamondAssembly () =
 
     rm cfg "provider.dll"
 
-    fsc cfg "%s" "--out:provided.dll -a" [".." ++ "helloWorld" ++ "provided.fs"]
+    // Add a version flag to make this generate native resources. The native resources aren't important and 
+    // can be dropped when the provided.dll is linked but we need to tolerate generated DLLs that have them
+    fsc cfg "%s" "--out:provided.dll -a --version:0.0.0.1" [".." ++ "helloWorld" ++ "provided.fs"]
 
     fsc cfg "%s" "--out:provider.dll -a" [".." ++ "helloWorld" ++ "provider.fsx"]
 


### PR DESCRIPTION
Our test suite for generative type providers didn't have a test where the intermediate DLL has native resources.

The C# compiler always generates DLLs with native resources by default

The F# compiler only does it if there is some version information, see https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/fsc.fs#L928

@KevinRansom  Note that after thinking this over more, we should almost certainly just switch to drop the native resources when statically linking the intermediate DLL.  It is just wrong to be linking them in (e.g. duplicate/conflicting assembly version information?) and may mean incorrect binary generation.  I think we should just change our spec to drop the native resources from the generated DLL fragment.
