### PR TITLE
Rev Dev15.8 to build F# 4.5, FSharp.Core 4.5.0.0

### DIFF
--- a/build/targets/AssemblyVersions.props
+++ b/build/targets/AssemblyVersions.props
@@ -19,9 +19,9 @@
     <_Build_Number>$(BUILD_BUILDNUMBER.Substring(9))</_Build_Number>
     <Build_FileVersion>$(_Build_Year).$(_Build_Month).$(_Build_Day).$(_Build_Number)</Build_FileVersion>
 
-    <FSCoreVersion>4.4.3.0</FSCoreVersion>
-    <FSProductVersion>10.1.1.0</FSProductVersion>
-    <FSPackageVersion>10.1.4</FSPackageVersion>
+    <FSCoreVersion>4.5.0.0</FSCoreVersion>
+    <FSProductVersion>10.2.0.0</FSProductVersion>
+    <FSPackageVersion>10.2.0</FSPackageVersion>
     <VSAssemblyVersion>15.8.0.0</VSAssemblyVersion>
     <MicroBuildAssemblyVersion Condition="'$(MicroBuildAssemblyVersion)' == ''">$(FSCoreVersion)</MicroBuildAssemblyVersion>
 

--- a/setup/FSharp.SDK/FSharp.SDK.wxs
+++ b/setup/FSharp.SDK/FSharp.SDK.wxs
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 
-  <?define ProductVersion = "10.1"?>
+  <?define ProductVersion = "10.2"?>
   <?define ProductPlatform = "x86"?>
   <?define ProductManufacturer = "Microsoft Corporation"?>
   <?define ProductDescription = "Visual F# $(var.ProductVersion) SDK"?>

--- a/setup/Swix/Microsoft.FSharp.SDK.Core/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Core/Files.swr
@@ -3,7 +3,7 @@ use vs
 package name=Microsoft.FSharp.SDK.Core
         version=$(FSharpPackageVersion)
         vs.package.type=msi
-        vs.package.providerKey=Microsoft.FSharp.SDK.Core,v10.1
+        vs.package.providerKey=Microsoft.FSharp.SDK.Core,v10.2
 
 vs.installSize
   SystemDrive=194670592

--- a/setup/Swix/Microsoft.FSharp.SDK.Resources/Empty.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Resources/Empty.swr
@@ -4,4 +4,4 @@ package name=Microsoft.FSharp.SDK.Resources
         version=$(FSharpPackageVersion)
         vs.package.language=$(LocaleSpecificCulture)
         vs.package.installSize=1
-        vs.package.providerKey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),v10.1
+        vs.package.providerKey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),v10.2

--- a/setup/Swix/Microsoft.FSharp.SDK.Resources/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.SDK.Resources/Files.swr
@@ -4,7 +4,7 @@ package name=Microsoft.FSharp.SDK.Resources
         version=$(FSharpPackageVersion)
         vs.package.type=msi
         vs.package.language=$(LocaleSpecificCulture)
-        vs.package.providerKey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),v10.1
+        vs.package.providerKey=Microsoft.FSharp.SDK.Resources,$(LocaleSpecificCulture),v10.2
 
 vs.installSize
   SystemDrive=12681438

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -20,9 +20,9 @@
 
   <!-- Version number computation -->
   <PropertyGroup>
-    <FSCoreVersion>4.4.3.0</FSCoreVersion>
-    <FSProductVersion>10.1.1.0</FSProductVersion>
-    <FSPackageVersion>10.1.4</FSPackageVersion>
+    <FSCoreVersion>4.5.0.0</FSCoreVersion>
+    <FSProductVersion>10.2.0.0</FSProductVersion>
+    <FSPackageVersion>10.2.0</FSPackageVersion>
     <VSAssemblyVersion>15.7.0.0</VSAssemblyVersion>
   </PropertyGroup>
 
@@ -101,8 +101,8 @@
     <!-- Frozen FSharp.Core package being built with this build -->
     <FSharpCore41TargetPackageVersion>4.1.19</FSharpCore41TargetPackageVersion>
     <FSharpCore41TargetMajorVersion>4.1</FSharpCore41TargetMajorVersion>
