### PR TITLE
Switch legacy project System Templates to use nuget.

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -19,6 +19,7 @@
   <package id="System.Reflection.Metadata" version="1.4.2" />
   <package id="System.ValueTuple" version="4.3.1" />
   <package id="System.ValueTuple" version="4.4.0" />
+  <package id="FSharp.Core" version="4.3.4"/>
   <package id="Microsoft.VisualFSharp.Msbuild.15.0" version="1.0.1" />
   <package id="Microsoft.Build" version="14.3.0" />
   <package id="Microsoft.Build.Framework" version="14.3.0" />

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
@@ -12,11 +12,6 @@
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseStandardResourceNames>true</UseStandardResourceNames>
-    $if$ ($targetframeworkversion$ >= 4.0)
-    <TargetFSharpCoreVersion>4.4.3.0</TargetFSharpCoreVersion>
-    $else$
-    <TargetFSharpCoreVersion>2.3.0.0</TargetFSharpCoreVersion>
-    $endif$
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,22 +38,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib"/>
+    <Reference Include="System"/>
+    <Reference Include="System.Core"/>
+    <Reference Include="System.Numerics"/>
     <Reference Include="FSharp.Core">
-      <Name>FSharp.Core</Name>
-      <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.3.4\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System"/>
-    $if$ ($targetframeworkversion$ >= 3.5)
-    <Reference Include="System.Core"/>
-    $endif$
-    $if$ ($targetframeworkversion$ > 3.5)
-    <Reference Include="System.Numerics"/>
-    $endif$
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -68,18 +58,9 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets') ">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets') ">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+  <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets') ">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
   <Import Project="$(FSharpTargetsPath)" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4001" />
     <TemplateID>Microsoft.FSharp.Application</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.0</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>ConsoleApplication</DefaultName>
@@ -27,6 +27,7 @@
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
       <package id="System.ValueTuple" version="4.4.0" targetFramework="net40" />
+      <package id="FSharp.Core" version="4.3.4" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
@@ -11,11 +11,6 @@
     <AssemblyName>$safeprojectname$</AssemblyName>
     <UseStandardResourceNames>true</UseStandardResourceNames>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
-    $if$ ($targetframeworkversion$ >= 4.0)
-    <TargetFSharpCoreVersion>4.4.3.0</TargetFSharpCoreVersion>
-    $else$
-    <TargetFSharpCoreVersion>2.3.0.0</TargetFSharpCoreVersion>
-    $endif$
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -39,22 +34,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib"/>
+    <Reference Include="System"/>
+    <Reference Include="System.Core"/>
+    <Reference Include="System.Numerics"/>
     <Reference Include="FSharp.Core">
-      <Name>FSharp.Core</Name>
-      <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.3.4\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System"/>
-    $if$ ($targetframeworkversion$ >= 3.5)
-    <Reference Include="System.Core"/>
-    $endif$
-    $if$ ($targetframeworkversion$ > 3.5)
-    <Reference Include="System.Numerics"/>
-    $endif$
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -64,18 +54,9 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets') ">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets') ">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+  <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets') ">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
   <Import Project="$(FSharpTargetsPath)" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4002" />
     <TemplateID>Microsoft.FSharp.Library</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.0</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>Library</DefaultName>
@@ -27,6 +27,7 @@
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
       <package id="System.ValueTuple" version="4.4.0" targetFramework="net40" />
-     </packages>
+      <package id="FSharp.Core" version="4.3.4" targetFramework="net40" />
+    </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
@@ -12,11 +12,6 @@
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseStandardResourceNames>true</UseStandardResourceNames>
-    $if$ ($targetframeworkversion$ >= 4.0)
-    <TargetFSharpCoreVersion>4.4.3.0</TargetFSharpCoreVersion>
-    $else$
-    <TargetFSharpCoreVersion>2.3.0.0</TargetFSharpCoreVersion>
-    $endif$
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -44,20 +39,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib"/>
-    <Reference Include="FSharp.Core">
-      <Name>FSharp.Core</Name>
-      <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System"/>
-    $if$ ($targetframeworkversion$ >= 3.5)
     <Reference Include="System.Core"/>
-    $endif$
-    $if$ ($targetframeworkversion$ > 3.5)
     <Reference Include="System.Numerics"/>
-    $endif$
     <Reference Include="System.Drawing"/>
     <Reference Include="System.Windows.Forms"/>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\packages\FSharp.Core.4.3.4\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ValueTuple">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
@@ -69,18 +59,9 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets') ">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets') ">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+  <PropertyGroup Condition=" '$(FSharpTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets') ">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
   <Import Project="$(FSharpTargetsPath)" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4004" />
     <TemplateID>Microsoft.FSharp.Tutorial</TemplateID>
     <ProjectType>FSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.0</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>Tutorial</DefaultName>
@@ -25,6 +25,7 @@
   <WizardData>
     <packages repository="extension" repositoryId="VisualFSharp">
       <package id="System.ValueTuple" version="4.4.0" targetFramework="net40" />
+      <package id="FSharp.Core" version="4.3.4" targetFramework="net40" />
      </packages>
   </WizardData>
 </VSTemplate>

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -23,6 +23,11 @@
       <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="$(FSharpSourcesRoot)\..\packages\FSharp.Core.4.3.4\FSharp.Core.4.3.4.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>packages\FSharp.Core.4.3.4.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.1\System.ValueTuple.4.3.1.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>packages\System.ValueTuple.4.3.1.nupkg</Link>

