### PR TITLE
Span: complete matrix of tests

### DIFF
--- a/src/fsharp/AttributeChecking.fs
+++ b/src/fsharp/AttributeChecking.fs
@@ -291,7 +291,7 @@ let CheckFSharpAttributes g attribs m =
                 match namedArgs with 
                 | ExtractAttribNamedArg "IsError" (AttribBoolArg v) -> v 
                 | _ -> false 
-            if isError then ErrorD msg else WarnD msg
+            if isError && (not g.compilingFslib || n <> 1204) then ErrorD msg else WarnD msg
                  
         | _ -> 
             CompleteD

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -267,7 +267,9 @@ let isIntegerTy g ty =
     isUnsignedIntegerTy g ty 
     
 let isStringTy g ty = typeEquiv g g.string_ty ty 
+
 let isCharTy g ty = typeEquiv g g.char_ty ty 
+
 let isBoolTy g ty = typeEquiv g g.bool_ty ty 
 
 /// float or float32 or float<_> or float32<_> 
@@ -890,9 +892,9 @@ and SolveTypSubsumesTyp (csenv:ConstraintSolverEnv) ndeep m2 (trace: OptionalTra
         | [ h1; tag1 ], [ h2; tag2 ] -> 
             SolveTypEqualsTyp csenv ndeep m2 trace None h1 h2 ++ (fun () -> 
             match stripTyEqnsA csenv.g canShortcut tag1, stripTyEqnsA csenv.g canShortcut tag2 with 
-            | TType_app(tagc1, []), TType_app(tagc2, choices) 
-                when (tyconRefEq g tagc2 g.choice2_tcr && 
-                      choices |> List.exists (function AppTy g (choicetc, []) -> tyconRefEq g tagc1 choicetc | _ -> false)) -> CompleteD
+            | TType_app(tagc1, []), TType_app(tagc2, []) 
+                when (tyconRefEq g tagc2 g.byrefkind_InOut_tcr && 
+                      (tyconRefEq g tagc1 g.byrefkind_In_tcr || tyconRefEq g tagc1 g.byrefkind_Out_tcr) ) -> CompleteD
             | _ -> SolveTypEqualsTyp csenv ndeep m2 trace cxsln tag1 tag2)
         | _ -> SolveTypEqualsTypEqns csenv ndeep m2 trace cxsln l1 l2
 
@@ -2682,7 +2684,7 @@ let CodegenWitnessThatTypSupportsTraitConstraint tcVal g amap m (traitInfo:Trait
             // the address of the object then go do that 
             if minfo.IsStruct && minfo.IsInstance && (match argExprs with [] -> false | h :: _ -> not (isByrefTy g (tyOfExpr g h))) then 
                 let h, t = List.headAndTail argExprs
-                let wrap, h', _readonly = mkExprAddrOfExpr g true false PossiblyMutates h None m 
+                let wrap, h', _readonly, _writeonly = mkExprAddrOfExpr g true false PossiblyMutates h None m 
                 ResultD (Some (wrap (Expr.Op(TOp.TraitCall(traitInfo), [], (h' :: t), m))))
             else        
                 ResultD (Some (MakeMethInfoCall amap m minfo methArgTys argExprs ))
@@ -2697,7 +2699,7 @@ let CodegenWitnessThatTypSupportsTraitConstraint tcVal g amap m (traitInfo:Trait
                         // the address of the object then go do that 
                         if rfref.Tycon.IsStructOrEnumTycon && not (isByrefTy g (tyOfExpr g argExprs.[0])) then 
                             let h = List.head argExprs
-                            let wrap, h', _readonly = mkExprAddrOfExpr g true false DefinitelyMutates h None m 
+                            let wrap, h', _readonly, _writeonly = mkExprAddrOfExpr g true false DefinitelyMutates h None m 
                             Some (wrap (mkRecdFieldSetViaExprAddr (h', rfref, tinst, argExprs.[1], m)))
                         else        
                             Some (mkRecdFieldSetViaExprAddr (argExprs.[0], rfref, tinst, argExprs.[1], m))

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -16,6 +16,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>FSharp.Core</AssemblyName>
     <DefineConstants>FSHARP_CORE;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition=" '$(Configuration)' == 'Proto'">BUILDING_WITH_LKG;$(DefineConstants)</DefineConstants>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <BaseAddress>0x05000000</BaseAddress>
     <CompilingFsLib>true</CompilingFsLib>

--- a/src/fsharp/FSharp.Core/prim-types-prelude.fs
+++ b/src/fsharp/FSharp.Core/prim-types-prelude.fs
@@ -64,12 +64,6 @@ namespace Microsoft.FSharp.Core
 
     type array<'T> = 'T[]
 
-    /// <summary>Represents a managed pointer in F# code.</summary>
-    type byref<'T, 'Kind> = (# "!0&" #)
-
-    /// <summary>Represents a managed pointer in F# code. For F# 4.5+ this is considered equivalent to <c>byref&lt'T, ByRefKinds.InOut&gt</c></summary>
-    type byref<'T> = (# "!0&" #)
-
     type nativeptr<'T when 'T : unmanaged> = (# "native int" #)
 
     type voidptr = (# "void*" #)

--- a/src/fsharp/FSharp.Core/prim-types-prelude.fsi
+++ b/src/fsharp/FSharp.Core/prim-types-prelude.fsi
@@ -228,12 +228,6 @@ namespace Microsoft.FSharp.Core
     /// values.</remarks>   
     type 'T array = 'T[]
             
-    /// <summary>Represents a managed pointer in F# code.</summary>
-    type byref<'T, 'Kind> = (# "!0&" #)
-
-    /// <summary>Represents a managed pointer in F# code. For F# 4.5+ this is considered equivalent to <c>byref&lt'T, ByRefKinds.InOut&gt</c></summary>
-    type byref<'T> = (# "!0&" #)
-
     /// <summary>Represents an unmanaged pointer in F# code.</summary>
     ///
     /// <remarks>This type should only be used when writing F# code that interoperates

--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -347,6 +347,33 @@ namespace Microsoft.FSharp.Core
     [<MeasureAnnotatedAbbreviation>] type int16<[<Measure>] 'Measure> = int16
     [<MeasureAnnotatedAbbreviation>] type int64<[<Measure>] 'Measure> = int64
 
+    /// <summary>Represents a managed pointer in F# code.</c></summary>
+    type byref<'T> = (# "!0&" #)
+
+    /// <summary>Represents a managed pointer in F# code.</summary>
+    type byref<'T, 'Kind> = (# "!0&" #)
+
+    /// Represents the types of byrefs in F# 4.5+
+    module ByRefKinds = 
+
+        /// Represents a byref that can be written
+        [<Sealed>]
+        type Out() = class end
+
+        /// Represents a byref that can be read
+        [<Sealed>]
+        type In() = class end
+
+        /// Represents a byref that can be both read and written
+        [<Sealed>]
+        type InOut = class end 
+
+    /// <summary>Represents a in-argument or readonly managed pointer in F# code. This type should only be used with F# 4.5+.</summary>
+    type inref<'T> = byref<'T, ByRefKinds.In>
+
+    /// <summary>Represents a out-argument managed pointer in F# code. This type should only be used with F# 4.5+.</summary>
+    type outref<'T> = byref<'T, ByRefKinds.Out>
+
 #if FX_RESHAPED_REFLECTION
     module PrimReflectionAdapters =
         
@@ -511,10 +538,10 @@ namespace Microsoft.FSharp.Core
             // Byref usage checks prohibit type instantiations involving byrefs.
 
             [<NoDynamicInvocation>]
-            let inline (~&)  (obj : 'T) : 'T byref     = 
+            let inline (~&)  (obj : 'T) : byref<'T>     = 
                 ignore obj // pretend the variable is used
                 let e = new System.ArgumentException(ErrorStrings.AddressOpNotFirstClassString) 
-                (# "throw" (e :> System.Exception) : 'T byref #)
+                (# "throw" (e :> System.Exception) : byref<'T> #)
                  
             [<NoDynamicInvocation>]
             let inline (~&&) (obj : 'T) : nativeptr<'T> = 
@@ -5651,24 +5678,6 @@ namespace Microsoft.FSharp.Core
                          (let x = (retype x : decimal) in
                           if n >= 0 then PowDecimal x n else 1.0M /  PowDecimal x n)
 
-
-    /// Represents the types of byrefs in F# 4.5+
-    module ByRefKinds = 
-
-        /// Represents a byref that can be written
-        type Out() = class end
-
-        /// Represents a byref that can be read
-        type In() = class end
-
-        /// Represents a byref that can be both read and written
-        type InOut = Choice<In, Out>
-
-    /// <summary>Represents a in-argument or readonly managed pointer in F# code. This type should only be used with F# 4.5+.</summary>
-    type inref<'T> = byref<'T, ByRefKinds.In>
-
-    /// <summary>Represents a out-argument managed pointer in F# code. This type should only be used with F# 4.5+.</summary>
-    type outref<'T> = byref<'T, ByRefKinds.Out>
 
 namespace Microsoft.FSharp.Control
 

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -800,6 +800,55 @@ namespace Microsoft.FSharp.Core
     /// <c>System.Int64</c>.</summary>
     type int64<[<Measure>] 'Measure> = int64
 
+    /// <summary>Represents a managed pointer in F# code.</summary>
+#if BUILDING_WITH_LKG || BUILD_FROM_SOURCE
+    [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true)>]
+#else
+    [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true, IsError=true)>]
+#endif
+    type byref<'T, 'Kind> = (# "!0&" #)
+
+    /// <summary>Represents a managed pointer in F# code. For F# 4.5+ this is considered equivalent to <c>byref&lt'T, ByRefKinds.InOut&gt</c></summary>
+    type byref<'T> = (# "!0&" #)
+
+    /// Represents the types of byrefs in F# 4.5+
+#if BUILDING_WITH_LKG || BUILD_FROM_SOURCE
+    [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true)>]
+#else
+    [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true, IsError=true)>]
+#endif
+    module ByRefKinds = 
+
+        /// Represents a byref that can be written
+#if BUILDING_WITH_LKG || BUILD_FROM_SOURCE
+        [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true)>]
+#else
+        [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true, IsError=true)>]
+#endif
+        type Out
+
+        /// Represents a byref that can be read
+#if BUILDING_WITH_LKG || BUILD_FROM_SOURCE
+        [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true)>]
+#else
+        [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true, IsError=true)>]
+#endif
+        type In
+
+        /// Represents a byref that can be both read and written
+#if BUILDING_WITH_LKG || BUILD_FROM_SOURCE
+        [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true)>]
+#else
+        [<CompilerMessage("This construct is for use in the FSharp.Core library and should not be used directly", 1204, IsHidden=true, IsError=true)>]
+#endif
+        type InOut
+
+    /// <summary>Represents a in-argument or readonly managed pointer in F# code. This type should only be used with F# 4.5+.</summary>
+    type inref<'T> = byref<'T, ByRefKinds.In>
+
+    /// <summary>Represents a out-argument managed pointer in F# code. This type should only be used with F# 4.5+.</summary>
+    type outref<'T> = byref<'T, ByRefKinds.Out>
+
     /// <summary>Language primitives associated with the F# language</summary>
     module LanguagePrimitives =
 
@@ -1097,7 +1146,7 @@ namespace Microsoft.FSharp.Core
             /// <param name="obj">The input object.</param>
             /// <returns>The managed pointer.</returns>
             [<NoDynamicInvocation>]
-            val inline ( ~& ) : obj:'T -> 'T byref
+            val inline ( ~& ) : obj:'T -> byref<'T>
 
             /// <summary>Address-of. Uses of this value may result in the generation of unverifiable code.</summary>
             /// <param name="obj">The input object.</param>
@@ -1658,24 +1707,6 @@ namespace Microsoft.FSharp.Core
             /// arguments without intervening execution.</summary>
             /// <returns>The optimized function.</returns>
             new : unit ->  FSharpFunc<'T1,'T2,'T3,'T4,'T5,'U>
-
-    /// Represents the types of byrefs in F# 4.5+
-    module ByRefKinds = 
-
-        /// Represents a byref that can be written
-        type Out = class end
-
-        /// Represents a byref that can be read
-        type In = class end
-
-        /// Represents a byref that can be both read and written
-        type InOut = Choice<In, Out>
-
-    /// <summary>Represents a in-argument or readonly managed pointer in F# code. This type should only be used with F# 4.5+.</summary>
-    type inref<'T> = byref<'T, ByRefKinds.In>
-
-    /// <summary>Represents a out-argument managed pointer in F# code. This type should only be used with F# 4.5+.</summary>
-    type outref<'T> = byref<'T, ByRefKinds.Out>
 
     /// <summary>The type of mutable references. Use the functions [!] and [:=] to get and
     /// set values of this type.</summary>

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -581,7 +581,7 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
             let hasCallInfo = ccallInfo.IsSome
             let mustTakeAddress = hasCallInfo || minfo.ObjArgNeedsAddress(amap, m)
             let objArgTy = tyOfExpr g objArgExpr
-            let wrap, objArgExpr', _readonly = mkExprAddrOfExpr g mustTakeAddress hasCallInfo isMutable objArgExpr None m
+            let wrap, objArgExpr', _readonly, _writeonly = mkExprAddrOfExpr g mustTakeAddress hasCallInfo isMutable objArgExpr None m
             
             // Extension members and calls to class constraints may need a coercion for their object argument
             let objArgExpr' = 
@@ -1104,7 +1104,7 @@ module ProvidedMethodCalls =
             match ea.PApplyOption((function ProvidedAddressOfExpr x -> Some x | _ -> None), m) with
             | Some e -> 
                 let eT =  exprToExpr e
-                let wrap,ce, _readonly = mkExprAddrOfExpr g true false DefinitelyMutates eT None m
+                let wrap,ce, _readonly, _writeonly = mkExprAddrOfExpr g true false DefinitelyMutates eT None m
                 let ce = wrap ce
                 None, (ce, tyOfExpr g ce)
             | None -> 

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -2273,11 +2273,11 @@ and TakeAddressOfStructArgumentIfNeeded cenv (vref:ValRef) ty args m =
     if vref.IsInstanceMember && isStructTy cenv.g ty then 
         match args with 
         | objArg::rest -> 
-            // REVIEW: we set NeverMutates. This is valid because we only ever use DevirtualizeApplication to transform 
+            // We set NeverMutates here, allowing more address-taking. This is valid because we only ever use DevirtualizeApplication to transform 
             // known calls to known generated F# code for CompareTo, Equals and GetHashCode.
             // If we ever reuse DevirtualizeApplication to transform an arbitrary virtual call into a 
             // direct call then this assumption is not valid.
-            let wrap, objArgAddress, _readonly = mkExprAddrOfExpr cenv.g true false NeverMutates objArg None m
+            let wrap, objArgAddress, _readonly, _writeonly = mkExprAddrOfExpr cenv.g true false NeverMutates objArg None m
             wrap, (objArgAddress::rest)
         | _ -> 
             // no wrapper, args stay the same 
@@ -2289,8 +2289,6 @@ and DevirtualizeApplication cenv env (vref:ValRef) ty tyargs args m =
     let wrap, args = TakeAddressOfStructArgumentIfNeeded cenv vref ty args m
     let transformedExpr = wrap (MakeApplicationAndBetaReduce cenv.g (exprForValRef m vref, vref.Type, (if isNil tyargs then [] else [tyargs]), args, m))
     OptimizeExpr cenv env transformedExpr
-
-    
   
 and TryDevirtualizeApplication cenv env (f, tyargs, args, m) =
     match f, tyargs, args with 

--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -904,7 +904,7 @@ let CompilePatternBasic
                  when isNil topgtvs && ucref.Tycon.IsStructRecordOrUnionTycon ->
 
              let argexp = GetSubExprOfInput subexpr
-             let vOpt, addrexp, _readonly = mkExprAddrOfExprAux g true false NeverMutates argexp None matchm
+             let vOpt, addrexp, _readonly, _writeonly = mkExprAddrOfExprAux g true false NeverMutates argexp None matchm
              match vOpt with 
              | None -> Some addrexp, None
              | Some (v,e) -> 

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -5750,62 +5750,68 @@ let rec mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress 
         // LVALUE of "*x" where "x" is byref is just the byref itself
         | Expr.Op (TOp.LValueOp (LByrefGet, vref), _, [], m) when MustTakeAddressOfByrefGet g vref || CanTakeAddressOfByrefGet g vref mut -> 
             let readonly = not (MustTakeAddressOfByrefGet g vref)
-            None, exprForValRef m vref, readonly
+            let writeonly = isOutByrefTy g vref.Type
+            None, exprForValRef m vref, readonly, writeonly
 
         // LVALUE of "x" where "x" is mutable local, mutable intra-assembly module/static binding, or operation doesn't mutate.
         // Note: we can always take the address of mutable intra-assembly values
         | Expr.Val(vref, _, m) when MustTakeAddressOfVal g vref || CanTakeAddressOfImmutableVal g m vref mut ->
             let readonly = not (MustTakeAddressOfVal g vref)
-            None, mkValAddr m readonly vref, readonly
+            let writeonly = false
+            None, mkValAddr m readonly vref, readonly, writeonly
 
         // LVALUE of "e.f" where "f" is record field. 
         | Expr.Op (TOp.ValFieldGet rfref, tinst, [obje], m) when MustTakeAddressOfRecdFieldRef rfref || CanTakeAddressOfRecdFieldRef g m rfref tinst mut ->
             let exprty = tyOfExpr g obje
-            let wrap, expra, readonly = mkExprAddrOfExprAux g (isStructTy g exprty) false mut obje None m
+            let wrap, expra, readonly, writeonly = mkExprAddrOfExprAux g (isStructTy g exprty) false mut obje None m
             let readonly = readonly || not (MustTakeAddressOfRecdFieldRef rfref)
-            wrap, mkRecdFieldGetAddrViaExprAddr(readonly, expra, rfref, tinst, m), readonly
+            wrap, mkRecdFieldGetAddrViaExprAddr(readonly, expra, rfref, tinst, m), readonly, writeonly
 
         // LVALUE of "e.f" where "f" is union field. 
         | Expr.Op (TOp.UnionCaseFieldGet (uref, cidx), tinst, [obje], m) when MustTakeAddressOfRecdField (uref.FieldByIndex(cidx)) || CanTakeAddressOfUnionFieldRef g m uref cidx tinst mut ->
             let exprty = tyOfExpr g obje
-            let wrap, expra, readonly = mkExprAddrOfExprAux g (isStructTy g exprty) false mut obje None m
+            let wrap, expra, readonly, writeonly = mkExprAddrOfExprAux g (isStructTy g exprty) false mut obje None m
             let readonly = readonly || not (MustTakeAddressOfRecdField (uref.FieldByIndex(cidx)))
-            wrap, mkUnionCaseFieldGetAddrProvenViaExprAddr(readonly, expra, uref, tinst, cidx, m), readonly
+            wrap, mkUnionCaseFieldGetAddrProvenViaExprAddr(readonly, expra, uref, tinst, cidx, m), readonly, writeonly
 
         // LVALUE of "f" where "f" is a .NET static field. 
         | Expr.Op (TOp.ILAsm ([IL.I_ldsfld(_vol, fspec)], [ty2]), tinst, [], m) -> 
             let readonly = false // we never consider taking the address of a .NET static field to give an inref pointer
-            None, Expr.Op (TOp.ILAsm ([IL.I_ldsflda(fspec)], [mkByrefTy g ty2]), tinst, [], m), readonly
+            let writeonly = false
+            None, Expr.Op (TOp.ILAsm ([IL.I_ldsflda(fspec)], [mkByrefTy g ty2]), tinst, [], m), readonly, writeonly
 
         // LVALUE of "e.f" where "f" is a .NET instance field. 
         | Expr.Op (TOp.ILAsm ([IL.I_ldfld(_align, _vol, fspec)], [ty2]), tinst, [obje], m) -> 
             let exprty = tyOfExpr g obje
             // we never consider taking the address of an .NET instance field to give an inref pointer, unless the object pointer is an inref pointer
-            let wrap, expra, readonly = mkExprAddrOfExprAux g (isStructTy g exprty) false mut obje None m
-            wrap, Expr.Op (TOp.ILAsm ([IL.I_ldflda(fspec)], [mkByrefTyWithFlag g readonly ty2]), tinst, [expra], m), readonly
+            let wrap, expra, readonly, writeonly = mkExprAddrOfExprAux g (isStructTy g exprty) false mut obje None m
+            wrap, Expr.Op (TOp.ILAsm ([IL.I_ldflda(fspec)], [mkByrefTyWithFlag g readonly ty2]), tinst, [expra], m), readonly, writeonly
 
         // LVALUE of "f" where "f" is a static F# field. 
         | Expr.Op (TOp.ValFieldGet rfref, tinst, [], m) when MustTakeAddressOfRecdFieldRef rfref || CanTakeAddressOfRecdFieldRef g m rfref tinst mut ->
             let readonly = not (MustTakeAddressOfRecdFieldRef rfref)
-            None, mkStaticRecdFieldGetAddr(readonly, rfref, tinst, m), readonly
+            let writeonly = false
+            None, mkStaticRecdFieldGetAddr(readonly, rfref, tinst, m), readonly, writeonly
 
         // LVALUE of "e.[n]" where e is an array of structs 
         | Expr.App(Expr.Val(vf, _, _), _, [elemTy], [aexpr;nexpr], _) when (valRefEq g vf g.array_get_vref) -> 
         
             let readonly = false // array address is never forced to be readonly
+            let writeonly = false
             let shape = ILArrayShape.SingleDimensional
             let ilInstrReadOnlyAnnotation = if isTyparTy g elemTy &&  useReadonlyForGenericArrayAddress then ReadonlyAddress else NormalAddress
             let isNativePtr = 
                 match addrExprVal with
                 | Some(vf) -> valRefEq g vf g.addrof2_vref
                 | _ -> false
-            None, mkArrayElemAddress g (readonly, ilInstrReadOnlyAnnotation, isNativePtr, shape, elemTy, [aexpr; nexpr], m), readonly
+            None, mkArrayElemAddress g (readonly, ilInstrReadOnlyAnnotation, isNativePtr, shape, elemTy, [aexpr; nexpr], m), readonly, writeonly
 
         // LVALUE of "e.[n1, n2]", "e.[n1, n2, n3]", "e.[n1, n2, n3, n4]" where e is an array of structs 
         | Expr.App(Expr.Val(vref, _, _), _, [elemTy], (aexpr::args), _) 
              when (valRefEq g vref g.array2D_get_vref || valRefEq g vref g.array3D_get_vref || valRefEq g vref g.array4D_get_vref) -> 
         
             let readonly = false // array address is never forced to be readonly
+            let writeonly = false
             let shape = ILArrayShape.FromRank args.Length
             let ilInstrReadOnlyAnnotation = if isTyparTy g elemTy &&  useReadonlyForGenericArrayAddress then ReadonlyAddress else NormalAddress
             let isNativePtr = 
@@ -5813,12 +5819,14 @@ let rec mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress 
                 | Some(vf) -> valRefEq g vf g.addrof2_vref
                 | _ -> false
             
-            None, mkArrayElemAddress g (readonly, ilInstrReadOnlyAnnotation, isNativePtr, shape, elemTy,  (aexpr::args), m), readonly
+            None, mkArrayElemAddress g (readonly, ilInstrReadOnlyAnnotation, isNativePtr, shape, elemTy,  (aexpr::args), m), readonly, writeonly
 
         // LVALUE:  "&meth(args)" where meth has a byref or inref return.  Includes "&span.[idx]".
         | Expr.Let(TBind(vref, e, _), Expr.Op(TOp.LValueOp (LByrefGet, vref2), _, _, _), _, _)  when (valRefEq g (mkLocalValRef vref) vref2)  && (MustTakeAddressOfByrefGet g vref2 || CanTakeAddressOfByrefGet g vref2 mut) -> 
-            let readonly = isInByrefTy g (tyOfExpr g e)
-            None, e, readonly
+            let ty = tyOfExpr g e
+            let readonly = isInByrefTy g ty
+            let writeonly = isOutByrefTy g ty
+            None, e, readonly, writeonly
         
         // Give a nice error message for address-of-byref
         | Expr.Val(vref, _, m) when isByrefTy g vref.Type -> 
@@ -5854,30 +5862,30 @@ let rec mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress 
                 | NeverMutates -> mkCompGenLocal m "copyOfStruct" ty 
                 | _ -> mkMutableCompGenLocal m "copyOfStruct" ty
             let readonly = true
-            Some (tmp, expr), (mkValAddr m readonly (mkLocalValRef tmp)), readonly
+            let writeonly = false
+            Some (tmp, expr), (mkValAddr m readonly (mkLocalValRef tmp)), readonly, writeonly
     else
-        None, expr, false
+        None, expr, false, false
 
 let mkExprAddrOfExpr g mustTakeAddress useReadonlyForGenericArrayAddress mut e addrExprVal m =
-    let optBind, addre, readonly = mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress mut e addrExprVal m
+    let optBind, addre, readonly, writeonly = mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress mut e addrExprVal m
     match optBind with 
-    | None -> (fun x -> x), addre, readonly
-    | Some (tmp, rval) -> (fun x -> mkCompGenLet m tmp rval x), addre, readonly
+    | None -> (fun x -> x), addre, readonly, writeonly
+    | Some (tmp, rval) -> (fun x -> mkCompGenLet m tmp rval x), addre, readonly, writeonly
 
 let mkTupleFieldGet g (tupInfo, e, tinst, i, m) = 
-    let wrap, e', _readonly = mkExprAddrOfExpr g (evalTupInfoIsStruct tupInfo) false NeverMutates e None m
+    let wrap, e', _readonly, _writeonly = mkExprAddrOfExpr g (evalTupInfoIsStruct tupInfo) false NeverMutates e None m
     wrap (mkTupleFieldGetViaExprAddr(tupInfo, e', tinst, i, m))
 
 let mkRecdFieldGet g (e, fref:RecdFieldRef, tinst, m) = 
     assert (not (isByrefTy g (tyOfExpr g e)))
-    let wrap, e', _readonly = mkExprAddrOfExpr g fref.Tycon.IsStructOrEnumTycon false NeverMutates e None m
+    let wrap, e', _readonly, _writeonly = mkExprAddrOfExpr g fref.Tycon.IsStructOrEnumTycon false NeverMutates e None m
     wrap (mkRecdFieldGetViaExprAddr(e', fref, tinst, m))
 
 let mkUnionCaseFieldGetUnproven g (e, cref:UnionCaseRef, tinst, j, m) = 
     assert (not (isByrefTy g (tyOfExpr g e)))
-    let wrap, e', _readonly = mkExprAddrOfExpr g cref.Tycon.IsStructOrEnumTycon false NeverMutates e None m
+    let wrap, e', _readonly, _writeonly = mkExprAddrOfExpr g cref.Tycon.IsStructOrEnumTycon false NeverMutates e None m
     wrap (mkUnionCaseFieldGetUnprovenViaExprAddr (e', cref, tinst, j, m))
-
 
 let mkArray (argty, args, m) = Expr.Op(TOp.Array, [argty], args, m)
 

--- a/src/fsharp/TastOps.fsi
+++ b/src/fsharp/TastOps.fsi
@@ -267,8 +267,8 @@ val convertToTypeWithMetadataIfPossible : TcGlobals -> TType -> TType
 
 exception DefensiveCopyWarning of string * range 
 type Mutates = AddressOfOp | DefinitelyMutates | PossiblyMutates | NeverMutates
-val mkExprAddrOfExprAux : TcGlobals -> bool -> bool -> Mutates -> Expr -> ValRef option -> range -> (Val * Expr) option * Expr * bool
-val mkExprAddrOfExpr : TcGlobals -> bool -> bool -> Mutates -> Expr -> ValRef option -> range -> (Expr -> Expr) * Expr * bool
+val mkExprAddrOfExprAux : TcGlobals -> bool -> bool -> Mutates -> Expr -> ValRef option -> range -> (Val * Expr) option * Expr * bool * bool
+val mkExprAddrOfExpr : TcGlobals -> bool -> bool -> Mutates -> Expr -> ValRef option -> range -> (Expr -> Expr) * Expr * bool * bool
 
 //-------------------------------------------------------------------------
 // Tables keyed on values and/or type parameters

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4005,11 +4005,15 @@ let buildApp cenv expr resultTy arg m =
             let argTy = tyOfExpr g arg
             if readonly then
                 mkInByrefTy g argTy
-            // See RFC FS-1053 - we do _not_ introduce outref here, e.g. '&x' where 'x' is outref<_> is _not_ outref.  
+
+            // "`outref<'T>` types are never introduced implicitly by F#.", see rationale in RFC FS-1053
+            //
+            // We do _not_ introduce outref here, e.g. '&x' where 'x' is outref<_> is _not_ outref.  
             // This effectively makes 'outref<_>' documentation-only. There is frequently a need to pass outref
             // pointers to .NET library functions whose signatures are not tagged with [<Out>]
             //elif writeonly then
             //    mkOutByrefTy g argTy
+
             else
                 mkByrefTyWithInference g argTy (NewByRefKindInferenceType g m)
 

--- a/src/fsharp/ast.fs
+++ b/src/fsharp/ast.fs
@@ -1812,11 +1812,23 @@ let mkSynInfix opm (l:SynExpr) oper (r:SynExpr) =
     let firstTwoRange = unionRanges l.Range opm
     let wholeRange = unionRanges l.Range r.Range
     SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, mkSynOperator opm oper, l, firstTwoRange), r, wholeRange)
+
 let mkSynBifix   m oper x1 x2 = SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, mkSynOperator m oper,x1,m), x2,m)
 let mkSynTrifix  m oper x1 x2 x3 = SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, mkSynOperator m oper,x1,m), x2,m), x3,m)
 let mkSynQuadfix m oper x1 x2 x3 x4 = SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, mkSynOperator m oper,x1,m), x2,m), x3,m),x4,m)
 let mkSynQuinfix m oper x1 x2 x3 x4 x5 = SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, false, SynExpr.App (ExprAtomicFlag.NonAtomic, true, mkSynOperator m oper,x1,m), x2,m), x3,m),x4,m),x5,m)
-let mkSynPrefix opm m oper x = SynExpr.App (ExprAtomicFlag.NonAtomic, false, mkSynOperator opm oper, x,m)
+
+let mkSynPrefixPrim opm m oper x = 
+    SynExpr.App (ExprAtomicFlag.NonAtomic, false, mkSynOperator opm oper, x,m)
+
+let mkSynPrefix opm m oper x = 
+    if oper = "~&" then 
+        SynExpr.AddressOf(true,x,opm,m)
+    elif oper = "~&&" then 
+        SynExpr.AddressOf(false,x,opm,m)
+    else
+        mkSynPrefixPrim opm m oper x
+
 let mkSynCaseName m n = [mkSynId m (CompileOpName n)]
 
 let mkSynApp1 f x1 m = SynExpr.App(ExprAtomicFlag.NonAtomic,false,f,x1,m)

--- a/src/fsharp/pars.fsy
+++ b/src/fsharp/pars.fsy
@@ -3500,71 +3500,86 @@ ifExprThen:
 ifExprElifs: 
   | 
       { None }
+
   | ELSE declExpr 
       { Some $2 }
+
   | OELSE  OBLOCKBEGIN typedSeqExpr oblockend 
       { Some $3 }
+
   | OELSE  OBLOCKBEGIN typedSeqExpr recover 
       { if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileElse())
         Some (exprFromParseError $3) }
+
   | ELIF declExpr ifExprCases 
       { let mElif = rhs parseState 1 
         Some ($3 $2 mElif) }
+
   | ELIF declExpr recover 
       { Some (exprFromParseError $2) }
 
 tupleExpr: 
   | tupleExpr COMMA declExpr   
       { let exprs,commas = $1 in ($3 :: exprs),((rhs parseState 2)::commas) }
+
   | tupleExpr COMMA ends_coming_soon_or_recover
       { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedExpressionAfterToken())
         let exprs,commas = $1     
         let zeroWidthAtNextToken = (rhs parseState 3).StartRange
         ((arbExpr("tupleExpr1",zeroWidthAtNextToken)) :: exprs), (rhs parseState 2)::commas }
+
   | declExpr COMMA ends_coming_soon_or_recover
       { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedExpressionAfterToken())
         let zeroWidthAtNextToken = (rhs parseState 3).StartRange 
         ((arbExpr("tupleExpr2",zeroWidthAtNextToken)) :: [$1]), [rhs parseState 2] }
+
   | declExpr COMMA declExpr  
       { [$3 ; $1], [rhs parseState 2] }
 
 minusExpr: 
   | MINUS minusExpr   %prec expr_prefix_plus_minus
       { mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) "~-" $2 }
