### PR TITLE
allow `FSharpTargetsPath` to be properly overwritten in a project file

### DIFF
--- a/setup/resources/Microsoft.FSharp.NetSdk.Shim.props
+++ b/setup/resources/Microsoft.FSharp.NetSdk.Shim.props
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.NetSdk.props" />
+  <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.NetSdk.props" />
+  <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.NetSdk.props" />
 
 </Project>

--- a/setup/resources/Microsoft.FSharp.NetSdk.Shim.targets
+++ b/setup/resources/Microsoft.FSharp.NetSdk.Shim.targets
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.NetSdk.targets" />
+  <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.NetSdk.targets" />
+  <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.NetSdk.targets" />
 
 </Project>

--- a/setup/resources/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
+++ b/setup/resources/Microsoft.FSharp.Overrides.NetSdk.Shim.targets
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.Overrides.NetSdk.targets" />
+  <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.Overrides.NetSdk.targets" />
+  <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.Overrides.NetSdk.targets" />
 
 </Project>

--- a/setup/resources/Microsoft.FSharp.Shim.targets
+++ b/setup/resources/Microsoft.FSharp.Shim.targets
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
-  <Import Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.targets" />
-  
+
+  <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.FSharp.targets" />
+  <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.targets" />
+
 </Project>

--- a/setup/resources/Microsoft.Portable.FSharp.Shim.targets
+++ b/setup/resources/Microsoft.Portable.FSharp.Shim.targets
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
-  <Import Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.Portable.FSharp.targets" />
-  
+
+  <Import Condition="'$(FSharpCompilerPath)' != ''" Project="$(FSharpCompilerPath)\Microsoft.Portable.FSharp.targets" />
+  <Import Condition="'$(FSharpCompilerPath)' == ''" Project="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.Portable.FSharp.targets" />
+
 </Project>

--- a/vsintegration/src/FSharp.Editor/Build/SetGlobalPropertiesForSdkProjects.fs
+++ b/vsintegration/src/FSharp.Editor/Build/SetGlobalPropertiesForSdkProjects.fs
@@ -22,10 +22,5 @@ type internal SetGlobalPropertiesForSdkProjects
     inherit StaticGlobalPropertiesProviderBase(projectService.Services)
 
     override __.GetGlobalPropertiesAsync(_cancellationToken: CancellationToken): Task<IImmutableDictionary<string, string>> =
-        let editorDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
-        [ "FSharpPropsShim", "Microsoft.FSharp.NetSdk.props"
-          "FSharpTargetsShim", "Microsoft.FSharp.NetSdk.targets"
-          "FSharpOverridesTargetsShim", "Microsoft.FSharp.Overrides.NetSdk.targets" ]
-        |> List.map (fun (key, value) -> (key, Path.Combine(editorDirectory, value)))
-        |> List.fold (fun (map:ImmutableDictionary<string, string>) (key, value) -> map.Add(key, value)) (Empty.PropertiesMap)
-        |> Task.FromResult<IImmutableDictionary<string, string>>
+        let properties = Empty.PropertiesMap.Add("FSharpCompilerPath", Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
+        Task.FromResult<IImmutableDictionary<string, string>>(properties)

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Utilities.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Utilities.cs
@@ -738,11 +738,13 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
             if (buildProject == null)
             {
-                buildProject = buildEngine.LoadProject(fullProjectPath);
+                var globalProperties = new Dictionary<string, string>()
+                {
+                    { "FSharpCompilerPath", Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) }
+                };
+                buildProject = buildEngine.LoadProject(fullProjectPath, globalProperties, null);
                 buildProject.IsBuildEnabled = true;
             }
-
-            buildProject.SetProperty("FSharpTargetsPath", Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Microsoft.FSharp.targets"));
 
             return buildProject;
         }


### PR DESCRIPTION
Followup to #4922.

By previously setting `FSharpTargetsPath`, etc. directly we didn't allow for that to be manually set in a project, props, or target file.  By using this method the IDE can communicate where the compiler is located, but the user can still override this should they choose.

Edit:
With this change compiler redirection will require a shipped version of the targets shim changes which will happen in VS 15.8.