### PR TITLE
add `FSharp.Data.TypeProviders.dll` to the sign exclusion list

### DIFF
--- a/build/config/AssemblySignToolData.json
+++ b/build/config/AssemblySignToolData.json
@@ -57,6 +57,7 @@
     }
   ],
   "exclude": [
+    "FSharp.Data.TypeProviders.dll",
     "Microsoft.Build.Conversion.Core.dll",
     "Microsoft.Build.dll",
     "Microsoft.Build.Engine.dll",


### PR DESCRIPTION
Fixes #4932.