### PR TITLE
Make enum cases public

### DIFF
--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6303,9 +6303,8 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                         // Enums always have public cases irrespective of Enum Visibility
                         if tycon.IsEnumTycon then false
                         else 
-                            ((fspec.IsCompilerGenerated && not tycon.IsEnumTycon) ||
-                              hiddenRepr ||
-                              IsHiddenRecdField eenv.sigToImplRemapInfo (tcref.MakeNestedRecdFieldRef fspec))
+                            (fspec.IsCompilerGenerated || hiddenRepr ||
+                             IsHiddenRecdField eenv.sigToImplRemapInfo (tcref.MakeNestedRecdFieldRef fspec))
                    let ilType = GenType cenv.amap m eenvinner.tyenv fspec.FormalType
                    let ilFieldName = ComputeFieldName tycon fspec
                         

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6302,7 +6302,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
                    let isPropHidden =
                         // Enums always have public cases irrespective of Enum Visibility
                         if tycon.IsEnumTycon then false
-                        else 
+                        else
                             (fspec.IsCompilerGenerated || hiddenRepr ||
                              IsHiddenRecdField eenv.sigToImplRemapInfo (tcref.MakeNestedRecdFieldRef fspec))
                    let ilType = GenType cenv.amap m eenvinner.tyenv fspec.FormalType

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -6294,15 +6294,18 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
              [ for fspec in tycon.AllFieldsAsList do
 
                    let useGenuineField = useGenuineField tycon fspec
-                   
+
                    // The property (or genuine IL field) is hidden in these circumstances:  
                    //     - secret fields apart from "__value" fields for enums 
                    //     - the representation of the type is hidden 
                    //     - the F# field is hidden by a signature or private declaration 
-                   let isPropHidden = 
-                       ((fspec.IsCompilerGenerated && not tycon.IsEnumTycon) ||
-                        hiddenRepr ||
-                        IsHiddenRecdField eenv.sigToImplRemapInfo (tcref.MakeNestedRecdFieldRef fspec))
+                   let isPropHidden =
+                        // Enums always have public cases irrespective of Enum Visibility
+                        if tycon.IsEnumTycon then false
+                        else 
+                            ((fspec.IsCompilerGenerated && not tycon.IsEnumTycon) ||
+                              hiddenRepr ||
+                              IsHiddenRecdField eenv.sigToImplRemapInfo (tcref.MakeNestedRecdFieldRef fspec))
                    let ilType = GenType cenv.amap m eenvinner.tyenv fspec.FormalType
                    let ilFieldName = ComputeFieldName tycon fspec
                         

--- a/tests/fsharp/core/enum/test.fsx
+++ b/tests/fsharp/core/enum/test.fsx
@@ -1,0 +1,58 @@
+// #Conformance #Regression 
+#if TESTS_AS_APP
+module Core_enum
+#endif
+
+open System.Reflection
+let failures = ref []
+
+let report_failure (s : string) = 
+    stderr.Write" Failed: "
+    stderr.WriteLine s
+    failures := !failures @ [s]
+
+let test (s : string) b = 
+    stderr.Write(s)
+    if b then stderr.WriteLine " Passed"
+    else report_failure (s)
+
+let check s b1 b2 = test s (b1 = b2)
+
+type internal internalEnum = Red=0 | Yellow=1 | Blue=2
+type public publicEnum = Red=0 | Yellow=1 | Blue=2
+
+module enum =
+
+    let AreCasesPublic (t:System.Type) =
+        let bindingFlags = BindingFlags.Static ||| BindingFlags.Public
+        try
+            let red = t.GetField("Red", bindingFlags)
+            let yellow = t.GetField("Yellow", bindingFlags)
+            let blue = t.GetField("Blue", bindingFlags)
+            let value__ = t.GetField("value__", bindingFlags ||| BindingFlags.Instance)
+
+            if isNull red || not (red.IsPublic) then failwith (sprintf "Type: %s) - Red is not public.  All enum cases should always be public" t.FullName)
+            if isNull yellow || not (yellow.IsPublic) then failwith (sprintf "Type: %s) - Yellow is not public.  All enum cases should always be public" t.FullName)
+            if isNull blue || not (blue.IsPublic) then failwith (sprintf "Type: %s) - Blue is not public.  All enum cases should always be public" t.FullName)
+            if isNull value__ || not (value__.IsPublic) then failwith (sprintf "Type: %s) - value__ is not public.  value__ should always be public" t.FullName)
+            true
+        with _ -> false
+
+    do check "publicEnum" (AreCasesPublic typeof<publicEnum>) true
+    do check "internalEnum" (AreCasesPublic typeof<internalEnum>) true
+
+
+#if TESTS_AS_APP
+let RUN() = !failures
+#else
+let aa =
+  match !failures with 
+  | [] -> 
+      stdout.WriteLine "Test Passed"
+      System.IO.File.WriteAllText("test.ok","ok")
+      exit 0
+  | _ -> 
+      stdout.WriteLine "Test Failed"
+      exit 1
+#endif
+

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -237,6 +237,14 @@ module CoreTests =
     [<Test>]
     let csext () = singleTestBuildAndRun "core/csext" FSC_BASIC
 
+
+    [<Test>]
+    let fscenum () = singleTestBuildAndRun "core/enum" FSC_BASIC
+
+    [<Test>]
+    let fsienum () = singleTestBuildAndRun "core/enum" FSI_BASIC
+
+
 #if !FSHARP_SUITE_DRIVES_CORECLR_TESTS
 
     [<Test>]


### PR DESCRIPTION
- Current F# Code generation for internal Enums makes the cases internal.  This PR aligns our code gen with C# by generating Enum Cases that are public, under all conditions.

![image](https://user-images.githubusercontent.com/5175830/40529908-a206300a-5fab-11e8-9f2b-58d8a4514138.png)