-    <FSharpCoreLatestTargetPackageVersion>4.3.5</FSharpCoreLatestTargetPackageVersion>
-    <FSharpCoreLatestTargetMajorVersion>4.3</FSharpCoreLatestTargetMajorVersion>
+    <FSharpCoreLatestTargetPackageVersion>4.5.0</FSharpCoreLatestTargetPackageVersion>
+    <FSharpCoreLatestTargetMajorVersion>4.5</FSharpCoreLatestTargetMajorVersion>
 
     <!-- Always qualify the IntermediateOutputPath by the TargetDotnetProfile if any exists -->
     <IntermediateOutputPath>obj\$(Configuration)\$(TargetDotnetProfile)\</IntermediateOutputPath>
@@ -111,7 +111,7 @@
     <!-- Frozen FSharp.Core package -->
     <FSharpCoreFrozenPortablePackageVersion>10.1.0</FSharpCoreFrozenPortablePackageVersion>
     <FSharpCoreFrozenPortableTargetPackageVersion>10.2.0</FSharpCoreFrozenPortableTargetPackageVersion>
-    <FSharpCoreFrozenPortableTargetMajorVersion>10.1</FSharpCoreFrozenPortableTargetMajorVersion>
+    <FSharpCoreFrozenPortableTargetMajorVersion>10.2</FSharpCoreFrozenPortableTargetMajorVersion>
 
     <!-- Nunit -->
     <NUnitVersion>3.5.0</NUnitVersion>

--- a/src/buildfromsource/BuildFromSource.targets
+++ b/src/buildfromsource/BuildFromSource.targets
@@ -3,7 +3,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <FSCoreVersion>4.4.3.0</FSCoreVersion>
+    <FSCoreVersion>4.5.0.0</FSCoreVersion>
     <OutputPath>$(MSBuildThisFileDirectory)../../BuildFromSource/$(Configuration)/bin</OutputPath>
     <FSharpSourcesRoot>$(MSBuildThisFileDirectory)..</FSharpSourcesRoot>
 

--- a/src/buildfromsource/FSharp.Build/AssemblyInfo.fs
+++ b/src/buildfromsource/FSharp.Build/AssemblyInfo.fs
@@ -8,7 +8,7 @@ open System.Reflection
 [<assembly:AssemblyTitle("FSharp.Build.dll")>]
 [<assembly:AssemblyCopyright("\169 Microsoft Corporation.  All Rights Reserved.")>]
 [<assembly:AssemblyProduct("Microsoft\174 F#")>]
-[<assembly:AssemblyInformationalVersion("10.1.1.0")>]
-[<assembly:AssemblyVersion("10.1.1.0")>]
-[<assembly:AssemblyFileVersion("2017.06.27.0")>]
+[<assembly:AssemblyInformationalVersion("10.2.0.0")>]
+[<assembly:AssemblyVersion("10.2.0.0")>]
+[<assembly:AssemblyFileVersion("2018.05.22.0")>]
 do()

--- a/src/buildfromsource/FSharp.Compiler.Interactive.Settings/AssemblyInfo.fs
+++ b/src/buildfromsource/FSharp.Compiler.Interactive.Settings/AssemblyInfo.fs
@@ -10,7 +10,7 @@ open System.Runtime.InteropServices
 [<assembly:AssemblyCopyright("\169 Microsoft Corporation.  All Rights Reserved.")>]
 [<assembly:AssemblyProduct("Microsoft\174 F#")>]
 [<assembly:ComVisible(false)>]
-[<assembly:AssemblyInformationalVersion("10.1.1.0")>]
-[<assembly:AssemblyVersion("10.1.1.0")>]
-[<assembly:AssemblyFileVersion("2017.06.27.0")>]
+[<assembly:AssemblyInformationalVersion("10.2.0.0")>]
+[<assembly:AssemblyVersion("10.2.0.0")>]
+[<assembly:AssemblyFileVersion("2018.05.22.0")>]
 do()

--- a/src/buildfromsource/FSharp.Compiler.Private/AssemblyInfo.fs
+++ b/src/buildfromsource/FSharp.Compiler.Private/AssemblyInfo.fs
@@ -10,7 +10,7 @@ open System.Runtime.InteropServices
 [<assembly:AssemblyCopyright("\169 Microsoft Corporation.  All Rights Reserved.")>]
 [<assembly:AssemblyProduct("Microsoft\174 F#")>]
 [<assembly:ComVisible(false)>]
