### PR TITLE
ensure primitive types are defined before auto-generated resources that might consume them

### DIFF
--- a/src/buildfromsource/FSharp.Core/FSharp.Core.fsproj
+++ b/src/buildfromsource/FSharp.Core/FSharp.Core.fsproj
@@ -19,12 +19,12 @@
     <EmbeddedResource Include="$(FsCoreDir)\FSCore.resx">
       <Link>FSCore.resx</Link>
     </EmbeddedResource>
-    <Compile Include="$(FsCoreDir)\prim-types-prelude.fsi">
+    <CompileBefore Include="$(FsCoreDir)\prim-types-prelude.fsi">
       <Link>Primitives/prim-types-prelude.fsi</Link>
-    </Compile>
-    <Compile Include="$(FsCoreDir)\prim-types-prelude.fs">
+    </CompileBefore>
+    <CompileBefore Include="$(FsCoreDir)\prim-types-prelude.fs">
       <Link>Primitives/prim-types-prelude.fs</Link>
-    </Compile>
+    </CompileBefore>
     <Compile Include="$(FsCoreDir)\SR.fs">
       <Link>Primitives/SR.fs</Link>
     </Compile>


### PR DESCRIPTION
Porting a subset of #4830 to fix source-build work.