### PR TITLE
exclude NuGet package from VSIX signing requirements

### DIFF
--- a/build/config/AssemblySignToolData.json
+++ b/build/config/AssemblySignToolData.json
@@ -57,6 +57,7 @@
     }
   ],
   "exclude": [
+    "FSharp.Core.4.3.4.nupkg",
     "FSharp.Data.TypeProviders.dll",
     "Microsoft.Build.Conversion.Core.dll",
     "Microsoft.Build.dll",


### PR DESCRIPTION
Follow-up to #4977.

The signed build failed because VisualFSharpFull.vsix now contains a copy of a NuGet package.  This needs to be excluded from signing like the existing references to the System.ValueTuple packages.