### PR TITLE
Ref scoping

### DIFF
--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
@@ -4353,7 +4353,7 @@ type internal SR private() =
     static member chkNoSpanLikeValueFromExpression() = (3237, GetStringFunc("chkNoSpanLikeValueFromExpression",",,,") )
     /// Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
     /// (Originally from ..\FSComp.txt:1442)
-    static member tcCantTakeAddressOfExpression() = (3238, GetStringFunc("tcCantTakeAddressOfExpression",",,,") )
+    static member tastCantTakeAddressOfExpression() = (3238, GetStringFunc("tastCantTakeAddressOfExpression",",,,") )
 
     /// Call this method once to validate that all known resources are valid; throws if not
     static member RunStartupValidation() =
@@ -5769,5 +5769,5 @@ type internal SR private() =
         ignore(GetString("chkNoByrefLikeFunctionCall"))
         ignore(GetString("chkNoSpanLikeVariable"))
         ignore(GetString("chkNoSpanLikeValueFromExpression"))
-        ignore(GetString("tcCantTakeAddressOfExpression"))
+        ignore(GetString("tastCantTakeAddressOfExpression"))
         ()

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
@@ -4351,6 +4351,9 @@ type internal SR private() =
     /// A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.
     /// (Originally from ..\FSComp.txt:1441)
     static member chkNoSpanLikeValueFromExpression() = (3237, GetStringFunc("chkNoSpanLikeValueFromExpression",",,,") )
+    /// Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+    /// (Originally from ..\FSComp.txt:1442)
+    static member tcCantTakeAddressOfExpression() = (3238, GetStringFunc("tcCantTakeAddressOfExpression",",,,") )
 
     /// Call this method once to validate that all known resources are valid; throws if not
     static member RunStartupValidation() =
@@ -5766,4 +5769,5 @@ type internal SR private() =
         ignore(GetString("chkNoByrefLikeFunctionCall"))
         ignore(GetString("chkNoSpanLikeVariable"))
         ignore(GetString("chkNoSpanLikeValueFromExpression"))
+        ignore(GetString("tcCantTakeAddressOfExpression"))
         ()

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
@@ -4354,7 +4354,7 @@
   <data name="chkNoSpanLikeValueFromExpression" xml:space="preserve">
     <value>A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</value>
   </data>
-  <data name="tcCantTakeAddressOfExpression" xml:space="preserve">
+  <data name="tastCantTakeAddressOfExpression" xml:space="preserve">
     <value>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</value>
   </data>
 </root>

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
@@ -4354,4 +4354,7 @@
   <data name="chkNoSpanLikeValueFromExpression" xml:space="preserve">
     <value>A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</value>
   </data>
+  <data name="tcCantTakeAddressOfExpression" xml:space="preserve">
+    <value>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</value>
+  </data>
 </root>

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1439,4 +1439,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3235,chkNoByrefLikeFunctionCall,"The function or method call cannot be used at this point, because one argument that is a byref of a non-stack-local Span or IsByRefLike type is used with another argument that is a stack-local Span or IsByRefLike type. This is to ensure the address of the local value does not escape its scope."
 3236,chkNoSpanLikeVariable,"The Span or IsByRefLike variable '%s' cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
 3237,chkNoSpanLikeValueFromExpression,"A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope."
-3238,tcCantTakeAddressOfExpression,"Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address."
+3238,tastCantTakeAddressOfExpression,"Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1439,3 +1439,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3235,chkNoByrefLikeFunctionCall,"The function or method call cannot be used at this point, because one argument that is a byref of a non-stack-local Span or IsByRefLike type is used with another argument that is a stack-local Span or IsByRefLike type. This is to ensure the address of the local value does not escape its scope."
 3236,chkNoSpanLikeVariable,"The Span or IsByRefLike variable '%s' cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
 3237,chkNoSpanLikeValueFromExpression,"A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope."
