### PR TITLE
Clean up IntelliSense perf UI and flow options for IntelliSense

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddOpenCodeFixProvider.fs
@@ -98,7 +98,7 @@ type internal FSharpAddOpenCodeFixProvider
             let document = context.Document
             let! parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject document
             let! sourceText = context.Document.GetTextAsync(context.CancellationToken)
-            let! _, parsedInput, checkResults = checker.ParseAndCheckDocument(document, projectOptions, allowStaleResults = true, sourceText = sourceText, userOpName = userOpName)
+            let! _, parsedInput, checkResults = checker.ParseAndCheckDocument(document, projectOptions, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, sourceText = sourceText, userOpName = userOpName)
             let line = sourceText.Lines.GetLineFromPosition(context.Span.End)
             let linePos = sourceText.Lines.GetLinePosition(context.Span.End)
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions

--- a/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ImplementInterfaceCodeFixProvider.fs
@@ -141,7 +141,7 @@ type internal FSharpImplementInterfaceCodeFixProvider
             let! parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject context.Document
             let cancellationToken = context.CancellationToken
             let! sourceText = context.Document.GetTextAsync(cancellationToken)
-            let! _, parsedInput, checkFileResults = checker.ParseAndCheckDocument(context.Document, projectOptions, sourceText = sourceText, allowStaleResults = true, userOpName = userOpName)
+            let! _, parsedInput, checkFileResults = checker.ParseAndCheckDocument(context.Document, projectOptions, sourceText = sourceText, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
             let textLine = sourceText.Lines.GetLineFromPosition context.Span.Start
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
             // Notice that context.Span doesn't return reliable ranges to find tokens at exact positions.

--- a/vsintegration/src/FSharp.Editor/CodeFix/RenameUnusedValue.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/RenameUnusedValue.fs
@@ -58,7 +58,7 @@ type internal FSharpRenameUnusedValueCodeFixProvider
             // where backtickes are replaced with parens.
             if not (PrettyNaming.IsOperatorOrBacktickedName ident) && not (ident.StartsWith "``") then
                 let! parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject document
-                let! _, _, checkResults = checker.ParseAndCheckDocument(document, projectOptions, allowStaleResults = true, sourceText = sourceText, userOpName=userOpName)
+                let! _, _, checkResults = checker.ParseAndCheckDocument(document, projectOptions, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, sourceText = sourceText, userOpName=userOpName)
                 let m = RoslynHelpers.TextSpanToFSharpRange(document.FilePath, context.Span, sourceText)
                 let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
                 let! lexerSymbol = Tokenizer.getSymbolAtPosition (document.Id, sourceText, context.Span.Start, document.FilePath, defines, SymbolLookupKind.Greedy, false)

--- a/vsintegration/src/FSharp.Editor/Commands/HelpContextService.fs
+++ b/vsintegration/src/FSharp.Editor/Commands/HelpContextService.fs
@@ -25,7 +25,7 @@ type internal FSharpHelpContextService
     static let userOpName = "ImplementInterfaceCodeFix"
     static member GetHelpTerm(checker: FSharpChecker, sourceText : SourceText, fileName, options, span: TextSpan, tokens: List<ClassifiedSpan>, textVersion) : Async<string option> = 
         asyncMaybe {
-            let! _, _, check = checker.ParseAndCheckDocument(fileName, textVersion, sourceText.ToString(), options, allowStaleResults = true, userOpName = userOpName)
+            let! _, _, check = checker.ParseAndCheckDocument(fileName, textVersion, sourceText.ToString(), options, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
             let textLines = sourceText.Lines
             let lineInfo = textLines.GetLineFromPosition(span.Start)
             let line = lineInfo.LineNumber

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -103,7 +103,7 @@ type internal FSharpCompletionProvider
     static member ProvideCompletionsAsyncAux(checker: FSharpChecker, sourceText: SourceText, caretPosition: int, options: FSharpProjectOptions, filePath: string, 
                                              textVersionHash: int, getAllSymbols: FSharpCheckFileResults -> AssemblySymbol list) = 
         asyncMaybe {
-            let! parseResults, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults = true, userOpName = userOpName)
+            let! parseResults, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
 
             let textLines = sourceText.Lines
             let caretLinePos = textLines.GetLinePosition(caretPosition)

--- a/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs
@@ -62,7 +62,7 @@ type internal SimplifyNameDiagnosticAnalyzer() =
                 | _ ->
                     let! sourceText = document.GetTextAsync()
                     let checker = getChecker document
-                    let! _, _, checkResults = checker.ParseAndCheckDocument(document, projectOptions, sourceText = sourceText, allowStaleResults = true, userOpName=userOpName)
+                    let! _, _, checkResults = checker.ParseAndCheckDocument(document, projectOptions, sourceText = sourceText, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName=userOpName)
                     let! symbolUses = checkResults.GetAllUsesOfAllSymbolsInFile() |> liftAsync
                     let mutable result = ResizeArray()
                     let symbolUses =

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedDeclarationsAnalyzer.fs
@@ -110,7 +110,7 @@ type internal UnusedDeclarationsAnalyzer() =
             | Some (_parsingOptions, projectOptions) ->
                 let! sourceText = document.GetTextAsync()
                 let checker = getChecker document
-                let! _, _, checkResults = checker.ParseAndCheckDocument(document, projectOptions, sourceText = sourceText, allowStaleResults = true, userOpName = userOpName)
+                let! _, _, checkResults = checker.ParseAndCheckDocument(document, projectOptions, sourceText = sourceText, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
                 let! allSymbolUsesInFile = checkResults.GetAllUsesOfAllSymbolsInFile() |> liftAsync
                 let unusedRanges = getUnusedDeclarationRanges allSymbolUsesInFile (isScriptFile document.FilePath)
                 return

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
@@ -43,7 +43,7 @@ type internal UnusedOpensDiagnosticAnalyzer() =
         asyncMaybe {
             do! Option.guard Settings.CodeFixes.UnusedOpens
             let! sourceText = document.GetTextAsync()
-            let! _, _, checkResults = checker.ParseAndCheckDocument(document, options, sourceText = sourceText, allowStaleResults = true, userOpName = userOpName)
+            let! _, _, checkResults = checker.ParseAndCheckDocument(document, options, sourceText = sourceText, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
 #if DEBUG
             let sw = Stopwatch.StartNew()
 #endif

--- a/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
+++ b/vsintegration/src/FSharp.Editor/DocumentHighlights/DocumentHighlightsService.fs
@@ -59,7 +59,7 @@ type internal FSharpDocumentHighlightsService [<ImportingConstructor>] (checkerP
             let textLinePos = sourceText.Lines.GetLinePosition(position)
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let! symbol = Tokenizer.getSymbolAtPosition(documentKey, sourceText, position, filePath, defines, SymbolLookupKind.Greedy, false)
-            let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults = true, userOpName = userOpName)
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland, userOpName=userOpName)
             let! symbolUses = checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol) |> liftAsync
             return 

--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -149,7 +149,7 @@ type internal InlineRenameService
             let textLinePos = sourceText.Lines.GetLinePosition(position)
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy, false)
-            let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, options, allowStaleResults = true, userOpName = userOpName)
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, options, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.Text.ToString(), symbol.FullIsland, userOpName=userOpName)
             let! declLoc = symbolUse.GetDeclarationLocation(document)
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpCheckerExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpCheckerExtensions.fs
@@ -63,10 +63,10 @@ type FSharpChecker with
                     | Ready x -> async.Return x
                     | StillRunning worker ->
                         async {
-                            match allowStaleResults, checker.TryGetRecentCheckResultsForFile(filePath, options) with
-                            | true, Some (parseResults, checkFileResults, _) ->
+                            match checker.TryGetRecentCheckResultsForFile(filePath, options) with
+                            | Some (parseResults, checkFileResults, _) ->
                                 return Some (parseResults, checkFileResults)
-                            | _ ->
+                            | None ->
                                 return! worker
                         }
                 return bindParsedInput results

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -33,7 +33,7 @@ module internal SymbolHelpers =
             let! parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject(document) 
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
             let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, position, document.FilePath, defines, SymbolLookupKind.Greedy, false)
