### PR TITLE
create packages using build-assigned version number

### DIFF
--- a/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.props
+++ b/src/fsharp/FSharp.Compiler.nuget/FSharp.Compiler.Template.nuget.props
@@ -13,7 +13,7 @@
     <PackageAuthors    Condition="'$(PackageAuthors)' == ''"   >Microsoft and F# Software Foundation</PackageAuthors> 
     <PackageTags       Condition="'$(PackageTags)' == ''"      >Visual F# Compiler FSharp functional programming</PackageTags> 
     <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\coreclr\bin</OutputPath>
-    <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rtm-$(BuildRevision.Trim())-0</PreReleaseSuffix>
+    <PreReleaseSuffix  Condition="'$(PreRelease)' != 'false'">-rtm-$(NuGetPackageVersionSuffix)</PreReleaseSuffix>
     <PackageVersion>$(FSPackageVersion)$(PreReleaseSuffix)</PackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Official build numbers are UTC for reasons outside of our control so we could get into a situation where a build queued late enough in the day would create NuGet packages with a date of `n`, having been calculated from [here](https://github.com/Microsoft/visualfsharp/blob/08c0f887446509e3064e0925a509444221cdf2ec/src/FSharpSource.Settings.targets#L201) but the assembly versions would have a version of `n+1` calculated from the `BUILD_BUILDNUMBER` environment variable from [here](https://github.com/Microsoft/visualfsharp/blob/08c0f887446509e3064e0925a509444221cdf2ec/src/FSharpSource.Settings.targets#L31) (which correctly falls back to `DateTime.Now` if no build number was specified.)