### PR TITLE
Fixed highlights service

### DIFF
--- a/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
@@ -9,7 +9,6 @@ open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.DocumentHighlighting
-open Microsoft.CodeAnalysis.Editor
 open Microsoft.CodeAnalysis.Host.Mef
 open Microsoft.CodeAnalysis.Text
 


### PR DESCRIPTION
We needed to use the `IDocumentHighlightsService` from `CodeAnalysis.DocumentHighlighting` as the one from `CodeAnalysis.Editor` is gone.