### PR TITLE
[RFCs FS-1037, FS-1055] allow flexible inference (subsumption) at union construction and list/sequence/array yield points

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -418,8 +418,6 @@ let PreferUnifyTypar (v1:Typar) (v2:Typar) =
          | true, false -> false
          | _ -> true
 
-
-
 /// Reorder a list of (variable, exponent) pairs so that a variable that is Preferred
 /// is at the head of the list, if possible
 let FindPreferredTypar vs =
@@ -471,12 +469,12 @@ and SolveTypStaticReq (csenv:ConstraintSolverEnv) trace req ty =
             | Some tpr -> SolveTypStaticReqTypar csenv trace req tpr
             | None -> CompleteD
       
-let rec TransactDynamicReq (trace:OptionalTrace) (tpr:Typar) req = 
+let TransactDynamicReq (trace:OptionalTrace) (tpr:Typar) req = 
     let orig = tpr.DynamicReq
     trace.Exec (fun () -> tpr.SetDynamicReq req) (fun () -> tpr.SetDynamicReq orig)
     CompleteD
 
-and SolveTypDynamicReq (csenv:ConstraintSolverEnv) trace req ty =
+let SolveTypDynamicReq (csenv:ConstraintSolverEnv) trace req ty =
     match req with 
     | TyparDynamicReq.No -> CompleteD
     | TyparDynamicReq.Yes -> 
@@ -484,6 +482,19 @@ and SolveTypDynamicReq (csenv:ConstraintSolverEnv) trace req ty =
         | Some tpr when tpr.DynamicReq <> TyparDynamicReq.Yes ->
             TransactDynamicReq trace tpr TyparDynamicReq.Yes
         | _ -> CompleteD
+
+let TransactIsCompatFlex (trace:OptionalTrace) (tpr:Typar) req = 
+    let orig = tpr.IsCompatFlex
+    trace.Exec (fun () -> tpr.SetIsCompatFlex req) (fun () -> tpr.SetIsCompatFlex orig)
+    CompleteD
+
+let SolveTypIsCompatFlex (csenv:ConstraintSolverEnv) trace req ty =
+    if req then 
+        match tryAnyParTy csenv.g ty with
+        | Some tpr when not tpr.IsCompatFlex -> TransactIsCompatFlex trace tpr req
+        | _ -> CompleteD
+    else
+        CompleteD
 
 let SubstMeasureWarnIfRigid (csenv:ConstraintSolverEnv) trace (v:Typar) ms =
     if v.Rigidity.WarnIfUnified && not (isAnyParTy csenv.g (TType_measure ms)) then         
@@ -717,21 +728,23 @@ let rec SolveTyparEqualsTyp (csenv:ConstraintSolverEnv) ndeep m2 (trace:Optional
            CompleteD) ++ (fun _ ->
       
       // Re-solve the other constraints associated with this type variable 
-      solveTypMeetsTyparConstraints csenv ndeep m2 trace ty (r.DynamicReq, r.StaticReq, r.Constraints)))
+      solveTypMeetsTyparConstraints csenv ndeep m2 trace ty r))
 
     | _ -> failwith "SolveTyparEqualsTyp")
     
 
-/// Given a type 'ty' and a set of constraints on that type, solve those constraints. 
-and solveTypMeetsTyparConstraints (csenv:ConstraintSolverEnv) ndeep m2 trace ty (dreq, sreq, cs) =
+/// Apply the constraints on 'typar' to the type 'ty'
+and solveTypMeetsTyparConstraints (csenv:ConstraintSolverEnv) ndeep m2 trace ty (r: Typar) = 
     let g = csenv.g
