### PR TITLE
Enable redirection of hintpath for projects using the inbox type provider

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -34,6 +34,7 @@
   <package id="BenchmarkDotNet" version="0.9.8"/>
   <package id="BenchmarkDotNet.Diagnostics.Windows" version="0.9.8"/>
   <package id="Newtonsoft.Json" version="9.0.1"/>
+  <package id="Microsoft.VisualFSharp.Type.Providers.Redist" version="1.0.0" />
   <package id="Microsoft.FSharp.TupleSample" version="1.0.0-alpha-161121"/>
   <package id="Microsoft.VSSDK.BuildTools" version="15.1.192" />
 

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -59,6 +59,9 @@
     <Reference Include="Microsoft.Build.Tasks.Core, Version=$(VisualStudioVersion).0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualFSharp.Msbuild.15.0.1.0.1\lib\net45\Microsoft.Build.Tasks.Core.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Data.TypeProviders.dll, Version=4.3.0.0">
+      <HintPath>$(FSharpSourcesRoot)\..\packages\Microsoft.VisualFSharp.Type.Providers.Redist.$(MicrosoftVisualFSharpTypeProvidersRedistPackageVersion)\content\4.3.0.0\FSharp.Data.TypeProviders.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetDotnetProfile)' != 'coreclr' AND '$(MonoPackaging)' == 'true' ">
     <Reference Include="Microsoft.Build.Framework, Version=$(MonoPackagingMSBuildVersionFull), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -401,7 +401,6 @@ this file.
     </Target>
 
     <!--
-
     The old reference assemblies are no longer installed to `Program Files (x86)\Reference Assemblies\Microsoft\FSharp`.
 
     To avoid breaking legacy projects the hint path for FSharp.Core will be rewritten if and only if the existing hint
@@ -411,7 +410,8 @@ this file.
     <Target Name="RedirectFSharpCoreReferenceToNewRedistributableLocation" BeforeTargets="ResolveAssemblyReferences">
       <PropertyGroup>
         <_OldRootSdkLocation>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp</_OldRootSdkLocation>
-        <_NewRootSdkLocation>$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharpSdk</_NewRootSdkLocation>
+
+        <NewFSharpSdkLocation Condition=" '$(NewFSharpSdkLocation)' == '' ">$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharpSdk</NewFSharpSdkLocation>
 
         <_CoreRelativeSuffix>.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</_CoreRelativeSuffix>
         <_FrameworkRelativeSuffix>.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</_FrameworkRelativeSuffix>
@@ -419,38 +419,59 @@ this file.
 
         <!-- .NETCore -->
         <_OldCoreSdkPath>$(_OldRootSdkLocation)\$(_CoreRelativeSuffix)</_OldCoreSdkPath>
-        <_NewCoreSdkPath>$(_NewRootSdkLocation)\$(_CoreRelativeSuffix)</_NewCoreSdkPath>
+        <_NewCoreSdkPath>$(NewFSharpSdkLocation)\$(_CoreRelativeSuffix)</_NewCoreSdkPath>
 
         <!-- .NETFramework\v4.0 -->
         <_OldFrameworkSdkPath>$(_OldRootSdkLocation)\$(_FrameworkRelativeSuffix)</_OldFrameworkSdkPath>
-        <_NewFrameworkSdkPath>$(_NewRootSdkLocation)\$(_FrameworkRelativeSuffix)</_NewFrameworkSdkPath>
+        <_NewFrameworkSdkPath>$(NewFSharpSdkLocation)\$(_FrameworkRelativeSuffix)</_NewFrameworkSdkPath>
 
         <!-- .NETPortable -->
         <_OldPortableSdkPath>$(_OldRootSdkLocation)\$(_PortableRelativeSuffix)</_OldPortableSdkPath>
-        <_NewPortableSdkPath>$(_NewRootSdkLocation)\$(_PortableRelativeSuffix)</_NewPortableSdkPath>
+        <_NewPortableSdkPath>$(NewFSharpSdkLocation)\$(_PortableRelativeSuffix)</_NewPortableSdkPath>
       </PropertyGroup>
 
       <ItemGroup>
         <!-- Update references to `.NETCore\*\FSharp.Core.dll`. -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Core' and
