### PR TITLE
Sdk projects don't need to explicitly reference framework assemblies

### DIFF
--- a/vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj
+++ b/vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj
@@ -21,12 +21,4 @@
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
I noticed this