### PR TITLE
[WIP] Protect isDisposableTy

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1311,7 +1311,7 @@ type TypeCheckInfo
                 sResolutions.CapturedNameResolutions :> seq<_>
 
         let isDisposableTy (ty: TType) =
-            Infos.ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_IDisposable
+            protectAssemblyExploration false (fun () -> Infos.ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_IDisposable)
 
         resolutions
         |> Seq.choose (fun cnr ->


### PR DESCRIPTION
This is an attempt to fix https://github.com/Microsoft/visualfsharp/issues/4896

@dsyme you suggested to use `protectAssemblyExploration`, but it mutes `UnresolvedPathReferenceNoRange` exception only, while we have another one:

![image](https://user-images.githubusercontent.com/873919/40487939-42320e0c-5f6e-11e8-9f19-c614e2adeb87.png)