-[<assembly:AssemblyInformationalVersion("10.1.1.0")>]
-[<assembly:AssemblyVersion("10.1.1.0")>]
-[<assembly:AssemblyFileVersion("2017.06.27.0")>]
+[<assembly:AssemblyInformationalVersion("10.2.0.0")>]
+[<assembly:AssemblyVersion("10.2.0.0")>]
+[<assembly:AssemblyFileVersion("2018.05.22.0")>]
 do()

--- a/src/buildfromsource/FSharp.Compiler.nuget/FSharp.Compiler.nuget.fsproj
+++ b/src/buildfromsource/FSharp.Compiler.nuget/FSharp.Compiler.nuget.fsproj
@@ -20,7 +20,7 @@
     <PackageAuthors    Condition="'$(PackageAuthors)' == ''"   >Microsoft and F# Software Foundation</PackageAuthors> 
     <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags> 
     <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rc-$(BuildRevision.Trim())-0</PreReleaseSuffix>
-    <PackageVersion>10.1.1$(PreReleaseSuffix)</PackageVersion>
+    <PackageVersion>10.2.0$(PreReleaseSuffix)</PackageVersion>
     <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)"</PackageProperties>
   </PropertyGroup>
 

--- a/src/buildfromsource/FSharp.Core/AssemblyInfo.fs
+++ b/src/buildfromsource/FSharp.Core/AssemblyInfo.fs
@@ -16,8 +16,8 @@ open System.Runtime.InteropServices
 [<assembly:AssemblyFlags(System.Reflection.AssemblyNameFlags.Retargetable)>]
 #endif
 
-[<assembly:AssemblyInformationalVersion("4.4.3.0")>]
-[<assembly:AssemblyVersion("4.4.3.0")>]
-[<assembly:AssemblyFileVersion("2017.06.27.0")>]
+[<assembly:AssemblyInformationalVersion("4.5.0.0")>]
+[<assembly:AssemblyVersion("4.5.0.0")>]
+[<assembly:AssemblyFileVersion("2018.05.23.0")>]
 do()
 

--- a/src/buildfromsource/Fsc/AssemblyInfo.fs
+++ b/src/buildfromsource/Fsc/AssemblyInfo.fs
@@ -10,7 +10,7 @@ open System.Runtime.InteropServices
 [<assembly:AssemblyCopyright("\169 Microsoft Corporation.  All Rights Reserved.")>]
 [<assembly:AssemblyProduct("Microsoft\174 F#")>]
 [<assembly:ComVisible(false)>]
-[<assembly:AssemblyInformationalVersion("10.1.1.0")>]
-[<assembly:AssemblyVersion("10.1.1.0")>]
-[<assembly:AssemblyFileVersion("2017.06.27.0")>]
+[<assembly:AssemblyInformationalVersion("10.2.0.0")>]
+[<assembly:AssemblyVersion("10.2.0.0")>]
+[<assembly:AssemblyFileVersion("2018.05.22.0")>]
 do()

--- a/src/buildfromsource/Fsi/AssemblyInfo.fs
+++ b/src/buildfromsource/Fsi/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly:AssemblyTitle("fsi.exe")>]
 [<assembly:AssemblyCopyright("\169 Microsoft Corporation.  All Rights Reserved.")>]
 [<assembly:AssemblyProduct("Microsoft\174 F#")>]
-[<assembly:AssemblyInformationalVersion("10.1.1.0")>]
-[<assembly:AssemblyVersion("10.1.1.0")>]
-[<assembly:AssemblyFileVersion("2017.06.27.0")>]
+[<assembly:AssemblyInformationalVersion("10.2.0.0")>]
+[<assembly:AssemblyVersion("10.2.0.0")>]
+[<assembly:AssemblyFileVersion("2018.05.22.0")>]
 do()

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
@@ -3,10 +3,10 @@
     <metadata>
         <!-- rename to FSharp.Core when done -->
         <id>FSharp.Core</id>
-        <title>FSharp.Core for F# 4.1</title>
-        <summary>FSharp.Core for F# 4.1</summary>
+        <title>FSharp.Core for F# 4.5</title>
+        <summary>FSharp.Core for F# 4.5</summary>
         <description>