+
   | PLUS_MINUS_OP minusExpr  
       { if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt $2.Range (FSComp.SR.parsInvalidPrefixOperator())
         mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) ("~"^($1)) $2 } 
+
   | ADJACENT_PREFIX_OP minusExpr 
       { if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt $2.Range (FSComp.SR.parsInvalidPrefixOperator())
-        if $1 = "&" then 
-            SynExpr.AddressOf(true,$2,rhs parseState 1,unionRanges (rhs parseState 1) $2.Range)
-        elif $1 = "&&" then 
-            SynExpr.AddressOf(false,$2,rhs parseState 1,unionRanges (rhs parseState 1) $2.Range)
-        else
-            mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) ("~"^($1)) $2 }
+        mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) ("~"^($1)) $2 }
+
   | PERCENT_OP minusExpr
       { if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt $2.Range (FSComp.SR.parsInvalidPrefixOperator())
         mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) ("~"^($1)) $2 }
+
   | AMP  minusExpr    
       { SynExpr.AddressOf(true,$2,rhs parseState 1,unionRanges (rhs parseState 1) $2.Range) } 
+
   | AMP_AMP  minusExpr   
       { SynExpr.AddressOf(false,$2,rhs parseState 1, unionRanges (rhs parseState 1) $2.Range) } 
