### PR TITLE
Fix annotation view regression

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -675,7 +675,7 @@ type internal FSharpLanguageService(package : FSharpPackage) =
 
                     this.SetupProjectFile(siteProvider, this.Workspace, "SetupNewTextView")
 
-                | h when not (IsScript(filename)) ->
+                | h when not (isNull h) && not (IsScript(filename)) ->
                     
                     let docId = this.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filename).FirstOrDefault()
                     match docId with


### PR DESCRIPTION
Fixes #4937

#4328 introduced a regression where a null `IVsHierarchy` was captured into a binding, where it would cause a nullref: https://github.com/Microsoft/visualfsharp/blob/master/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs#L683

Here we just short circuit out to the default case (where it would have gone prior to this change) when it is null.