-            FSharp.Core redistributables from Visual F# Tools version 10.1 For F# 4.1
+            FSharp.Core redistributables from Visual F# Tools version 10.2 For F# 4.5
                 Supported Platforms:
                     .NET 4.5+           (net45)
                     netstandard1.6      (netstandard1.6)

--- a/src/fsharp/Fsc/app.config
+++ b/src/fsharp/Fsc/app.config
@@ -6,7 +6,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-4.4.3.0" newVersion="4.4.3.0"/>
+        <bindingRedirect oldVersion="2.0.0.0-4.5.0.0" newVersion="4.5.0.0"/>
       </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/fsharp/fsi/app.config
+++ b/src/fsharp/fsi/app.config
@@ -5,7 +5,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-4.4.3.0" newVersion="4.4.3.0"/>
+        <bindingRedirect oldVersion="2.0.0.0-4.5.0.0" newVersion="4.5.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/fsharp/fsiAnyCpu/app.config
+++ b/src/fsharp/fsiAnyCpu/app.config
@@ -6,7 +6,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-4.4.3.0" newVersion="4.4.3.0"/>
+        <bindingRedirect oldVersion="2.0.0.0-4.4.5.0" newVersion="4.5.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/fsharp/fsiAnyCpu/app.config
+++ b/src/fsharp/fsiAnyCpu/app.config
@@ -6,7 +6,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-4.4.5.0" newVersion="4.5.0.0"/>
+        <bindingRedirect oldVersion="2.0.0.0-4.5.0.0" newVersion="4.5.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -12,7 +12,7 @@ open System.Runtime.InteropServices
 module internal FSharpEnvironment =
 
     /// The F# version reported in the banner
-    let FSharpBannerVersion = "10.1.0 for F# 4.1"
+    let FSharpBannerVersion = "10.2.0 for F# 4.5"
 
     let versionOf<'t> =
 #if FX_RESHAPED_REFLECTION

--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -52,7 +52,7 @@
 "1"="{92EF0900-2251-11D2-B72E-0000F87572EF}" 
 
 [$RootKey$\Packages\{91a04a73-4f2c-4e7c-ad38-c1a68e7da05c}]
-"ProductVersion"="10.1"
+"ProductVersion"="10.2"
 "ProductName"="Visual F#"
 "CompanyName"="Microsoft Corp."
 

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -45,7 +45,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
     [<assembly:ProvideCodeBase(AssemblyName = "FSharp.Compiler.Private", CodeBase = @"$PackageFolder$\FSharp.Compiler.Private.dll")>]
     [<assembly:ProvideCodeBase(AssemblyName = "FSharp.Compiler.Server.Shared", CodeBase = @"$PackageFolder$\FSharp.Compiler.Server.Shared.dll")>]
     [<assembly:ProvideCodeBase(AssemblyName = "FSharp.UIResources", CodeBase = @"$PackageFolder$\FSharp.UIResources.dll")>]
-    [<assembly:ProvideBindingRedirection(AssemblyName = "FSharp.Core", OldVersionLowerBound = "2.0.0.0", OldVersionUpperBound = "4.4.3.0", NewVersion = "4.4.3.0", CodeBase = @"$PackageFolder$\FSharp.Core.dll")>]
+    [<assembly:ProvideBindingRedirection(AssemblyName = "FSharp.Core", OldVersionLowerBound = "2.0.0.0", OldVersionUpperBound = "4.5.0.0", NewVersion = "4.5.0.0", CodeBase = @"$PackageFolder$\FSharp.Core.dll")>]
     do ()
 
     module internal VSHiveUtilities =

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
@@ -468,10 +468,10 @@
     <value>Customizes the environment to maximize code editor screen space and improve the visibility of F# commands and tool windows.</value>
   </data>
   <data name="ProductDetails" xml:space="preserve">
-    <value>Microsoft Visual F# Tools 10.1 for F# 4.1</value>
+    <value>Microsoft Visual F# Tools 10.2 for F# 4.5</value>
   </data>
   <data name="9002" xml:space="preserve">
-    <value>Microsoft Visual F# Tools 10.1 for F# 4.1</value>
+    <value>Microsoft Visual F# Tools 10.2 for F# 4.5</value>
   </data>
   <data name="ProductID" xml:space="preserve">
     <value>1.0</value>