--- a/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
+++ b/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>net46</TargetFramework>
     <OutputType>Library</OutputType>
     <ExtensionInstallationFolder>Microsoft\FSharpTemplates</ExtensionInstallationFolder>
-    <DeployExtension>false</DeployExtension>
+    <DeployExtension>true</DeployExtension>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
+++ b/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>net46</TargetFramework>
     <OutputType>Library</OutputType>
     <ExtensionInstallationFolder>Microsoft\FSharpTemplates</ExtensionInstallationFolder>
-    <DeployExtension>true</DeployExtension>
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -330,19 +329,19 @@
     <value>File.fs</value>
   </data>
   <data name="5014" xml:space="preserve">
-    <value>Console Application</value>
+    <value>Console Application (.NET Framework)</value>
   </data>
   <data name="5015" xml:space="preserve">
     <value>A project for creating a command-line application</value>
   </data>
   <data name="5016" xml:space="preserve">
-    <value>Library</value>
+    <value>Library (.NET Framework)</value>
   </data>
   <data name="5017" xml:space="preserve">
     <value>A project for creating an F# library</value>
   </data>
   <data name="5018" xml:space="preserve">
-    <value>Tutorial</value>
+    <value>Tutorial (.NET Framework)</value>
   </data>
   <data name="5019" xml:space="preserve">
     <value>A tutorial project providing a walkthrough of the F# language</value>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.cs.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.cs.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Konzolová aplikace</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Konzolová aplikace</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Knihovna</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Knihovna</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Tutoriál</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Tutoriál</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.de.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.de.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Konsolenanwendung</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Konsolenanwendung</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Bibliothek</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Bibliothek</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Tutorial</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Tutorial</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.en.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.en.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="new">Console Application</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="new">Console Application (.NET Framework)</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="new">Library</target>
+        <source>Library (.NET Framework)</source>
+        <target state="new">Library (.NET Framework)</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="new">Tutorial</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="new">Tutorial (.NET Framework)</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.es.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.es.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Aplicación de consola</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Aplicación de consola</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Biblioteca</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Biblioteca</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Tutorial</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Tutorial</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.fr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.fr.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Application console</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Application console</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Bibliothèque</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Bibliothèque</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Didacticiel</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Didacticiel</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.it.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.it.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Applicazione console</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Applicazione console</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Libreria</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Libreria</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Esercitazione</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Esercitazione</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ja.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ja.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">コンソール アプリケーション</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">コンソール アプリケーション</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">ライブラリ</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">ライブラリ</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">チュートリアル</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">チュートリアル</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ko.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ko.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">콘솔 응용 프로그램</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">콘솔 응용 프로그램</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">라이브러리</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">라이브러리</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">자습서</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">자습서</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pl.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pl.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Aplikacja konsolowa</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Aplikacja konsolowa</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Biblioteka</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Biblioteka</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Samouczek</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Samouczek</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pt-BR.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pt-BR.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Aplicativo do Console</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Aplicativo do Console</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Biblioteca</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Biblioteca</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Tutorial</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Tutorial</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ru.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ru.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Консольное приложение</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Консольное приложение</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Библиотека</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Библиотека</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Учебник</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Учебник</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.tr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.tr.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">Konsol Uygulaması</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">Konsol Uygulaması</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">Kitaplık</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">Kitaplık</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">Öğretici</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">Öğretici</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hans.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">控制台应用程序</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">控制台应用程序</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">库</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">库</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">教程</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">教程</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hant.xlf
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5014">
-        <source>Console Application</source>
-        <target state="translated">主控台應用程式</target>
+        <source>Console Application (.NET Framework)</source>
+        <target state="needs-review-translation">主控台應用程式</target>
         <note />
       </trans-unit>
       <trans-unit id="5015">
@@ -213,8 +213,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5016">
-        <source>Library</source>
-        <target state="translated">程式庫</target>
+        <source>Library (.NET Framework)</source>
+        <target state="needs-review-translation">程式庫</target>
         <note />
       </trans-unit>
       <trans-unit id="5017">
@@ -223,8 +223,8 @@
         <note />
       </trans-unit>
       <trans-unit id="5018">
-        <source>Tutorial</source>
-        <target state="translated">教學課程</target>
+        <source>Tutorial (.NET Framework)</source>
+        <target state="needs-review-translation">教學課程</target>
         <note />
       </trans-unit>
       <trans-unit id="5019">


### PR DESCRIPTION
We are improving the deployment mechanism for VisualFSharp as part of VisualStudio.  Part of that effort involves eliminating the Global MSI install of the compiler and reference assemblies and replacing it with a VSIX.

Once this is is completed, VisualFSharp will be truly side by side between VS previews and RTMs.  Frankly I can't wait.  @brettfo  is working on that PR.  An additional part of that is to use regular nuget mechanisms to deploy reference FSharp.Core.  In a similar way to how we currently reference System.ValueTuple.

The project files are somewhat simplified with this PR.  Support for DotNet framework 2.0 is gone.  The TargetFSharpCore mechanism is removed, replaced by the nuget management tooling.   The project properties page, shows the TargetFSharpCore field greyed out.

Existing "TargetFSharpCore" projects will continue work, however, they will not be updatable to Future FSharp.Core versions, without migrating to the nuget mechanism.

/CC @brettfo, @cartermp, @dsyme 