+3238,tcCantTakeAddressOfExpression,"Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address."

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -134,10 +134,14 @@ let AdjustCalledArgType (infoReader:InfoReader) isConstraint (calledArg: CalledA
 
         // If the called method argument is an inref type, then the caller may provide a byref or value
         if isInByrefTy g calledArgTy then
+#if IMPLICIT_ADDRESS_OF
             if isByrefTy g callerArgTy then 
                 calledArgTy
             else 
                 destByrefTy g calledArgTy
+#else
+            calledArgTy
+#endif
 
         // If the called method argument is a (non inref) byref type, then the caller may provide a byref or ref.
         elif isByrefTy g calledArgTy then

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -733,7 +733,7 @@ and CheckCallLimitArgs cenv m (returnTy: TType) limitArgs (context: PermitByRefE
          HasLimitFlag LimitFlags.LocalByRefOfStackReferringSpanLike limitArgs)
 
     if cenv.reportErrors then
-        if context.PermitOnlyReturnable && (isReturnLimitedByRef || isReturnLimitedSpanLike) then
+        if context.PermitOnlyReturnable && (isReturnLimitedByRef || isReturnLimitedSpanLike) && limitArgs.maxScope >= cenv.scope then
             if isReturnLimitedSpanLike then
                 errorR(Error(FSComp.SR.chkNoSpanLikeValueFromExpression(), m))
             else

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -842,9 +842,9 @@ and CheckExpr (cenv:cenv) (env:env) origExpr (context:PermitByRefExpr) : Limit =
             NoLimit
 
     | Expr.Let ((TBind(v,_,_) as bind),body,_,_) ->  
-        let limit = CheckBinding cenv env false bind  
+        let limit = CheckBinding { cenv with scope = cenv.scope + 1 } env false bind  
         BindVal cenv env v
-        LimitVal cenv v { limit with maxScope = cenv.scope }
+        LimitVal cenv v { limit with maxScope = if limit.flags = LimitFlags.None then cenv.scope else limit.maxScope }
         CheckExpr cenv env body context
 
     | Expr.Const (_,m,ty) -> 
@@ -1370,7 +1370,7 @@ and CheckLambdas isTop (memInfo: ValMemberInfo option) cenv env inlined topValIn
         let limit = 
             if not inlined && (isByrefLikeTy g m ety || isNativePtrTy g ety) then
                 // allow byref to occur as RHS of byref binding. 
-                CheckExprPermitByRefLike cenv env e
+                CheckExprPermitReturnableByRef cenv env e
             else 
                 CheckExprNoByrefs cenv env e
                 NoLimit

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -739,10 +739,8 @@ and CheckCallLimitArgs cenv env m returnTy limitArgs (context: PermitByRefExpr) 
         (HasLimitFlag LimitFlags.StackReferringSpanLike limitArgs ||
          HasLimitFlag LimitFlags.ByRefOfStackReferringSpanLike limitArgs)
 
-    let hasPotentialByRefEscapeScope = limitArgs.scope >= env.returnScope
-
     if cenv.reportErrors then
-        if context.PermitOnlyReturnable && ((isReturnLimitedByRef && hasPotentialByRefEscapeScope) || isReturnLimitedSpanLike) then
+        if context.PermitOnlyReturnable && ((isReturnLimitedByRef && limitArgs.scope >= env.returnScope) || isReturnLimitedSpanLike) then
             if isReturnLimitedSpanLike then
                 errorR(Error(FSComp.SR.chkNoSpanLikeValueFromExpression(), m))
             else

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -789,7 +789,7 @@ and CheckCallLimitArgs cenv env m returnTy limitArgs (context: PermitByRefExpr) 
             { limitArgs with flags = LimitFlags.ByRef }
 
     elif isReturnLimitedSpanLike then
-        { scope = env.returnScope; flags = LimitFlags.StackReferringSpanLike }
+        { scope = 1; flags = LimitFlags.StackReferringSpanLike }
 
     elif isReturnByref then
         if isSpanLikeTy cenv.g m (destByrefTy cenv.g returnTy) then
@@ -798,10 +798,10 @@ and CheckCallLimitArgs cenv env m returnTy limitArgs (context: PermitByRefExpr) 
             { limitArgs with flags = LimitFlags.ByRef }
 
     elif isReturnSpanLike then
-        { scope = env.returnScope; flags = LimitFlags.SpanLike }
+        { scope = 1; flags = LimitFlags.SpanLike }
 
     else
-        { scope = env.returnScope; flags = LimitFlags.None }
+        { scope = 1; flags = LimitFlags.None }
 
 /// Check call arguments, including the return argument.
 and CheckCall cenv env m returnTy args contexts context =
@@ -1168,11 +1168,11 @@ and CheckExprOp cenv env (op,tyargs,args,m) context expr =
                 else
                     errorR(Error(FSComp.SR.chkNoSpanLikeVariable(vref.DisplayName), m))
 
-            { limit with flags = LimitFlags.StackReferringSpanLike }
+            { scope = 1; flags = LimitFlags.StackReferringSpanLike }
         elif HasLimitFlag LimitFlags.ByRefOfSpanLike limit then
-            { limit with flags = LimitFlags.SpanLike }
+            { scope = 1; flags = LimitFlags.SpanLike }
         else
-            { limit with flags = LimitFlags.None }
+            { scope = 1; flags = LimitFlags.None }
 
     | TOp.LValueOp(LSet _, vref),_,[arg] -> 
         let isVrefLimited = not (HasLimitFlag LimitFlags.StackReferringSpanLike (GetLimitVal cenv env m vref.Deref))

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -227,7 +227,7 @@ let GetLimitVal cenv env m (v: Val) =
         | true, limit -> limit
         | _ ->
             if IsValLocal env v then
-                { scope = env.returnScope; flags = LimitFlags.None }
+                { scope = 1; flags = LimitFlags.None }
             else
                 NoLimit
 
@@ -873,15 +873,14 @@ and CheckExpr (cenv:cenv) (env:env) origExpr (context:PermitByRefExpr) : Limit =
         let isByRef = isByrefTy cenv.g v.Type
 
         let bindingContext =
-            // Don't apply scoped returns on binding for compiler generated values.
-            if isByRef && not v.IsCompilerGenerated then
+            if isByRef then
                 PermitByRefExpr.YesReturnable
             else
                 PermitByRefExpr.Yes
 
         let limit = CheckBinding cenv { env with returnScope = env.returnScope + 1 } false bindingContext bind  
         BindVal cenv env v
-        LimitVal cenv v { limit with scope = if v.IsCompilerGenerated then 1 elif isByRef then limit.scope else env.returnScope }
+        LimitVal cenv v { limit with scope = if isByRef then limit.scope else env.returnScope }
         CheckExpr cenv env body context
 
     | Expr.Const (_,m,ty) -> 

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -1797,7 +1797,7 @@ let CheckModuleBinding cenv env (TBind(v,e,_) as bind) =
         with e -> errorRecovery e v.Range 
     end
 
-    CheckBinding cenv { env with returnScope = env.returnScope + 1 } true PermitByRefExpr.Yes bind |> ignore
+    CheckBinding cenv { env with returnScope = 1 } true PermitByRefExpr.Yes bind |> ignore
 
 let CheckModuleBindings cenv env binds = 
     binds |> List.iter (CheckModuleBinding cenv env)

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -845,17 +845,17 @@ and CheckExpr (cenv:cenv) (env:env) origExpr (context:PermitByRefExpr) : Limit =
             CheckExprNoByrefs cenv {env with ctorLimitedZone=false} e2
             NoLimit
 
-    | Expr.Let ((TBind(v,bindRhs,_) as bind),body,_,_) ->
+    | Expr.Let ((TBind(v,_bindRhs,_) as bind),body,_,_) ->
         let isByRef = isByrefTy cenv.g v.Type
 
         let bindingContext =
             if isByRef then
-                let isRhsCompilerGenerated =
-                    match bindRhs with
-                    | Expr.Let((TBind(v,_,_)),_,_,_) -> v.IsCompilerGenerated
-                    | _ -> false
+                //let isRhsCompilerGenerated =
+                //    match bindRhs with
+                //    | Expr.Let((TBind(v,_,_)),_,_,_) -> v.IsCompilerGenerated
+                //    | _ -> false
 
-                if isRhsCompilerGenerated || v.IsCompilerGenerated then
+                if v.IsCompilerGenerated then
                     PermitByRefExpr.Yes
                 else
                     PermitByRefExpr.YesReturnable

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -854,12 +854,9 @@ and CheckExpr (cenv:cenv) (env:env) origExpr (context:PermitByRefExpr) : Limit =
         let isByRef = isByrefTy cenv.g v.Type
 
         let bindingContext =
-            if isByRef then
-                // Don't apply scoped returns for compiler generated values.
-                if v.IsCompilerGenerated then
-                    PermitByRefExpr.Yes
-                else
-                    PermitByRefExpr.YesReturnable
+            // Don't apply scoped returns on binding for compiler generated values.
+            if isByRef && not v.IsCompilerGenerated then
+                PermitByRefExpr.YesReturnable
             else
                 PermitByRefExpr.Yes
 

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -881,7 +881,7 @@ and CheckExpr (cenv:cenv) (env:env) origExpr (context:PermitByRefExpr) : Limit =
 
         let limit = CheckBinding cenv { env with returnScope = env.returnScope + 1 } false bindingContext bind  
         BindVal cenv env v
-        LimitVal cenv v { limit with scope = if isByRef then limit.scope else env.returnScope }
+        LimitVal cenv v { limit with scope = if v.IsCompilerGenerated then 1 elif isByRef then limit.scope else env.returnScope }
         CheckExpr cenv env body context
 
     | Expr.Const (_,m,ty) -> 

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -105,7 +105,7 @@ type env =
       /// Are we in an extern declaration?
       external : bool 
     
-      /// Current scope of the expr.
+      /// Current return scope of the expr.
       returnScope : int } 
 
 let BindTypar env (tp:Typar) = 