+    // Propagate compat flex requirements from 'tp' to 'ty'
+    SolveTypIsCompatFlex csenv trace r.IsCompatFlex ty ++ (fun () -> 
     // Propagate dynamic requirements from 'tp' to 'ty'
-    SolveTypDynamicReq csenv trace dreq ty ++ (fun () -> 
+    SolveTypDynamicReq csenv trace r.DynamicReq ty ++ (fun () -> 
     // Propagate static requirements from 'tp' to 'ty' 
-    SolveTypStaticReq csenv trace sreq ty ++ (fun () -> 
+    SolveTypStaticReq csenv trace r.StaticReq ty ++ (fun () -> 
     
     // Solve constraints on 'tp' w.r.t. 'ty' 
-    cs |> IterateD (function
+    r.Constraints |> IterateD (function
       | TyparConstraint.DefaultsTo (priority, dty, m) -> 
           if typeEquiv g ty dty then 
               CompleteD
@@ -754,7 +767,7 @@ and solveTypMeetsTyparConstraints (csenv:ConstraintSolverEnv) ndeep m2 trace ty 
       | TyparConstraint.CoercesTo(ty2, m2)              -> SolveTypSubsumesTypKeepAbbrevs     csenv ndeep m2 trace None ty2 ty
       | TyparConstraint.MayResolveMember(traitInfo, m2) -> 
           SolveMemberConstraint csenv false false ndeep m2 trace traitInfo ++ (fun _ -> CompleteD) 
-    )))
+    ))))
 
         
 /// Add the constraint "ty1 = ty2" to the constraint problem. 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -2164,11 +2164,13 @@ module GeneralizationHelpers =
 
         // Some situations, e.g. implicit class constructions that represent functions as fields, 
         // do not allow generalisation over constrained typars. (since they can not be represented as fields)
+        //
+        // Don't generalize IsCompatFlex type parameters to avoid changing inferred types.
         let generalizedTypars, ungeneralizableTypars3 = 
             generalizedTypars 
             |> List.partition (fun tp -> 
-                genConstrainedTyparFlag = CanGeneralizeConstrainedTypars || 
-                tp.Constraints.IsEmpty) 
+                (genConstrainedTyparFlag = CanGeneralizeConstrainedTypars || tp.Constraints.IsEmpty) &&
+                not tp.IsCompatFlex) 
 
         if isNil ungeneralizableTypars1 && isNil ungeneralizableTypars2 && isNil ungeneralizableTypars3 then
             generalizedTypars, freeInEnv

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -2930,7 +2930,7 @@ let TcRuntimeTypeTest isCast isOperator cenv denv m tgty srcTy =
     if TypeDefinitelySubsumesTypeNoCoercion 0 cenv.g cenv.amap m tgty srcTy then 
       warning(TypeTestUnnecessary(m))
 
-    if isTyparTy cenv.g srcTy && not (destTyparTy cenv.g tgty).IsCompatFlex then 
+    if isTyparTy cenv.g srcTy && not (destTyparTy cenv.g srcTy).IsCompatFlex then 
         error(IndeterminateRuntimeCoercion(denv, srcTy, tgty, m))
 
     if isSealedTy cenv.g srcTy then 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -2930,7 +2930,7 @@ let TcRuntimeTypeTest isCast isOperator cenv denv m tgty srcTy =
     if TypeDefinitelySubsumesTypeNoCoercion 0 cenv.g cenv.amap m tgty srcTy then 
       warning(TypeTestUnnecessary(m))
 
-    if isTyparTy cenv.g srcTy then 
+    if isTyparTy cenv.g srcTy && not (destTyparTy cenv.g tgty).IsCompatFlex then 
         error(IndeterminateRuntimeCoercion(denv, srcTy, tgty, m))
 
     if isSealedTy cenv.g srcTy then 
@@ -2956,19 +2956,17 @@ let TcRuntimeTypeTest isCast isOperator cenv denv m tgty srcTy =
 ///  Checks, warnings and constraint assertions for upcasts 
 let TcStaticUpcast cenv denv m tgty srcTy =
     if isTyparTy cenv.g tgty then 
-        error(IndeterminateStaticCoercion(denv, srcTy, tgty, m)) 
+        if not (destTyparTy cenv.g tgty).IsCompatFlex then 
+            error(IndeterminateStaticCoercion(denv, srcTy, tgty, m)) 
+            //else warning(UpcastUnnecessary(m))
 
-    if isSealedTy cenv.g tgty then 
+    if isSealedTy cenv.g tgty && not (isTyparTy cenv.g tgty) then 
         warning(CoercionTargetSealed(denv, tgty, m))
 
     if typeEquiv cenv.g srcTy tgty then 
         warning(UpcastUnnecessary(m)) 
 
     AddCxTypeMustSubsumeType ContextInfo.NoContext denv cenv.css m NoTrace tgty srcTy