+
   | NEW appTypeNonAtomicDeprecated  opt_HIGH_PRECEDENCE_APP atomicExprAfterType 
       { SynExpr.New(false,$2,$4,unionRanges (rhs parseState 1) $4.Range) }
+
   | NEW appTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP error   
       { SynExpr.New(false,$2,arbExpr("minusExpr",(rhs parseState 4)),unionRanges (rhs parseState 1) ($2).Range) }
+
   | NEW error
       { arbExpr("minusExpr2",(rhs parseState 1)) }
+
   | UPCAST  minusExpr 
       { SynExpr.InferredUpcast($2,unionRanges (rhs parseState 1) $2.Range) }   
+
   | DOWNCAST  minusExpr 
       { SynExpr.InferredDowncast($2,unionRanges (rhs parseState 1) $2.Range)}   
+
   | appExpr 
       { $1 }
 
 appExpr:
   | appExpr argExpr %prec expr_app
       { SynExpr.App (ExprAtomicFlag.NonAtomic, false, $1,$2,unionRanges $1.Range $2.Range)  }
+
   | atomicExpr 
       { let arg,_ = $1 
         arg }
@@ -3575,11 +3590,11 @@ argExpr:
         if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt arg2.Range (FSComp.SR.parsInvalidPrefixOperator())
         if hpa2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
         mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) arg2.Range) ("~"^($1)) arg2 }