@@ -850,11 +850,7 @@ and CheckExpr (cenv:cenv) (env:env) origExpr (context:PermitByRefExpr) : Limit =
 
         let bindingContext =
             if isByRef then
-                //let isRhsCompilerGenerated =
-                //    match bindRhs with
-                //    | Expr.Let((TBind(v,_,_)),_,_,_) -> v.IsCompilerGenerated
-                //    | _ -> false
-
+                // Don't apply scoped returns for compiler generated values.
                 if v.IsCompilerGenerated then
                     PermitByRefExpr.Yes
                 else
@@ -1437,7 +1433,7 @@ and CheckDecisionTree cenv env x =
     | TDSuccess (es,_) -> 
         CheckExprsNoByRefLike cenv env es |> ignore
     | TDBind(bind,rest) -> 
-        CheckBinding cenv env false PermitByRefExpr.YesReturnable bind |> ignore
+        CheckBinding cenv env false PermitByRefExpr.Yes bind |> ignore
         CheckDecisionTree cenv env rest 
     | TDSwitch (e,cases,dflt,m) -> 
         CheckDecisionTreeSwitch cenv env (e,cases,dflt,m)

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -233,7 +233,7 @@ let GetLimitVal cenv env m (v: Val) =
 
     if isSpanLikeTy cenv.g m v.Type then
         // The value is a limited Span or might have become one through mutation
-        let isMutable = v.IsMutable //&& cenv.isInternalTestSpanStackReferring
+        let isMutable = v.IsMutable && cenv.isInternalTestSpanStackReferring
         let isLimited = HasLimitFlag LimitFlags.StackReferringSpanLike limit
 
         if isMutable || isLimited then