-
-
-
-
 
 let BuildPossiblyConditionalMethodCall cenv env isMutable m isProp minfo valUseFlags minst objArgs args =
 
@@ -5460,9 +5458,11 @@ and TcExprOfUnknownType cenv env tpenv expr =
     let expr', tpenv = TcExpr cenv exprty env tpenv expr
     expr', exprty, tpenv
 
-and TcExprFlex cenv flex ty (env: TcEnv) tpenv (e: SynExpr) =
+and TcExprFlex cenv flex compat ty (env: TcEnv) tpenv (e: SynExpr) =
     if flex then
         let argty = NewInferenceType ()
+        if compat then 
+            (destTyparTy cenv.g argty).SetIsCompatFlex(true)
         AddCxTypeMustSubsumeType ContextInfo.NoContext env.DisplayEnv cenv.css e.Range NoTrace ty argty 
         let e', tpenv  = TcExpr cenv argty env tpenv e 
         let e' = mkCoerceIfNeeded cenv.g ty argty e'
@@ -5592,7 +5592,7 @@ and TcExprThen cenv overallTy env tpenv synExpr delayed =
 and TcExprs cenv env m tpenv flexes argtys args = 
     if List.length args <> List.length argtys then error(Error(FSComp.SR.tcExpressionCountMisMatch((List.length argtys), (List.length args)), m))
     (tpenv, List.zip3 flexes argtys args) ||> List.mapFold (fun tpenv (flex, ty, e) -> 
-         TcExprFlex cenv flex ty env tpenv e)
+         TcExprFlex cenv flex false ty env tpenv e)
 
 and CheckSuperInit cenv objTy m =
     // Check the type is not abstract
@@ -5757,7 +5757,7 @@ and TcExprUndelayed cenv overallTy env tpenv (expr: SynExpr) =
             else
                 { env with eContextInfo = ContextInfo.CollectionElement (isArray, m) }
 
