### PR TITLE
Increase lexer identifier dictionary initial capacity to reduce resizing

### DIFF
--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -43,7 +43,7 @@ type LightSyntaxStatus(initial:bool,warn:bool) =
 /// Manage lexer resources (string interning)
 [<Sealed>]
 type LexResourceManager() =
-    let strings = new System.Collections.Generic.Dictionary<string, Parser.token>(100)
+    let strings = new System.Collections.Generic.Dictionary<string, Parser.token>(1024)
     member x.InternIdentifierToken(s) = 
         let mutable res = Unchecked.defaultof<_> 
         let ok = strings.TryGetValue(s, &res)  


### PR DESCRIPTION
Change something in `TypeChecker.fs`, wait for CPU idle. 

Before 

![image](https://user-images.githubusercontent.com/873919/40962295-cefd98c2-68ad-11e8-8bf5-ed41c2479f10.png)

After

![image](https://user-images.githubusercontent.com/873919/40962783-33828bc6-68af-11e8-86e5-0782b9e42b6f.png)
