### PR TITLE
Warning FS0104: Fix 

### DIFF
--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -4,6 +4,7 @@ module internal Microsoft.FSharp.Compiler.PatternMatchCompilation
 
 open System.Collections.Generic
 open Microsoft.FSharp.Compiler 
+open Microsoft.FSharp.Compiler.AbstractIL.IL
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 open Microsoft.FSharp.Compiler.AbstractIL.Diagnostics 
 open Microsoft.FSharp.Compiler.Range
@@ -154,6 +155,24 @@ let rec pathEq p1 p2 =
     | PathEmpty(_), PathEmpty(_) -> true
     | _ -> false
 
+//// (Temporarily copy-pasted from TypeChecker.fs)
+let TcFieldInit lit = 
+    match lit with 
+    | ILFieldInit.String s -> Const.String s
+    | ILFieldInit.Null -> Const.Zero
+    | ILFieldInit.Bool b -> Const.Bool b
+    | ILFieldInit.Char c -> Const.Char (char (int c))
+    | ILFieldInit.Int8 x -> Const.SByte x
+    | ILFieldInit.Int16 x -> Const.Int16 x
+    | ILFieldInit.Int32 x -> Const.Int32 x
+    | ILFieldInit.Int64 x -> Const.Int64 x
+    | ILFieldInit.UInt8 x -> Const.Byte x
+    | ILFieldInit.UInt16 x -> Const.UInt16 x
+    | ILFieldInit.UInt32 x -> Const.UInt32 x
+    | ILFieldInit.UInt64 x -> Const.UInt64 x
+    | ILFieldInit.Single f -> Const.Single f
+    | ILFieldInit.Double f -> Const.Double f 
+
 
 //---------------------------------------------------------------------------
 // Counter example generation 
@@ -238,16 +257,27 @@ let RefuteDiscrimSet g m path discrims =
             | Some c ->
                 match tryDestAppTy g ty with
                 | Some tcref when tcref.IsEnumTycon ->
-                    // search for an enum value that pattern match (consts) does not contain
-                    let nonCoveredEnumValues =
-                        tcref.AllFieldsArray |> Array.tryFind (fun f ->
-                            match f.rfield_const with
-                            | None -> false
-                            | Some fieldValue -> (not (consts.Contains fieldValue)) && f.rfield_static)
+                    let enumValues =
+                        if tcref.IsILEnumTycon then
+                            let (TILObjectReprData(_, _, tdef)) = tcref.ILTyconInfo
+                            tdef.Fields.AsList
+                            |> Seq.choose (fun ilField ->
+                                if ilField.IsStatic then
+                                    ilField.LiteralValue |> Option.map (fun ilValue ->
+                                        ilField.Name, TcFieldInit ilValue)
+                                else None)
+                        else
+                            tcref.AllFieldsArray |> Seq.choose (fun fsField ->
+                                match fsField.rfield_const, fsField.rfield_static with
+                                | Some fsFieldValue, true -> Some (fsField.rfield_id.idText, fsFieldValue)
+                                | _ -> None)
+
+                    let nonCoveredEnumValues = Seq.tryFind (fun (_, fldValue) -> not (consts.Contains fldValue)) enumValues
+                          
                     match nonCoveredEnumValues with
                     | None -> Expr.Const(c,m,ty), true
-                    | Some f ->
-                        let v = RecdFieldRef.RFRef(tcref, f.rfield_id.idText)
+                    | Some (fldName, _) ->
+                        let v = RecdFieldRef.RFRef(tcref, fldName)
                         Expr.Op(TOp.ValFieldGet v, [ty], [], m), false
                 | _ -> Expr.Const(c,m,ty), false
             

--- a/tests/fsharp/typecheck/sigs/neg102.bsl
+++ b/tests/fsharp/typecheck/sigs/neg102.bsl
@@ -9,6 +9,10 @@ neg102.fs(18,14,18,22): typecheck error FS0025: Incomplete pattern matches on th
 
 neg102.fs(22,14,22,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'Some (EnumABC.C)' may indicate a case not covered by the pattern(s).
 
-neg102.fs(29,14,29,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<EnumABC> (2)' may indicate a case not covered by the pattern(s).
+neg102.fs(27,14,27,22): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'System.DateTimeKind.Utc' may indicate a case not covered by the pattern(s).
 
-neg102.fs(34,14,34,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'Some (enum<EnumABC> (2))' may indicate a case not covered by the pattern(s).
+neg102.fs(32,14,32,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<EnumABC> (2)' may indicate a case not covered by the pattern(s).
+
+neg102.fs(37,14,37,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'Some (enum<EnumABC> (2))' may indicate a case not covered by the pattern(s).
+
+neg102.fs(44,14,44,22): typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<System.DateTimeKind> (3)' may indicate a case not covered by the pattern(s).

--- a/tests/fsharp/typecheck/sigs/neg102.fs
+++ b/tests/fsharp/typecheck/sigs/neg102.fs
@@ -4,7 +4,7 @@ type UnionAB = A | B
 
 module FS0025 =
     // All of these should emit warning FS0025 ("Incomplete pattern match....")
-        
+
 
     let f1 = function
         | UnionAB.A -> "A"
@@ -23,6 +23,9 @@ module FS0025 =
         | Some(EnumABC.A) | Some(EnumABC.B) -> "A|B"
         | None -> "neither"
 
+    // try a non-F#-defined enum
+    let f6 = function System.DateTimeKind.Unspecified -> 0
+
 module FS0104 =
     // These should emit warning FS0104 ("Enums may take values outside of known cases....")
 
@@ -36,3 +39,9 @@ module FS0104 =
         | Some(EnumABC.B) -> "B"
         | Some(EnumABC.C) -> "C"
         | None -> "none"
+
+    // try a non-F#-defined enum
+    let f3 = function
+        | System.DateTimeKind.Unspecified -> "Unspecified"
+        | System.DateTimeKind.Utc -> "Utc"
+        | System.DateTimeKind.Local -> "Local"


### PR DESCRIPTION
PR #4522 has a bug, causing it to always produce FS0104 for non-F#-defined enum. For example, the following code:

```fsharp
// System.DateTimeKind = | Unspecified = 0 | Utc = 1 | Local = 2
let f = function System.DateTimeKind.Unspecified -> 0
```

currently produces this compiler warning:

```
typecheck error FS0104: Enums may take values outside known cases. For example, the value 'enum<System.DateTimeKind> (1)' may indicate a case not covered by the pattern(s).
```

when it is supposed to produce:

```
typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value 'System.DateTimeKind.Utc' may indicate a case not covered by the pattern(s).
```

This PR corrects the issue.

Thanks to @charlesroddie [for identifying the bug](
https://github.com/Microsoft/visualfsharp/pull/4522#issuecomment-387603467).