### PR TITLE
Make matched brace highlighting work exactly as in C# editor

### DIFF
--- a/vsintegration/src/FSharp.Editor/Formatting/BraceMatchingService.fs
+++ b/vsintegration/src/FSharp.Editor/Formatting/BraceMatchingService.fs
@@ -24,9 +24,7 @@ type internal FSharpBraceMatchingService
             let isPositionInRange range = 
                 match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, range) with
                 | None -> false
-                | Some range ->
-                    let length = position - range.Start
-                    length >= 0 && length <= range.Length
+                | Some span -> span.Contains position
             return matchedBraces |> Array.tryFind(fun (left, right) -> isPositionInRange left || isPositionInRange right)
         }
         


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/3794

F# 

![_1](https://user-images.githubusercontent.com/873919/40777767-73226a16-64d7-11e8-8c63-e31d80af5af2.gif)

C#

![_1](https://user-images.githubusercontent.com/873919/40777826-9f87f080-64d7-11e8-858b-50591875b384.gif)