@@ -480,7 +480,7 @@
     <value>Microsoft Visual F# Tools</value>
   </data>
   <data name="9001" xml:space="preserve">
-    <value>Visual F# Tools 10.1 for F# 4.1</value>
+    <value>Visual F# Tools 10.2 for F# 4.5</value>
   </data>
   <data name="9027" xml:space="preserve">
     <value>F# Interactive</value>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.cs.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.cs.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 pro F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 pro F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 pro F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 pro F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 pro F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 pro F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.de.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.de.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 für F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 für F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 für F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 für F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 für F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 für F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.en.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.en.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="new">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="new">Microsoft Visual F# Tools 10.2 for F# 4.5</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="new">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="new">Microsoft Visual F# Tools 10.2 for F# 4.5</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="new">Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="new">Visual F# Tools 10.2 for F# 4.5</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.es.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.es.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Herramientas de Microsoft Visual F# 10.1 para F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Herramientas de Microsoft Visual F# 10.1 para F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Herramientas de Microsoft Visual F# 10.1 para F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Herramientas de Microsoft Visual F# 10.1 para F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Herramientas de Visual F# 10.1 para F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Herramientas de Visual F# 10.1 para F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.fr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.fr.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 pour F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 pour F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 pour F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 pour F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 pour F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 pour F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.it.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.it.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 per F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 per F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 per F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 per F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 per F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 per F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ja.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ja.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ko.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ko.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">F# 4.1용 Microsoft Visual F# Tools 10.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">F# 4.1용 Microsoft Visual F# Tools 10.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">F# 4.1용 Microsoft Visual F# Tools 10.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">F# 4.1용 Microsoft Visual F# Tools 10.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">F# 4.1용 Visual F# Tools 10.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">F# 4.1용 Visual F# Tools 10.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pl.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pl.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pt-BR.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pt-BR.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 para F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 para F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 para F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 para F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 para F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 para F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ru.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ru.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 для F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 для F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 для F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 для F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 для F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 для F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.tr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.tr.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">F# 4.1 için Microsoft Visual F# Tools 10.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">F# 4.1 için Microsoft Visual F# Tools 10.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">F# 4.1 için Microsoft Visual F# Tools 10.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">F# 4.1 için Microsoft Visual F# Tools 10.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">F# 4.1 için Visual F# Araçları 10.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">F# 4.1 için Visual F# Araçları 10.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hans.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hant.xlf
@@ -433,13 +433,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ProductDetails">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9002">
-        <source>Microsoft Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Microsoft Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Microsoft Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="ProductID">
@@ -453,8 +453,8 @@
         <note />
       </trans-unit>
       <trans-unit id="9001">
-        <source>Visual F# Tools 10.1 for F# 4.1</source>
-        <target state="translated">Visual F# Tools 10.1 for F# 4.1</target>
+        <source>Visual F# Tools 10.2 for F# 4.5</source>
+        <target state="needs-review-translation">Visual F# Tools 10.1 for F# 4.1</target>
         <note />
       </trans-unit>
       <trans-unit id="9027">

--- a/vsintegration/update-vsintegration.cmd
+++ b/vsintegration/update-vsintegration.cmd
@@ -83,7 +83,7 @@ GOTO :start
 
 echo.
 echo Installs or restores F# SDK bits, which applies system-wide to all Visual Studio
-echo 2017 installations. After running this, each project targeting F# 4.1 will use
+echo 2017 installations. After running this, each project targeting F# 4.5 will use
 echo your locally built FSC.exe. It will not update other F# tools, see remarks below.
 echo.
 echo Requires Administrator privileges for removing/restoring strong-naming.


### PR DESCRIPTION
Language and FSharp.Core, have aligned version numbers again.

Moving forward version numbers should look like:

Language:                  F# 4.5
FSharp.Core:              4.5.0.0
FSharp.Core.nuget:    4.5.*
Compiler.Tools          10.2.*
VS tooling                  Match VS  --- 15.8.0.0

The dotnet cli aligned with VS 2017.8 will also ship F# 4.5

dotnet cli, will continue to target FSharp.Core 4.3.4 until we publish 4.5.0 to nuget.