-        let args', tpenv = List.mapFold (fun tpenv (x:SynExpr) -> TcExprFlex cenv flex argty (getInitEnv x.Range) tpenv x) tpenv args
+        let args', tpenv = List.mapFold (fun tpenv (x:SynExpr) -> TcExprFlex cenv flex false argty (getInitEnv x.Range) tpenv x) tpenv args
         
         let expr = 
             if isArray then Expr.Op(TOp.Array, [argty], args', m)
@@ -5844,17 +5844,37 @@ and TcExprUndelayed cenv overallTy env tpenv (expr: SynExpr) =
 
             TcExprUndelayed cenv overallTy env tpenv replacementExpr
         | _ -> 
+
             let genCollElemTy = NewInferenceType ()
+
             let genCollTy =  (if isArray then mkArrayType else mkListTy) cenv.g genCollElemTy
+
             UnifyTypes cenv env m overallTy genCollTy
+
             let exprty =  mkSeqTy cenv.g genCollElemTy
+
+            // Check the comprehension
             let expr, tpenv = TcExpr cenv exprty env tpenv comp
+
             let expr = mkCoerceIfNeeded cenv.g exprty (tyOfExpr cenv.g expr) expr
-            (if isArray then mkCallSeqToArray else mkCallSeqToList) 
-                cenv.g m genCollElemTy 
-                // We add a call to 'seq ... ' to make sure sequence expression compilation gets applied to the contents of the
-                // comprehension. But don't do this in FSharp.Core.dll since 'seq' may not yet be defined.
-                (mkCoerceExpr((if cenv.g.compilingFslib then id else mkCallSeq cenv.g m genCollElemTy) expr, exprty, expr.Range, overallTy)), tpenv
+
+            let expr = 
+                if cenv.g.compilingFslib then 
+                    expr 
+                else 
+                    // We add a call to 'seq ... ' to make sure sequence expression compilation gets applied to the contents of the
+                    // comprehension. But don't do this in FSharp.Core.dll since 'seq' may not yet be defined.
+                   mkCallSeq cenv.g m genCollElemTy expr
+                   
+            let expr = mkCoerceExpr(expr, exprty, expr.Range, overallTy)
+
+            let expr = 
+                if isArray then 
+                    mkCallSeqToArray cenv.g m genCollElemTy expr
+                else 
+                    mkCallSeqToList cenv.g m genCollElemTy expr
+                
+            expr, tpenv
 
     | SynExpr.LetOrUse _ ->
         TcLinearExprs (TcExprThatCanBeCtorBody cenv) cenv env overallTy tpenv false expr (fun x -> x) 
@@ -6067,6 +6087,7 @@ and TcIteratedLambdas cenv isFirst (env: TcEnv) overallTy takenNames tpenv e =
     | e -> 
         // Dive into the expression to check for syntax errors and suppress them if they show.
         conditionallySuppressErrorReporting (not isFirst && synExprContainsError e) (fun () ->
+            //TcExprFlex cenv true true overallTy env tpenv e)
             TcExpr cenv overallTy env tpenv e)
         
 
@@ -6277,7 +6298,7 @@ and TcRecordConstruction cenv overallTy env tpenv optOrigExpr objTy fldsList m =
     let fldsList, tpenv = 
         let env = { env with eContextInfo = ContextInfo.RecordFields }
         (tpenv, fldsList) ||> List.mapFold (fun tpenv (fname, fexpr, fty, flex) ->
-              let fieldExpr, tpenv = TcExprFlex cenv flex fty env tpenv fexpr
+              let fieldExpr, tpenv = TcExprFlex cenv flex false fty env tpenv fexpr
               (fname, fieldExpr), tpenv)
               
     // Add rebindings for unbound field when an "old value" is available 
@@ -8066,6 +8087,12 @@ and TcComputationExpression cenv env overallTy mWhole interpExpr builderTy tpenv
 /// Also "ienumerable extraction" is performed on arguments to "for".
 and TcSequenceExpression cenv env tpenv comp overallTy m = 
 
+        let genEnumElemTy = NewInferenceType ()
+        UnifyTypes cenv env m overallTy (mkSeqTy cenv.g genEnumElemTy)
+
+        // Allow subsumption at 'yield' if the element type is nominal prior to the analysis of the body of the sequence expression
+        let flex = not (isTyparTy cenv.g genEnumElemTy)
+
         let mkDelayedExpr (coreExpr:Expr) = 
             let m = coreExpr.Range
             let overallTy = tyOfExpr cenv.g coreExpr
@@ -8215,7 +8242,7 @@ and TcSequenceExpression cenv env tpenv comp overallTy m =
                 if not isYield then errorR(Error(FSComp.SR.tcSeqResultsUseYield(), m)) 
                 UnifyTypes cenv env m genOuterTy (mkSeqTy cenv.g genResultTy)
 
-                let resultExpr, tpenv = TcExprFlex cenv true genResultTy env tpenv yieldExpr
+                let resultExpr, tpenv = TcExprFlex cenv flex true genResultTy env tpenv yieldExpr
                 Some(mkCallSeqSingleton cenv.g m genResultTy resultExpr, tpenv )
 
             | _ -> None
@@ -8230,9 +8257,6 @@ and TcSequenceExpression cenv env tpenv comp overallTy m =
                 let env = { env with eContextInfo = ContextInfo.SequenceExpression genOuterTy }
                 let expr, tpenv = TcStmtThatCantBeCtorBody cenv env tpenv comp
                 Expr.Sequential(expr, mkSeqEmpty cenv env m genOuterTy, NormalSeq, SuppressSequencePointOnStmtOfSequential, m), tpenv
-
-        let genEnumElemTy = NewInferenceType ()
-        UnifyTypes cenv env m overallTy (mkSeqTy cenv.g genEnumElemTy)
 
         let coreExpr, tpenv = tcSequenceExprBody env overallTy tpenv comp
         let delayedExpr = mkDelayedExpr coreExpr
@@ -8821,7 +8845,7 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
                     if not vref.IsMutable then error (ValNotMutable(env.DisplayEnv, vref, mStmt))
                     vty 
             // Always allow subsumption on assignment to fields
-            let e2', tpenv = TcExprFlex cenv true vty2 env tpenv e2
+            let e2', tpenv = TcExprFlex cenv true false vty2 env tpenv e2
             let vexp = 
                 if isByrefTy cenv.g vty then 
                   mkAddrSet mStmt vref e2'
@@ -8887,7 +8911,7 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
         | DelayedSet(e2, mStmt) :: _delayed' ->
             UnifyTypes cenv env mStmt overallTy cenv.g.unit_ty
             // Always allow subsumption on assignment to fields
-            let e2', tpenv = TcExprFlex cenv true exprty env tpenv e2
+            let e2', tpenv = TcExprFlex cenv true false exprty env tpenv e2
             let expr = BuildILStaticFieldSet mStmt finfo e2'
             expr, tpenv
         | _ -> 
@@ -8925,7 +8949,7 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
             UnifyTypes cenv env mStmt overallTy cenv.g.unit_ty
             let fieldTy = rfinfo.FieldType
             // Always allow subsumption on assignment to fields
-            let e2', tpenv = TcExprFlex cenv true fieldTy env tpenv e2
+            let e2', tpenv = TcExprFlex cenv true false fieldTy env tpenv e2
             let expr = mkStaticRecdFieldSet (rfinfo.RecdFieldRef, rfinfo.TypeInst, e2', mStmt)
             expr, tpenv
         | _  ->
@@ -9065,7 +9089,7 @@ and TcLookupThen cenv overallTy env tpenv mObjExpr objExpr objExprTy longId dela
             CheckRecdFieldMutation mItem env.DisplayEnv rfinfo
             UnifyTypes cenv env mStmt overallTy cenv.g.unit_ty
             // Always allow subsumption on assignment to fields
-            let e2', tpenv = TcExprFlex cenv true fieldTy env tpenv e2
+            let e2', tpenv = TcExprFlex cenv true false fieldTy env tpenv e2
             BuildRecdFieldSet cenv.g mStmt objExpr rfinfo e2', tpenv
 
         | _ ->
@@ -9084,7 +9108,7 @@ and TcLookupThen cenv overallTy env tpenv mObjExpr objExpr objExprTy longId dela
         | DelayedSet(e2, mStmt) :: _delayed' ->
             UnifyTypes cenv env mStmt overallTy cenv.g.unit_ty
             // Always allow subsumption on assignment to fields
-            let e2', tpenv = TcExprFlex cenv true exprty env tpenv e2
+            let e2', tpenv = TcExprFlex cenv true false exprty env tpenv e2
             let expr = BuildILFieldSet cenv.g mStmt objExpr finfo e2'
             expr, tpenv
         | _ ->        

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -310,73 +310,84 @@ type TyparRigidity =
 type TyparFlags(flags:int32) =
 
     new (kind:TyparKind, rigidity:TyparRigidity, isFromError:bool, isCompGen:bool, staticReq:TyparStaticReq, dynamicReq:TyparDynamicReq, equalityDependsOn: bool, comparisonDependsOn: bool) = 
-        TyparFlags((if isFromError then                0b0000000000010 else 0) |||
-                   (if isCompGen   then                0b0000000000100 else 0) |||
+        TyparFlags((if isFromError then                0b00000000000000010 else 0) |||
+                   (if isCompGen   then                0b00000000000000100 else 0) |||
                    (match staticReq with
-                     | NoStaticReq                  -> 0b0000000000000
-                     | HeadTypeStaticReq            -> 0b0000000001000) |||
+                     | NoStaticReq                  -> 0b00000000000000000
+                     | HeadTypeStaticReq            -> 0b00000000000001000) |||
                    (match rigidity with
-                     | TyparRigidity.Rigid          -> 0b0000000000000
-                     | TyparRigidity.WillBeRigid    -> 0b0000000100000
-                     | TyparRigidity.WarnIfNotRigid -> 0b0000001000000
-                     | TyparRigidity.Flexible       -> 0b0000001100000
-                     | TyparRigidity.Anon           -> 0b0000010000000) |||
+                     | TyparRigidity.Rigid          -> 0b00000000000000000
+                     | TyparRigidity.WillBeRigid    -> 0b00000000000100000
+                     | TyparRigidity.WarnIfNotRigid -> 0b00000000001000000
+                     | TyparRigidity.Flexible       -> 0b00000000001100000
+                     | TyparRigidity.Anon           -> 0b00000000010000000) |||
                    (match kind with
-                     | TyparKind.Type               -> 0b0000000000000
-                     | TyparKind.Measure            -> 0b0000100000000) |||   
+                     | TyparKind.Type               -> 0b00000000000000000
+                     | TyparKind.Measure            -> 0b00000000100000000) |||   
                    (if comparisonDependsOn then 
-                                                       0b0001000000000 else 0) |||
+                                                       0b00000001000000000 else 0) |||
                    (match dynamicReq with
-                     | TyparDynamicReq.No           -> 0b0000000000000
-                     | TyparDynamicReq.Yes          -> 0b0010000000000) |||
+                     | TyparDynamicReq.No           -> 0b00000000000000000
+                     | TyparDynamicReq.Yes          -> 0b00000010000000000) |||
                    (if equalityDependsOn then 
-                                                       0b0100000000000 else 0))
+                                                       0b00000100000000000 else 0))
 
     /// Indicates if the type inference variable was generated after an error when type checking expressions or patterns