-            let! _, _, checkFileResults = checker.ParseAndCheckDocument(document.FilePath, textVersionHash, sourceText.ToString(), projectOptions, allowStaleResults = true, userOpName = userOpName) 
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument(document.FilePath, textVersionHash, sourceText.ToString(), projectOptions, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName) 
             let! symbolUse = checkFileResults.GetSymbolUseAtLocation(fcsTextLineNumber, symbol.Ident.idRange.EndColumn, textLine.ToString(), symbol.FullIsland, userOpName=userOpName)
             let! symbolUses = checkFileResults.GetUsesOfSymbolInFile(symbolUse.Symbol) |> liftAsync
             return symbolUses
@@ -106,7 +106,7 @@ module internal SymbolHelpers =
             let! parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject document
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
             let! symbol = Tokenizer.getSymbolAtPosition(document.Id, sourceText, symbolSpan.Start, document.FilePath, defines, SymbolLookupKind.Greedy, false)
-            let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, projectOptions, allowStaleResults = true, userOpName = userOpName)
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, projectOptions, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
             let textLine = sourceText.Lines.GetLineFromPosition(symbolSpan.Start)
             let textLinePos = sourceText.Lines.GetLinePosition(symbolSpan.Start)
             let fcsTextLineNumber = Line.fromZ textLinePos.Line