-                              '%(Reference.HintPath)' == '$(_OldCoreSdkPath)' and
-                              Exists('$(_NewCoreSdkPath)')">
+                              '%(Reference.HintPath)' == '$(_OldCoreSdkPath)'">
           <HintPath>$(_NewCoreSdkPath)</HintPath>
         </Reference>
 
         <!-- Update references to `.NETFramework\v4.0\*\FSharp.Core.dll`. -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Core' and
-                              '%(Reference.HintPath)' == '$(_OldFrameworkSdkPath)' and
-                              Exists('$(_NewFrameworkSdkPath)')">
+                              '%(Reference.HintPath)' == '$(_OldFrameworkSdkPath)'">
           <HintPath>$(_NewFrameworkSdkPath)</HintPath>
         </Reference>
 
         <!-- Update references to `.Portable\*\FSharp.Core.dll`. -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Core' and
-                              '%(Reference.HintPath)' == '$(_OldPortableSdkPath)' and
-                              Exists('$(_NewPortableSdkPath)')">
+                              '%(Reference.HintPath)' == '$(_OldPortableSdkPath)'">
           <HintPath>$(_NewPortableSdkPath)</HintPath>
         </Reference>
+      </ItemGroup>
+    </Target>
+
+    <Target Name="RedirectTPReferenceToNewRedistributableLocation" BeforeTargets="RedirectFSharpCoreReferenceToNewRedistributableLocation">
+      <PropertyGroup>
+        <_OldRefAssemTPLocation>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers</_OldRefAssemTPLocation>
+        <_OldSdkTPLocation>Framework\v4.0\FSharp.Data.TypeProviders.dll</_OldSdkTPLocation>
+
+        <NewFSharpSdkLocation Condition=" '$(NewFSharpSdkLocation)' == '' ">$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharpSdk</NewFSharpSdkLocation>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <!-- Update references to FSharp.Data.TypeProviders.dll -->
+        <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
+                              '%(Reference.HintPath)' == '$(_OldTPSDkLocation)\FSharp.Data.TypeProviders.dll'">
+          <HintPath>$(NewFSharpSdkLocation)\FSharp.Data.TypeProviders.dll</HintPath>
+        </Reference>
+
+        <!-- Update references to FSharp.Data.TypeProviders.dll -->
+        <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
+                              '%(Reference.HintPath.EndsWith($(_OldSdkTPLocation), System.StringComparison.OrdinalIgnoreCase))'">
+          <HintPath>$(NewFSharpSdkLocation)\FSharp.Data.TypeProviders.dll</HintPath>
+        </Reference>
+
       </ItemGroup>
     </Target>
 

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -451,25 +451,26 @@ this file.
       </ItemGroup>
     </Target>
 
+
     <Target Name="RedirectTPReferenceToNewRedistributableLocation" BeforeTargets="RedirectFSharpCoreReferenceToNewRedistributableLocation">
       <PropertyGroup>
-        <_OldRefAssemTPLocation>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers</_OldRefAssemTPLocation>
+        <_OldRefAssemTPLocation>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers\FSharp.Data.TypeProviders.dll</_OldRefAssemTPLocation>
         <_OldSdkTPLocation>Framework\v4.0\FSharp.Data.TypeProviders.dll</_OldSdkTPLocation>
 
-        <NewFSharpSdkLocation Condition=" '$(NewFSharpSdkLocation)' == '' ">$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\FSharpSdk</NewFSharpSdkLocation>
+        <NewFSharpCompilerLocation Condition=" '$(NewFSharpCompilerLocation)' == '' ">$(MSBuildThisFileDirectory)</NewFSharpCompilerLocation>
       </PropertyGroup>
 
       <ItemGroup>
         <!-- Update references to FSharp.Data.TypeProviders.dll -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
