### PR TITLE
Reduce build warnings

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -11,6 +11,7 @@
     <ToolsRoot>$(RepoRoot)Tools</ToolsRoot>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ProtoOutputPath>$(RepoRoot)Proto\net40\bin</ProtoOutputPath>
+    <ValueTupleImplicitPackageVersion>4.4.0</ValueTupleImplicitPackageVersion>
   </PropertyGroup>
 
   <!-- nuget -->

--- a/build.cmd
+++ b/build.cmd
@@ -481,9 +481,9 @@ if NOT EXIST Proto\net40\bin\fsc.exe (
   set BUILD_PROTO=1
 )
 
--rem turn off vs ide unit tests until they pass again
--set TEST_VS_IDEUNIT_SUITE= 0
--
+rem turn off vs ide unit tests until they pass again
+set TEST_VS_IDEUNIT_SUITE= 0
+
 rem
 rem This stops the dotnet cli from hunting around and 
 rem finding the highest possible dotnet sdk version to use.

--- a/build.cmd
+++ b/build.cmd
@@ -481,9 +481,9 @@ if NOT EXIST Proto\net40\bin\fsc.exe (
   set BUILD_PROTO=1
 )
 
-rem turn off vs ide unit tests until they pass again
-set TEST_VS_IDEUNIT_SUITE= 0
-
+-rem turn off vs ide unit tests until they pass again
+-set TEST_VS_IDEUNIT_SUITE= 0
+-
 rem
 rem This stops the dotnet cli from hunting around and 
 rem finding the highest possible dotnet sdk version to use.

--- a/vsintegration/src/FSharp.PatternMatcher/IObjectWritable.cs
+++ b/vsintegration/src/FSharp.PatternMatcher/IObjectWritable.cs
@@ -1,8 +1,7 @@
 ﻿namespace Microsoft.CodeAnalysis
 {
     /// <summary>
-    /// Objects that implement this interface know how to write their contents to an <see cref="ObjectWriter"/>,
-    /// so they can be reconstructed later by an <see cref="ObjectReader"/>.
+    /// Objects that implement this interface know how to write their contents to an <see cref="ObjectWriter"/>
     /// </summary>
     internal interface IObjectWritable
     {

--- a/vsintegration/src/FSharp.PatternMatcher/PatternMatchKind.cs
+++ b/vsintegration/src/FSharp.PatternMatcher/PatternMatchKind.cs
@@ -29,8 +29,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
 
         /// <summary>
         /// The pattern matches the candidate in a fuzzy manner.  Fuzzy matching allows for 
-        /// a certain amount of misspellings, missing words, etc. See <see cref="SpellChecker"/> for 
-        /// more details.
+        /// misspellings, missing words, etc.
         /// </summary>
         Fuzzy
     }


### PR DESCRIPTION
Reduce warnings in the OSS build:

1.  Ensure build uses System.ValueTuple 4.4.0
2. Remove some comment references in FSharp.PatternMatcher


