### PR TITLE
add more SDK props/targets overrides

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -54,8 +54,9 @@
 
   <!-- SDK targets override -->
   <PropertyGroup Condition="'$(Configuration)' != 'Proto'">
-    <ProtoFSharpTargetsShim>$(ProtoOutputPath)\Microsoft.FSharp.NetSdk.targets</ProtoFSharpTargetsShim>
-    <FSharpTargetsShim Condition="Exists('$(ProtoFSharpTargetsShim)')">$(ProtoFSharpTargetsShim)</FSharpTargetsShim>
+    <FSharpPropsShim Condition="Exists('$(ProtoOutputPath)\Microsoft.FSharp.NetSdk.props')">$(ProtoOutputPath)\Microsoft.FSharp.NetSdk.props</FSharpPropsShim>
+    <FSharpTargetsShim Condition="Exists('$(ProtoOutputPath)\Microsoft.FSharp.NetSdk.targets')">$(ProtoOutputPath)\Microsoft.FSharp.NetSdk.targets</FSharpTargetsShim>
+    <FSharpOverridesTargetsShim Condition="Exists('$(ProtoOutputPath)\Microsoft.FSharp.Overrides.NetSdk.targets')">$(ProtoOutputPath)\Microsoft.FSharp.Overrides.NetSdk.targets</FSharpOverridesTargetsShim>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Handle additional props/targets overrides that were recently added.  This will prevent build errors when future versions of the .NET SDK are used to build.  I discovered this while locally building with preview versions of the SDK installed.