### PR TITLE
UIThread

### DIFF
--- a/vsintegration/src/FSharp.LanguageService.Base/DocumentTask.cs
+++ b/vsintegration/src/FSharp.LanguageService.Base/DocumentTask.cs
@@ -21,7 +21,8 @@ using IServiceProvider = System.IServiceProvider;
 using VsShell = Microsoft.VisualStudio.Shell.VsShellUtilities;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.VisualStudio.FSharp.LanguageService {
+namespace Microsoft.VisualStudio.FSharp.LanguageService
+{
     internal static class UIThread {
         static SynchronizationContext ctxt;
         static bool isUnitTestingMode = false;

--- a/vsintegration/src/FSharp.LanguageService.Base/LanguageService.cs
+++ b/vsintegration/src/FSharp.LanguageService.Base/LanguageService.cs
@@ -685,8 +685,8 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         // Implemented in FSharpLanguageService.fs
         internal abstract BackgroundRequest_DEPRECATED CreateBackgroundRequest(int line, int col, TokenInfo info, string sourceText, ITextSnapshot snapshot, MethodTipMiscellany_DEPRECATED methodTipMiscellany, string fname, BackgroundRequestReason reason, IVsTextView view,AuthoringSink sink, ISource source, int timestamp, bool synchronous);
 
-		// Implemented in FSharpLanguageService.fs
-		internal abstract void OnParseFileOrCheckFileComplete(BackgroundRequest_DEPRECATED req);
+        // Implemented in FSharpLanguageService.fs
+        internal abstract void OnParseFileOrCheckFileComplete(BackgroundRequest_DEPRECATED req);
 
         internal void EnsureBackgroundThreadStarted()
         {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAFileItem.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAFileItem.cs
@@ -15,7 +15,6 @@ using VSConstants = Microsoft.VisualStudio.VSConstants;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.VisualStudio.FSharp.ProjectSystem;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAFolderItem.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAFolderItem.cs
@@ -13,7 +13,6 @@ using Microsoft.VisualStudio.OLE.Interop;
 using EnvDTE;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.FSharp.ProjectSystem;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OANavigableProjectItems.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OANavigableProjectItems.cs
@@ -13,7 +13,6 @@ using IServiceProvider = System.IServiceProvider;
 using Microsoft.VisualStudio.OLE.Interop;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.FSharp.ProjectSystem;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAProject.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAProject.cs
@@ -15,7 +15,6 @@ using Microsoft.VisualStudio.OLE.Interop;
 using EnvDTE;
 using System.Globalization;
 using Microsoft.VisualStudio.FSharp.ProjectSystem;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAProjectItem.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAProjectItem.cs
@@ -12,7 +12,6 @@ using IServiceProvider = System.IServiceProvider;
 using Microsoft.VisualStudio.OLE.Interop;
 using EnvDTE;
 using Microsoft.VisualStudio.FSharp.ProjectSystem;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAProjectItems.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAProjectItems.cs
@@ -16,8 +16,6 @@ using System.IO;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.VisualStudio.FSharp.ProjectSystem;
-using Microsoft.VisualStudio.FSharp.LanguageService;
-
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAProperties.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/OAProperties.cs
@@ -14,7 +14,6 @@ using Microsoft.VisualStudio.OLE.Interop;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.VisualStudio.FSharp.ProjectSystem;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/VSProject/OAReferenceBase.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/VSProject/OAReferenceBase.cs
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.FSharp.ProjectSystem;
 using VSLangProj;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/VSProject/OAReferences.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/Automation/VSProject/OAReferences.cs
@@ -11,7 +11,6 @@ using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;
 using VSLangProj;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem.Automation
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ConfigurationProperties.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ConfigurationProperties.cs
@@ -11,7 +11,6 @@ using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/HierarchyNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/HierarchyNode.cs
@@ -3172,7 +3172,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
                     // replace existing fscore with one that has matching version with current target framework
                     var existingFsCore =
-                        Microsoft.VisualStudio.FSharp.LanguageService.UIThread.DoOnUIThread(
+                        UIThread.DoOnUIThread(
                             () => references
                                 .OfType<Automation.OAAssemblyReference>()
                                 .FirstOrDefault(r => r.Name == fsCoreName.Name && r.PublicKeyToken == Utilities.FsCorePublicKeyToken && r.Culture == fsCoreName.CultureName)
@@ -3180,7 +3180,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 
                     if (existingFsCore != null)
                     {
-                        Microsoft.VisualStudio.FSharp.LanguageService.UIThread.DoOnUIThread(() =>
+                        UIThread.DoOnUIThread(() =>
                         {
                             // save copyLocal value - after calling existingFsCore.Remove() becomes invalid and can raise exceptions
                             var copyLocal = existingFsCore.CopyLocal;

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/IDEBuildLogger.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/IDEBuildLogger.cs
@@ -14,7 +14,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Win32;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
@@ -251,22 +250,22 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             span.iEndLine = endLine < startLine ? span.iStartLine : endLine;
             span.iEndIndex = (endColumn < startColumn) && (span.iStartLine == span.iEndLine) ? span.iStartIndex : endColumn;
 
-			if (OutputWindowPane != null
-				&& (this.Verbosity != LoggerVerbosity.Quiet || errorEvent is BuildErrorEventArgs))
-			{
-				// Format error and output it to the output window
-				string message = this.FormatMessage(errorEvent.Message);
+            if (OutputWindowPane != null
+                && (this.Verbosity != LoggerVerbosity.Quiet || errorEvent is BuildErrorEventArgs))
+            {
+                // Format error and output it to the output window
+                string message = this.FormatMessage(errorEvent.Message);
                 DefaultCompilerError e = new DefaultCompilerError(file,
                                                 span.iStartLine,
                                                 span.iStartIndex,
                                                 span.iEndLine,
                                                 span.iEndIndex,
                                                 errorCode,
-					                            message);
-				e.IsWarning = isWarning;
+                                                message);
+                e.IsWarning = isWarning;
 
-				Output(GetFormattedErrorMessage(e));
-			}
+                Output(GetFormattedErrorMessage(e));
+            }
 
             UIThread.Run(delegate()
             {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/NodeProperties.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/NodeProperties.cs
@@ -20,7 +20,6 @@ using System.Diagnostics;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 using IServiceProvider = System.IServiceProvider;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 using System.Runtime.Versioning;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectConfig.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectConfig.cs
@@ -12,7 +12,6 @@ using System.IO;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.VisualStudio.FSharp.LanguageService;
 using Microsoft.Win32;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
@@ -35,8 +35,6 @@ using Microsoft.Win32;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Build.Execution;
-
-using Microsoft.VisualStudio.FSharp.LanguageService;
 using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.FSharp.ProjectSystem

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectReferenceNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectReferenceNode.cs
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// </summary>
         public void CleanProjectReferenceErrorState()
         {
-            Microsoft.VisualStudio.FSharp.LanguageService.UIThread.DoOnUIThread(() =>
+            UIThread.DoOnUIThread(() =>
                 {
                     if (projectRefError != null)
                     {
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// <param name="text"></param>
         private void SetError(string text)
         {
-            Microsoft.VisualStudio.FSharp.LanguageService.UIThread.DoOnUIThread(() =>
+            UIThread.DoOnUIThread(() =>
                 {
                     // delete existing error if exists
                     CleanProjectReferenceErrorState();
@@ -295,7 +295,7 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
         /// </summary>
         public void RefreshProjectReferenceErrorState()
         {
-            Microsoft.VisualStudio.FSharp.LanguageService.UIThread.DoOnUIThread(() =>
+            UIThread.DoOnUIThread(() =>
                 {
                     CleanProjectReferenceErrorState();
 

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/UIThread.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/UIThread.cs
@@ -21,7 +21,7 @@ using IServiceProvider = System.IServiceProvider;
 using VsShell = Microsoft.VisualStudio.Shell.VsShellUtilities;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.VisualStudio.FSharp.LanguageService
+namespace Microsoft.VisualStudio.FSharp.ProjectSystem
 {
     internal static class UIThread
     {

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -200,7 +200,8 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                 resourceValue
 
             override this.Initialize() =
-                UIThread.CaptureSynchronizationContext()
+                Microsoft.VisualStudio.FSharp.LanguageService.UIThread.CaptureSynchronizationContext()
+                Microsoft.VisualStudio.FSharp.ProjectSystem.UIThread.CaptureSynchronizationContext()
 
                 base.Initialize()
 

--- a/vsintegration/tests/UnitTests/TestLib.Utils.fs
+++ b/vsintegration/tests/UnitTests/TestLib.Utils.fs
@@ -52,6 +52,7 @@ module Asserts =
 
 module UIStuff =
     let SetupSynchronizationContext() =
+        Microsoft.VisualStudio.FSharp.ProjectSystem.UIThread.InitUnitTestingMode()
         Microsoft.VisualStudio.FSharp.LanguageService.UIThread.InitUnitTestingMode()
 
 module FilesystemHelpers =


### PR DESCRIPTION
Whilst trying to get the tests passing I needed to initialize the UIThread helper class for testing.

It turns out we have two, one for LanguageService base, and One for ProjectSystem.Base.  It looks like there was a copy and paste job, because both were in the Blah.LanguageService namespace.  I renamed the one in the ProjectSystem library to be in the Blah.ProjectSystem namespace.

Further it turns out that only one of the two helpers were ever initialized on package load, so I now initialize both.

I guess the notion for two seperate assemblies, was to not have the ProjectSystem.base take a dependency on the LanguageService.Base assembly.  I guess for this one type that was probably an okay call.

Kevin