-    member x.IsFromError         = (flags &&& 0b0000000000010) <> 0x0
+    member x.IsFromError         = (flags &&& 0b00000000000000010) <> 0x0
 
     /// Indicates if the type variable is compiler generated, i.e. is an implicit type inference variable 
-    member x.IsCompilerGenerated = (flags &&& 0b0000000000100) <> 0x0
+    member x.IsCompilerGenerated = (flags &&& 0b00000000000000100) <> 0x0
 
     /// Indicates if the type variable has a static "head type" requirement, i.e. ^a variables used in FSharp.Core and member constraints.
     member x.StaticReq           = 
-                             match (flags &&& 0b0000000001000) with 
-                                            | 0b0000000000000 -> NoStaticReq
-                                            | 0b0000000001000 -> HeadTypeStaticReq
+                             match (flags &&& 0b00000000000001000) with 
+                                            | 0b00000000000000000 -> NoStaticReq
+                                            | 0b00000000000001000 -> HeadTypeStaticReq
                                             | _             -> failwith "unreachable"
 
     /// Indicates if the type variable can be solved or given new constraints. The status of a type variable
     /// generally always evolves towards being either rigid or solved. 
     member x.Rigidity = 
-                             match (flags &&& 0b0000011100000) with 
-                                            | 0b0000000000000 -> TyparRigidity.Rigid
-                                            | 0b0000000100000 -> TyparRigidity.WillBeRigid
-                                            | 0b0000001000000 -> TyparRigidity.WarnIfNotRigid
-                                            | 0b0000001100000 -> TyparRigidity.Flexible
-                                            | 0b0000010000000 -> TyparRigidity.Anon
+                             match (flags &&& 0b00000000011100000) with 
+                                            | 0b00000000000000000 -> TyparRigidity.Rigid
+                                            | 0b00000000000100000 -> TyparRigidity.WillBeRigid
+                                            | 0b00000000001000000 -> TyparRigidity.WarnIfNotRigid
+                                            | 0b00000000001100000 -> TyparRigidity.Flexible
+                                            | 0b00000000010000000 -> TyparRigidity.Anon
                                             | _          -> failwith "unreachable"
 
     /// Indicates whether a type variable can be instantiated by types or units-of-measure.
     member x.Kind           = 