@@ -795,7 +795,7 @@ and CheckCallLimitArgs cenv env m returnTy limitArgs (context: PermitByRefExpr) 
         if isSpanLikeTy cenv.g m (destByrefTy cenv.g returnTy) then
             { limitArgs with flags = LimitFlags.ByRefOfSpanLike }
         else
-            { limitArgs with flags = LimitFlags.None }
+            { limitArgs with flags = LimitFlags.ByRef }
 
     elif isReturnSpanLike then
         { scope = env.returnScope; flags = LimitFlags.SpanLike }

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -5864,7 +5864,9 @@ let rec mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress 
             if isStructTy g ty then 
                 match mut with 
                 | NeverMutates -> ()
-                | AddressOfOp -> () // we get an inref
+                | AddressOfOp -> 
+                    // we get an inref
+                    errorR(Error(FSComp.SR.tastCantTakeAddressOfExpression(), m))
                 | DefinitelyMutates -> 
                     // Give a nice error message for mutating something we can't take the address of
                     errorR(Error(FSComp.SR.tastInvalidMutationOfConstant(), m))

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4011,7 +4011,8 @@ let buildApp cenv expr resultTy arg m =
                 match arg with
                 | Expr.Val _
                 | Expr.Op(TOp.LValueOp(LByrefGet _, _), _, _, _)
-                | Expr.Let(_, Expr.Op(TOp.LValueOp(LByrefGet _, _), _, _, _), _, _) -> ()
+                | Expr.Let(_, Expr.Op(TOp.LValueOp(LByrefGet _, _), _, _, _), _, _)
+                | Expr.Let(_, Expr.Let(_, Expr.Op(TOp.LValueOp(LByrefGet _, _), _, _, _), _, _), _, _) -> ()
                 | _ -> 
                     errorR(Error(FSComp.SR.tcCantTakeAddressOfExpression(), m))
 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4007,6 +4007,14 @@ let buildApp cenv expr resultTy arg m =
         let resultTy = 
             let argTy = tyOfExpr g arg
             if readonly then
+
+                match arg with
+                | Expr.Val _
+                | Expr.Op(TOp.LValueOp(LByrefGet _, _), _, _, _)
+                | Expr.Let(_, Expr.Op(TOp.LValueOp(LByrefGet _, _), _, _, _), _, _) -> ()
+                | _ -> 
+                    errorR(Error(FSComp.SR.tcCantTakeAddressOfExpression(), arg.Range))
+
                 mkInByrefTy g argTy
 
             // "`outref<'T>` types are never introduced implicitly by F#.", see rationale in RFC FS-1053

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -4013,7 +4013,7 @@ let buildApp cenv expr resultTy arg m =
                 | Expr.Op(TOp.LValueOp(LByrefGet _, _), _, _, _)
                 | Expr.Let(_, Expr.Op(TOp.LValueOp(LByrefGet _, _), _, _, _), _, _) -> ()
                 | _ -> 
-                    errorR(Error(FSComp.SR.tcCantTakeAddressOfExpression(), arg.Range))
+                    errorR(Error(FSComp.SR.tcCantTakeAddressOfExpression(), m))
 
                 mkInByrefTy g argTy
 

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCantTakeAddressOfExpression">
+        <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
+        <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -7057,7 +7057,7 @@
         <target state="new">A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCantTakeAddressOfExpression">
+      <trans-unit id="tastCantTakeAddressOfExpression">
         <source>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</source>
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />

