### PR TITLE
parameterize vs package binding redirects

### DIFF
--- a/build/targets/GenerateAssemblyAttributes.targets
+++ b/build/targets/GenerateAssemblyAttributes.targets
@@ -2,6 +2,24 @@
 
   <Import Project="GitHash.props" />
 
+  <Target Name="GenerateAssemblyLevelAttributes"
+          BeforeTargets="CoreCompile">
+
+    <PropertyGroup>
+      <GeneratedFSharpAssemblyLevelAttributesFile>$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyLevelAttributes$(DefaultLanguageSourceExtension)</GeneratedFSharpAssemblyLevelAttributesFile>
+    </PropertyGroup>
+
+    <WriteCodeFragment AssemblyAttributes="@(AssemblyLevelAttribute)"
+                       Language="$(Language)"
+                       OutputFile="$(GeneratedFSharpAssemblyLevelAttributesFile)"
+                       Condition="'@(AssemblyLevelAttribute)' != ''">
+      <Output TaskParameter="OutputFile" ItemName="Compile" Condition="'$(Language)' != 'F#'" />
+      <Output TaskParameter="OutputFile" ItemName="CompileBefore" Condition="'$(Language)' == 'F#'" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+
+  </Target>
+
   <Target Name="GenerateAssemblyFileVersion"
           BeforeTargets="CoreCompile"
           Condition="'$(Configuration)' != 'Proto'">

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -45,7 +45,6 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
     [<assembly:ProvideCodeBase(AssemblyName = "FSharp.Compiler.Private", CodeBase = @"$PackageFolder$\FSharp.Compiler.Private.dll")>]
     [<assembly:ProvideCodeBase(AssemblyName = "FSharp.Compiler.Server.Shared", CodeBase = @"$PackageFolder$\FSharp.Compiler.Server.Shared.dll")>]
     [<assembly:ProvideCodeBase(AssemblyName = "FSharp.UIResources", CodeBase = @"$PackageFolder$\FSharp.UIResources.dll")>]
-    [<assembly:ProvideBindingRedirection(AssemblyName = "FSharp.Core", OldVersionLowerBound = "2.0.0.0", OldVersionUpperBound = "4.4.3.0", NewVersion = "4.4.3.0", CodeBase = @"$PackageFolder$\FSharp.Core.dll")>]
     do ()
 
     module internal VSHiveUtilities =

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
@@ -40,6 +40,28 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyLevelAttribute Include="Microsoft.VisualStudio.Shell.ProvideBindingRedirectionAttribute">
+      <AssemblyName>FSharp.Core</AssemblyName>
+      <OldVersionLowerBound>2.0.0.0</OldVersionLowerBound>
+      <OldVersionUpperBound>$(FSCoreVersion)</OldVersionUpperBound>
+      <NewVersion>$(FSCoreVersion)</NewVersion>
+      <CodeBase>$PackageFolder$\FSharp.Core.dll</CodeBase>
+    </AssemblyLevelAttribute>
+    <AssemblyLevelAttribute Include="Microsoft.VisualStudio.Shell.ProvideBindingRedirectionAttribute">
+      <AssemblyName>FSharp.ProjectSystem.FSharp</AssemblyName>
+      <OldVersionLowerBound>15.0.0.0</OldVersionLowerBound>
+      <OldVersionUpperBound>$(VSAssemblyVersion)</OldVersionUpperBound>
+      <NewVersion>$(VSAssemblyVersion)</NewVersion>
+    </AssemblyLevelAttribute>
+    <AssemblyLevelAttribute Include="Microsoft.VisualStudio.Shell.ProvideBindingRedirectionAttribute">
+      <AssemblyName>FSharp.ProjectSystem.PropertyPages</AssemblyName>
+      <OldVersionLowerBound>15.0.0.0</OldVersionLowerBound>
+      <OldVersionUpperBound>$(VSAssemblyVersion)</OldVersionUpperBound>
+      <NewVersion>$(VSAssemblyVersion)</NewVersion>
+    </AssemblyLevelAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj" />
     <ProjectReference Include="..\FSharp.VS.FSI\FSharp.VS.FSI.fsproj" />


### PR DESCRIPTION
This is a more-complete version of #5009 which will prevent the issue going forward.

By creating an assembly level attribute for the package binding redirects, we can avoid having to change these values every time a version number is bumped, and instead directly consume the MSBuild properties.