-                             match (flags &&& 0b1000100000000) with 
-                                            | 0b0000000000000 -> TyparKind.Type
-                                            | 0b0000100000000 -> TyparKind.Measure
+                             match (flags &&& 0b00001000100000000) with 
+                                            | 0b00000000000000000 -> TyparKind.Type
+                                            | 0b00000000100000000 -> TyparKind.Measure
                                             | _             -> failwith "unreachable"
 
 
     /// Indicates that whether or not a generic type definition satisfies the comparison constraint is dependent on whether this type variable satisfies the comparison constraint.
     member x.ComparisonConditionalOn =
-                                   (flags &&& 0b0001000000000) <> 0x0
+                                   (flags &&& 0b00000001000000000) <> 0x0
+
     /// Indicates if a type parameter is needed at runtime and may not be eliminated
     member x.DynamicReq     = 
-                             match (flags &&& 0b0010000000000) with 
-                                            | 0b0000000000000 -> TyparDynamicReq.No
-                                            | 0b0010000000000 -> TyparDynamicReq.Yes
+                             match (flags &&& 0b00000010000000000) with 
+                                            | 0b00000000000000000 -> TyparDynamicReq.No
+                                            | 0b00000010000000000 -> TyparDynamicReq.Yes
                                             | _             -> failwith "unreachable"
