### PR TITLE
Re-enable some of the VS ide unit tests

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -486,9 +486,6 @@ if NOT EXIST Proto\net40\bin\fsc.exe (
   set BUILD_PROTO=1
 )
 
-rem turn off vs ide unit tests until they pass again
-set TEST_VS_IDEUNIT_SUITE= 0
-
 rem
 rem This stops the dotnet cli from hunting around and 
 rem finding the highest possible dotnet sdk version to use.

--- a/vsintegration/tests/UnitTests/Tests.Build.fs
+++ b/vsintegration/tests/UnitTests/Tests.Build.fs
@@ -179,8 +179,8 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--warnaserror-:52,109" + Environment.NewLine +
                      "--warnaserror:76" + Environment.NewLine +
+                     "--warnaserror-:52,109" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine)

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -24,12 +24,14 @@
     </Compile>
     <Compile Include="TestLib.Utils.fs" />
     <Compile Include="TestLib.Salsa.fs" />
+<!-- TODO:  Fix this test
     <Compile Include="TestLib.LanguageService.fs" />
     <Compile Include="TestLib.ProjectSystem.fs" />
-    <Compile Include="Tests.InternalCollections.fs" />
+-->    <Compile Include="Tests.InternalCollections.fs" />
     <Compile Include="Tests.Build.fs" />
     <Compile Include="Tests.TaskReporter.fs" />
     <Compile Include="Tests.Watson.fs" />
+<!-- TODO:  Fix this test
     <Compile Include="Tests.XmlDocComments.fs" />
     <Compile Include="LegacyLanguageService\Tests.LanguageService.General.fs" />
     <Compile Include="LegacyLanguageService\Tests.LanguageService.Completion.fs" />
@@ -51,6 +53,7 @@
     <Compile Include="LegacyProjectSystem\Tests.ProjectSystem.References.fs" />
     <Compile Include="LegacyProjectSystem\Tests.ProjectSystem.RoundTrip.fs" />
     <Compile Include="LegacyProjectSystem\Tests.ProjectSystem.UpToDate.fs" />
+-->
     <Compile Include="..\..\..\tests\service\FsUnit.fs">
       <Link>CompilerService\FsUnit.fs</Link>
     </Compile>
@@ -81,27 +84,34 @@
     <Compile Include="..\..\..\tests\service\ExprTests.fs">
       <Link>CompilerService\ExprTests.fs</Link>
     </Compile>
+<!-- TODO:  Fix this test
     <Compile Include="..\..\..\tests\service\CSharpProjectAnalysis.fs">
       <Link>CompilerService\CSharpProjectAnalysis.fs</Link>
     </Compile>
+-->
     <Compile Include="..\..\..\tests\service\ProjectOptionsTests.fs">
       <Link>CompilerService\ProjectOptionsTests.fs</Link>
     </Compile>
     <Compile Include="..\..\..\tests\service\StructureTests.fs">
       <Link>CompilerService\StructureTests.fs</Link>
     </Compile>
+<!-- TODO:  Fix this test
     <Compile Include="..\..\..\tests\service\AssemblyContentProviderTests.fs">
       <Link>CompilerService\AssemblyContentProviderTests.fs</Link>
     </Compile>
+-->
     <Compile Include="..\..\..\tests\service\ServiceUntypedParseTests.fs">
       <Link>CompilerService\ServiceUntypedParseTests.fs</Link>
     </Compile>
+<!-- TODO:  Fix this test
     <Compile Include="UnusedOpensTests.fs">
       <Link>CompilerService\UnusedOpensTests.fs</Link>
     </Compile>
+-->
     <Compile Include="SyntacticColorizationServiceTests.fs">
       <Link>Roslyn\SyntacticColorizationServiceTests.fs</Link>
     </Compile>
+<!-- TODO:  Fix this test
     <Compile Include="SemanticColorizationServiceTests.fs">
       <Link>Roslyn\SemanticColorizationServiceTests.fs</Link>
     </Compile>
@@ -111,24 +121,30 @@
     <Compile Include="HelpContextServiceTests.fs">
       <Link>Roslyn\HelpContextServiceTests.fs</Link>
     </Compile>
+-->
     <Compile Include="EditorFormattingServiceTests.fs">
       <Link>Roslyn\EditorFormattingServiceTests.fs</Link>
     </Compile>
+<!-- TODO:  Fix this test
     <Compile Include="IndentationServiceTests.fs">
       <Link>Roslyn\IndentationServiceTests.fs</Link>
     </Compile>
     <Compile Include="BreakpointResolutionService.fs">
       <Link>Roslyn\BreakpointResolutionService.fs</Link>
     </Compile>
+-->
     <Compile Include="LanguageDebugInfoServiceTests.fs">
       <Link>Roslyn\LanguageDebugInfoServiceTests.fs</Link>
     </Compile>
+<!-- TODO:  Fix this test
     <Compile Include="DocumentDiagnosticAnalyzerTests.fs">
       <Link>Roslyn\DocumentDiagnosticAnalyzerTests.fs</Link>
     </Compile>
+-->
     <Compile Include="ProjectDiagnosticAnalyzerTests.fs">
       <Link>Roslyn\ProjectDiagnosticAnalyzerTests.fs</Link>
     </Compile>
+<!-- TODO:  Fix this test
     <Compile Include="CompletionProviderTests.fs">
       <Link>Roslyn\CompletionProviderTests.fs</Link>
     </Compile>
@@ -144,6 +160,7 @@
     <Compile Include="DocumentHighlightsServiceTests.fs">
       <Link>Roslyn\DocumentHighlightsServiceTests.fs</Link>
     </Compile>
+-->
     <None Include="VisualFSharp.UnitTests.dll.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="app.runsettings" />
   </ItemGroup>


### PR DESCRIPTION
This re-enables those tests in the vs ide unit test suite that builds and successfully runs.

There will be much additional work getting the commented out tests building and running.  But at least this will stop the tests bitrotting further