### PR TITLE
target net46 instead of net45

### DIFF
--- a/src/FSharp.Profiles.props
+++ b/src/FSharp.Profiles.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
 <Project>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
     <DefineConstants Condition="'$(MonoPackaging)' == 'true'">$(DefineConstants);CROSS_PLATFORM_COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);ENABLE_MONO_SUPPORT</DefineConstants>
     <DefineConstants>$(DefineConstants);BE_SECURITY_TRANSPARENT</DefineConstants>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -56,7 +56,7 @@
   <Import Project="FSharpSource.Profiles.targets" />
 
   <PropertyGroup Condition="'$(TargetDotnetProfile)'=='net40'">
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile></TargetFrameworkProfile>
     <!-- MSbuild works out the assembly references -->
   </PropertyGroup>

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -6,6 +6,7 @@
     <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
     <ProjectLanguage>FSharp</ProjectLanguage>
     <BuildWith Condition=" '$(Configuration)' == 'Proto' ">LKG</BuildWith>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
 
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.targets" />

--- a/tests/fsharpqa/testenv/src/HostedCompilerServer/HostedCompilerServer.fsproj
+++ b/tests/fsharpqa/testenv/src/HostedCompilerServer/HostedCompilerServer.fsproj
@@ -12,7 +12,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>HostedCompilerServer</RootNamespace>
     <AssemblyName>HostedCompilerServer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <OutputPath>..\..\bin</OutputPath>
 	<CustomOutputPath>true</CustomOutputPath>


### PR DESCRIPTION
This is the start of ongoing work to move our build to use official versions of MSBuild packages.  Step one is to retarget `fsc.exe`, et al. to `net46` instead of `net45`, because that's what the official Microsoft.Build NuGet packages support.

Future steps will be to actually migrate to the new packages, but this will be a larger work item because of some APIs that were removed between MSBuild 15.0 and 15.1.