### PR TITLE
Simplify some code around isAppTy calls

### DIFF
--- a/src/fsharp/AugmentWithHashCompare.fs
+++ b/src/fsharp/AugmentWithHashCompare.fs
@@ -1061,8 +1061,9 @@ let MakeBindingsForEqualsAugmentation (g: TcGlobals) (tycon:Tycon) =
     elif tycon.IsRecordTycon || tycon.IsStructOrEnumTycon then mkEquals mkRecdEquality 
     else []
 
-let rec TypeDefinitelyHasEquality g ty = 
-    if isAppTy g ty && HasFSharpAttribute g g.attrib_NoEqualityAttribute (tcrefOfAppTy g ty).Attribs then
+let rec TypeDefinitelyHasEquality g ty =
+    let isTypeApplication = isAppTy g ty
+    if isTypeApplication && HasFSharpAttribute g g.attrib_NoEqualityAttribute (tcrefOfAppTy g ty).Attribs then
         false
     elif isTyparTy g ty && (destTyparTy g ty).Constraints |> List.exists (function TyparConstraint.SupportsEquality _ -> true | _ -> false) then
         true
@@ -1074,7 +1075,7 @@ let rec TypeDefinitelyHasEquality g ty =
             false
         | _ -> 
            // The type is equatable because it has Object.Equals(...)
-           isAppTy g ty &&
+           isTypeApplication &&
            let tcref,tinst = destAppTy g ty 
            // Give a good error for structural types excluded from the equality relation because of their fields
            not (TyconIsCandidateForAugmentationWithEquals g tcref.Deref && Option.isNone tcref.GeneratedHashAndEqualsWithComparerValues) &&

--- a/src/fsharp/AugmentWithHashCompare.fs
+++ b/src/fsharp/AugmentWithHashCompare.fs
@@ -1062,8 +1062,8 @@ let MakeBindingsForEqualsAugmentation (g: TcGlobals) (tycon:Tycon) =
     else []
 
 let rec TypeDefinitelyHasEquality g ty =
-    let isTypeApplication = isAppTy g ty
-    if isTypeApplication && HasFSharpAttribute g g.attrib_NoEqualityAttribute (tcrefOfAppTy g ty).Attribs then
+    let isTypeApp = isAppTy g ty // store it to avoid checking more than once
+    if isTypeApp && HasFSharpAttribute g g.attrib_NoEqualityAttribute (tcrefOfAppTy g ty).Attribs then
         false
     elif isTyparTy g ty && (destTyparTy g ty).Constraints |> List.exists (function TyparConstraint.SupportsEquality _ -> true | _ -> false) then
         true
@@ -1075,7 +1075,7 @@ let rec TypeDefinitelyHasEquality g ty =
             false
         | _ -> 
            // The type is equatable because it has Object.Equals(...)
-           isTypeApplication &&
+           isTypeApp &&
            let tcref,tinst = destAppTy g ty 
            // Give a good error for structural types excluded from the equality relation because of their fields
            not (TyconIsCandidateForAugmentationWithEquals g tcref.Deref && Option.isNone tcref.GeneratedHashAndEqualsWithComparerValues) &&

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -4068,14 +4068,14 @@ let ResolveCompletionsInTypeForItem (ncenv: NameResolver) nenv m ad statics typ 
         ncenv.InfoReader.GetRecordOrClassFieldsOfType(None,ad,m,typ)
         |> List.filter (fun rfref -> rfref.IsStatic = statics  &&  IsFieldInfoAccessible ad rfref)
         |> List.map Item.RecdField
-        :> _
+        |> List.toSeq
     | Item.UnionCase _ ->
         if statics && isAppTy g typ then 
             let tc, tinst = destAppTy g typ
             tc.UnionCasesAsRefList 
             |> List.filter (IsUnionCaseUnseen ad g ncenv.amap m >> not)
             |> List.map (fun ucref ->  Item.UnionCase(UnionCaseInfo(tinst,ucref),false))
-            :> _
+            |> List.toSeq
         else
             Seq.empty
     | Item.Event _ ->
@@ -4084,7 +4084,7 @@ let ResolveCompletionsInTypeForItem (ncenv: NameResolver) nenv m ad statics typ 
             IsStandardEventInfo ncenv.InfoReader m ad x &&
             x.IsStatic = statics)
         |> List.map Item.Event
-        :> _
+        |> List.toSeq
     | Item.ILField _ ->
         ncenv.InfoReader.GetILFieldInfosOfType(None,ad,m,typ)
         |> List.filter (fun x -> 
@@ -4092,10 +4092,10 @@ let ResolveCompletionsInTypeForItem (ncenv: NameResolver) nenv m ad statics typ 
             x.IsStatic = statics && 
             IsILFieldInfoAccessible g amap m ad x)
         |> List.map Item.ILField
-        :> _
+        |> List.toSeq
     | Item.Types _ ->
         if statics then