+
    | atomicExpr 
       { let arg,hpa = $1 
         if hpa then reportParseErrorAt arg.Range (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
         arg }
-    
     
 atomicExpr:
   | atomicExpr HIGH_PRECEDENCE_BRACK_APP atomicExpr
@@ -3601,40 +3616,52 @@ atomicExpr:
   | PREFIX_OP  atomicExpr  
       { let arg2,hpa2 = $2 
         if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt arg2.Range (FSComp.SR.parsInvalidPrefixOperator())
-        mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) arg2.Range) $1 arg2,hpa2 }
+        mkSynPrefixPrim (rhs parseState 1) (unionRanges (rhs parseState 1) arg2.Range) $1 arg2,hpa2 }
 
   | atomicExpr DOT atomicExprQualification 
       { let arg1,hpa1 = $1 
         $3 arg1 (lhs parseState) (rhs parseState 2),hpa1 }
+
   | BASE DOT atomicExprQualification 
       { let arg1 = SynExpr.Ident(ident("base",rhs parseState 1))
         $3 arg1 (lhs parseState) (rhs parseState 2),false }
+
   | QMARK nameop 
       { SynExpr.LongIdent (true,LongIdentWithDots([$2],[]),None,rhs parseState 2),false }
+
   | atomicExpr QMARK dynamicArg
       { let arg1,hpa1 = $1
         mkSynInfix (rhs parseState 2) arg1 "?" $3, hpa1 }