+
     /// Indicates that whether or not a generic type definition satisfies the equality constraint is dependent on whether this type variable satisfies the equality constraint.
     member x.EqualityConditionalOn = 
-                                   (flags &&& 0b0100000000000) <> 0x0
+                                   (flags &&& 0b00000100000000000) <> 0x0
 
+    /// Indicates that whether this type parameter is a compat-flex type parameter (i.e. where "expr :> tp" only emits an optional warning)
+    member x.IsCompatFlex = 
+                                   (flags &&& 0b00010000000000000) <> 0x0
+
+    member x.WithCompatFlex(b) =  
+                  if b then 
+                      TyparFlags(flags |||    0b00010000000000000)
+                  else
+                      TyparFlags(flags &&& ~~~0b00010000000000000)
 
     /// Get the flags as included in the F# binary metadata. We pickle this as int64 to allow for future expansion
     member x.PickledBits =         flags       
@@ -2059,6 +2070,12 @@ and
 
     /// Indicates if the type inference variable was generated after an error when type checking expressions or patterns
     member x.IsFromError         = x.typar_flags.IsFromError
+
+    /// Indicates that whether this type parameter is a compat-flex type parameter (i.e. where "expr :> tp" only emits an optional warning)
+    member x.IsCompatFlex        = x.typar_flags.IsCompatFlex
+
+    /// Set whether this type parameter is a compat-flex type parameter (i.e. where "expr :> tp" only emits an optional warning)
+    member x.SetIsCompatFlex(b)  = x.typar_flags <- x.typar_flags.WithCompatFlex(b)
 
     /// Indicates whether a type variable can be instantiated by types or units-of-measure.
     member x.Kind                = x.typar_flags.Kind

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1822,7 +1822,7 @@ module TypecheckTests =
     [<Test>]
     let ``sigs pos31`` () = 
         let cfg = testConfig "typecheck/sigs"
-        fsc cfg "%s --target:exe -o:pos31.exe --warnaserror" cfg.fsc_flags ["pos31.fs"]
+        fsc cfg "%s --target:exe -o:pos31.exe --warnaserror" cfg.fsc_flags ["pos31.fsi"; "pos31.fs"]
         peverify cfg "pos31.exe"
 
     [<Test>]

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1820,6 +1820,12 @@ module TypecheckTests =
         peverify cfg "pos24.exe"
 
     [<Test>]
+    let ``sigs pos31`` () = 
+        let cfg = testConfig "typecheck/sigs"
+        fsc cfg "%s --target:exe -o:pos31.exe --warnaserror" cfg.fsc_flags ["pos31.fs"]
+        peverify cfg "pos31.exe"
+
+    [<Test>]
     let ``sigs pos23`` () = 
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos23.exe" cfg.fsc_flags ["pos23.fs"]

--- a/tests/fsharp/typecheck/sigs/pos31.fs
+++ b/tests/fsharp/typecheck/sigs/pos31.fs
@@ -17,15 +17,6 @@ let g4 () : System.Reflection.MemberInfo[] =
     [| yield! g2()
        yield Unchecked.defaultof<System.Type> |]
 
-// Still not allowed
-//let g5 () = 
-//    [| yield Unchecked.defaultof<System.Type>
-//       yield Unchecked.defaultof<System.Reflection.MemberInfo> |]
-
-// Still not allowed
-//let g6 () = 
-//    [| 
-//       yield Unchecked.defaultof<System.Reflection.MemberInfo> 
- //      yield Unchecked.defaultof<System.Type>
- //   |]
-
+let g5 xs : System.Reflection.MemberInfo[] = 
+    [| for x in xs do yield x |]
+    

