### PR TITLE
Revert - [RFCs FS-1037] allow flexible inference (subsumption) at union construction #5030 

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -2909,7 +2909,7 @@ let MakeApplicableExprNoFlex cenv expr =
 /// This "special" node is immediately eliminated by the use of IteratedFlexibleAdjustArityOfLambdaBody as soon as we 
 /// first transform the tree (currently in optimization)
 
-let MakeApplicableExprWithFlex cenv (env: TcEnv) compat expr =
+let MakeApplicableExprWithFlex cenv (env: TcEnv) expr =
     let exprTy = tyOfExpr cenv.g expr
     let m = expr.Range
     
@@ -2917,31 +2917,19 @@ let MakeApplicableExprWithFlex cenv (env: TcEnv) compat expr =
     
     let argTys, retTy = stripFunTy cenv.g exprTy
     let curriedActualTypes = argTys |> List.map (tryDestRefTupleTy cenv.g)
-    let noFlexInserted = 
-        (curriedActualTypes.IsEmpty ||
-         curriedActualTypes |> List.exists (List.exists (isByrefTy cenv.g)) ||
-         curriedActualTypes |> List.forall (List.forall isNonFlexibleType))
-
-    if noFlexInserted then 
+    if (curriedActualTypes.IsEmpty ||
+        curriedActualTypes |> List.exists (List.exists (isByrefTy cenv.g)) ||
+        curriedActualTypes |> List.forall (List.forall isNonFlexibleType)) then 
+       
         ApplicableExpr (cenv, expr, true)
     else
         let curriedFlexibleTypes = 
             curriedActualTypes |> List.mapSquared (fun actualType -> 
-
-                if isNonFlexibleType actualType then 
-                    actualType 
+                if isNonFlexibleType actualType 
+                then actualType 
                 else 
-
                    let flexibleType = NewInferenceType ()
-
-                   // For backwards compatibility mark some extra flexibility points as IsCompatFlex, meaning that the
-                   // type variable will not be generalized
-                   if compat then 
-                       let tp = destTyparTy cenv.g flexibleType
-                       tp.SetIsCompatFlex(true)
-
-                   AddCxTypeMustSubsumeType ContextInfo.NoContext env.DisplayEnv cenv.css m NoTrace actualType flexibleType
-
+                   AddCxTypeMustSubsumeType ContextInfo.NoContext env.DisplayEnv cenv.css m NoTrace actualType flexibleType;
                    flexibleType)
 
         // Create a coercion to represent the expansion of the application
@@ -5255,7 +5243,7 @@ and TcPat warnOnUpper cenv env topValInfo vFlags (tpenv, names, takenNames) ty p
             let args = match args with SynConstructorArgs.Pats args -> args | _ -> error(Error(FSComp.SR.tcNamedActivePattern(apinfo.ActiveTags.[idx]), m))
             // TOTAL/PARTIAL ACTIVE PATTERNS 
             let _, vexp, _, _, tinst, _ = TcVal true cenv env tpenv vref None None m
-            let vexp = MakeApplicableExprWithFlex cenv env false vexp
+            let vexp = MakeApplicableExprWithFlex cenv env vexp
             let vexpty = vexp.Type
 
             let activePatArgsAsSynPats, patarg = 
@@ -5541,13 +5529,8 @@ and TcExprOfUnknownType cenv env tpenv expr =
 and TcExprFlex cenv flex compat ty (env: TcEnv) tpenv (e: SynExpr) =
     if flex then
         let argty = NewInferenceType ()
-        
-        // For backwards compatibility mark some extra flexibility points as IsCompatFlex, meaning that the
-        // type variable will not be generalized
         if compat then 
-            let tp = destTyparTy cenv.g argty
-            tp.SetIsCompatFlex(true)
-
+            (destTyparTy cenv.g argty).SetIsCompatFlex(true)
         AddCxTypeMustSubsumeType ContextInfo.NoContext env.DisplayEnv cenv.css e.Range NoTrace ty argty 
         let e', tpenv  = TcExpr cenv argty env tpenv e 
         let e' = mkCoerceIfNeeded cenv.g ty argty e'
@@ -8702,9 +8685,9 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
                         let lam = mkMultiLambda mItem vs (constrApp, tyOfExpr cenv.g constrApp)
                         lam)
             UnionCaseOrExnCheck env nargtys nargs mItem