-                              '%(Reference.HintPath)' == '$(_OldTPSDkLocation)\FSharp.Data.TypeProviders.dll'">
-          <HintPath>$(NewFSharpSdkLocation)\FSharp.Data.TypeProviders.dll</HintPath>
+                              '%(Reference.HintPath)' == '$(_OldRefAssemTPLocation)'">
+          <HintPath>$(NewFSharpCompilerLocation)\FSharp.Data.TypeProviders.dll</HintPath>
         </Reference>
 
         <!-- Update references to FSharp.Data.TypeProviders.dll -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
-                              '%(Reference.HintPath.EndsWith($(_OldSdkTPLocation), System.StringComparison.OrdinalIgnoreCase))'">
-          <HintPath>$(NewFSharpSdkLocation)\FSharp.Data.TypeProviders.dll</HintPath>
+                               $([System.String]::new('%(Reference.HintPath)').Endswith('$(_OldSdkTPLocation)', System.StringComparison.OrdinalIgnoreCase)) ">
+          <HintPath>$(NewFSharpCompilerLocation)\FSharp.Data.TypeProviders.dll</HintPath>
         </Reference>
 
       </ItemGroup>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -455,7 +455,7 @@ this file.
     </Target>
 
 
-    <Target Name="RedirectTPReferenceToNewRedistributableLocation" BeforeTargets="RedirectFSharpCoreReferenceToNewRedistributableLocation">
+    <Target Name="RedirectTPReferenceToNewRedistributableLocation" BeforeTargets="ResolveAssemblyReferences">
       <PropertyGroup>
         <_OldRefAssemTPLocation>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers\FSharp.Data.TypeProviders.dll</_OldRefAssemTPLocation>
         <_OldSdkTPLocationPrefix>$(MSBuildProgramFiles32)\Microsoft SDKs\F#</_OldSdkTPLocationPrefix>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -454,7 +454,6 @@ this file.
       </ItemGroup>
     </Target>
 
-
     <Target Name="RedirectTPReferenceToNewRedistributableLocation" BeforeTargets="ResolveAssemblyReferences">
       <PropertyGroup>
         <_OldRefAssemTPLocation>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers\FSharp.Data.TypeProviders.dll</_OldRefAssemTPLocation>
@@ -462,7 +461,7 @@ this file.
         <_OldSdkTPLocationSuffix>Framework\v4.0\FSharp.Data.TypeProviders.dll</_OldSdkTPLocationSuffix>
 
         <NewFSharpCompilerLocation Condition=" '$(NewFSharpCompilerLocation)' == '' ">$(MSBuildThisFileDirectory)</NewFSharpCompilerLocation>
-        <NewFSharpCompilerLocation Condition=" $(NewFSharpCompilerLocation.EndsWith('\\')) ">$(NewFSharpCompilerLocation)</NewFSharpCompilerLocation>
+        <NewFSharpCompilerLocation Condition=" !HasTrailingSlash('$(NewFSharpCompilerLocation)') ">$(NewFSharpCompilerLocation)\</NewFSharpCompilerLocation>
       </PropertyGroup>
 
       <ItemGroup>

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -433,19 +433,22 @@ this file.
       <ItemGroup>
         <!-- Update references to `.NETCore\*\FSharp.Core.dll`. -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Core' and
-                              '%(Reference.HintPath)' == '$(_OldCoreSdkPath)'">
+                              '%(Reference.HintPath)' == '$(_OldCoreSdkPath)' and
+                              Exists('$(_NewCoreSdkPath)')">
           <HintPath>$(_NewCoreSdkPath)</HintPath>
         </Reference>
 
         <!-- Update references to `.NETFramework\v4.0\*\FSharp.Core.dll`. -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Core' and
-                              '%(Reference.HintPath)' == '$(_OldFrameworkSdkPath)'">
+                              '%(Reference.HintPath)' == '$(_OldFrameworkSdkPath)' and
+                              Exists('$(_NewFrameworkSdkPath)')">
           <HintPath>$(_NewFrameworkSdkPath)</HintPath>
         </Reference>
 
         <!-- Update references to `.Portable\*\FSharp.Core.dll`. -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Core' and
