### PR TITLE
when this fails, the developer doesn't know why, tell to run "build test"

### DIFF
--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -143,7 +143,7 @@ type FSLibPaths =
     { FSCOREDLLPATH : string }
 
 let requireFile nm = 
-    if Commands.fileExists __SOURCE_DIRECTORY__ nm |> Option.isSome then nm else failwith (sprintf "couldn't find %s" nm)
+    if Commands.fileExists __SOURCE_DIRECTORY__ nm |> Option.isSome then nm else failwith (sprintf "couldn't find %s. Running 'build test' once might solve this issue" nm)
 
 let config configurationName envVars =
 


### PR DESCRIPTION
This is just improving an error message that developer faces if running the NUnit tests without first running "build test".

Note that we might consider adding whatever is missing to just "build" so that it wouldn't be necessary (clone, click build, open vs, run tests should work for default scenario).