-            let expr = MakeApplicableExprWithFlex cenv env true (mkExpr())
-            let exprTy = expr.Type
-            PropagateThenTcDelayed cenv overallTy env tpenv mItem expr exprTy ExprAtomicFlag.Atomic delayed 
+            let expr = mkExpr()
+            let exprTy = tyOfExpr cenv.g expr
+            PropagateThenTcDelayed cenv overallTy env tpenv mItem (MakeApplicableExprNoFlex cenv expr) exprTy ExprAtomicFlag.Atomic delayed 
 
     | Item.Types(nm, (ty::_)) -> 
     
@@ -9001,7 +8984,7 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
             //   - it isn't a VSlotDirectCall (uses of base values do not take type arguments 
             let checkTys tpenv kinds = TcTypesOrMeasures (Some kinds) cenv NewTyparsOK CheckCxs ItemOccurence.UseInType env tpenv tys mItem
             let _, vexp, isSpecial, _, _, tpenv = TcVal true cenv env tpenv vref (Some (NormalValUse, checkTys)) (Some afterResolution) mItem
-            let vexpFlex = (if isSpecial then MakeApplicableExprNoFlex cenv vexp else MakeApplicableExprWithFlex cenv env false vexp)
+            let vexpFlex = (if isSpecial then MakeApplicableExprNoFlex cenv vexp else MakeApplicableExprWithFlex cenv env vexp)
             // We need to eventually record the type resolution for an expression, but this is done
             // inside PropagateThenTcDelayed, so we don't have to explicitly call 'CallExprHasTypeSink' here            
             PropagateThenTcDelayed cenv overallTy env tpenv mExprAndTypeArgs vexpFlex vexpFlex.Type  ExprAtomicFlag.Atomic otherDelayed
@@ -9009,7 +8992,7 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
         // Value get 
         | _ ->  
             let _, vexp, isSpecial, _, _, tpenv = TcVal true cenv env tpenv vref None (Some afterResolution) mItem
-            let vexpFlex = (if isSpecial then MakeApplicableExprNoFlex cenv vexp else MakeApplicableExprWithFlex cenv env false vexp)
+            let vexpFlex = (if isSpecial then MakeApplicableExprNoFlex cenv vexp else MakeApplicableExprWithFlex cenv env vexp)
             PropagateThenTcDelayed cenv overallTy env tpenv mItem vexpFlex vexpFlex.Type ExprAtomicFlag.Atomic delayed
         
     | Item.Property (nm, pinfos) ->
@@ -9080,7 +9063,7 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
 
                 // Add an I_nop if this is an initonly field to make sure we never recognize it as an lvalue. See mkExprAddrOfExpr. 
                 mkAsmExpr ([ mkNormalLdsfld fspec ] @ (if finfo.IsInitOnly then [ AI_nop ] else []), finfo.TypeInst, [], [exprty], mItem)
-            PropagateThenTcDelayed cenv overallTy env tpenv mItem (MakeApplicableExprWithFlex cenv env false expr) exprty ExprAtomicFlag.Atomic delayed
+            PropagateThenTcDelayed cenv overallTy env tpenv mItem (MakeApplicableExprWithFlex cenv env expr) exprty ExprAtomicFlag.Atomic delayed
 
     | Item.RecdField rfinfo -> 
         // Get static F# field or literal 
@@ -9109,7 +9092,7 @@ and TcItemThen cenv overallTy env tpenv (item, mItem, rest, afterResolution) del
               | Some lit -> Expr.Const(lit, mItem, exprty)
               // Get static F# field 
               | None -> mkStaticRecdFieldGet (fref, rfinfo.TypeInst, mItem) 
-            PropagateThenTcDelayed cenv overallTy env tpenv mItem (MakeApplicableExprWithFlex cenv env false expr) exprty ExprAtomicFlag.Atomic delayed
+            PropagateThenTcDelayed cenv overallTy env tpenv mItem (MakeApplicableExprWithFlex cenv env expr) exprty ExprAtomicFlag.Atomic delayed
 
     | Item.Event einfo -> 
         // Instance IL event (fake up event-as-value) 
@@ -9254,7 +9237,7 @@ and TcLookupThen cenv overallTy env tpenv mObjExpr objExpr objExprTy longId dela
 
             // Instance F# Record or Class field 
             let objExpr' = mkRecdFieldGet cenv.g (objExpr, rfinfo.RecdFieldRef, rfinfo.TypeInst, mExprAndItem)
