### PR TITLE
Remove value tuple 431 from VisualFSharpFull.vsix

### DIFF
--- a/build/config/AssemblySignToolData.json
+++ b/build/config/AssemblySignToolData.json
@@ -68,7 +68,6 @@
     "Newtonsoft.Json.dll",
     "System.Collections.Immutable.dll",
     "System.Reflection.Metadata.dll",
-    "System.ValueTuple.4.3.1.nupkg",
     "System.ValueTuple.4.4.0.nupkg",
     "System.ValueTuple.dll"
   ]

--- a/packages.config
+++ b/packages.config
@@ -17,7 +17,6 @@
   <!-- Actual dependencies of FSharp.Compiler.dll and FSharp.Core.dll -->
   <package id="System.Collections.Immutable" version="1.3.1" />
   <package id="System.Reflection.Metadata" version="1.4.2" />
-  <package id="System.ValueTuple" version="4.3.1" />
   <package id="System.ValueTuple" version="4.4.0" />
   <package id="FSharp.Core" version="4.3.4"/>
   <package id="Microsoft.VisualFSharp.Msbuild.15.0" version="1.0.1" />

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -28,11 +28,6 @@
       <Link>packages\FSharp.Core.4.3.4.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.3.1\System.ValueTuple.4.3.1.nupkg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>packages\System.ValueTuple.4.3.1.nupkg</Link>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0\System.ValueTuple.4.4.0.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>packages\System.ValueTuple.4.4.0.nupkg</Link>


### PR DESCRIPTION
When we updated the templates to use ValueTuple 4.4.0 a while back, we needed to add both ValueTuple 4.4.0 and 4.3.1 to the VSix to ensure that, both new and old templates worked with the nightlies build.  We do not need the 4.3.1 version of System.ValueTuple in the shipped product.



