### PR TITLE
Fixed multi-targeted projects from invalidating the MruCache on document open/changed 

### DIFF
--- a/fcs/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
+++ b/fcs/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
@@ -38,6 +38,7 @@ module Utils =
 
             logMap := Map.add opts.ProjectFile opts.LogOutput !logMap
             { ProjectFileName = opts.ProjectFile
+              ProjectId = None
               SourceFiles = sourceFiles
               OtherOptions = otherOptions
               ReferencedProjects = referencedProjects()

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1760,6 +1760,7 @@ type UnresolvedReferencesSet = UnresolvedReferencesSet of UnresolvedAssemblyRefe
 type FSharpProjectOptions =
     { 
       ProjectFileName: string
+      ProjectId: string option
       SourceFiles: string[]
       OtherOptions: string[]
       ReferencedProjects: (string * FSharpProjectOptions)[]
@@ -1773,15 +1774,18 @@ type FSharpProjectOptions =
     }
     member x.ProjectOptions = x.OtherOptions
     /// Whether the two parse options refer to the same project.
-    static member UseSameProjectFileName(options1,options2) =
-        options1.ProjectFileName = options2.ProjectFileName
+    static member UseSameProject(options1,options2) =
+        match options1.ProjectId, options2.ProjectId with
+        | Some(projectId1), Some(projectId2) -> String.Equals(projectId1, projectId2, StringComparison.OrdinalIgnoreCase)
+        | None, None -> options1.ProjectFileName = options2.ProjectFileName
+        | _ -> false
 
     /// Compare two options sets with respect to the parts of the options that are important to building.
     static member AreSameForChecking(options1,options2) =
         match options1.Stamp, options2.Stamp with 
         | Some x, Some y -> (x = y)
         | _ -> 
-        options1.ProjectFileName = options2.ProjectFileName &&
+        FSharpProjectOptions.UseSameProject(options1, options2) &&
         options1.SourceFiles = options2.SourceFiles &&
         options1.OtherOptions = options2.OtherOptions &&
         options1.UnresolvedReferences = options2.UnresolvedReferences &&
@@ -2155,7 +2159,7 @@ module Helpers =
     /// Determine whether two (fileName,options) keys should be identical w.r.t. resource usage
     let AreSubsumable2((fileName1:string,o1:FSharpProjectOptions),(fileName2:string,o2:FSharpProjectOptions)) =
         (fileName1 = fileName2)
-        && FSharpProjectOptions.UseSameProjectFileName(o1,o2)
+        && FSharpProjectOptions.UseSameProject(o1,o2)
 
     /// Determine whether two (fileName,sourceText,options) keys should be identical w.r.t. parsing
     let AreSameForParsing((fileName1: string, source1: string, options1), (fileName2, source2, options2)) =
@@ -2173,7 +2177,7 @@ module Helpers =
     /// Determine whether two (fileName,sourceText,options) keys should be identical w.r.t. resource usage
     let AreSubsumable3((fileName1:string,_,o1:FSharpProjectOptions),(fileName2:string,_,o2:FSharpProjectOptions)) =
         (fileName1 = fileName2)
-        && FSharpProjectOptions.UseSameProjectFileName(o1,o2)
+        && FSharpProjectOptions.UseSameProject(o1,o2)
 
 module CompileHelpers =
     let mkCompilationErorHandlers() = 
@@ -2316,7 +2320,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     let scriptClosureCache = 
         MruCache<ScriptClosureCacheToken, FSharpProjectOptions, LoadClosure>(projectCacheSize, 
             areSame=FSharpProjectOptions.AreSameForChecking, 
-            areSimilar=FSharpProjectOptions.UseSameProjectFileName)
+            areSimilar=FSharpProjectOptions.UseSameProject)
 
     let scriptClosureCacheLock = Lock<ScriptClosureCacheToken>()
     let frameworkTcImportsCache = FrameworkImportsCache(frameworkTcImportsCacheStrongSize)
@@ -2389,7 +2393,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
         MruCache<CompilationThreadToken, FSharpProjectOptions, (IncrementalBuilder option * FSharpErrorInfo[] * IDisposable)>
                 (keepStrongly=projectCacheSize, keepMax=projectCacheSize, 
                  areSame =  FSharpProjectOptions.AreSameForChecking, 
-                 areSimilar =  FSharpProjectOptions.UseSameProjectFileName,
+                 areSimilar =  FSharpProjectOptions.UseSameProject,
                  requiredToKeep=(fun (builderOpt,_,_) -> match builderOpt with None -> false | Some (b:IncrementalBuilder) -> b.IsBeingKeptAliveApartFromCacheEntry),
                  onDiscard = (fun (_, _, decrement:IDisposable) -> decrement.Dispose()))
 
