### PR TITLE
Fix printf specifiers highlighting which have dots

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationService.fs
@@ -19,6 +19,8 @@ open Microsoft.CodeAnalysis.Text
 // IVT, we'll maintain the status quo.
 #nowarn "44"
 
+open Microsoft.FSharp.Compiler.SourceCodeServices
+
 [<ExportLanguageService(typeof<IEditorClassificationService>, FSharpConstants.FSharpLanguageName)>]
 type internal FSharpClassificationService
     [<ImportingConstructor>]
@@ -56,7 +58,10 @@ type internal FSharpClassificationService
                     match RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, range) with
                     | None -> ()
                     | Some span -> 
-                        let span = Tokenizer.fixupSpan(sourceText, span)
+                        let span = 
+                            match classificationType with
+                            | SemanticClassificationType.Printf -> span
+                            | _ -> Tokenizer.fixupSpan(sourceText, span)
                         result.Add(ClassifiedSpan(span, FSharpClassificationTypes.getClassificationTypeName(classificationType)))
             } 
             |> Async.Ignore |> RoslynHelpers.StartAsyncUnitAsTask cancellationToken


### PR DESCRIPTION
This fixes https://github.com/Microsoft/visualfsharp/issues/3703

![image](https://user-images.githubusercontent.com/873919/40785274-bead5824-64f0-11e8-97fc-8e94d936690a.png)