-                              '%(Reference.HintPath)' == '$(_OldPortableSdkPath)'">
+                              '%(Reference.HintPath)' == '$(_OldPortableSdkPath)' and
+                              Exists('$(_NewPortableSdkPath)')">
           <HintPath>$(_NewPortableSdkPath)</HintPath>
         </Reference>
       </ItemGroup>
@@ -455,22 +458,28 @@ this file.
     <Target Name="RedirectTPReferenceToNewRedistributableLocation" BeforeTargets="RedirectFSharpCoreReferenceToNewRedistributableLocation">
       <PropertyGroup>
         <_OldRefAssemTPLocation>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers\FSharp.Data.TypeProviders.dll</_OldRefAssemTPLocation>
-        <_OldSdkTPLocation>Framework\v4.0\FSharp.Data.TypeProviders.dll</_OldSdkTPLocation>
+        <_OldSdkTPLocationPrefix>$(MSBuildProgramFiles32)\Microsoft SDKs\F#</_OldSdkTPLocationPrefix>
+        <_OldSdkTPLocationSuffix>Framework\v4.0\FSharp.Data.TypeProviders.dll</_OldSdkTPLocationSuffix>
 
         <NewFSharpCompilerLocation Condition=" '$(NewFSharpCompilerLocation)' == '' ">$(MSBuildThisFileDirectory)</NewFSharpCompilerLocation>
+        <NewFSharpCompilerLocation Condition=" $(NewFSharpCompilerLocation.EndsWith('\\')) ">$(NewFSharpCompilerLocation)</NewFSharpCompilerLocation>
       </PropertyGroup>
 
       <ItemGroup>
         <!-- Update references to FSharp.Data.TypeProviders.dll -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
-                              '%(Reference.HintPath)' == '$(_OldRefAssemTPLocation)'">
-          <HintPath>$(NewFSharpCompilerLocation)\FSharp.Data.TypeProviders.dll</HintPath>
+                              '%(Reference.HintPath)' == '$(_OldRefAssemTPLocation)' and
+                              Exists('$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll')">
+          <HintPath>$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll</HintPath>
         </Reference>
 
         <!-- Update references to FSharp.Data.TypeProviders.dll -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
-                               $([System.String]::new('%(Reference.HintPath)').Endswith('$(_OldSdkTPLocation)', System.StringComparison.OrdinalIgnoreCase)) ">
-          <HintPath>$(NewFSharpCompilerLocation)\FSharp.Data.TypeProviders.dll</HintPath>
+                               $([System.String]::new('%(Reference.HintPath)').StartsWith('$(_OldSdkTPLocationPrefix)', System.StringComparison.OrdinalIgnoreCase)) and
+                               $([System.String]::new('%(Reference.HintPath)').EndsWith('$(_OldSdkTPLocationSuffix)', System.StringComparison.OrdinalIgnoreCase)) and
+                               Exists('$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll')">
+
+          <HintPath>$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll</HintPath>
         </Reference>
 
       </ItemGroup>


### PR DESCRIPTION
The new mechanism for deploying the compiler as a vsix, will mean that if any existing projects use the inbox type providers from one of the two standard locations.

Either the reference assembly location:
$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\Type Providers\FSharp.Data.TypeProviders.dll

or the beside the compiler location:
$(MSBuildProgramFiles32)\Microsoft SDKs\F#\10.1\Framework\v4.0\FSharp.Data.TypeProviders.dll

Will be detected nd redirected to the new beside the compiler location.

This also adds a reference to the TypeProvider from FSharp.Build.dll, this will ensure that the TP is available for testing, and also will be packaged in the VisualFSharpFull.vsix, for F5 debugging.

And removes a couple of file exists on conditions.  We want the build to fail when redirection fails, since it will be an actual deployment bug.

And enable projects and targets to set:
- NewFSharpSdkLocation
- NewFSharpCompilerLocation 




