### PR TITLE
[RFCs FS-1037] allow flexible inference (subsumption) at union construction 

### DIFF
--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -1744,6 +1744,30 @@ module QuotationStructUnionTests =
     //test "check NewUnionCase"   (<@ A1(1,2) @> |> (function NewUnionCase(unionCase,[ Int32 1; Int32 2 ]) -> true | _ -> false))
 
 
+module FlexibleUnionConstructorTests = 
+
+    [<Struct>]
+    type T = | A of seq<int>
+
+    type U = | B of seq<int>
+    let testList = [1..3]
+    let testFunction caseName x =
+        match x with
+        | Call(None, _, 
+               [PropertyGet (None,_,_) ;
+                 Let (_, Lambda (_, NewUnionCase(unioncase, _)), 
+                    Lambda(_, Application(_, Coerce(_, ty))))]) -> 
+                 unioncase.Name = caseName &&
+                 ty.Name = "IEnumerable`1"
+        | _ -> false
+
+    test "check struct flexible union constructor"   
+        (<@ testList |> A @> |> testFunction "A")
+    
+    test "check flexible union constructor"   
+        (<@ testList |> B @> |> testFunction "B")
+
+
 module EqualityOnExprDoesntFail = 
     let q = <@ 1 @>
     check "we09ceo" (q.Equals(1)) false

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -131,24 +131,6 @@ but here has type
 
 neg20.fs(99,26,99,33): typecheck error FS0001: All elements of a list constructor expression must have the same type. This expression was expected to have type 'B', but here has type 'A'.
 
-neg20.fs(108,12,108,16): typecheck error FS0001: Type mismatch. Expecting a
-    'B * B -> 'a'    
-but given a
-    'A * A -> Data'    
-The type 'B' does not match the type 'A'
-
-neg20.fs(109,12,109,16): typecheck error FS0001: Type mismatch. Expecting a
-    'A * B -> 'a'    
-but given a
-    'A * A -> Data'    
-The type 'B' does not match the type 'A'
-
-neg20.fs(110,12,110,16): typecheck error FS0001: Type mismatch. Expecting a
-    'B * A -> 'a'    
-but given a
-    'A * A -> Data'    
-The type 'B' does not match the type 'A'
-
 neg20.fs(128,19,128,22): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type

--- a/tests/fsharp/typecheck/sigs/neg20.fs
+++ b/tests/fsharp/typecheck/sigs/neg20.fs
@@ -105,9 +105,9 @@ module NoSubsumptionForLists2 =
     let pBB = (new B(),new B())
     let pAB = (new A(),new B())
     let pBA = (new B(),new A())
-    pBB |> Data   // not permitted (questionable)
-    pAB |> Data   // not permitted (questionable)
-    pBA |> Data   // not permitted (questionable)
+    pBB |> Data   // permitted
+    pAB |> Data   // permitted
+    pBA |> Data   // permitted
     pBB |> data   // permitted
     pAB |> data   // permitted
     pBA |> data   // permitted

--- a/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/ConstructorFlexibleWhenPiping.fsx
+++ b/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/ConstructorFlexibleWhenPiping.fsx
@@ -1,0 +1,8 @@
+// #Conformance #TypesAndModules #Unions 
+// DU constructor should be flexible when piping
+//<Expects status=success></Expects>
+
+type Foo = Items of seq<int>
+[1;2;3] |> Items
+
+exit 0

--- a/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/StructConstructorFlexibleWhenPiping.fsx
+++ b/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/StructConstructorFlexibleWhenPiping.fsx
@@ -1,0 +1,9 @@
+// #Conformance #TypesAndModules #Unions 
+// Struct DU constructor should be flexible when piping
+//<Expects status=success></Expects>
+
+[<Struct>]
+type Foo = Items of seq<int>
+[1;2;3] |> Items
+
+exit 0

--- a/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/env.lst
+++ b/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/env.lst
@@ -100,3 +100,6 @@ NoMT	SOURCE=Overload_ToString.fs    COMPILE_ONLY=1 SCFLAGS=--warnaserror+ FSIMOD
 	SOURCE=E_UnionConstructorBadFieldName.fs    SCFLAGS="--test:ErrorRanges"				# E_UnionConstructorBadFieldName.fs
 	SOURCE=E_FieldNameUsedMulti.fs              SCFLAGS="--test:ErrorRanges"				# E_FieldNameUsedMulti.fs
 	SOURCE=E_FieldMemberClash.fs                SCFLAGS="--test:ErrorRanges"				# E_FieldMemberClash.fs
+
+	SOURCE=ConstructorFlexibleWhenPiping.fsx							# ConstructorFlexibleWhenPiping.fsx
+	SOURCE=StructConstructorFlexibleWhenPiping.fsx							# StructConstructorFlexibleWhenPiping.fsx


### PR DESCRIPTION
The missing commits from https://github.com/Microsoft/visualfsharp/pull/4930

RFC FS-1037  https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1037-allow-union-constructors-to-deal-with-flexible-types.md via #4798