--- a/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/FindUsagesService.fs
@@ -52,7 +52,7 @@ type internal FSharpFindUsagesService
             let! sourceText = document.GetTextAsync(context.CancellationToken) |> Async.AwaitTask |> liftAsync
             let checker = checkerProvider.Checker
             let! parsingOptions, _, projectOptions = projectInfoManager.TryGetOptionsForDocumentOrProject(document)
-            let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, projectOptions, sourceText = sourceText, allowStaleResults = true, userOpName = userOpName)
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument(document, projectOptions, sourceText = sourceText, allowStaleResults = Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName = userOpName)
             let textLine = sourceText.Lines.GetLineFromPosition(position).ToString()
             let lineNumber = sourceText.Lines.GetLinePosition(position).Line + 1
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -181,7 +181,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
             let fcsTextLineNumber = Line.fromZ textLinePos.Line
             let lineText = (sourceText.Lines.GetLineFromPosition position).ToString()  
             
-            let! _, _, checkFileResults = checker.ParseAndCheckDocument (originDocument, projectOptions, allowStaleResults=true,sourceText=sourceText, userOpName=userOpName)
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument (originDocument, projectOptions, allowStaleResults=Settings.LanguageServicePerformance.AllowStaleCompletionResults,sourceText=sourceText, userOpName=userOpName)
             let idRange = lexerSymbol.Ident.idRange
             let! fsSymbolUse = checkFileResults.GetSymbolUseAtLocation (fcsTextLineNumber, idRange.EndColumn, lineText, lexerSymbol.FullIsland, userOpName=userOpName)
             let symbol = fsSymbolUse.Symbol
@@ -194,7 +194,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
                 let! implDoc = originDocument.Project.Solution.TryGetDocumentFromPath fsfilePath
                 let! implSourceText = implDoc.GetTextAsync ()
                 let! _parsingOptions, projectOptions = projectInfoManager.TryGetOptionsForEditingDocumentOrProject implDoc
-                let! _, _, checkFileResults = checker.ParseAndCheckDocument (implDoc, projectOptions, allowStaleResults=true, sourceText=implSourceText, userOpName=userOpName)
+                let! _, _, checkFileResults = checker.ParseAndCheckDocument (implDoc, projectOptions, allowStaleResults=Settings.LanguageServicePerformance.AllowStaleCompletionResults, sourceText=implSourceText, userOpName=userOpName)
                 let! symbolUses = checkFileResults.GetUsesOfSymbolInFile symbol |> liftAsync
                 let! implSymbol  = symbolUses |> Array.tryHead 
                 let! implTextSpan = RoslynHelpers.TryFSharpRangeToTextSpan (implSourceText, implSymbol.RangeAlternate)
