### PR TITLE
Fixed rename crashing

### DIFF
--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -53,12 +53,6 @@ type internal InlineRenameLocationSet(locations: InlineRenameLocation [], origin
         
             async {
                 let! newSolution = applyChanges originalSolution (locations |> Array.toList |> List.groupBy (fun x -> x.Document))
-                // > debug
-                let newDoc = newSolution.GetDocument(locations.[0].Document.Id)
-                let! newSource = newDoc.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                let newText = newSource.ToString()
-                let _ = newText
-                // < debug
                 return 
                     { new IInlineRenameReplacementInfo with
                         member __.NewSolution = newSolution


### PR DESCRIPTION
This fixes an issue with inline rename from causing errors and crashes.