+
   | GLOBAL
       { SynExpr.Ident (ident(MangledGlobalName,rhs parseState 1)), false }
+
   | nameop
       { SynExpr.Ident ($1),false }
+
   | LBRACK listExprElements RBRACK 
       { $2 (lhs parseState) false,false }
+
   | LBRACK listExprElements recover 
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
         exprFromParseError ($2 (rhs2 parseState 1 2) false), false }
+
   | LBRACK error RBRACK 
       { // silent recovery 
         SynExpr.ArrayOrList(false,[ ], lhs parseState),false  } 
+
   | LBRACK recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
         // silent recovery 
         exprFromParseError (SynExpr.ArrayOrList(false,[ ], rhs parseState 1)),false  } 
+
   | STRUCT LPAREN tupleExpr rparen  
       { let exprs,commas = $3 in SynExpr.StructTuple(List.rev exprs, List.rev commas, (commas.Head, exprs) ||> unionRangeWithListBy (fun e -> e.Range) ), false }
+
   | STRUCT LPAREN tupleExpr recover  
       { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedBracket()); 
         let exprs,commas = $3 in SynExpr.StructTuple(List.rev exprs, List.rev commas, (commas.Head, exprs) ||> unionRangeWithListBy (fun e -> e.Range) ), false }
+
   | atomicExprAfterType 
       { $1,false }
 
