### PR TITLE
Color struct types with measure as value types

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1313,12 +1313,10 @@ type TypeCheckInfo
         let isDisposableTy (ty: TType) =
             protectAssemblyExplorationNoReraise false false (fun () -> Infos.ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_IDisposable)
 
-        let isStructTyconRef (tyconRef: TyconRef) =
-            let tyconRef =
-                match tyconRef.Deref.entity_tycon_repr with
-                | TMeasureableRepr (TType_app (tyconRef, _)) -> tyconRef
-                | _ -> tyconRef
-            isStructTy g (generalizedTyconRef tyconRef)
+        let isStructTyconRef (tyconRef: TyconRef) = 
+            let ty = generalizedTyconRef tyconRef
+            let underlyingTy = stripTyEqnsAndMeasureEqns g ty
+            isStructTy g underlyingTy
 
         resolutions
         |> Seq.choose (fun cnr ->

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1351,6 +1351,8 @@ type TypeCheckInfo
                 Some (m, SemanticClassificationType.Interface)
             | CNR(_, Item.Types(_, types), LegitTypeOccurence, _, _, _, m) when types |> List.exists (isStructTy g) -> 
                 Some (m, SemanticClassificationType.ValueType)
+            | CNR(_, Item.Types(_, TType_app(_, TType_measure _ :: _) :: _), LegitTypeOccurence, _, _, _, m) -> 
+                Some (m, SemanticClassificationType.ValueType)
             | CNR(_, Item.Types(_, types), LegitTypeOccurence, _, _, _, m) when types |> List.exists isDisposableTy ->
                 Some (m, SemanticClassificationType.Disposable)
             | CNR(_, Item.Types _, LegitTypeOccurence, _, _, _, m) -> 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1315,15 +1315,10 @@ type TypeCheckInfo
 
         let isStructTyconRef (tyconRef: TyconRef) =
             let tyconRef =
-                if tyconRef.CanDeref then
-                    match tyconRef.Deref.entity_tycon_repr with
-                    | TMeasureableRepr (TType_app (tyconRef, _)) -> tyconRef
-                    | _ -> tyconRef
-                else tyconRef
-                
-            match tyconRef.TypeAbbrev with
-            | Some ty -> isStructTy g ty
-            | _ -> tyconRef.IsStructOrEnumTycon
+                match tyconRef.Deref.entity_tycon_repr with
+                | TMeasureableRepr (TType_app (tyconRef, _)) -> tyconRef
+                | _ -> tyconRef
+            isStructTy g (generalizedTyconRef tyconRef)
 
         resolutions
         |> Seq.choose (fun cnr ->

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -99,8 +99,11 @@
     <Compile Include="UnusedOpensTests.fs">
       <Link>CompilerService\UnusedOpensTests.fs</Link>
     </Compile>
-    <Compile Include="ColorizationServiceTests.fs">
-      <Link>Roslyn\ColorizationServiceTests.fs</Link>
+    <Compile Include="SyntacticColorizationServiceTests.fs">
+      <Link>Roslyn\SyntacticColorizationServiceTests.fs</Link>
+    </Compile>
+    <Compile Include="SemanticColorizationServiceTests.fs">
+      <Link>Roslyn\SemanticColorizationServiceTests.fs</Link>
     </Compile>
     <Compile Include="BraceMatchingServiceTests.fs">
       <Link>Roslyn\BraceMatchingServiceTests.fs</Link>

--- a/vsintegration/tests/unittests/SemanticColorizationServiceTests.fs
+++ b/vsintegration/tests/unittests/SemanticColorizationServiceTests.fs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+namespace Microsoft.VisualStudio.FSharp.Editor.Tests.Roslyn
+
+open System
+open NUnit.Framework
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.FSharp.Compiler.SourceCodeServices
+open Microsoft.FSharp.Compiler
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Text
+
+[<TestFixture>][<Category "Roslyn Services">]
+type SemanticClassificationServiceTests()  =
+    let filePath = "C:\\test.fs"
+
+    let projectOptions = { 
+        ProjectFileName = "C:\\test.fsproj"
+        ProjectId = None
+        SourceFiles =  [| filePath |]
+        ReferencedProjects = [| |]
+        OtherOptions = [| |]
+        IsIncompleteTypeCheckEnvironment = true
+        UseScriptResolutionRules = false
+        LoadTime = DateTime.MaxValue
+        UnresolvedReferences = None
+        OriginalLoadReferences = []
+        ExtraProjectInfo = None
+        Stamp = None
+    }
+
+    let checker = FSharpChecker.Create()
+
+    let getRanges (sourceText: string) : (Range.range * SemanticClassificationType) list =
+        asyncMaybe {
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, 0, sourceText, projectOptions, false, "")
+            return checkFileResults.GetSemanticClassification(None)
+        } 
+        |> Async.RunSynchronously
+        |> Option.toList
+        |> List.collect Array.toList
+
+    let verifyColorizerAtEndOfMarker(fileContents: string, marker: string, classificationType: string) =
+        let text = SourceText.From fileContents
+        let ranges = getRanges fileContents
+        let line = text.Lines.GetLineFromPosition (fileContents.IndexOf(marker) + marker.Length - 1)
+        let col = line.ToString().IndexOf(marker) + marker.Length - 1
+        let markerPos = Range.mkPos (Range.Line.toZ line.LineNumber) col
+        printfn "parker pos: %A, ranges: %A" markerPos ranges
+        match ranges |> List.tryFind (fun (range, _) -> Range.rangeContainsPos range markerPos) with
+        | None -> Assert.Fail("Cannot find colorization data for end of marker")
+        | Some(_, ty) -> Assert.AreEqual(classificationType, FSharpClassificationTypes.getClassificationTypeName ty, "Classification data doesn't match for end of marker")
+
+    [<TestCase("(*1*)Guid", FSharpClassificationTypes.ReferenceType)>]
+    [<TestCase("(*2*)string", FSharpClassificationTypes.ReferenceType)>]
+    [<TestCase("(*3*)Guid", FSharpClassificationTypes.ValueType)>]
+    [<TestCase("(*4*)string", FSharpClassificationTypes.ReferenceType)>]
+    [<TestCase("(*5*)int", FSharpClassificationTypes.ValueType)>]
+    [<TestCase("(*6*)Guid", FSharpClassificationTypes.ValueType)>]
+    [<TestCase("(*7*)string", FSharpClassificationTypes.ReferenceType)>]
+    member public this.Measured_Types(marker: string, classificationType: string) =
+        verifyColorizerAtEndOfMarker(
+             """#light (*Light*)
+                open System
+                
+                [<MeasureAnnotatedAbbreviation>] type (*1*)Guid<[<Measure>] 'm> = Guid
+                [<MeasureAnnotatedAbbreviation>] type (*2*)string<[<Measure>] 'm> = string
+                
+                let inline cast<'a, 'b> (a : 'a) : 'b = (# "" a : 'b #)
+                
+                type Uom =
+                    static member inline tag<[<Measure>]'m> (x : Guid) : (*3*)Guid<'m> = cast x
+                    static member inline tag<[<Measure>]'m> (x : string) : (*4*)string<'m> = cast x
+                
+                type [<Measure>] Ms
+                
+                let i: (*5*)int<Ms> = 1<Ms>
+                let g: (*6*)Guid<Ms> = Uom.tag Guid.Empty
+                let s: (*7*)string<Ms> = Uom.tag "foo" """,
+            marker, 
+            classificationType)

--- a/vsintegration/tests/unittests/SemanticColorizationServiceTests.fs
+++ b/vsintegration/tests/unittests/SemanticColorizationServiceTests.fs
@@ -6,11 +6,10 @@ open NUnit.Framework
 open Microsoft.VisualStudio.FSharp.Editor
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.FSharp.Compiler
-open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Text
 
-[<TestFixture>][<Category "Roslyn Services">]
-type SemanticClassificationServiceTests()  =
+[<TestFixture; Category "Roslyn Services">]
+type SemanticClassificationServiceTests() =
     let filePath = "C:\\test.fs"
 
     let projectOptions = { 
@@ -42,24 +41,22 @@ type SemanticClassificationServiceTests()  =
     let verifyColorizerAtEndOfMarker(fileContents: string, marker: string, classificationType: string) =
         let text = SourceText.From fileContents
         let ranges = getRanges fileContents
-        let line = text.Lines.GetLineFromPosition (fileContents.IndexOf(marker) + marker.Length - 1)
-        let col = line.ToString().IndexOf(marker) + marker.Length - 1
-        let markerPos = Range.mkPos (Range.Line.toZ line.LineNumber) col
-        printfn "parker pos: %A, ranges: %A" markerPos ranges
+        let line = text.Lines.GetLinePosition (fileContents.IndexOf(marker) + marker.Length - 1)
+        let markerPos = Range.mkPos (Range.Line.fromZ line.Line) (line.Character + marker.Length - 1)
         match ranges |> List.tryFind (fun (range, _) -> Range.rangeContainsPos range markerPos) with
         | None -> Assert.Fail("Cannot find colorization data for end of marker")
         | Some(_, ty) -> Assert.AreEqual(classificationType, FSharpClassificationTypes.getClassificationTypeName ty, "Classification data doesn't match for end of marker")
 
-    [<TestCase("(*1*)Guid", FSharpClassificationTypes.ReferenceType)>]
-    [<TestCase("(*2*)string", FSharpClassificationTypes.ReferenceType)>]
-    [<TestCase("(*3*)Guid", FSharpClassificationTypes.ValueType)>]
-    [<TestCase("(*4*)string", FSharpClassificationTypes.ReferenceType)>]
-    [<TestCase("(*5*)int", FSharpClassificationTypes.ValueType)>]
-    [<TestCase("(*6*)Guid", FSharpClassificationTypes.ValueType)>]
-    [<TestCase("(*7*)string", FSharpClassificationTypes.ReferenceType)>]
-    member public this.Measured_Types(marker: string, classificationType: string) =
+    [<TestCase("(*1*)", FSharpClassificationTypes.ValueType)>]
+    [<TestCase("(*2*)", FSharpClassificationTypes.ReferenceType)>]
+    [<TestCase("(*3*)", FSharpClassificationTypes.ValueType)>]
+    [<TestCase("(*4*)", FSharpClassificationTypes.ReferenceType)>]
+    [<TestCase("(*5*)", FSharpClassificationTypes.ValueType)>]
+    [<TestCase("(*6*)", FSharpClassificationTypes.ValueType)>]
+    [<TestCase("(*7*)", FSharpClassificationTypes.ReferenceType)>]
+    member __.Measured_Types(marker: string, classificationType: string) =
         verifyColorizerAtEndOfMarker(
-             """#light (*Light*)
+                """#light (*Light*)
                 open System
                 
                 [<MeasureAnnotatedAbbreviation>] type (*1*)Guid<[<Measure>] 'm> = Guid

--- a/vsintegration/tests/unittests/SyntacticColorizationServiceTests.fs
+++ b/vsintegration/tests/unittests/SyntacticColorizationServiceTests.fs
@@ -12,7 +12,7 @@ open Microsoft.CodeAnalysis.Text
 open Microsoft.VisualStudio.FSharp.Editor
 
 [<TestFixture>][<Category "Roslyn Services">]
-type ClassificationServiceTests()  =
+type SyntacticClassificationServiceTests()  =
 
     member private this.ExtractMarkerData(fileContents: string, marker: string, defines: string list, isScriptFile: Option<bool>) =
         let textSpan = TextSpan(0, fileContents.Length)


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/3110 

It colors any type having a measure attached as value type. I've tried to determine is the `TyconRef` at 

![image](https://user-images.githubusercontent.com/873919/40612250-64d8e630-6282-11e8-951f-60c1f6929a14.png)

is a value type, but failed. The entity (for example, `int'1` for `int<M>`) is not a structure and it's not an abbreviation, so I was stuck. 