### PR TITLE
[15.8] Code lens option page

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.resx
@@ -207,4 +207,7 @@
   <data name="6012" xml:space="preserve">
     <value>Advanced</value>
   </data>
+  <data name="6013" xml:space="preserve">
+    <value>CodeLens</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.cs.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Upřesnit</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.de.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Erweitert</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.en.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.en.xlf
@@ -152,6 +152,11 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.es.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Avanzadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.fr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Avancé</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.it.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Avanzate</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ja.xlf
@@ -152,6 +152,11 @@
         <target state="translated">詳細</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ko.xlf
@@ -152,6 +152,11 @@
         <target state="translated">고급</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pl.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Zaawansowane</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Avançado</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.ru.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Дополнительно</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.tr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Gelişmiş</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="translated">高级</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.Editor/xlf/FSharp.Editor.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="translated">進階</target>
         <note />
       </trans-unit>
+      <trans-unit id="6013">
+        <source>CodeLens</source>
+        <target state="new">CodeLens</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Follow-up to #4950 to add a resource string for the CodeLens option page specified on [this line](https://github.com/cartermp/visualfsharp/blob/ac5fc46c931473addd0bab8d0b4d767446cc8374/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs#L331).