@@ -3700,12 +3727,16 @@ optRangeSeqExpr:
 optRange:
   | declExpr DOT_DOT declExpr 
       { SynIndexerArg.Two(mkSynOptionalExpr (rhs parseState 1) (Some $1), mkSynOptionalExpr (rhs parseState 3) (Some $3)) }
+
   | declExpr DOT_DOT 
       { SynIndexerArg.Two(mkSynOptionalExpr (rhs parseState 1) (Some $1), mkSynOptionalExpr (rhs parseState 2) None) }
+
   | DOT_DOT declExpr 
       { SynIndexerArg.Two(mkSynOptionalExpr (rhs parseState 1) None, mkSynOptionalExpr (rhs parseState 2) (Some $2)) }
+
   | STAR 
       { SynIndexerArg.Two(mkSynOptionalExpr (rhs parseState 1) None, mkSynOptionalExpr (rhs parseState 1) None) }
+
   | declExpr %prec slice_expr
       { SynIndexerArg.One($1) }
 

--- a/tests/FSharp.Core.UnitTests/SurfaceArea.coreclr.fs
+++ b/tests/FSharp.Core.UnitTests/SurfaceArea.coreclr.fs
@@ -800,6 +800,10 @@ Microsoft.FSharp.Core.ByRefKinds+In: Boolean Equals(System.Object)
 Microsoft.FSharp.Core.ByRefKinds+In: Int32 GetHashCode()
 Microsoft.FSharp.Core.ByRefKinds+In: System.String ToString()
 Microsoft.FSharp.Core.ByRefKinds+In: System.Type GetType()
+Microsoft.FSharp.Core.ByRefKinds+InOut: Boolean Equals(System.Object)
+Microsoft.FSharp.Core.ByRefKinds+InOut: Int32 GetHashCode()
+Microsoft.FSharp.Core.ByRefKinds+InOut: System.String ToString()
+Microsoft.FSharp.Core.ByRefKinds+InOut: System.Type GetType()
 Microsoft.FSharp.Core.ByRefKinds+Out: Boolean Equals(System.Object)
 Microsoft.FSharp.Core.ByRefKinds+Out: Int32 GetHashCode()
 Microsoft.FSharp.Core.ByRefKinds+Out: System.String ToString()
@@ -807,6 +811,7 @@ Microsoft.FSharp.Core.ByRefKinds+Out: System.Type GetType()
 Microsoft.FSharp.Core.ByRefKinds: Boolean Equals(System.Object)
 Microsoft.FSharp.Core.ByRefKinds: Int32 GetHashCode()
 Microsoft.FSharp.Core.ByRefKinds: Microsoft.FSharp.Core.ByRefKinds+In
+Microsoft.FSharp.Core.ByRefKinds: Microsoft.FSharp.Core.ByRefKinds+InOut
 Microsoft.FSharp.Core.ByRefKinds: Microsoft.FSharp.Core.ByRefKinds+Out
 Microsoft.FSharp.Core.ByRefKinds: System.String ToString()
 Microsoft.FSharp.Core.ByRefKinds: System.Type GetType()

--- a/tests/FSharp.Core.UnitTests/SurfaceArea.net40.fs
+++ b/tests/FSharp.Core.UnitTests/SurfaceArea.net40.fs
@@ -804,6 +804,10 @@ Microsoft.FSharp.Core.ByRefKinds+In: Boolean Equals(System.Object)
 Microsoft.FSharp.Core.ByRefKinds+In: Int32 GetHashCode()
 Microsoft.FSharp.Core.ByRefKinds+In: System.String ToString()
 Microsoft.FSharp.Core.ByRefKinds+In: System.Type GetType()
+Microsoft.FSharp.Core.ByRefKinds+InOut: Boolean Equals(System.Object)
+Microsoft.FSharp.Core.ByRefKinds+InOut: Int32 GetHashCode()
+Microsoft.FSharp.Core.ByRefKinds+InOut: System.String ToString()
+Microsoft.FSharp.Core.ByRefKinds+InOut: System.Type GetType()
 Microsoft.FSharp.Core.ByRefKinds+Out: Boolean Equals(System.Object)
 Microsoft.FSharp.Core.ByRefKinds+Out: Int32 GetHashCode()
 Microsoft.FSharp.Core.ByRefKinds+Out: System.String ToString()
@@ -811,6 +815,7 @@ Microsoft.FSharp.Core.ByRefKinds+Out: System.Type GetType()
 Microsoft.FSharp.Core.ByRefKinds: Boolean Equals(System.Object)
 Microsoft.FSharp.Core.ByRefKinds: Int32 GetHashCode()
 Microsoft.FSharp.Core.ByRefKinds: Microsoft.FSharp.Core.ByRefKinds+In
+Microsoft.FSharp.Core.ByRefKinds: Microsoft.FSharp.Core.ByRefKinds+InOut
 Microsoft.FSharp.Core.ByRefKinds: Microsoft.FSharp.Core.ByRefKinds+Out
 Microsoft.FSharp.Core.ByRefKinds: System.String ToString()
 Microsoft.FSharp.Core.ByRefKinds: System.Type GetType()

--- a/tests/fsharp/core/byrefs/test.fsx
+++ b/tests/fsharp/core/byrefs/test.fsx
@@ -1243,7 +1243,215 @@ module ByrefReturnMemberTests =
 
         test()
 
+    module MatrixOfTests = 
+        [<Struct>]
+        type S = 
+            [<DefaultValue(true)>]
+            val mutable X : int
 