@@ -233,7 +233,7 @@ type internal GoToDefinition(checker: FSharpChecker, projectInfoManager: FSharpP
             
             let preferSignature = isSignatureFile originDocument.FilePath
 
-            let! _, _, checkFileResults = checker.ParseAndCheckDocument (originDocument, projectOptions, allowStaleResults=true, sourceText=sourceText, userOpName=userOpName)
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument (originDocument, projectOptions, allowStaleResults=Settings.LanguageServicePerformance.AllowStaleCompletionResults, sourceText=sourceText, userOpName=userOpName)
                 
             let! lexerSymbol = Tokenizer.getSymbolAtPosition (originDocument.Id, sourceText, position,originDocument.FilePath, defines, SymbolLookupKind.Greedy, false)
             let idRange = lexerSymbol.Ident.idRange

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -43,6 +43,7 @@ type CodeFixesOptions =
 [<CLIMutable>]
 type LanguageServicePerformanceOptions = 
     { EnableInMemoryCrossProjectReferences: bool
+      AllowStaleCompletionResults: bool
       TimeUntilStaleCompletion: int
       ProjectCheckCacheSize: int }
 
@@ -74,6 +75,7 @@ type internal Settings [<ImportingConstructor>](store: SettingsStore) =
 
         store.RegisterDefault
             { EnableInMemoryCrossProjectReferences = true
+              AllowStaleCompletionResults = true
               TimeUntilStaleCompletion = 2000 // In ms, so this is 2 seconds
               ProjectCheckCacheSize = 200 }
 

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -169,7 +169,7 @@ type internal FSharpAsyncQuickInfoSource
     // test helper
     static member ProvideQuickInfo(checker:FSharpChecker, documentId:DocumentId, sourceText:SourceText, filePath:string, position:int, parsingOptions:FSharpParsingOptions, options:FSharpProjectOptions, textVersionHash:int) =
         asyncMaybe {
-            let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults=true, userOpName=FSharpQuickInfo.userOpName)
+            let! _, _, checkFileResults = checker.ParseAndCheckDocument(filePath, textVersionHash, sourceText.ToString(), options, allowStaleResults=Settings.LanguageServicePerformance.AllowStaleCompletionResults, userOpName=FSharpQuickInfo.userOpName)
             let textLine = sourceText.Lines.GetLineFromPosition position
             let textLineNumber = textLine.LineNumber + 1 // Roslyn line numbers are zero-based
             let defines = CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions

--- a/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
+++ b/vsintegration/src/FSharp.UIResources/FSharp.UIResources.csproj
@@ -36,8 +36,16 @@
     <Compile Update="$(IntermediateOutputPath)**\*.g.cs" Visible="false" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Update="Strings.resx">
-      <Generator></Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
@@ -23,7 +23,7 @@
                                   IsChecked="{Binding EnableInMemoryCrossProjectReferences}"
                                   Content="{x:Static local:Strings.Enable_in_memory_cross_project_references}"
                                   ToolTip="{x:Static local:Strings.Tooltip_in_memory_cross_project_references}"/>
-                        <Grid IsEnabled="{Binding IsChecked, ElementName=enableInMemoryCrossProjectReferences}">
+                        <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="auto"/>
                                 <ColumnDefinition Width="70" />

--- a/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
@@ -17,11 +17,36 @@
     <Grid>
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel>
-                <GroupBox Header="{x:Static local:Strings.Enable_in_memory_cross_project_references}">
+                <GroupBox Header="{x:Static local:Strings.Project_Performance}">
                     <StackPanel>
                         <CheckBox x:Name="enableInMemoryCrossProjectReferences"
                                   IsChecked="{Binding EnableInMemoryCrossProjectReferences}"
                                   Content="{x:Static local:Strings.Enable_in_memory_cross_project_references}"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto"/>
+                                <ColumnDefinition Width="70" />
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" x:Name="projectCheckCacheSizeLabel" Content="{x:Static local:Strings.Project_check_cache_size}"/>
+                            <TextBox Grid.Column="1" 
+                                     HorizontalContentAlignment="Right" 
+                                     VerticalContentAlignment="Center">
+                                <TextBox.Text>
+                                    <Binding UpdateSourceTrigger="PropertyChanged" Path="ProjectCheckCacheSize">
+                                        <Binding.ValidationRules>
+                                            <local:IntegerRangeValidationRule Min="1" Max="1000" />
+                                        </Binding.ValidationRules>
+                                    </Binding>
+                                </TextBox.Text>
+                            </TextBox>
+                        </Grid>
+                    </StackPanel>
+                </GroupBox>
+                <GroupBox Header="{x:Static local:Strings.IntelliSense_Performance}">
+                    <StackPanel>
+                        <CheckBox x:Name="enableStaleIntelliSenseResults"
+                                  IsChecked="{Binding AllowStaleCompletionResults}"
+                                  Content="{x:Static local:Strings.Enable_Stale_IntelliSense_Results}"/>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="300"/>
@@ -34,25 +59,8 @@
                                 <TextBox.Text>
                                     <Binding UpdateSourceTrigger="PropertyChanged" Path="TimeUntilStaleCompletion">
                                         <Binding.ValidationRules>
-                                            <local:IntegerRangeValidationRule Min="0" Max="10000"/> <!-- If people truly want more than 10 seconds before stale results come in, they can open an issue on VisualFSharp. -->
-                                        </Binding.ValidationRules>
-                                    </Binding>
-                                </TextBox.Text>
-                            </TextBox>
-                        </Grid>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="300"/>
-                                <ColumnDefinition Width="70" />
-                            </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" x:Name="projectCheckCacheSizeLabel" Content="{x:Static local:Strings.Project_check_cache_size}"/>
-                            <TextBox Grid.Column="1" 
-                                     HorizontalContentAlignment="Right" 
-                                     VerticalContentAlignment="Center">
-                                <TextBox.Text>
-                                    <Binding UpdateSourceTrigger="PropertyChanged" Path="ProjectCheckCacheSize">
-                                        <Binding.ValidationRules>
-                                            <local:IntegerRangeValidationRule Min="1" Max="1000" />
+                                            <local:IntegerRangeValidationRule Min="0" Max="10000"/>
+                                            <!-- If people truly want more than 10 seconds before stale results come in, they can open an issue on VisualFSharp. -->
                                         </Binding.ValidationRules>
                                     </Binding>
                                 </TextBox.Text>

--- a/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
@@ -21,13 +21,17 @@
                     <StackPanel>
                         <CheckBox x:Name="enableInMemoryCrossProjectReferences"
                                   IsChecked="{Binding EnableInMemoryCrossProjectReferences}"
-                                  Content="{x:Static local:Strings.Enable_in_memory_cross_project_references}"/>
-                        <Grid>
+                                  Content="{x:Static local:Strings.Enable_in_memory_cross_project_references}"
+                                  ToolTip="{x:Static local:Strings.Tooltip_in_memory_cross_project_references}"/>
+                        <Grid IsEnabled="{Binding IsChecked, ElementName=enableInMemoryCrossProjectReferences}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="auto"/>
                                 <ColumnDefinition Width="70" />
                             </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" x:Name="projectCheckCacheSizeLabel" Content="{x:Static local:Strings.Project_check_cache_size}"/>
+                            <Label Grid.Column="0"
+                                   x:Name="projectCheckCacheSizeLabel"
+                                   Content="{x:Static local:Strings.Project_check_cache_size}"
+                                   ToolTip="{x:Static local:Strings.Tooltip_project_check_cache_size}"/>
                             <TextBox Grid.Column="1" 
                                      HorizontalContentAlignment="Right" 
                                      VerticalContentAlignment="Center">
@@ -47,24 +51,27 @@
                         <CheckBox x:Name="enableStaleIntelliSenseResults"
                                   IsChecked="{Binding AllowStaleCompletionResults}"
                                   Content="{x:Static local:Strings.Enable_Stale_IntelliSense_Results}"/>
-                        <Grid>
+                        <Grid IsEnabled="{Binding IsChecked, ElementName=enableStaleIntelliSenseResults}">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="300"/>
+                                <ColumnDefinition Width="auto"/>
                                 <ColumnDefinition Width="70" />
                             </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" x:Name="timeUntilStaleIntelliSenseLabel" Content="{x:Static local:Strings.Time_until_stale_completion}"/>
-                            <TextBox Grid.Column="1"
+                                <Label Grid.Column="0"
+                                   x:Name="timeUntilStaleIntelliSenseLabel"
+                                   Content="{x:Static local:Strings.Time_until_stale_completion}"
+                                   Margin="15 0 0 0"/>
+                                <TextBox Grid.Column="1"
                                      HorizontalContentAlignment="Right" 
                                      VerticalContentAlignment="Center">
-                                <TextBox.Text>
-                                    <Binding UpdateSourceTrigger="PropertyChanged" Path="TimeUntilStaleCompletion">
-                                        <Binding.ValidationRules>
-                                            <local:IntegerRangeValidationRule Min="0" Max="10000"/>
-                                            <!-- If people truly want more than 10 seconds before stale results come in, they can open an issue on VisualFSharp. -->
-                                        </Binding.ValidationRules>
-                                    </Binding>
-                                </TextBox.Text>
-                            </TextBox>
+                                    <TextBox.Text>
+                                        <Binding UpdateSourceTrigger="PropertyChanged" Path="TimeUntilStaleCompletion">
+                                            <Binding.ValidationRules>
+                                                <local:IntegerRangeValidationRule Min="0" Max="10000"/>
+                                                <!-- If people truly want more than 10 seconds before stale results come in, they can open an issue on VisualFSharp. -->
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </TextBox.Text>
+                                </TextBox>
                         </Grid>
                     </StackPanel>
                 </GroupBox>

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work..
+        ///   Looks up a localized string similar to Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions..
         /// </summary>
         public static string Tooltip_project_check_cache_size {
             get {

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable stale results in IntelliSense completion lists.
+        ///   Looks up a localized string similar to Enable stale data for IntelliSense features.
         /// </summary>
         public static string Enable_Stale_IntelliSense_Results {
             get {
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project check cache size.
+        ///   Looks up a localized string similar to Number of projects whose data is cached in memory.
         /// </summary>
         public static string Project_check_cache_size {
             get {
@@ -259,11 +259,29 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Time until stale results for completion (in milliseconds).
+        ///   Looks up a localized string similar to Time until stale results are used (in milliseconds).
         /// </summary>
         public static string Time_until_stale_completion {
             get {
                 return ResourceManager.GetString("Time_until_stale_completion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In-memory cross-project references store project-level data in memory to allow IDE features to work across projects..
+        /// </summary>
+        public static string Tooltip_in_memory_cross_project_references {
+            get {
+                return ResourceManager.GetString("Tooltip_in_memory_cross_project_references", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work..
+        /// </summary>
+        public static string Tooltip_project_check_cache_size {
+            get {
+                return ResourceManager.GetString("Tooltip_project_check_cache_size", resourceCulture);
             }
         }
         

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -124,6 +124,24 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable stale results in IntelliSense completion lists.
+        /// </summary>
+        public static string Enable_Stale_IntelliSense_Results {
+            get {
+                return ResourceManager.GetString("Enable_Stale_IntelliSense_Results", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to IntelliSense Performance Options.
+        /// </summary>
+        public static string IntelliSense_Performance {
+            get {
+                return ResourceManager.GetString("IntelliSense_Performance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Performance.
         /// </summary>
         public static string Language_Service_Performance {
@@ -156,6 +174,15 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         public static string Project_check_cache_size {
             get {
                 return ResourceManager.GetString("Project_check_cache_size", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to F# Project and Caching Performance Options.
+        /// </summary>
+        public static string Project_Performance {
+            get {
+                return ResourceManager.GetString("Project_Performance", resourceCulture);
             }
         }
         

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -196,6 +196,6 @@
     <value>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</value>
   </data>
   <data name="Tooltip_project_check_cache_size" xml:space="preserve">
-    <value>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</value>
+    <value>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</value>
   </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -183,4 +183,13 @@
   <data name="Time_until_stale_completion" xml:space="preserve">
     <value>Time until stale results for completion (in milliseconds)</value>
   </data>
+  <data name="IntelliSense_Performance" xml:space="preserve">
+    <value>IntelliSense Performance Options</value>
+  </data>
+  <data name="Project_Performance" xml:space="preserve">
+    <value>F# Project and Caching Performance Options</value>
+  </data>
+  <data name="Enable_Stale_IntelliSense_Results" xml:space="preserve">
+    <value>Enable stale results in IntelliSense completion lists</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -151,7 +151,7 @@
     <value>_Enable in-memory cross project references</value>
   </data>
   <data name="Project_check_cache_size" xml:space="preserve">
-    <value>Project check cache size</value>
+    <value>Number of projects whose data is cached in memory</value>
   </data>
   <data name="Show_navigation_links_as" xml:space="preserve">
     <value>S_how navigation links as</value>
@@ -181,7 +181,7 @@
     <value>Show outlining and collapsable nodes for F# code</value>
   </data>
   <data name="Time_until_stale_completion" xml:space="preserve">
-    <value>Time until stale results for completion (in milliseconds)</value>
+    <value>Time until stale results are used (in milliseconds)</value>
   </data>
   <data name="IntelliSense_Performance" xml:space="preserve">
     <value>IntelliSense Performance Options</value>
@@ -190,6 +190,12 @@
     <value>F# Project and Caching Performance Options</value>
   </data>
   <data name="Enable_Stale_IntelliSense_Results" xml:space="preserve">
-    <value>Enable stale results in IntelliSense completion lists</value>
+    <value>Enable stale data for IntelliSense features</value>
+  </data>
+  <data name="Tooltip_in_memory_cross_project_references" xml:space="preserve">
+    <value>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</value>
+  </data>
+  <data name="Tooltip_project_check_cache_size" xml:space="preserve">
+    <value>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</value>
   </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Velikost mezipaměti pro kontrolu projektů</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Velikost mezipaměti pro kontrolu projektů</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Überprüfung der Projektcachegröße</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Überprüfung der Projektcachegröße</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="new">Project check cache size</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="new">Number of projects whose data is cached in memory</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.en.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Tamaño de caché de comprobación de proyectos</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Tamaño de caché de comprobación de proyectos</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Taille du cache de vérification du projet</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Taille du cache de vérification du projet</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Dimensioni della cache di controllo del progetto</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Dimensioni della cache di controllo del progetto</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">プロジェクト チェックのキャッシュ サイズ</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">プロジェクト チェックのキャッシュ サイズ</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">프로젝트 검사 캐시 크기</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">프로젝트 검사 캐시 크기</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Rozmiar pamięci podręcznej sprawdzania projektu</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Rozmiar pamięci podręcznej sprawdzania projektu</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Tamanho do cache de verificação do projeto</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Tamanho do cache de verificação do projeto</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Размер кэша проверки проекта</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Размер кэша проверки проекта</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">Proje denetimi önbelleği boyutu</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">Proje denetimi önbelleği boyutu</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">项目检查缓存大小</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">项目检查缓存大小</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -133,8 +133,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Tooltip_project_check_cache_size">
-        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
-        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
+        <source>Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</source>
+        <target state="new">Project data is cached for IDE features. Higher values use more memory because more projects are cached. Tuning this value should not affect small or medium-sized solutions.</target>
         <note />
       </trans-unit>
     </body>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -112,6 +112,21 @@
         <target state="new">Time until stale results for completion (in milliseconds)</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntelliSense_Performance">
+        <source>IntelliSense Performance Options</source>
+        <target state="new">IntelliSense Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Project_Performance">
+        <source>F# Project and Caching Performance Options</source>
+        <target state="new">F# Project and Caching Performance Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Enable_Stale_IntelliSense_Results">
+        <source>Enable stale results in IntelliSense completion lists</source>
+        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Project_check_cache_size">
-        <source>Project check cache size</source>
-        <target state="translated">專案檢查快取大小</target>
+        <source>Number of projects whose data is cached in memory</source>
+        <target state="needs-review-translation">專案檢查快取大小</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_navigation_links_as">
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Time_until_stale_completion">
-        <source>Time until stale results for completion (in milliseconds)</source>
-        <target state="new">Time until stale results for completion (in milliseconds)</target>
+        <source>Time until stale results are used (in milliseconds)</source>
+        <target state="new">Time until stale results are used (in milliseconds)</target>
         <note />
       </trans-unit>
       <trans-unit id="IntelliSense_Performance">
@@ -123,8 +123,18 @@
         <note />
       </trans-unit>
       <trans-unit id="Enable_Stale_IntelliSense_Results">
-        <source>Enable stale results in IntelliSense completion lists</source>
-        <target state="new">Enable stale results in IntelliSense completion lists</target>
+        <source>Enable stale data for IntelliSense features</source>
+        <target state="new">Enable stale data for IntelliSense features</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_in_memory_cross_project_references">
+        <source>In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</source>
+        <target state="new">In-memory cross-project references store project-level data in memory to allow IDE features to work across projects.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Tooltip_project_check_cache_size">
+        <source>Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</source>
+        <target state="new">Data from projects is kept in memory to enable cross-project IDE features. Higher values use more memory. Lower values incur more computational work.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
I was unhappy with the performance options UI after making some changes to it. It now looks like this (note the tooltips if you hover over the project options):

![image](https://user-images.githubusercontent.com/6309070/41616771-ac53d1a4-73b3-11e8-94cd-b88ecf706e91.png)

![image](https://user-images.githubusercontent.com/6309070/41623892-fc7502e2-73c8-11e8-92ea-74f49cdad175.png)


Additionally, stale results options are now flowed through the places `true` is set.

I also noticed that in `ClassificationService.fs`, we set `allowStaleResults` to `false`. This is in contrast to everywhere else, where it is `true`. I left this as-is for now.