--- a/tests/fsharp/core/byrefs/test.bsl
+++ b/tests/fsharp/core/byrefs/test.bsl
@@ -43,6 +43,6 @@ test.fsx(66,34,66,47): typecheck error FS1204: This construct is for use in the 
 
 test.fsx(66,34,66,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
-test.fsx(71,22,71,23): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+test.fsx(71,21,71,23): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
-test.fsx(72,22,72,23): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+test.fsx(72,21,72,23): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.

--- a/tests/fsharp/core/byrefs/test.bsl
+++ b/tests/fsharp/core/byrefs/test.bsl
@@ -46,3 +46,10 @@ test.fsx(66,34,66,47): typecheck error FS1204: This construct is for use in the 
 test.fsx(71,21,71,23): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 test.fsx(72,21,72,23): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
+test.fsx(78,21,78,37): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
+test.fsx(85,22,85,23): typecheck error FS0001: This expression was expected to have type
+    'inref<System.DateTime>'    
+but here has type
+    'System.DateTime'    

--- a/tests/fsharp/core/byrefs/test.bsl
+++ b/tests/fsharp/core/byrefs/test.bsl
@@ -42,3 +42,7 @@ The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 test.fsx(66,34,66,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
 
 test.fsx(66,34,66,47): typecheck error FS1204: This construct is for use in the FSharp.Core library and should not be used directly
+
+test.fsx(71,22,71,23): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
+test.fsx(72,22,72,23): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.

--- a/tests/fsharp/core/byrefs/test.fsx
+++ b/tests/fsharp/core/byrefs/test.fsx
@@ -63,59 +63,7 @@ module ByrefNegativeTests =
 
     module UseOfLibraryOnly =
         type C() = 
-            static member f1 (x: byref<'T, 'U>) = 1
-
-    module Scoping =
-
-        let test1 doIt =
-            let mutable x = 42
-            let r =
-                if doIt then
-                    let mutable y = 1
-                    &y // not allowed
-                else
-                    &x
-
-            let c = 
-                if doIt then
-                    let mutable z = 2
-                    &z // not allowed
-                else
-                    &x
-
-            x + r + c
-
-        let test2 () =
-            let x =
-                let mutable x = 1
-                &x // not allowed
-
-            let y =
-                let mutable y = 2
-                &y // not allowed
-
-            x + y
-
-        let test3 () =
-            let x = &1 // not allowed
-            let y = &2 // not allowed
-            x + y
-
-        let test4 doIt =
-            let mutable x = 1
-            if doIt then
-                &x // not allowed
-            else
-                &1 // not allowed
-
-        let test5 doIt =
-            let mutable x = 1
-            let y =
-                if doIt then
-                    &x
-                else
-                    &1 // not allowed
-            &y // not allowed            
+            static member f1 (x: byref<'T, 'U>) = 1         
 #endif
 
 // Test a simple ref  argument

--- a/tests/fsharp/core/byrefs/test.fsx
+++ b/tests/fsharp/core/byrefs/test.fsx
@@ -48,8 +48,8 @@ module ByrefNegativeTests =
 
     module InRefToOutRefClassMethod =
         type C() = 
-            static member f1 (x: outref<'T>) = 1 // not allowed
-        let f2 (x: inref<'T>) = C.f1 &x
+            static member f1 (x: outref<'T>) = 1 // not allowed (not yet)
+        let f2 (x: inref<'T>) = C.f1 &x // not allowed
 
     module InRefToByRefClassMethod2 = 
         type C() = 
@@ -58,12 +58,64 @@ module ByrefNegativeTests =
 
     module InRefToOutRefClassMethod2 =
         type C() = 
-            static member f1 (x: outref<'T>) = 1 // not allowed
-        let f2 (x: inref<'T>) = C.f1(&x)
+            static member f1 (x: outref<'T>) = 1 // not allowed (not yet)
+        let f2 (x: inref<'T>) = C.f1(&x) // not allowed
 
     module UseOfLibraryOnly =
         type C() = 
-            static member f1 (x: byref<'T, 'U>) = 1            
+            static member f1 (x: byref<'T, 'U>) = 1
+
+    module Scoping =
+
+        let test1 doIt =
+            let mutable x = 42
+            let r =
+                if doIt then
+                    let mutable y = 1
+                    &y // not allowed
+                else
+                    &x
+
+            let c = 
+                if doIt then
+                    let mutable z = 2
+                    &z // not allowed
+                else
+                    &x
+
+            x + r + c
+
+        let test2 () =
+            let x =
+                let mutable x = 1
+                &x // not allowed
+
+            let y =
+                let mutable y = 2
+                &y // not allowed
+
+            x + y
+
+        let test3 () =
+            let x = &1 // not allowed
+            let y = &2 // not allowed
+            x + y
+
+        let test4 doIt =
+            let mutable x = 1
+            if doIt then
+                &x // not allowed
+            else
+                &1 // not allowed
+
+        let test5 doIt =
+            let mutable x = 1
+            let y =
+                if doIt then
+                    &x
+                else
+                    &1 // not allowed
+            &y // not allowed            
 #endif
 
 // Test a simple ref  argument

--- a/tests/fsharp/core/byrefs/test.fsx
+++ b/tests/fsharp/core/byrefs/test.fsx
@@ -71,6 +71,19 @@ module ByrefNegativeTests =
             let x = &1 // not allowed
             let y = &2 // not allowed
             x + y
+
+        let test2_helper (x: byref<int>) = x
+        let test2 () =
+            let mutable x = 1
+            let y = &test2_helper &x // not allowed
+            ()
+
+    module InRefParam_DateTime = 
+        type C() = 
+            static member M(x: inref<System.DateTime>) = x
+        let w = System.DateTime.Now
+        let v =  C.M(w) // not allowed
+        check "cweweoiwe51btw" v w
              
 #endif
 
@@ -330,7 +343,7 @@ module InRefParamOverload_ImplicitAddressOfAtCallSite2  =
         check "cweweoiwe51btw2" v2 (res.AddDays(1.0))
     Test()
 
-
+#if IMPLICIT_ADDRESS_OF
 module InRefParam_DateTime   = 
     type C() = 
          static member M(x: inref<System.DateTime>) = x
@@ -364,6 +377,7 @@ module InRefParam_DateTime_ImplicitAddressOfAtCallSite4  =
     let w = [| date |]
     let v =  C.M(w.[0])
     check "lmvjvwo1" v date
+#endif
 
 module InRefParam_Generic_ExplicitAddressOfAttCallSite1 = 
     type C() = 

--- a/tests/fsharp/core/byrefs/test.fsx
+++ b/tests/fsharp/core/byrefs/test.fsx
@@ -63,7 +63,15 @@ module ByrefNegativeTests =
 
     module UseOfLibraryOnly =
         type C() = 
-            static member f1 (x: byref<'T, 'U>) = 1         
+            static member f1 (x: byref<'T, 'U>) = 1
+
+    module CantTakeAddress =
+
+        let test1 () =
+            let x = &1 // not allowed
+            let y = &2 // not allowed
+            x + y
+             
 #endif
 
 // Test a simple ref  argument

--- a/tests/fsharp/core/byrefs/test2.bsl
+++ b/tests/fsharp/core/byrefs/test2.bsl
@@ -7,24 +7,20 @@ test2.fsx(45,14,45,15): typecheck error FS3209: The address of the variable 'x' 
 
 test2.fsx(49,14,49,15): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(54,17,54,19): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(56,14,56,15): typecheck error FS3209: The address of the variable 'x' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(55,17,55,19): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(59,14,59,15): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(61,14,61,15): typecheck error FS3209: The address of the variable 'x' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(68,18,68,19): typecheck error FS3209: The address of the variable 'z' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(63,13,63,15): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(69,10,69,11): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(71,17,71,19): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(79,14,79,28): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(72,10,72,11): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(87,14,87,28): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(82,14,82,28): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(93,28,93,29): typecheck error FS0421: The address of the variable 'x' cannot be used at this point
 
-test2.fsx(90,14,90,28): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(93,17,93,29): typecheck error FS0425: The type of a first-class function cannot contain byrefs
 
-test2.fsx(96,28,96,29): typecheck error FS0421: The address of the variable 'x' cannot be used at this point
-
-test2.fsx(96,17,96,29): typecheck error FS0425: The type of a first-class function cannot contain byrefs
-
-test2.fsx(96,17,96,29): typecheck error FS0425: The type of a first-class function cannot contain byrefs
+test2.fsx(93,17,93,29): typecheck error FS0425: The type of a first-class function cannot contain byrefs

--- a/tests/fsharp/core/byrefs/test2.bsl
+++ b/tests/fsharp/core/byrefs/test2.bsl
@@ -1,0 +1,20 @@
+
+test2.fsx(29,18,29,19): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(36,18,36,19): typecheck error FS3209: The address of the variable 'z' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(45,14,45,15): typecheck error FS3209: The address of the variable 'x' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(49,14,49,15): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(54,17,54,19): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(55,17,55,19): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(61,14,61,15): typecheck error FS3209: The address of the variable 'x' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(63,13,63,15): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(71,17,71,19): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(72,10,72,11): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.

--- a/tests/fsharp/core/byrefs/test2.bsl
+++ b/tests/fsharp/core/byrefs/test2.bsl
@@ -15,9 +15,9 @@ test2.fsx(68,18,68,19): typecheck error FS3209: The address of the variable 'z' 
 
 test2.fsx(69,10,69,11): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(79,14,79,28): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(79,14,79,29): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(87,14,87,28): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+test2.fsx(87,14,87,29): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
 test2.fsx(93,28,93,29): typecheck error FS0421: The address of the variable 'x' cannot be used at this point
 

--- a/tests/fsharp/core/byrefs/test2.bsl
+++ b/tests/fsharp/core/byrefs/test2.bsl
@@ -18,3 +18,13 @@ test2.fsx(63,13,63,15): typecheck error FS3228: The address of a value returned 
 test2.fsx(71,17,71,19): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
 test2.fsx(72,10,72,11): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(82,14,82,28): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(90,14,90,28): typecheck error FS3228: The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(96,28,96,29): typecheck error FS0421: The address of the variable 'x' cannot be used at this point
+
+test2.fsx(96,17,96,29): typecheck error FS0425: The type of a first-class function cannot contain byrefs
+
+test2.fsx(96,17,96,29): typecheck error FS0425: The type of a first-class function cannot contain byrefs

--- a/tests/fsharp/core/byrefs/test2.fsx
+++ b/tests/fsharp/core/byrefs/test2.fsx
@@ -76,7 +76,7 @@ module NegativeTests =
 
         let y =
             let x = 1
-            &Coolio.Cool(x) // not allowed
+            &Coolio.Cool(&x) // not allowed
 
         () 
 
@@ -84,7 +84,7 @@ module NegativeTests =
 
         let y =
             let mutable x = 1
-            &Coolio.Cool(x) // not allowed
+            &Coolio.Cool(&x) // not allowed
 
         () 
 

--- a/tests/fsharp/core/byrefs/test2.fsx
+++ b/tests/fsharp/core/byrefs/test2.fsx
@@ -1,0 +1,79 @@
+#if TESTS_AS_APP
+module Core_byrefs
+#endif
+
+let failures = ref false
+let report_failure (s) = 
+  stderr.WriteLine ("NO: " + s); failures := true
+let test s b = if b then () else report_failure(s) 
+
+(* TEST SUITE FOR Int32 *)
+
+let out r (s:string) = r := !r @ [s]
+
+let check s actual expected = 
+    if actual = expected then printfn "%s: OK" s
+    else report_failure (sprintf "%s: FAILED, expected %A, got %A" s expected actual)
+
+let check2 s expected actual = check s actual expected
+
+// POST INFERENCE CHECKS
+#if NEGATIVE
+module NegativeScoping =
+
+    let test1 doIt =
+        let mutable x = 42
+        let r =
+            if doIt then
+                let mutable y = 1
+                &y // not allowed
+            else
+                &x
+
+        let c = 
+            if doIt then
+                let mutable z = 2
+                &z // not allowed
+            else
+                &x
+
+        x + r + c
+
+    let test2 () =
+        let x =
+            let mutable x = 1
+            &x // not allowed
+
+        let y =
+            let mutable y = 2
+            &y // not allowed
+
+        x + y
+
+    let test3 () =
+        let x = &1 // not allowed
+        let y = &2 // not allowed
+        x + y
+
+    let test4 doIt =
+        let mutable x = 1
+        if doIt then
+            &x // not allowed
+        else
+            &1 // not allowed
+
+    let test5 doIt =
+        let mutable x = 1
+        let y =
+            if doIt then
+                &x
+            else
+                &1 // not allowed
+        &y // not allowed 
+#endif
+
+let aa =
+  if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
+  else (stdout.WriteLine "Test Passed"; 
+        System.IO.File.WriteAllText("test2.ok","ok"); 
+        exit 0)

--- a/tests/fsharp/core/byrefs/test2.fsx
+++ b/tests/fsharp/core/byrefs/test2.fsx
@@ -50,32 +50,29 @@ module NegativeTests =
 
         x + y
 
-    let test3 () =
-        let x = &1 // not allowed
-        let y = &2 // not allowed
-        x + y
-
-    let test4 doIt =
+    let test3 doIt =
         let mutable x = 1
         if doIt then
             &x // not allowed
         else
-            &1 // not allowed
+            let mutable y = 1
+            &y // not allowed
 
-    let test5 doIt =
+    let test4 doIt =
         let mutable x = 1
         let y =
             if doIt then
                 &x
             else
-                &1 // not allowed
+                let mutable z = 1
+                &z // not allowed
         &y // not allowed
 
     type Coolio() =
 
         static member Cool(x: inref<int>) = &x
 
-    let test6 () =
+    let test5 () =
 
         let y =
             let x = 1
@@ -83,7 +80,7 @@ module NegativeTests =
 
         () 
 
-    let test7 () =
+    let test6 () =
 
         let y =
             let mutable x = 1
@@ -91,7 +88,7 @@ module NegativeTests =
 
         () 
 
-    let test8 () =
+    let test7 () =
         let mutable x = 1
         let f = fun () -> &x // not allowed
         

--- a/tests/fsharp/core/span/test.fsx
+++ b/tests/fsharp/core/span/test.fsx
@@ -105,16 +105,16 @@ namespace Tests
         let SafeSum6(bytes: ReadOnlySpan<byte>) =
             let mutable sum = 0
             for i in 0 .. bytes.Length - 1 do 
-                let byteAddr = &bytes.[i]
-                sum <- sum + int byteAddr
+                let byte = bytes.[i]
+                sum <- sum + int byte
             sum
 
         let SafeSum7(bytes: ReadOnlyMemory<byte>) =
             let bytes = bytes.Span
             let mutable sum = 0
             for i in 0 .. bytes.Length - 1 do 
-                let byteAddr = &bytes.[i]
-                sum <- sum + int byteAddr
+                let byte = bytes.[i]
+                sum <- sum + int byte
             sum
 
         let SafeSum8(bytes: ReadOnlyMemory<byte>) =

--- a/tests/fsharp/core/span/test2.bsl
+++ b/tests/fsharp/core/span/test2.bsl
@@ -50,3 +50,5 @@ test2.fsx(167,14,167,71): typecheck error FS3228: The address of a value returne
 test2.fsx(191,43,191,44): typecheck error FS3209: The address of the variable 'x' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
 test2.fsx(195,14,195,15): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(199,13,199,19): typecheck error FS3230: This value can't be assigned because the target 'x' may refer to non-stack-local memory, while the expression being assigned is assessed to potentially refer to stack-local memory. This is to help prevent pointers to stack-bound memory escaping their scope.

--- a/tests/fsharp/core/span/test2.fsx
+++ b/tests/fsharp/core/span/test2.fsx
@@ -326,3 +326,17 @@ namespace Tests
         let should_work28 (s: Span<int>) =
             let y = &s.[0]
             &y
+
+        let should_work29_helper (x: Span<int>) (y: byref<int>) = &y
+
+        let should_work29 () =
+            let yopac =
+                let mutable s = Span.Empty
+                &should_work29_helper s &beef // this looks like it's out of scope, but this is coming from a stack referring span-like type.
+            ()
+
+        let should_work30 () =
+            let yopac =
+                let mutable s = Span.Empty
+                &s.[0] // this looks like it's out of scope, but this is coming from a stack referring span-like type.
+            ()

--- a/tests/fsharp/core/span/test2.fsx
+++ b/tests/fsharp/core/span/test2.fsx
@@ -194,6 +194,10 @@ namespace Tests
             let y = &x
             &y
 
+        let should_not_work35 (x: byref<Span<int>>) =
+            let mutable y = Span.Empty
+            x <- y
+
 #endif
 
         let should_work1 () =

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -205,6 +205,18 @@ module CoreTests =
             testOkFile.CheckExists()
         end
 
+        begin
+            use testOkFile = fileguard cfg "test2.ok"
+
+            fsc cfg "%s -o:test2.exe -g" cfg.fsc_flags ["test2.fsx"]
+
+            singleNegTest cfg "test2"
+
+            exec cfg ("." ++ "test2.exe") ""
+
+            testOkFile.CheckExists()
+        end
+
     [<Test>]
     let span () = 
 

--- a/tests/fsharp/typecheck/sigs/neg106.bsl
+++ b/tests/fsharp/typecheck/sigs/neg106.bsl
@@ -38,6 +38,8 @@ is not compatible with type
     'byref<'a>'    
 .
 
+neg106.fs(17,59,17,61): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(17,14,17,68): typecheck error FS0041: No overloads match for method 'CompareExchange'. The available overloads are shown below.
 neg106.fs(17,14,17,68): typecheck error FS0041: Possible overload: 'System.Threading.Interlocked.CompareExchange(location1: byref<int>, value: int, comparand: int) : int'. Type constraint mismatch. The type 
     'inref<int>'    
@@ -133,6 +135,8 @@ but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
+neg106.fs(94,35,94,39): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(94,35,94,39): typecheck error FS0001: Type mismatch. Expecting a
     'byref<int>'    
 but given a
@@ -146,6 +150,8 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(102,37,102,40): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(102,36,102,40): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(102,36,102,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
@@ -161,6 +167,8 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(112,39,112,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(112,38,112,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(112,38,112,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -174,6 +182,8 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(122,39,122,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(122,38,122,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(122,38,122,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
@@ -189,6 +199,8 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(132,39,132,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(132,38,132,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(132,38,132,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -202,6 +214,8 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(142,39,142,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(142,38,142,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(142,38,142,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    

--- a/tests/fsharp/typecheck/sigs/neg106.bsl
+++ b/tests/fsharp/typecheck/sigs/neg106.bsl
@@ -135,8 +135,6 @@ but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-neg106.fs(94,35,94,39): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
-
 neg106.fs(94,35,94,39): typecheck error FS0001: Type mismatch. Expecting a
     'byref<int>'    
 but given a
@@ -150,8 +148,6 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(102,37,102,40): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
-
-neg106.fs(102,36,102,40): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(102,36,102,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
@@ -167,8 +163,6 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(112,39,112,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
-neg106.fs(112,38,112,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
-
 neg106.fs(112,38,112,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -182,8 +176,6 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(122,39,122,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
-
-neg106.fs(122,38,122,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(122,38,122,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
@@ -199,8 +191,6 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(132,39,132,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
-neg106.fs(132,38,132,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
-
 neg106.fs(132,38,132,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -214,8 +204,6 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(142,39,142,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
-
-neg106.fs(142,38,142,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(142,38,142,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    

--- a/tests/fsharp/typecheck/sigs/neg106.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg106.vsbsl
@@ -38,6 +38,8 @@ is not compatible with type
     'byref<'a>'    
 .
 
+neg106.fs(17,59,17,61): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(17,14,17,68): typecheck error FS0041: No overloads match for method 'CompareExchange'. The available overloads are shown below.
 neg106.fs(17,14,17,68): typecheck error FS0041: Possible overload: 'System.Threading.Interlocked.CompareExchange(location1: byref<int>, value: int, comparand: int) : int'. Type constraint mismatch. The type 
     'inref<int>'    
@@ -133,6 +135,8 @@ but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
+neg106.fs(94,35,94,39): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(94,35,94,39): typecheck error FS0001: Type mismatch. Expecting a
     'byref<int>'    
 but given a
@@ -146,6 +150,8 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(102,37,102,40): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(102,36,102,40): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(102,36,102,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
@@ -161,6 +167,8 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(112,39,112,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(112,38,112,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(112,38,112,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -174,6 +182,8 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(122,39,122,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(122,38,122,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(122,38,122,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
@@ -189,6 +199,8 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(132,39,132,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(132,38,132,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(132,38,132,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -202,6 +214,8 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(142,39,142,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(142,38,142,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(142,38,142,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    

--- a/tests/fsharp/typecheck/sigs/neg106.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg106.vsbsl
@@ -135,8 +135,6 @@ but given a
     'inref<'T>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-neg106.fs(94,35,94,39): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
-
 neg106.fs(94,35,94,39): typecheck error FS0001: Type mismatch. Expecting a
     'byref<int>'    
 but given a
@@ -150,8 +148,6 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(102,37,102,40): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
-
-neg106.fs(102,36,102,40): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(102,36,102,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
@@ -167,8 +163,6 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(112,39,112,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
-neg106.fs(112,38,112,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
-
 neg106.fs(112,38,112,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -182,8 +176,6 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(122,39,122,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
-
-neg106.fs(122,38,122,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(122,38,122,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
@@ -199,8 +191,6 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(132,39,132,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
-neg106.fs(132,38,132,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
-
 neg106.fs(132,38,132,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -214,8 +204,6 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(142,39,142,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
-
-neg106.fs(142,38,142,42): typecheck error FS3238: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(142,38,142,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    


### PR DESCRIPTION
This adds byref scoping.

Before, you could compile code like this:
```fsharp
let test () =
  let x =
    let mutable y = 1
    &y
  ()
```

As you can see, we can return the address of `y` from the expression, out of the scope of where it was defined. Technically, this is valid and will run. However, we suspect that no one is doing this as doing such a thing has the potential to cause bugs, as shown here: https://github.com/Microsoft/visualfsharp/issues/5235

This change will restrict returning the address of values from where it was defined in an expression, effectively its visibility.