### PR TITLE
Warn on use of inbox TP

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -465,6 +465,17 @@ this file.
       </PropertyGroup>
 
       <ItemGroup>
+        <!-- Issue warning message if there is an inbox TypeProvider referenced.-->
+        <ReferenceToInboxTP Include="@(Reference)"
+                            Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
+                                       '%(Reference.HintPath)' == '$(_OldRefAssemTPLocation)' and
+                                       Exists('$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll')" />
+        <ReferenceToInboxTP Include="@(Reference)"
+                            Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
+                                       $([System.String]::new('%(Reference.HintPath)').StartsWith('$(_OldSdkTPLocationPrefix)', System.StringComparison.OrdinalIgnoreCase)) and
+                                       $([System.String]::new('%(Reference.HintPath)').EndsWith('$(_OldSdkTPLocationSuffix)', System.StringComparison.OrdinalIgnoreCase)) and
+                                       Exists('$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll')" />
+
         <!-- Update references to FSharp.Data.TypeProviders.dll -->
         <Reference Condition="'%(Reference.Identity)' == 'FSharp.Data.TypeProviders' and
                               '%(Reference.HintPath)' == '$(_OldRefAssemTPLocation)' and
@@ -480,10 +491,11 @@ this file.
 
           <HintPath>$(NewFSharpCompilerLocation)FSharp.Data.TypeProviders.dll</HintPath>
         </Reference>
-
       </ItemGroup>
+      <Warning
+          Text="This Project references the obsolete in-box TypeProvider: FSharp.Data.TypeProviders.dll.  Consider Switching to the Nuget package version: https://www.nuget.org/packages/FSharp.Data.TypeProviders."
+          Condition=" '@(ReferenceToInboxTP->Count())' != '0' " />
     </Target>
 
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\$(MSBuildThisFile)\ImportAfter\*" Condition="'$(ImportByWildcardAfterMicrosoftFSharpTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\$(MSBuildThisFile)\ImportAfter')"/>
-
 </Project>


### PR DESCRIPTION
Add a warning message to the build if we discover the use of an inbox type provider.  Eventually we may stop deploying this .Dll.  The warning is in the build targets and benign.

The message:
Text="This Project references the obsolete in-box TypeProvider: FSharp.Data.TypeProviders.dll.  Consider Switching to the Nuget package version: https://www.nuget.org/packages/FSharp.Data.TypeProviders." 

@dsyme
There is a bit of an issue with this, because the nuget package has obsoleted use of the Microsoft.FSharp namespace.  I will be proposing a PR that removes that obsoletion.  We would prefer that developers can switch to the nuget version without having to modify source code.

![image](https://user-images.githubusercontent.com/5175830/40815137-22d75f86-64f9-11e8-9ead-b445b911975e.png)


