### PR TITLE
FSharpSuite: Provide direction when test initialization fails for some reason.

### DIFF
--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -272,9 +272,11 @@ type public InitializeSuiteAttribute () =
     inherit TestActionAttribute()
 
     override x.BeforeTest details =
-        if details.IsSuite 
-        then suiteHelpers.Force() |> ignore
-
+        try
+            if details.IsSuite 
+            then suiteHelpers.Force() |> ignore
+        with
+        | e -> raise (Exception("failed test suite initialization, debug code in InitializeSuiteAttribute", e))
     override x.AfterTest _details =
         ()
 


### PR DESCRIPTION
In FSharpSuite, when InitializeSuiteAttribute.BeforeTest fails, the output of test runners is too obscure to help one to troubleshoot the issue. Searching for `OneTimeSetUp` doesn't find any location.

Provide explicit pointer to the place to look at / debug.

Before:

![image](https://user-images.githubusercontent.com/87944/40525479-17b2ab56-5f95-11e8-816b-93aeacdd38a8.png)

After:

![image](https://user-images.githubusercontent.com/87944/40525490-2a755b8a-5f95-11e8-8928-17049b4256f1.png)
