### PR TITLE
Fix attribute completion for out of scope symbols

### DIFF
--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -966,7 +966,8 @@ module internal SymbolHelpers =
             let g = infoReader.g
             let amap = infoReader.amap
             match item with
-            | Item.Types(_, ((TType_app(tcref, _)):: _)) -> 
+            | Item.Types(_, ((TType_app(tcref, _)):: _))
+            | Item.UnqualifiedType(tcref :: _) ->
                 let ty = generalizedTyconRef tcref
                 Infos.ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_Attribute
             | _ -> false


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/873919/40675843-8906a7a4-6381-11e8-9c97-0bd487241414.png)

After

![image](https://user-images.githubusercontent.com/873919/40675736-39587368-6381-11e8-9394-8290028f781d.png)