@@ -2660,7 +2664,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
         let execWithReactorAsync action = reactor.EnqueueAndAwaitOpAsync(userOpName, "ParseAndCheckFileInProject", filename, action)
         async {
             try 
-                let strGuid = "_" + Guid.NewGuid().ToString()
+                let strGuid = "_ProjectId=" + (match options.ProjectId with Some(projectId) -> projectId | _ -> "null")
                 Logger.LogBlockMessageStart (filename + strGuid) LogCompilerFunctionId.Service_ParseAndCheckFileInProject
 
                 if implicitlyStartBackgroundWork then 
@@ -2832,6 +2836,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
             let options = 
                 {
                     ProjectFileName = filename + ".fsproj" // Make a name that is unique in this directory.
+                    ProjectId = None
                     SourceFiles = loadClosure.SourceFiles |> List.map fst |> List.toArray
                     OtherOptions = otherFlags 
                     ReferencedProjects= [| |]  
@@ -3184,6 +3189,7 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
     member ic.GetProjectOptionsFromCommandLineArgs(projectFileName, argv, ?loadedTimeStamp, ?extraProjectInfo: obj) = 
         let loadedTimeStamp = defaultArg loadedTimeStamp DateTime.MaxValue // Not 'now', we don't want to force reloading
         { ProjectFileName = projectFileName
+          ProjectId = None
           SourceFiles = [| |] // the project file names will be inferred from the ProjectOptions
           OtherOptions = argv 
           ReferencedProjects= [| |]  

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1611,7 +1611,7 @@ module internal Parser =
            userOpName: string) = 
         
         async {
-            use _logBlock = Logger.LogBlockMessage (Guid.NewGuid().ToString()) LogCompilerFunctionId.Service_CheckOneFile
+            use _logBlock = Logger.LogBlock LogCompilerFunctionId.Service_CheckOneFile
 
             match parseResults.ParseTree with 
             // When processing the following cases, we don't need to type-check
@@ -2664,7 +2664,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
         let execWithReactorAsync action = reactor.EnqueueAndAwaitOpAsync(userOpName, "ParseAndCheckFileInProject", filename, action)
         async {
             try 
-                let strGuid = "_ProjectId=" + (match options.ProjectId with Some(projectId) -> projectId | _ -> "null")
+                let strGuid = "_ProjectId=" + (options |> Option.defaultValue "null")
                 Logger.LogBlockMessageStart (filename + strGuid) LogCompilerFunctionId.Service_ParseAndCheckFileInProject
 
                 if implicitlyStartBackgroundWork then 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1776,7 +1776,9 @@ type FSharpProjectOptions =
     /// Whether the two parse options refer to the same project.
     static member UseSameProject(options1,options2) =
         match options1.ProjectId, options2.ProjectId with
-        | Some(projectId1), Some(projectId2) -> String.Equals(projectId1, projectId2, StringComparison.OrdinalIgnoreCase)
+        | Some(projectId1), Some(projectId2) when not (String.IsNullOrWhiteSpace(projectId1)) && not (String.IsNullOrWhiteSpace(projectId2)) -> 
+            String.Equals(projectId1, projectId2, StringComparison.OrdinalIgnoreCase)
+        | Some(_), Some(_)
         | None, None -> options1.ProjectFileName = options2.ProjectFileName
         | _ -> false
 
@@ -2664,7 +2666,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
         let execWithReactorAsync action = reactor.EnqueueAndAwaitOpAsync(userOpName, "ParseAndCheckFileInProject", filename, action)
         async {
             try 
-                let strGuid = "_ProjectId=" + (options |> Option.defaultValue "null")
+                let strGuid = "_ProjectId=" + (options.ProjectId |> Option.defaultValue "null")
                 Logger.LogBlockMessageStart (filename + strGuid) LogCompilerFunctionId.Service_ParseAndCheckFileInProject
 
                 if implicitlyStartBackgroundWork then 

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -309,6 +309,9 @@ type public FSharpProjectOptions =
       // Note that this may not reduce to just the project directory, because there may be two projects in the same directory.
       ProjectFileName: string
 
+      /// This is the unique identifier for the project, uses StringComparison.OrdinalIgnoreCase. If it's None, will key off of ProjectFileName in our caching.
+      ProjectId: string option
+
       /// The files in the project
       SourceFiles: string[]
 

--- a/tests/service/AssemblyContentProviderTests.fs
+++ b/tests/service/AssemblyContentProviderTests.fs
@@ -17,6 +17,7 @@ let private filePath = "C:\\test.fs"
 
 let private projectOptions : FSharpProjectOptions = 
     { ProjectFileName = "C:\\test.fsproj"
+      ProjectId = None
       SourceFiles =  [| filePath |]
       ReferencedProjects = [| |]
       OtherOptions = [| |]

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -100,6 +100,7 @@ let ``FileSystem compilation test``() =
                    yield "-r:" + r |]
  
         { ProjectFileName = @"c:\mycode\compilation.fsproj" // Make a name that is unique in this directory.
+          ProjectId = None
           SourceFiles = [| fileName1; fileName2 |]
           OtherOptions = allFlags 
           ReferencedProjects = [| |];

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -846,6 +846,7 @@ let ``Type provider project references should not throw exceptions`` () =
     //let options = ProjectCracker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Debug")])
     let options = 
           {ProjectFileName = __SOURCE_DIRECTORY__ + @"/data/TypeProviderConsole/TypeProviderConsole.fsproj";
+           ProjectId = None
            SourceFiles = [|__SOURCE_DIRECTORY__ + @"/data/TypeProviderConsole/Program.fs"|];
            Stamp = None
            OtherOptions =
@@ -871,6 +872,7 @@ let ``Type provider project references should not throw exceptions`` () =
            ReferencedProjects =
             [|(__SOURCE_DIRECTORY__ + @"/data/TypeProviderLibrary/TypeProviderLibrary.dll",
                {ProjectFileName = __SOURCE_DIRECTORY__ + @"/data/TypeProviderLibrary/TypeProviderLibrary.fsproj";
+                ProjectId = None
                 SourceFiles = [|__SOURCE_DIRECTORY__ + @"/data/TypeProviderLibrary/Library1.fs"|];
                 Stamp = None
                 OtherOptions =
@@ -935,7 +937,7 @@ let ``Projects creating generated types should not utilize cross-project-referen
     let options = 
           {ProjectFileName =
             __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/TestConsole.fsproj";
-           ProjectId = None;
+           ProjectId = None
            SourceFiles =
             [|__SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/AssemblyInfo.fs";
               __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/Program.fs"|];
@@ -964,7 +966,7 @@ let ``Projects creating generated types should not utilize cross-project-referen
             [|(__SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TypeProvidersBug/bin/Debug/TypeProvidersBug.dll",
                {ProjectFileName =
                  __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TypeProvidersBug/TypeProvidersBug.fsproj";
-                ProjectId = None;
+                ProjectId = None
                 SourceFiles =
                  [|__SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TypeProvidersBug/AssemblyInfo.fs";
                    __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TypeProvidersBug/Library1.fs"|];

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -935,6 +935,7 @@ let ``Projects creating generated types should not utilize cross-project-referen
     let options = 
           {ProjectFileName =
             __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/TestConsole.fsproj";
+           ProjectId = None;
            SourceFiles =
             [|__SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/AssemblyInfo.fs";
               __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/Program.fs"|];
@@ -963,6 +964,7 @@ let ``Projects creating generated types should not utilize cross-project-referen
             [|(__SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TypeProvidersBug/bin/Debug/TypeProvidersBug.dll",
                {ProjectFileName =
                  __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TypeProvidersBug/TypeProvidersBug.fsproj";
+                ProjectId = None;
                 SourceFiles =
                  [|__SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TypeProvidersBug/AssemblyInfo.fs";
                    __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TypeProvidersBug/Library1.fs"|];

--- a/vsintegration/Utils/LanguageServiceProfiling/Options.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Options.fs
@@ -196,6 +196,7 @@ let FCS (repositoryDir: string) : Options =
 
     { Options =
         {ProjectFileName = repositoryDir </> @"src\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj"
+         ProjectId = None
          SourceFiles = files |> Array.map (fun x -> repositoryDir </> x)
          OtherOptions =
           [|@"-o:obj\Release\FSharp.Compiler.Private.dll"; "-g"; "--noframework";
@@ -301,6 +302,7 @@ let FCS (repositoryDir: string) : Options =
 let VFPT (repositoryDir: string) : Options =
     { Options =
         {ProjectFileName = repositoryDir </> @"src\FSharp.Editing\FSharp.Editing.fsproj"
+         ProjectId = None
          SourceFiles =
           [|@"src\FSharp.Editing\AssemblyInfo.fs";
             @"src\FSharp.Editing\Common\Utils.fs";

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -24,7 +24,6 @@ type System.IServiceProvider with
     member x.GetService<'T>() = x.GetService(typeof<'T>) :?> 'T
     member x.GetService<'S, 'T>() = x.GetService(typeof<'S>) :?> 'T
 
-
 type FSharpNavigationDeclarationItem with
     member x.RoslynGlyph : Glyph =
         match x.Glyph with

--- a/vsintegration/src/FSharp.Editor/LanguageService/ProjectSitesAndFiles.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/ProjectSitesAndFiles.fs
@@ -274,6 +274,7 @@ type internal ProjectSitesAndFiles() =
         let option =
             let newOption () = {
                 ProjectFileName = projectSite.ProjectFileName
+                ProjectId = projectId |> Option.map (fun x -> x.Id.ToString())
                 SourceFiles = projectSite.CompilationSourceFiles
                 OtherOptions = projectSite.CompilationOptions
                 ReferencedProjects = referencedProjectOptions

--- a/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
@@ -358,6 +358,7 @@ type internal FSharpSource_DEPRECATED(service:LanguageService_DEPRECATED, textLi
             // get a sync parse of the file
             let co, _ = 
                 { ProjectFileName = fileName + ".dummy.fsproj"
+                  ProjectId = None
                   SourceFiles = [| fileName |]
                   OtherOptions = flags
                   ReferencedProjects = [| |]

--- a/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
+++ b/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
@@ -315,6 +315,7 @@ type internal ProjectSitesAndFiles() =
         let option =
             let newOption () = {
                 ProjectFileName = projectSite.ProjectFileName
+                ProjectId = None
                 SourceFiles = projectSite.CompilationSourceFiles
                 OtherOptions = projectSite.CompilationOptions
                 ReferencedProjects = referencedProjectOptions

--- a/vsintegration/tests/UnitTests/BraceMatchingServiceTests.fs
+++ b/vsintegration/tests/UnitTests/BraceMatchingServiceTests.fs
@@ -19,6 +19,7 @@ type BraceMatchingServiceTests()  =
     let fileName = "C:\\test.fs"
     let projectOptions: FSharpProjectOptions = { 
         ProjectFileName = "C:\\test.fsproj"
+        ProjectId = None
         SourceFiles =  [| fileName |]
         ReferencedProjects = [| |]
         OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/BreakpointResolutionService.fs
+++ b/vsintegration/tests/UnitTests/BreakpointResolutionService.fs
@@ -24,6 +24,7 @@ type BreakpointResolutionServiceTests()  =
     let fileName = "C:\\test.fs"
     let projectOptions: FSharpProjectOptions = { 
         ProjectFileName = "C:\\test.fsproj"
+        ProjectId = None
         SourceFiles =  [| fileName |]
         ReferencedProjects = [| |]
         OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/CompletionProviderTests.fs
+++ b/vsintegration/tests/UnitTests/CompletionProviderTests.fs
@@ -37,6 +37,7 @@ open UnitTests.TestLib.LanguageService
 let filePath = "C:\\test.fs"
 let internal projectOptions = { 
     ProjectFileName = "C:\\test.fsproj"
+    ProjectId = None
     SourceFiles =  [| filePath |]
     ReferencedProjects = [| |]
     OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/DocumentDiagnosticAnalyzerTests.fs
+++ b/vsintegration/tests/UnitTests/DocumentDiagnosticAnalyzerTests.fs
@@ -26,6 +26,7 @@ type DocumentDiagnosticAnalyzerTests()  =
     let endMarker = "(*end*)"
     let projectOptions: FSharpProjectOptions = { 
         ProjectFileName = "C:\\test.fsproj"
+        ProjectId = None
         SourceFiles =  [| filePath |]
         ReferencedProjects = [| |]
         OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/DocumentHighlightsServiceTests.fs
+++ b/vsintegration/tests/UnitTests/DocumentHighlightsServiceTests.fs
@@ -39,6 +39,7 @@ let filePath = "C:\\test.fs"
 
 let internal projectOptions = { 
     ProjectFileName = "C:\\test.fsproj"
+    ProjectId = None
     SourceFiles =  [| filePath |]
     ReferencedProjects = [| |]
     OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/EditorFormattingServiceTests.fs
+++ b/vsintegration/tests/UnitTests/EditorFormattingServiceTests.fs
@@ -20,6 +20,7 @@ type EditorFormattingServiceTests()  =
     let filePath = "C:\\test.fs"
     let projectOptions : FSharpProjectOptions = { 
         ProjectFileName = "C:\\test.fsproj"
+        ProjectId = None
         SourceFiles =  [| filePath |]
         ReferencedProjects = [| |]
         OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/GoToDefinitionServiceTests.fs
+++ b/vsintegration/tests/UnitTests/GoToDefinitionServiceTests.fs
@@ -103,6 +103,7 @@ let _ = Module1.foo 1
         let filePath = Path.GetTempFileName() + ".fs"
         let options: FSharpProjectOptions = { 
             ProjectFileName = "C:\\test.fsproj"
+            ProjectId = None
             SourceFiles =  [| filePath |]
             ReferencedProjects = [| |]
             OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/HelpContextServiceTests.fs
+++ b/vsintegration/tests/UnitTests/HelpContextServiceTests.fs
@@ -22,6 +22,7 @@ type HelpContextServiceTests() =
     let fileName = "C:\\test.fs"
     let options: FSharpProjectOptions = { 
         ProjectFileName = "C:\\test.fsproj"
+        ProjectId = None
         SourceFiles =  [| fileName |]
         ReferencedProjects = [| |]
         OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/IndentationServiceTests.fs
+++ b/vsintegration/tests/UnitTests/IndentationServiceTests.fs
@@ -21,6 +21,7 @@ type IndentationServiceTests()  =
     let filePath = "C:\\test.fs"
     let projectOptions: FSharpProjectOptions = { 
         ProjectFileName = "C:\\test.fsproj"
+        ProjectId = None
         SourceFiles =  [| filePath |]
         ReferencedProjects = [| |]
         OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/QuickInfoProviderTests.fs
+++ b/vsintegration/tests/UnitTests/QuickInfoProviderTests.fs
@@ -36,6 +36,7 @@ let filePath = "C:\\test.fs"
 
 let internal projectOptions = { 
     ProjectFileName = "C:\\test.fsproj"
+    ProjectId = None
     SourceFiles =  [| filePath |]
     ReferencedProjects = [| |]
     OtherOptions = [| |]

--- a/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/UnitTests/SignatureHelpProviderTests.fs
@@ -36,6 +36,7 @@ let PathRelativeToTestAssembly p = Path.Combine(Path.GetDirectoryName(Uri( Syste
 
 let internal projectOptions = { 
     ProjectFileName = "C:\\test.fsproj"
+    ProjectId = None
     SourceFiles =  [| filePath |]
     ReferencedProjects = [| |]
     OtherOptions = [| "-r:" + PathRelativeToTestAssembly(@"UnitTests\MockTypeProviders\DummyProviderForLanguageServiceTesting.dll") |]

--- a/vsintegration/tests/UnitTests/UnusedOpensTests.fs
+++ b/vsintegration/tests/UnitTests/UnusedOpensTests.fs
@@ -12,6 +12,7 @@ let private filePath = "C:\\test.fs"
 
 let private projectOptions : FSharpProjectOptions = 
     { ProjectFileName = "C:\\test.fsproj"
+      ProjectId = None
       SourceFiles =  [| filePath |]
       ReferencedProjects = [| |]
       OtherOptions = [| |]


### PR DESCRIPTION
Here are the things that this PR does:

- Added a new field to `FSharpProjectOptions`, `ProjectId`. It is an optional string. If set to None, the cache will key off the `ProjectFileName`. When it is set, it will key off the `ProjectId`. This extends FCS to be able to handle multi-targeted projects since each target is a different project with the same `ProjectFileName`.
- We clear the options table based on the `ProjectId` when a workspace `ProjectRemoved` event happens; this handles removing multi-targeted projects.

All of this should fix more perf issues related to multi-targeted projects, specifically when invalidating the cache. Type checking will still happen for each target, but that is what Roslyn does today; we could add option to only type check on the document in current context if people really want that.