### PR TITLE
Fix tcRefOfAppTy usage in GetDeclarationListSymbols

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -993,7 +993,7 @@ type TypeCheckInfo
                             | Item.FakeInterfaceCtor (TType_app(tcref,_)) 
                             | Item.DelegateCtor (TType_app(tcref,_)) -> tcref.CompiledName
                             | Item.CtorGroup (_, (cinfo :: _)) ->
-                                (tcrefOfAppTy g cinfo.ApparentEnclosingType).CompiledName
+                                cinfo.ApparentEnclosingTyconRef.CompiledName
                             | _ -> d.Item.DisplayName)
 
                     // Filter out operators (and list)


### PR DESCRIPTION
Fixes error spotted while debugging VSMac intellisense.

This message was coming from the FCS trace logs.

```
FCS: recovering from error in GetDeclarationListSymbols: 'internal error: tcrefOfAppTy'
```