+
+        module ReturnAddressOfByRef = 
+            let f1 (x: byref<int>) = &x 
+
+        module ReturnAddressOfInRef = 
+            let f1 (x: inref<int>) = &x 
+
+        module ReturnAddressOfOutRef = 
+            let f1 (x: outref<int>) = &x 
+
+        //-----
+
+        module ReadByRef = 
+            let f1 (x: byref<int>) = x 
+
+        module ReadInRef = 
+            let f1 (x: inref<int>) = x 
+
+        module ReadOutRef = 
+            let f1 (x: outref<int>) = x 
+
+        //-----
+
+        module ReadByRefStructInner = 
+            let f1 (x: byref<S>) = x.X
+
+        module ReadInRefStructInner = 
+            let f1 (x: inref<S>) = x.X
+
+        module ReadOutRefStructInner = 
+            let f1 (x: outref<S>) = x.X
+
+        //-----
+        module WriteToByRef = 
+            let f1 (x: byref<int>) = x <- 1
+
+#if NEGATIVE
+        module WriteToInRef = 
+            let f1 (x: inref<int>) = x <- 1 // not allowed
+#endif
+
+        module WriteToOutRef = 
+            let f1 (x: outref<int>) = x <- 1
+
+        //-----
+        module WriteToByRefStructInner = 
+            let f1 (x: byref<S>) = x.X <- 1
+
+#if NEGATIVE
+        module WriteToInRefStructInner = 
+            let f1 (x: inref<S>) = x.X <- 1 //not allowed
+#endif
+
+        module WriteToOutRefStructInner = 
+            let f1 (x: outref<S>) = x.X <- 1
+
+        //-----
+        module OutRefToByRef = 
+            let f1 (x: byref<'T>) = 1
+            let f2 (x: outref<'T>) = f1 &x 
+
+#if NEGATIVE
+        module InRefToByRef = 
+            let f1 (x: byref<'T>) = 1
+            let f2 (x: inref<'T>) = f1 &x    // not allowed 
+#endif
+
+        module ByRefToByRef = 
+            let f1 (x: byref<'T>) = 1
+            let f2 (x: byref<'T>) = f1 &x        
+
+        module ByRefToOutRef = 
+            let f1 (x: outref<'T>) = 1
+            let f2 (x: byref<'T>) = f1 &x        
+
+        module OutRefToOutRef = 
+            let f1 (x: outref<'T>) = 1
+            let f2 (x: outref<'T>) = f1 &x        
+
+#if NEGATIVE
+        module InRefToOutRef = 
+            let f1 (x: outref<'T>) = 1
+            let f2 (x: inref<'T>) = f1 &x     // not allowed   
+#endif
+
+        module ByRefToInRef = 
+            let f1 (x: inref<'T>) = 1
+            let f2 (x: byref<'T>) = f1 &x        
+
+        module InRefToInRef = 
+            let f1 (x: inref<'T>) = 1
+            let f2 (x: inref<'T>) = f1 &x        
+
+        module OutRefToInRef = 
+            let f1 (x: inref<'T>) = 1
+            let f2 (x: outref<'T>) = f1 &x    // allowed, because &outref are treated as byref, see RFC
+
+        //---------------
+        module OutRefToByRefClassMethod = 
+            type C() = 
+                static member f1 (x: byref<'T>) = 1
+            let f2 (x: outref<'T>) = C.f1 &x
+
+#if NEGATIVE
+        module InRefToByRefClassMethod = 
+            type C() = 
+                static member f1 (x: byref<'T>) = 1
+            let f2 (x: inref<'T>) = C.f1 &x // not allowed   
+#endif
+
+        module ByRefToByRefClassMethod =
+            type C() = 
+                static member f1 (x: byref<'T>) = 1
+            let f2 (x: byref<'T>) = C.f1 &x        
+
+        module ByRefToOutRefClassMethod =
+            type C() = 
+                static member f1 (x: outref<'T>) = 1
+            let f2 (x: byref<'T>) = C.f1 &x        
+
+        module OutRefToOutRefClassMethod =
+            type C() = 
+                static member f1 (x: outref<'T>) = 1
+            let f2 (x: outref<'T>) = C.f1 &x        
+
+#if NEGATIVE
+        module InRefToOutRefClassMethod =
+            type C() = 
+                static member f1 (x: outref<'T>) = 1 // not allowed
+            let f2 (x: inref<'T>) = C.f1 &x        
+#endif
+
+        module ByRefToInRefClassMethod =
+            type C() = 
+                static member f1 (x: inref<'T>) = 1
+            let f2 (x: byref<'T>) = C.f1 &x        
+
+        module InRefToInRefClassMethod =
+            type C() = 
+                static member f1 (x: inref<'T>) = 1
+            let f2 (x: inref<'T>) = C.f1 &x        
+
+        module OutRefToInRefClassMethod =
+            type C() = 
+                static member f1 (x: inref<'T>) = 1
+            let f2 (x: outref<'T>) = C.f1 &x        
+
+        //---------------
+        module OutRefToByRefClassMethod2 = 
+            type C() = 
+                static member f1 (x: byref<'T>) = 1
+            let f2 (x: outref<'T>) = C.f1(&x)
+
+#if NEGATIVE
+        module InRefToByRefClassMethod2 = 
+            type C() = 
+                static member f1 (x: byref<'T>) = 1
+            let f2 (x: inref<'T>) = C.f1(&x) // not allowed   
+#endif
+
+        module ByRefToByRefClassMethod2 =
+            type C() = 
+                static member f1 (x: byref<'T>) = 1
+            let f2 (x: byref<'T>) = C.f1(&x)        
+
+        module ByRefToOutRefClassMethod2 =
+            type C() = 
+                static member f1 (x: outref<'T>) = 1
+            let f2 (x: byref<'T>) = C.f1(&x)        
+
+        module OutRefToOutRefClassMethod2 =
+            type C() = 
+                static member f1 (x: outref<'T>) = 1
+            let f2 (x: outref<'T>) = C.f1(&x)        
+
+#if NEGATIVE
+        module InRefToOutRefClassMethod2 =
+            type C() = 
+                static member f1 (x: outref<'T>) = 1 // not allowed
+            let f2 (x: inref<'T>) = C.f1(&x)        
+#endif
+
+        module ByRefToInRefClassMethod2 =
+            type C() = 
+                static member f1 (x: inref<'T>) = 1
+            let f2 (x: byref<'T>) = C.f1(&x)        
+
+        module InRefToInRefClassMethod2 =
+            type C() = 
+                static member f1 (x: inref<'T>) = 1
+            let f2 (x: inref<'T>) = C.f1(&x)        
+
+        module OutRefToInRefClassMethod2 =
+            type C() = 
+                static member f1 (x: inref<'T>) = 1
+            let f2 (x: outref<'T>) = C.f1(&x)        
+
+#if NEGATIVE
+        module UseOfLibraryOnly =
+            type C() = 
+                static member f1 (x: byref<'T, 'U>) = 1
+#endif
+    
 let aa =
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
   else (stdout.WriteLine "Test Passed"; 

--- a/tests/fsharp/typecheck/sigs/neg106.bsl
+++ b/tests/fsharp/typecheck/sigs/neg106.bsl
@@ -122,3 +122,59 @@ neg106.fs(60,9,60,25): typecheck error FS3224: The byref pointer is readonly, so
 neg106.fs(65,42,65,48): typecheck error FS3224: The byref pointer is readonly, so this write is not permitted.
 
 neg106.fs(74,9,74,17): typecheck error FS0257: Invalid mutation of a constant expression. Consider copying the expression to a mutable local, e.g. 'let mutable x = ...'.
+
+neg106.fs(83,34,83,40): typecheck error FS3224: The byref pointer is readonly, so this write is not permitted.
+
+neg106.fs(86,32,86,40): typecheck error FS0257: Invalid mutation of a constant expression. Consider copying the expression to a mutable local, e.g. 'let mutable x = ...'.
+
+neg106.fs(90,36,90,38): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(94,36,94,38): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(99,38,99,40): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(104,38,104,40): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(109,38,109,40): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(114,38,114,40): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(118,34,118,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(119,34,119,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(120,34,120,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(121,34,121,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(118,34,118,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(119,34,119,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(120,34,120,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(121,34,121,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly

--- a/tests/fsharp/typecheck/sigs/neg106.bsl
+++ b/tests/fsharp/typecheck/sigs/neg106.bsl
@@ -133,48 +133,94 @@ but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-neg106.fs(94,36,94,38): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(94,35,94,39): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<int>'    
+but given a
+    'inref<int>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(98,36,98,38): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
-neg106.fs(99,38,99,40): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(102,37,102,40): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(102,36,102,40): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(107,38,107,40): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-neg106.fs(104,38,104,40): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(112,39,112,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(112,38,112,42): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(117,38,117,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
-neg106.fs(109,38,109,40): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(122,39,122,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(122,38,122,42): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(127,38,127,40): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-neg106.fs(114,38,114,40): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(132,39,132,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(132,38,132,42): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(137,38,137,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
-neg106.fs(118,34,118,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(142,39,142,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
-neg106.fs(119,34,119,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(142,38,142,42): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
-neg106.fs(120,34,120,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(146,34,146,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(121,34,121,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(147,34,147,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(118,34,118,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(148,34,148,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(119,34,119,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(149,34,149,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(120,34,120,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(146,34,146,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(121,34,121,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(147,34,147,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(148,34,148,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(149,34,149,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly

--- a/tests/fsharp/typecheck/sigs/neg106.fs
+++ b/tests/fsharp/typecheck/sigs/neg106.fs
@@ -72,3 +72,50 @@ module MutateInRef1 =
 
     let testIn (m: inref<TestMut>) =
         m.x <- 1
+
+module MatrixOfTests = 
+    [<Struct>]
+    type S = 
+        [<DefaultValue(true)>]
+        val mutable X : int
+
+    module WriteToInRef = 
+        let f1 (x: inref<int>) = x <- 1 // not allowed
+
+    module WriteToInRefStructInner = 
+        let f1 (x: inref<S>) = x.X <- 1 //not allowed
+
+    module InRefToByRef = 
+        let f1 (x: byref<'T>) = 1
+        let f2 (x: inref<'T>) = f1 &x    // not allowed 
+
+    module InRefToOutRef = 
+        let f1 (x: outref<'T>) = 1
+        let f2 (x: inref<'T>) = f1 &x     // not allowed   
+
+    module InRefToByRefClassMethod = 
+        type C() = 
+            static member f1 (x: byref<'T>) = 1
+        let f2 (x: inref<'T>) = C.f1 &x // not allowed   
+
+    module InRefToOutRefClassMethod =
+        type C() = 
+            static member f1 (x: outref<'T>) = 1 // not allowed
+        let f2 (x: inref<'T>) = C.f1 &x        
+
+    module InRefToByRefClassMethod2 = 
+        type C() = 
+            static member f1 (x: byref<'T>) = 1
+        let f2 (x: inref<'T>) = C.f1(&x) // not allowed   
+
+    module InRefToOutRefClassMethod2 =
+        type C() = 
+            static member f1 (x: outref<'T>) = 1 // not allowed
+        let f2 (x: inref<'T>) = C.f1(&x)        
+
+    module UseOfLibraryOnly =
+        type C() = 
+            static member f1 (x: byref<'T, 'U>) = 1 // not allowed - library only
+            static member f2 (x: ByRefKinds.In) = 1 // not allowed - library only
+            static member f2 (x: ByRefKinds.InOut) = 1 // not allowed - library only
+            static member f2 (x: ByRefKinds.Out) = 1 // not allowed - library only

--- a/tests/fsharp/typecheck/sigs/neg106.fs
+++ b/tests/fsharp/typecheck/sigs/neg106.fs
@@ -89,29 +89,57 @@ module MatrixOfTests =
         let f1 (x: byref<'T>) = 1
         let f2 (x: inref<'T>) = f1 &x    // not allowed 
 
+    module InRefToByRefStructInner = 
+        let f1 (x: byref<'T>) = 1
+        let f2 (x: inref<S>) = f1 &x.X    // not allowed 
+
     module InRefToOutRef = 
         let f1 (x: outref<'T>) = 1
         let f2 (x: inref<'T>) = f1 &x     // not allowed   
+
+    module InRefToOutRefStructInner = 
+        let f1 (x: outref<'T>) = 1
+        let f2 (x: inref<'T>) = f1 &x.X     // not allowed   
 
     module InRefToByRefClassMethod = 
         type C() = 
             static member f1 (x: byref<'T>) = 1
         let f2 (x: inref<'T>) = C.f1 &x // not allowed   
 
+    module InRefToByRefClassMethodStructInner = 
+        type C() = 
+            static member f1 (x: byref<'T>) = 1
+        let f2 (x: inref<'T>) = C.f1 &x.X // not allowed   
+
     module InRefToOutRefClassMethod =
         type C() = 
             static member f1 (x: outref<'T>) = 1 // not allowed
         let f2 (x: inref<'T>) = C.f1 &x        
+
+    module InRefToOutRefClassMethodStructInner =
+        type C() = 
+            static member f1 (x: outref<'T>) = 1 // not allowed
+        let f2 (x: inref<'T>) = C.f1 &x.X        
 
     module InRefToByRefClassMethod2 = 
         type C() = 
             static member f1 (x: byref<'T>) = 1
         let f2 (x: inref<'T>) = C.f1(&x) // not allowed   
 
+    module InRefToByRefClassMethod2StructInner = 
+        type C() = 
+            static member f1 (x: byref<'T>) = 1
+        let f2 (x: inref<'T>) = C.f1(&x.X) // not allowed   
+
     module InRefToOutRefClassMethod2 =
         type C() = 
             static member f1 (x: outref<'T>) = 1 // not allowed
         let f2 (x: inref<'T>) = C.f1(&x)        
+
+    module InRefToOutRefClassMethod2StructInner =
+        type C() = 
+            static member f1 (x: outref<'T>) = 1 // not allowed
+        let f2 (x: inref<'T>) = C.f1(&x.X)        
 
     module UseOfLibraryOnly =
         type C() = 

--- a/tests/fsharp/typecheck/sigs/neg106.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg106.vsbsl
@@ -122,3 +122,59 @@ neg106.fs(60,9,60,25): typecheck error FS3224: The byref pointer is readonly, so
 neg106.fs(65,42,65,48): typecheck error FS3224: The byref pointer is readonly, so this write is not permitted.
 
 neg106.fs(74,9,74,17): typecheck error FS0257: Invalid mutation of a constant expression. Consider copying the expression to a mutable local, e.g. 'let mutable x = ...'.
+
+neg106.fs(83,34,83,40): typecheck error FS3224: The byref pointer is readonly, so this write is not permitted.
+
+neg106.fs(86,32,86,40): typecheck error FS0257: Invalid mutation of a constant expression. Consider copying the expression to a mutable local, e.g. 'let mutable x = ...'.
+
+neg106.fs(90,36,90,38): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(94,36,94,38): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(99,38,99,40): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(104,38,104,40): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(109,38,109,40): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(114,38,114,40): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'T>'    
+but given a
+    'inref<'T>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(118,34,118,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(119,34,119,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(120,34,120,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(121,34,121,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(118,34,118,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(119,34,119,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(120,34,120,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(121,34,121,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly

--- a/tests/fsharp/typecheck/sigs/neg106.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg106.vsbsl
@@ -133,48 +133,94 @@ but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-neg106.fs(94,36,94,38): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(94,35,94,39): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<int>'    
+but given a
+    'inref<int>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(98,36,98,38): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
-neg106.fs(99,38,99,40): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(102,37,102,40): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(102,36,102,40): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(107,38,107,40): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-neg106.fs(104,38,104,40): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(112,39,112,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(112,38,112,42): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(117,38,117,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
-neg106.fs(109,38,109,40): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(122,39,122,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(122,38,122,42): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
+
+neg106.fs(127,38,127,40): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-neg106.fs(114,38,114,40): typecheck error FS0001: Type mismatch. Expecting a
+neg106.fs(132,39,132,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(132,38,132,42): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+neg106.fs(137,38,137,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'T>'    
 but given a
     'inref<'T>'    
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
-neg106.fs(118,34,118,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(142,39,142,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
-neg106.fs(119,34,119,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(142,38,142,42): typecheck error FS0001: Type mismatch. Expecting a
+    'outref<'a>'    
+but given a
+    'inref<'a>'    
+The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
-neg106.fs(120,34,120,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(146,34,146,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(121,34,121,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(147,34,147,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(118,34,118,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(148,34,148,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(119,34,119,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(149,34,149,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(120,34,120,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(146,34,146,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-neg106.fs(121,34,121,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+neg106.fs(147,34,147,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(148,34,148,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+neg106.fs(149,34,149,44): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly


### PR DESCRIPTION
This adds a new matrix of tests for passing inref --> byref and so on.

It also clarifies the symmetry between inref (readonly) and outref (writeonly) and explicitly highlights the point where we weaken the rules around outref to allow reading from outref (see the RFC for why this is done, for compat purposes).

It also fixes one bug found by the matrix of tests and code review yesterday with @TIHan 

Finally, it labels the `byref<'T, 'Kind>` and the `ByRefKinds` as for-library-use-only, though they don't disappear.   After reviewing with @TIHan we concluded that for F# 4.5 the best plan was to do this, there is no need to make the more primitive form available for use by the user at this stage, there is nothing useful they can do with it that they can't do with `inref`, `byref` and `outref` and attempts to do so (e.g. user-defined tags) are neither useful nor under test.