-            typ |> GetNestedTypesOfType (ad, ncenv, None, TypeNameResolutionStaticArgsInfo.Indefinite, false, m) |> List.map (ItemOfTy g) :> _
+            typ |> GetNestedTypesOfType (ad, ncenv, None, TypeNameResolutionStaticArgsInfo.Indefinite, false, m) |> List.map (ItemOfTy g) |> List.toSeq
           else
             Seq.empty
     | _ ->

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -2178,7 +2178,7 @@ let rec ResolveLongIdentInTypePrim (ncenv:NameResolver) nenv lookupKind (resInfo
                 match lookupKind with 
                 | LookupKind.Expr | LookupKind.Pattern ->
                     if isAppTy g typ then 
-                        let tcref,_ = destAppTy g typ
+                        let tcref = tcrefOfAppTy g typ
                         tcref.UnionCasesArray
                         |> Array.map (fun uc -> uc.DisplayName)
                     else 
@@ -4059,42 +4059,47 @@ and ResolvePartialLongIdentToClassOrRecdFieldsImpl (ncenv: NameResolver) (nenv: 
         modsOrNs @ qualifiedFields
 
 let ResolveCompletionsInTypeForItem (ncenv: NameResolver) nenv m ad statics typ (item: Item) : seq<Item> =
-    seq {
-        let g = ncenv.g
-        let amap = ncenv.amap
+    
+    let g = ncenv.g
+    let amap = ncenv.amap
         
-        match item with
-        | Item.RecdField _ ->
-            yield!
-                ncenv.InfoReader.GetRecordOrClassFieldsOfType(None,ad,m,typ)
-                |> List.filter (fun rfref -> rfref.IsStatic = statics  &&  IsFieldInfoAccessible ad rfref)
-                |> List.map Item.RecdField
-        | Item.UnionCase _ ->
-            if statics && isAppTy g typ then 
-                let tc, tinst = destAppTy g typ
-                yield!
-                    tc.UnionCasesAsRefList 
-                    |> List.filter (IsUnionCaseUnseen ad g ncenv.amap m >> not)
-                    |> List.map (fun ucref ->  Item.UnionCase(UnionCaseInfo(tinst,ucref),false))
-        | Item.Event _ ->
-            yield!
-                ncenv.InfoReader.GetEventInfosOfType(None,ad,m,typ)
-                |> List.filter (fun x -> 
-                    IsStandardEventInfo ncenv.InfoReader m ad x &&
-                    x.IsStatic = statics)
-                |> List.map Item.Event
-        | Item.ILField _ ->
-            yield!
-                ncenv.InfoReader.GetILFieldInfosOfType(None,ad,m,typ)
-                |> List.filter (fun x -> 
-                    not x.IsSpecialName &&
-                    x.IsStatic = statics && 
-                    IsILFieldInfoAccessible g amap m ad x)
-                |> List.map Item.ILField
-        | Item.Types _ ->
-            if statics then
-                yield! typ |> GetNestedTypesOfType (ad, ncenv, None, TypeNameResolutionStaticArgsInfo.Indefinite, false, m) |> List.map (ItemOfTy g)
-        | _ ->
+    match item with
+    | Item.RecdField _ ->
+        ncenv.InfoReader.GetRecordOrClassFieldsOfType(None,ad,m,typ)
+        |> List.filter (fun rfref -> rfref.IsStatic = statics  &&  IsFieldInfoAccessible ad rfref)
+        |> List.map Item.RecdField
+        :> _
+    | Item.UnionCase _ ->
+        if statics && isAppTy g typ then 
+            let tc, tinst = destAppTy g typ
+            tc.UnionCasesAsRefList 
+            |> List.filter (IsUnionCaseUnseen ad g ncenv.amap m >> not)
+            |> List.map (fun ucref ->  Item.UnionCase(UnionCaseInfo(tinst,ucref),false))
+            :> _
+        else
+            Seq.empty
+    | Item.Event _ ->
+        ncenv.InfoReader.GetEventInfosOfType(None,ad,m,typ)
+        |> List.filter (fun x -> 
+            IsStandardEventInfo ncenv.InfoReader m ad x &&
+            x.IsStatic = statics)
+        |> List.map Item.Event
+        :> _
+    | Item.ILField _ ->
+        ncenv.InfoReader.GetILFieldInfosOfType(None,ad,m,typ)
+        |> List.filter (fun x -> 
+            not x.IsSpecialName &&
+            x.IsStatic = statics && 
+            IsILFieldInfoAccessible g amap m ad x)
+        |> List.map Item.ILField
+        :> _
+    | Item.Types _ ->
+        if statics then
+            typ |> GetNestedTypesOfType (ad, ncenv, None, TypeNameResolutionStaticArgsInfo.Indefinite, false, m) |> List.map (ItemOfTy g) :> _
+          else
+            Seq.empty
+    | _ ->
+        seq {
             let pinfosIncludingUnseen = 
                 AllPropInfosOfTypeInScope ncenv.InfoReader nenv (None,ad) PreferOverrides m typ
                 |> List.filter (fun x -> 
@@ -4225,7 +4230,7 @@ let ResolveCompletionsInTypeForItem (ncenv: NameResolver) nenv m ad statics typ 
             
                 yield! List.map Item.MakeMethGroup (NameMap.toList (partitionl minfos Map.empty))
             | _ -> ()
-    }
+        }
 
 let rec ResolvePartialLongIdentInTypeForItem (ncenv: NameResolver) nenv m ad statics plid (item: Item) typ =
     seq {

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -161,18 +161,19 @@ type AllowMultiIntfInstantiations = Yes | No
 /// Visit base types and interfaces first.
 let private FoldHierarchyOfTypeAux followInterfaces allowMultiIntfInst skipUnref visitor g amap m typ acc = 
     let rec loop ndeep typ ((visitedTycon,visited:TyconRefMultiMap<_>,acc) as state) =
-
-        let seenThisTycon = isAppTy g typ && Set.contains (tcrefOfAppTy g typ).Stamp visitedTycon 
+        let isTypeApplication = isAppTy g typ
+        let tcrefOfTypeApplication = lazy (tcrefOfAppTy g typ)
+        let seenThisTycon = isTypeApplication && Set.contains (tcrefOfTypeApplication.Value).Stamp visitedTycon 
 
         // Do not visit the same type twice. Could only be doing this if we've seen this tycon
-        if seenThisTycon && List.exists (typeEquiv g typ) (visited.Find (tcrefOfAppTy g typ)) then state else
+        if seenThisTycon && List.exists (typeEquiv g typ) (visited.Find (tcrefOfTypeApplication.Value)) then state else
 
         // Do not visit the same tycon twice, e.g. I<int> and I<string>, collect I<int> only, unless directed to allow this
         if seenThisTycon && allowMultiIntfInst = AllowMultiIntfInstantiations.No then state else
 
         let state = 
-            if isAppTy g typ then 
-                let tcref = tcrefOfAppTy g typ
+            if isTypeApplication then 
+                let tcref = tcrefOfTypeApplication.Value
                 let visitedTycon = Set.add tcref.Stamp visitedTycon 
                 visitedTycon, visited.Add (tcref,typ), acc
             else

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -161,19 +161,18 @@ type AllowMultiIntfInstantiations = Yes | No
 /// Visit base types and interfaces first.
 let private FoldHierarchyOfTypeAux followInterfaces allowMultiIntfInst skipUnref visitor g amap m typ acc = 
     let rec loop ndeep typ ((visitedTycon,visited:TyconRefMultiMap<_>,acc) as state) =
-        let isTypeApplication = isAppTy g typ
-        let tcrefOfTypeApplication = lazy (tcrefOfAppTy g typ)
-        let seenThisTycon = isTypeApplication && Set.contains (tcrefOfTypeApplication.Value).Stamp visitedTycon 
+        let isTypeApp = isAppTy g typ // store it to avoid checking more than once
+        let seenThisTycon = isTypeApp && Set.contains (tcrefOfAppTy g typ).Stamp visitedTycon 
 
         // Do not visit the same type twice. Could only be doing this if we've seen this tycon
-        if seenThisTycon && List.exists (typeEquiv g typ) (visited.Find (tcrefOfTypeApplication.Value)) then state else
+        if seenThisTycon && List.exists (typeEquiv g typ) (visited.Find (tcrefOfAppTy g typ)) then state else
 
         // Do not visit the same tycon twice, e.g. I<int> and I<string>, collect I<int> only, unless directed to allow this
         if seenThisTycon && allowMultiIntfInst = AllowMultiIntfInstantiations.No then state else
 
         let state = 
-            if isTypeApplication then 
-                let tcref = tcrefOfTypeApplication.Value
+            if isTypeApp then 
+                let tcref = tcrefOfAppTy g typ
                 let visitedTycon = Set.add tcref.Stamp visitedTycon 
                 visitedTycon, visited.Add (tcref,typ), acc
             else


### PR DESCRIPTION
changes made:
* AugmentWithHashCompare.TypeDefinitelyHasEquality: save one call to `isAppTy` (when we go in the else branch)
* Infos.FoldHierarchyOfTypeAux: save one call to `isAppTy` and make `tcrefOfTypeApplication` a lazy value to save one call to `tcrefOfAppTy` (when we go into the accumulator branch)
* NameResolution.ResolveLongIdentInTypePrim: use `tcrefOfAppTy` instead of `destAppTy` and only taking fst
* NameResolution.ResolveCompletionsInTypeForItem: avoid using a top level sequence CE, it is needed only in the last fallback branch, others are just returning single list expression