### PR TITLE
allow return of safe byref stored into immutable locals

### DIFF
--- a/tests/fsharp/core/byrefs/test.fsx
+++ b/tests/fsharp/core/byrefs/test.fsx
@@ -1243,6 +1243,21 @@ module ByrefReturnMemberTests =
 
         test()
 
+
+    module SafeByrefsInLocals2 = 
+        let mutable beef = 1
+        let test4 () = &beef
+        let test3 () =
+            let y = &test4 ()
+            &y
+
+    module SafeByrefsInLocals3 = 
+
+        let mutable beef = 1
+        let test5 () =
+            let y = &beef
+            &y
+
     module MatrixOfTests = 
         [<Struct>]
         type S = 

--- a/tests/fsharp/core/span/test.fsx
+++ b/tests/fsharp/core/span/test.fsx
@@ -359,6 +359,12 @@ namespace Tests
             // this is allowed
             &param1 // uncomment to test return
 
+    // This is not (yet) allowed
+    //module SpanSafetyTests5 = 
+    //    let test (x: byref<Span<int>>) =
+    //        let y = &x
+    //        y
+
 #if NEGATIVE
 
     module CheckReturnOfSpan4 = 


### PR DESCRIPTION
This weakens a check to allow code like this:

        let mutable beef = 1
        let test4 () = &beef
        let test3 () =
            let y = &test4 ()
            &y

This is a case spotted by @TIHan in his translation of C# tests