### PR TITLE
[experiment] reenable all visual f# unit tests

### DIFF
--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -30,7 +30,6 @@
     <Compile Include="Tests.Build.fs" />
     <Compile Include="Tests.TaskReporter.fs" />
     <Compile Include="Tests.Watson.fs" />
-<!-- TODO:  Fix this test
     <Compile Include="Tests.XmlDocComments.fs" />
     <Compile Include="LegacyLanguageService\Tests.LanguageService.General.fs" />
     <Compile Include="LegacyLanguageService\Tests.LanguageService.Completion.fs" />
@@ -52,7 +51,6 @@
     <Compile Include="LegacyProjectSystem\Tests.ProjectSystem.References.fs" />
     <Compile Include="LegacyProjectSystem\Tests.ProjectSystem.RoundTrip.fs" />
     <Compile Include="LegacyProjectSystem\Tests.ProjectSystem.UpToDate.fs" />
--->
     <Compile Include="..\..\..\tests\service\FsUnit.fs">
       <Link>CompilerService\FsUnit.fs</Link>
     </Compile>
@@ -104,19 +102,15 @@
     <Compile Include="SyntacticColorizationServiceTests.fs">
       <Link>Roslyn\SyntacticColorizationServiceTests.fs</Link>
     </Compile>
-<!-- TODO:  Fix this test
     <Compile Include="SemanticColorizationServiceTests.fs">
       <Link>Roslyn\SemanticColorizationServiceTests.fs</Link>
     </Compile>
--->
     <Compile Include="BraceMatchingServiceTests.fs">
       <Link>Roslyn\BraceMatchingServiceTests.fs</Link>
     </Compile>
-<!-- TODO:  Fix this test
     <Compile Include="HelpContextServiceTests.fs">
       <Link>Roslyn\HelpContextServiceTests.fs</Link>
     </Compile>
--->
     <Compile Include="EditorFormattingServiceTests.fs">
       <Link>Roslyn\EditorFormattingServiceTests.fs</Link>
     </Compile>
@@ -135,15 +129,12 @@
     <Compile Include="ProjectDiagnosticAnalyzerTests.fs">
       <Link>Roslyn\ProjectDiagnosticAnalyzerTests.fs</Link>
     </Compile>
-<!-- TODO:  Fix this test
     <Compile Include="CompletionProviderTests.fs">
       <Link>Roslyn\CompletionProviderTests.fs</Link>
     </Compile>
--->
     <Compile Include="SignatureHelpProviderTests.fs">
       <Link>Roslyn\SignatureHelpProviderTests.fs</Link>
     </Compile>
-<!-- TODO:  Fix this test
     <Compile Include="GoToDefinitionServiceTests.fs">
       <Link>Roslyn\GoToDefinitionServiceTests.fs</Link>
     </Compile>
@@ -153,7 +144,6 @@
     <Compile Include="DocumentHighlightsServiceTests.fs">
       <Link>Roslyn\DocumentHighlightsServiceTests.fs</Link>
     </Compile>
--->
     <None Include="VisualFSharp.UnitTests.dll.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="app.runsettings" />
   </ItemGroup>


### PR DESCRIPTION
@KevinRansom Given that https://github.com/Microsoft/visualfsharp/pull/5193 fixed some of the VisualFSharp.UnitTests I figured I'd re-enable them all to get visibility of remaining errors