-            PropagateThenTcDelayed cenv overallTy env tpenv mExprAndItem (MakeApplicableExprWithFlex cenv env false objExpr') fieldTy ExprAtomicFlag.Atomic delayed 
+            PropagateThenTcDelayed cenv overallTy env tpenv mExprAndItem (MakeApplicableExprWithFlex cenv env objExpr') fieldTy ExprAtomicFlag.Atomic delayed 
         
     | Item.ILField finfo -> 
         // Get or set instance IL field 
@@ -9271,7 +9254,7 @@ and TcLookupThen cenv overallTy env tpenv mObjExpr objExpr objExprTy longId dela
             expr, tpenv
         | _ ->        
             let expr = BuildILFieldGet cenv.g cenv.amap mExprAndItem objExpr finfo 
-            PropagateThenTcDelayed cenv overallTy env tpenv mExprAndItem (MakeApplicableExprWithFlex cenv env false expr) exprty ExprAtomicFlag.Atomic delayed 
+            PropagateThenTcDelayed cenv overallTy env tpenv mExprAndItem (MakeApplicableExprWithFlex cenv env expr) exprty ExprAtomicFlag.Atomic delayed 
 
     | Item.Event einfo -> 
         // Instance IL event (fake up event-as-value) 

--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -1744,30 +1744,6 @@ module QuotationStructUnionTests =
     //test "check NewUnionCase"   (<@ A1(1,2) @> |> (function NewUnionCase(unionCase,[ Int32 1; Int32 2 ]) -> true | _ -> false))
 
 
-module FlexibleUnionConstructorTests = 
-
-    [<Struct>]
-    type T = | A of seq<int>
-
-    type U = | B of seq<int>
-    let testList = [1..3]
-    let testFunction caseName x =
-        match x with
-        | Call(None, _, 
-               [PropertyGet (None,_,_) ;
-                 Let (_, Lambda (_, NewUnionCase(unioncase, _)), 
-                    Lambda(_, Application(_, Coerce(_, ty))))]) -> 
-                 unioncase.Name = caseName &&
-                 ty.Name = "IEnumerable`1"
-        | _ -> false
-
-    test "check struct flexible union constructor"   
-        (<@ testList |> A @> |> testFunction "A")
-    
-    test "check flexible union constructor"   
-        (<@ testList |> B @> |> testFunction "B")
-
-
 module EqualityOnExprDoesntFail = 
     let q = <@ 1 @>
     check "we09ceo" (q.Equals(1)) false

--- a/tests/fsharp/regression/OverloadResolution-bug/test.fs
+++ b/tests/fsharp/regression/OverloadResolution-bug/test.fs
@@ -1,0 +1,30 @@
+(*****************  Repro for issue#5246 ---- https://github.com/Microsoft/visualfsharp/issues/5246         *****************)
+(*
+    When the bug was present we saw this error:
+
+    Compile errors are raised:
+    error FS0041: A unique overload for method 'ofObject' could not be determined based on type 
+                  information prior to this program point. A type annotation may be needed. 
+                      Candidates: static member Methods.ofObject : t0:'a -> Methods option when 'a : null, 
+                      static member Methods.ofObject : t1:'a -> Methods option when 'a :> ITest1 and 'a : null
+
+    Expected behavior
+        The code should compile fine (possibly with a warning on :? obj always succeeding).
+
+*)
+
+module TestOfObj =
+
+    type [<AllowNullLiteral>] ITest1 = interface end
+
+    type Methods =
+        | Test1 of ITest1
+        | Other of obj
+
+        static member ofObject t1 = Option.ofObj t1 |> Option.map Test1
+        static member ofObject t0 = Option.ofObj t0 |> Option.map Other
+
+        static member convert (x: obj) =
+            match x with
+            | :? ITest1 as one -> Methods.ofObject one
+            | :? obj as one -> Methods.ofObject one

--- a/tests/fsharp/regression/OverloadResolution-bug/test.fsx
+++ b/tests/fsharp/regression/OverloadResolution-bug/test.fsx
@@ -28,3 +28,8 @@ module TestOfObj =
             match x with
             | :? ITest1 as one -> Methods.ofObject one
             | :? obj as one -> Methods.ofObject one
+            | _ -> None
+
+
+    System.IO.File.WriteAllText("test.ok","ok")
+    printfn "Succeeded"

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1631,10 +1631,16 @@ module RegressionTests =
     let ``literal-value-bug-2-FSI_BASIC`` () = singleTestBuildAndRun "regression/literal-value-bug-2" FSI_BASIC
 
     [<Test>]
+    let ``OverloadResolution-bug-FSC_BASIC`` () = singleTestBuildAndRun "regression/OverloadResolution-bug" FSC_BASIC
+
+    [<Test>]
+    let ``OverloadResolution-bug-FSI_BASIC`` () = singleTestBuildAndRun "regression/OverloadResolution-bug" FSI_BASIC
+
+    [<Test>]
     let ``struct-tuple-bug-1-FSC_BASIC`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSC_BASIC
 
     [<Test >]
-    let ``tuple-bug-1`` () = singleTestBuildAndRun "regression/tuple-bug-1" FSC_BASIC
+    let ``tuple-bug-1-FSC_BASIC`` () = singleTestBuildAndRun "regression/tuple-bug-1" FSC_BASIC
 
     [<Test>]
     let ``26`` () = singleTestBuildAndRun "regression/26" FSC_BASIC

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -131,6 +131,24 @@ but here has type
 
 neg20.fs(99,26,99,33): typecheck error FS0001: All elements of a list constructor expression must have the same type. This expression was expected to have type 'B', but here has type 'A'.
 
+neg20.fs(108,12,108,16): typecheck error FS0001: Type mismatch. Expecting a
+    'B * B -> 'a'    
+but given a
+    'A * A -> Data'    
+The type 'B' does not match the type 'A'
+
+neg20.fs(109,12,109,16): typecheck error FS0001: Type mismatch. Expecting a
+    'A * B -> 'a'    
+but given a
+    'A * A -> Data'    
+The type 'B' does not match the type 'A'
+
+neg20.fs(110,12,110,16): typecheck error FS0001: Type mismatch. Expecting a
+    'B * A -> 'a'    
+but given a
+    'A * A -> Data'    
+The type 'B' does not match the type 'A'
+
 neg20.fs(128,19,128,22): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type

--- a/tests/fsharp/typecheck/sigs/neg20.fs
+++ b/tests/fsharp/typecheck/sigs/neg20.fs
@@ -105,9 +105,9 @@ module NoSubsumptionForLists2 =
     let pBB = (new B(),new B())
     let pAB = (new A(),new B())
     let pBA = (new B(),new A())
-    pBB |> Data   // permitted
-    pAB |> Data   // permitted
-    pBA |> Data   // permitted
+    pBB |> Data   // not permitted (questionable)
+    pAB |> Data   // not permitted (questionable)
+    pBA |> Data   // not permitted (questionable)
     pBB |> data   // permitted
     pAB |> data   // permitted
     pBA |> data   // permitted

--- a/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/ConstructorFlexibleWhenPiping.fsx
+++ b/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/ConstructorFlexibleWhenPiping.fsx
@@ -1,8 +1,0 @@
-// #Conformance #TypesAndModules #Unions 
-// DU constructor should be flexible when piping
-//<Expects status=success></Expects>
-
-type Foo = Items of seq<int>
-[1;2;3] |> Items
-
-exit 0

--- a/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/StructConstructorFlexibleWhenPiping.fsx
+++ b/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/StructConstructorFlexibleWhenPiping.fsx
@@ -1,9 +1,0 @@
-// #Conformance #TypesAndModules #Unions 
-// Struct DU constructor should be flexible when piping
-//<Expects status=success></Expects>
-
-[<Struct>]
-type Foo = Items of seq<int>
-[1;2;3] |> Items
-
-exit 0

--- a/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/env.lst
+++ b/tests/fsharpqa/Source/Conformance/BasicTypeAndModuleDefinitions/UnionTypes/env.lst
@@ -100,6 +100,3 @@ NoMT	SOURCE=Overload_ToString.fs    COMPILE_ONLY=1 SCFLAGS=--warnaserror+ FSIMOD
 	SOURCE=E_UnionConstructorBadFieldName.fs    SCFLAGS="--test:ErrorRanges"				# E_UnionConstructorBadFieldName.fs
 	SOURCE=E_FieldNameUsedMulti.fs              SCFLAGS="--test:ErrorRanges"				# E_FieldNameUsedMulti.fs
 	SOURCE=E_FieldMemberClash.fs                SCFLAGS="--test:ErrorRanges"				# E_FieldMemberClash.fs
-
-	SOURCE=ConstructorFlexibleWhenPiping.fsx							# ConstructorFlexibleWhenPiping.fsx
-	SOURCE=StructConstructorFlexibleWhenPiping.fsx							# StructConstructorFlexibleWhenPiping.fsx


### PR DESCRIPTION
Test case for reversion because it broke overload resolution

Should fail.
