### PR TITLE
Update nuget metadata

### DIFF
--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
@@ -13,14 +13,16 @@
                     netstandard2.0      (netstandard2.0)
                 Commit hash: $githeadsha$.
         </description>
-        <language>en-US</language>
+        <owners>$owners$</owners>
         <version>$version$</version>
         <authors>$authors$</authors>
+        <copyright>$copyright$</copyright>
         <licenseUrl>$licenseUrl$</licenseUrl>
         <projectUrl>$projectUrl$</projectUrl>
         <iconUrl>http://fsharp.org/img/logo.png</iconUrl>
         <tags>$tags$</tags>
-        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <requireLicenseAcceptance>$requireLicenseAcceptance$</requireLicenseAcceptance>
+        <language>en-US</language>
         <dependencies>
             <group targetFramework=".NETStandard1.6">
                 <dependency id="System.Collections" version="4.0.11" />

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.LatestNuget.nuspec
@@ -7,10 +7,12 @@
         <summary>FSharp.Core for F# 4.1</summary>
         <description>
             FSharp.Core redistributables from Visual F# Tools version 10.1 For F# 4.1
+
                 Supported Platforms:
-                    .NET 4.5+           (net45)
+                    .NET Framework 4.5+ (net45)
                     netstandard1.6      (netstandard1.6)
                     netstandard2.0      (netstandard2.0)
+
                 Commit hash: $githeadsha$.
         </description>
         <owners>$owners$</owners>

--- a/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.proj
+++ b/src/fsharp/FSharp.Core.nuget/FSharp.Core.nuget.proj
@@ -12,6 +12,9 @@
     <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://github.com/Microsoft/visualfsharp</PackageProjectUrl>
     <PackageAuthors    Condition="'$(PackageAuthors)' == ''"   >Microsoft and F# Software Foundation</PackageAuthors>
     <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags>
+    <PackageOwners     Condition="'$(PackageOwners)' == ''"    >Microsoft and F# Software Foundation</PackageOwners>
+    <PackageCopyright  Condition="'$(PackageCopyright)' == ''" >(C) Microsoft Corporation. All rights reserved.</PackageCopyright>
+    <PackageRequireLicenceAcceptence  Condition="'$(PackageRequireLicenceAcceptence)' == ''"    >true</PackageRequireLicenceAcceptence>
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\artifacts</OutputPath>
   </PropertyGroup>
 
@@ -64,7 +67,7 @@
       <!-- can't have &lt; and &gt; which happens when building locally -->
       <NormalizedGitHeadSha>$(GitHeadSha)</NormalizedGitHeadSha>
       <NormalizedGitHeadSha Condition="'$(NormalizedGitHeadSha)' == '&lt;developer build&gt;'">[developer build]</NormalizedGitHeadSha>
-      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "githeadsha=$(NormalizedGitHeadSha)"</PackageProperties>
+      <PackageProperties>-prop "licenseUrl=$(PackageLicenceUrl)" -prop "version=$(PackageVersion)" -prop "authors=$(PackageAuthors)" -prop "projectUrl=$(PackageProjectUrl)" -prop "tags=$(PackageTags)" -prop "githeadsha=$(NormalizedGitHeadSha)" -prop "owners=$(PackageOwners)" -prop "copyright=$(PackageCopyright)" -prop "requireLicenseAcceptance=$(PackageRequireLicenceAcceptence)"</PackageProperties>
     </PropertyGroup>
 
     <MakeDir Directories="$(FSharpSourcesRoot)\..\artifacts\$(PackageMajorVersion)" />


### PR DESCRIPTION
Write Preview 
Update nuget metadata per RFC 1005 ---- https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1005-package-signing.md

````
    <id>FSharp.Core</id>
    <version>4.3.5</version>
    <title>FSharp.Core for F# 4.1</title>
    <authors>Microsoft and F# Software Foundation</authors>
    <owners>Microsoft and F# Software Foundation</owners>
    <requireLicenseAcceptance>true</requireLicenseAcceptance>
    <licenseUrl>https://github.com/Microsoft/visualfsharp/blob/master/License.txt</licenseUrl>
    <projectUrl>https://github.com/Microsoft/visualfsharp</projectUrl>
    <iconUrl>http://fsharp.org/img/logo.png</iconUrl>
    <description>FSharp.Core redistributables from Visual F# Tools version 10.1 For F# 4.1
                Supported Platforms:
                    .NET 4.5+           (net45)
                    netstandard1.6      (netstandard1.6)
                    netstandard2.0      (netstandard2.0)
                Commit hash: [developer build].</description>
    <summary>FSharp.Core for F# 4.1</summary>
    <copyright>(C) Microsoft Corporation. All rights reserved.</copyright>
    <language>en-US</language>
    <tags>Visual F# Compiler FSharp functional programming</tags>

````