### PR TITLE
version the .vsman insertion files

### DIFF
--- a/setup/FSharp.Setup.props
+++ b/setup/FSharp.Setup.props
@@ -19,7 +19,7 @@
         <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd.0))</BUILD_BUILDNUMBER>
         <!-- Remove .DRAFT suffix if it exists in the build number -->
         <FSharpPackageVersion>$(FSharpProductVersion).$(BUILD_BUILDNUMBER.Replace(".DRAFT", ""))</FSharpPackageVersion>
-        <!-- FSharpPackageVersion should be {F# version}.{today's date}.{build number}. Example: 4.1.20160901.3 -->
+        <!-- FSharpPackageVersion should be {F# version}.{today's date}.{build number}. Example: 15.6.20160901.3 -->
     </PropertyGroup>
 
     <PropertyGroup>

--- a/setup/Swix/Microsoft.FSharp.vsmanproj
+++ b/setup/Swix/Microsoft.FSharp.vsmanproj
@@ -10,6 +10,7 @@
         <IsPackage>true</IsPackage>
         <OutputPath>$(FSharpSourcesRoot)\..\$(Configuration)\insertion</OutputPath>
         <InsertionDir>$(OutputPath)</InsertionDir>
+        <ManifestBuildVersion>$(FSharpPackageVersion)</ManifestBuildVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
To help make our internal automation easier, we need to publish a version number with the insertion component.  The net result of this is the `release\insertion\Microsoft.FSharp.vsman` file will be modified to this:

``` javascript
{
  // ...
  "info": {
    // ...
    "buildVersion": "15.7.20180621.0", // <-- added this line
    // ...
  }
  // ...
}
```

See dotnet/roslyn-tools#280.

Internal verification build has completed and the new property is present.