--- a/tests/fsharp/typecheck/sigs/pos31.fs
+++ b/tests/fsharp/typecheck/sigs/pos31.fs
@@ -6,3 +6,26 @@ let x3 : obj list  = [ yield ""  ]
 let x4 : obj[]  = [| yield "" |]
 let x5 : seq<obj>  = seq { yield "" }
 let x6 : seq<obj>  = seq { yield "" :> obj  }
+
+let g2 () : System.Reflection.MemberInfo[] = 
+    [| yield (Unchecked.defaultof<System.Type> :> _) |]
+
+let g3 () : System.Reflection.MemberInfo[] = 
+    [| yield Unchecked.defaultof<System.Type> |]
+
+let g4 () : System.Reflection.MemberInfo[] = 
+    [| yield! g2()
+       yield Unchecked.defaultof<System.Type> |]
+
+// Still not allowed
+//let g5 () = 
+//    [| yield Unchecked.defaultof<System.Type>
+//       yield Unchecked.defaultof<System.Reflection.MemberInfo> |]
+
+// Still not allowed
+//let g6 () = 
+//    [| 
+//       yield Unchecked.defaultof<System.Reflection.MemberInfo> 
+ //      yield Unchecked.defaultof<System.Type>
+ //   |]
+

--- a/tests/fsharp/typecheck/sigs/pos31.fs
+++ b/tests/fsharp/typecheck/sigs/pos31.fs
@@ -1,0 +1,5 @@
+module Pos31
+
+let x1 : list<obj>  = [ yield "" ]
+let x2 : seq<obj>  = seq { yield "" }
+let x3 : seq<obj>  = seq { yield "" :> obj  }

--- a/tests/fsharp/typecheck/sigs/pos31.fs
+++ b/tests/fsharp/typecheck/sigs/pos31.fs
@@ -1,5 +1,8 @@
 module Pos31
 
-let x1 : list<obj>  = [ yield "" ]
-let x2 : seq<obj>  = seq { yield "" }
-let x3 : seq<obj>  = seq { yield "" :> obj  }
+let x1 : obj list  = [ ""  ]
+let x2 : obj [] = [| ""  |]
+let x3 : obj list  = [ yield ""  ]
+let x4 : obj[]  = [| yield "" |]
+let x5 : seq<obj>  = seq { yield "" }
+let x6 : seq<obj>  = seq { yield "" :> obj  }

--- a/tests/fsharp/typecheck/sigs/pos31.fsi
+++ b/tests/fsharp/typecheck/sigs/pos31.fsi
@@ -1,0 +1,13 @@
+module Pos31
+val x1 : obj list
+val x2 : obj []
+val x3 : obj list
+val x4 : obj []
+val x5 : seq<obj>
+val x6 : seq<obj>
+val g2 : unit -> System.Reflection.MemberInfo []
+val g3 : unit -> System.Reflection.MemberInfo []
+val g4 : unit -> System.Reflection.MemberInfo []
+
+// This checks that IsCompatFlex ensures that a more generic type is not inferred
+val g5 : xs:seq<System.Reflection.MemberInfo> -> System.Reflection.MemberInfo []


### PR DESCRIPTION
RFC FS-1037  https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1037-allow-union-constructors-to-deal-with-flexible-types.md via #4798

RFC FS-1055: https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1055-subsumption-for-yield-in-sequence-expression.md

F# array and list computation expressions are great.  However when you start to use `yield` you have to insert coercions, e.g.

```fsharp
let x1 : obj list  = [ yield "" :> obj ]
let x2 : seq<obj>  = seq { yield "" :> _ }
```

If the nominal type is known by type inference this should not be needed since the corresponding coercion is not needed for the simpler form.

```fsharp
let x1 : obj list  = [ yield ""  ]
let x2 : seq<obj>  = seq { yield "" }
```

This PR trial this language change.

RFC will follow tomorrow, I'm putting this in to run the whole test suite.
