### PR TITLE
Disallow byref field on IsByRefLike structs

### DIFF
--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -1543,10 +1543,12 @@ let CheckRecdField isUnion cenv env (tycon:Tycon) (rfield:RecdField) =
         (not isUnion && IsHiddenRecdField env.sigToImplRemapInfo (tcref.MakeNestedRecdFieldRef rfield))
     let access = AdjustAccess isHidden (fun () -> tycon.CompilationPath) rfield.Accessibility
     CheckTypeForAccess cenv env (fun () -> rfield.Name) access m rfield.FormalType
-    
+
     if TyconRefHasAttribute g m g.attrib_IsByRefLikeAttribute tcref then 
         // Permit Span fields in IsByRefLike types
         CheckTypePermitOuterSpanLike cenv env m rfield.FormalType
+        if cenv.reportErrors then
+            CheckForByrefType cenv env rfield.FormalType (fun () -> errorR(Error(FSComp.SR.chkCantStoreByrefValue(), tycon.Range)))
     else
         CheckTypeNoByrefs cenv env m rfield.FormalType
         if cenv.reportErrors then 

--- a/tests/fsharp/typecheck/sigs/neg107.bsl
+++ b/tests/fsharp/typecheck/sigs/neg107.bsl
@@ -64,3 +64,13 @@ neg107.fsx(53,34,53,38): typecheck error FS3234: Struct members cannot return th
 neg107.fsx(67,34,67,40): typecheck error FS3234: Struct members cannot return the address of fields of the struct by reference
 
 neg107.fsx(67,34,67,38): typecheck error FS3234: Struct members cannot return the address of fields of the struct by reference
+
+neg107.fsx(71,19,71,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+neg107.fsx(71,14,71,18): typecheck error FS0437: A type would store a byref typed value. This is not permitted by Common IL.
+
+neg107.fsx(71,19,71,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+neg107.fsx(71,19,71,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+neg107.fsx(71,19,71,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

--- a/tests/fsharp/typecheck/sigs/neg107.fsx
+++ b/tests/fsharp/typecheck/sigs/neg107.fsx
@@ -65,3 +65,10 @@ namespace Test
             val mutable x : TestMut1
 
             member this.XAddr = &this.x.x // not allowed, Struct members cannot return the address of fields of the struct by reference", not entirely clear why C# disallowed this
+
+    module DisallowIsByRefLikeWithByRefField =
+        [<IsByRefLike;Struct>]
+        type Beef(x: byref<int>) =
+
+            member __.X = &x
+

--- a/tests/fsharp/typecheck/sigs/neg107.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg107.vsbsl
@@ -64,3 +64,13 @@ neg107.fsx(53,34,53,38): typecheck error FS3234: Struct members cannot return th
 neg107.fsx(67,34,67,40): typecheck error FS3234: Struct members cannot return the address of fields of the struct by reference
 
 neg107.fsx(67,34,67,38): typecheck error FS3234: Struct members cannot return the address of fields of the struct by reference
+
+neg107.fsx(71,19,71,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+neg107.fsx(71,14,71,18): typecheck error FS0437: A type would store a byref typed value. This is not permitted by Common IL.
+
+neg107.fsx(71,19,71,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+neg107.fsx(71,19,71,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+neg107.fsx(71,19,71,20): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.


### PR DESCRIPTION
This disallows a struct with a IsByRefLikeAttribute to have byref fields, but it will still allow byref-like/span-like fields.

- [x] Need to add a test