### PR TITLE
Optimize truncate for n = 0

### DIFF
--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -756,12 +756,13 @@ module internal List =
             truncateToFreshConsTail cons2 (count-1) t
 
     let truncate count list =
-        match list with
-        | [] -> list
-        | _ :: ([] as nil) -> if count > 0 then list else nil
-        | h::t ->
-            if count <= 0 then []
-            else
+        if count <= 0 then 
+            []
+        else
+            match list with
+            | []
+            | [_] -> list
+            | h::t ->
                 let cons = freshConsNoTail h
                 truncateToFreshConsTail cons (count-1) t
                 cons

--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -852,6 +852,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Truncate")>]
         let truncate count (source: seq<'T>) =
             checkNonNull "source" source
+            if count <= 0 then empty else
             seq { let i = ref 0
                   use ie = source.GetEnumerator()
                   while !i < count && ie.MoveNext() do


### PR DESCRIPTION
@vasily-kirichenko is changing the compiler code to use truncate - it looks like we should optimize the 0 case