### PR TITLE
For..in expr now dereferences byref items

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -3338,7 +3338,7 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
         let currentExpr, currentTy = BuildPossiblyConditionalMethodCall cenv env DefinitelyMutates m true get_Current_minfo   NormalValUse get_Current_minst [enumeratorExpr] []
         let currentExpr            = mkCoerceExpr(currentExpr, enumElemTy, currentExpr.Range, currentTy)
         let currentExpr, enumElemTy =
-            // Dereference byref for expr 'for x in ...'
+            // Implicitly Dereference byref for expr 'for x in ...'
             if isByrefTy cenv.g currentTy then
                 let v, _ = mkCompGenLocal m "byrefReturn" enumElemTy
                 let expr = mkCompGenLet currentExpr.Range v currentExpr (mkAddrGet m (mkLocalValRef v))

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -3338,13 +3338,13 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
         let currentExpr, currentTy = BuildPossiblyConditionalMethodCall cenv env DefinitelyMutates m true get_Current_minfo   NormalValUse get_Current_minst [enumeratorExpr] []
         let currentExpr            = mkCoerceExpr(currentExpr, enumElemTy, currentExpr.Range, currentTy)
         let currentExpr, enumElemTy =
-            // Deference byref for expr 'for x in ...'
+            // Dereference byref for expr 'for x in ...'
             if isByrefTy cenv.g currentTy then
                 let v, _ = mkCompGenLocal m "byrefReturn" enumElemTy
                 let expr = mkCompGenLet currentExpr.Range v currentExpr (mkAddrGet m (mkLocalValRef v))
                 expr, destByrefTy cenv.g enumElemTy
             else
-                currentExpr, currentTy
+                currentExpr, enumElemTy
 
         Result(enumeratorVar, enumeratorExpr, retTypeOfGetEnumerator, enumElemTy, getEnumExpr, getEnumTy, guardExpr, guardTy, currentExpr)
 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -3338,8 +3338,8 @@ let AnalyzeArbitraryExprAsEnumerable cenv (env: TcEnv) localAlloc m exprty expr 
         let currentExpr, currentTy = BuildPossiblyConditionalMethodCall cenv env DefinitelyMutates m true get_Current_minfo   NormalValUse get_Current_minst [enumeratorExpr] []
         let currentExpr            = mkCoerceExpr(currentExpr, enumElemTy, currentExpr.Range, currentTy)
         let currentExpr, enumElemTy =
-            // Implicitly Dereference byref for expr 'for x in ...'
-            if isByrefTy cenv.g currentTy then
+            // Implicitly dereference byref for expr 'for x in ...'
+            if isByrefTy cenv.g enumElemTy then
                 let v, _ = mkCompGenLocal m "byrefReturn" enumElemTy
                 let expr = mkCompGenLet currentExpr.Range v currentExpr (mkAddrGet m (mkLocalValRef v))
                 expr, destByrefTy cenv.g enumElemTy

--- a/tests/fsharp/core/span/test2.bsl
+++ b/tests/fsharp/core/span/test2.bsl
@@ -52,3 +52,15 @@ test2.fsx(191,43,191,44): typecheck error FS3209: The address of the variable 'x
 test2.fsx(195,14,195,15): typecheck error FS3209: The address of the variable 'y' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
 test2.fsx(199,13,199,19): typecheck error FS3230: This value can't be assigned because the target 'x' may refer to non-stack-local memory, while the expression being assigned is assessed to potentially refer to stack-local memory. This is to help prevent pointers to stack-bound memory escaping their scope.
+
+test2.fsx(204,26,204,27): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+test2.fsx(204,26,204,27): typecheck error FS0406: The byref-typed variable 'inputSequence' is used in an invalid way. Byrefs cannot be captured by closures or passed to inner functions.
+
+test2.fsx(204,26,204,27): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+test2.fsx(204,26,204,27): typecheck error FS0425: The type of a first-class function cannot contain byrefs
+
+test2.fsx(204,26,204,27): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+test2.fsx(204,26,204,27): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.

--- a/tests/fsharp/core/span/test2.fsx
+++ b/tests/fsharp/core/span/test2.fsx
@@ -188,16 +188,22 @@ namespace Tests
 
 #endif
 
-        let should_not_work33 (x: int) = &x
+        let should_not_work23 (x: int) = &x
 
-        let should_not_work34 (x: int) =
+        let should_not_work24 (x: int) =
             let y = &x
             &y
 
-        let should_not_work35 (x: byref<Span<int>>) =
+        let should_not_work25 (x: byref<Span<int>>) =
             let mutable y = Span.Empty
             x <- y
 
+        let should_not_work26 () =
+            seq {
+                let s = Span<int>.Empty
+                for x in s do
+                    yield x
+            }
 #endif
 
         let should_work1 () =

--- a/tests/fsharp/core/span/test3.bsl
+++ b/tests/fsharp/core/span/test3.bsl
@@ -1,2 +1,14 @@
 
 test3.fsx(31,17,31,23): typecheck error FS0027: This value is not mutable. Consider using the mutable keyword, e.g. 'let mutable x = expression'.
+
+test3.fsx(39,21,39,27): typecheck error FS0027: This value is not mutable. Consider using the mutable keyword, e.g. 'let mutable x = expression'.
+
+test3.fsx(47,26,47,27): typecheck error FS0001: The type 'Span<int>' is not compatible with the type 'seq<'a>'
+
+test3.fsx(48,21,48,27): typecheck error FS0027: This value is not mutable. Consider using the mutable keyword, e.g. 'let mutable x = expression'.
+
+test3.fsx(47,26,47,27): typecheck error FS0193: Type constraint mismatch. The type 
+    'Span<int>'    
+is not compatible with type
+    'seq<'a>'    
+

--- a/tests/fsharp/core/span/test3.bsl
+++ b/tests/fsharp/core/span/test3.bsl
@@ -1,0 +1,2 @@
+
+test3.fsx(31,17,31,23): typecheck error FS0027: This value is not mutable. Consider using the mutable keyword, e.g. 'let mutable x = expression'.

--- a/tests/fsharp/core/span/test3.fsx
+++ b/tests/fsharp/core/span/test3.fsx
@@ -30,4 +30,22 @@ open System
             for x in s do
                 x <- 5
                 ()
+
+    module ForEachDereferenceSpanElementSeqCheck =
+        let doSomething () =
+            seq {
+                let s = Span<int>.Empty
+                for x in s do
+                    x <- 5
+                    yield x
+            }
+
+    module ForEachDereferenceSpanElementAsyncCheck =
+        let doSomething () =
+            async {
+                let s = Span<int>.Empty
+                for x in s do
+                    x <- 5
+                    ()
+            }
 #endif

--- a/tests/fsharp/core/span/test3.fsx
+++ b/tests/fsharp/core/span/test3.fsx
@@ -1,0 +1,33 @@
+#r @"..\..\..\..\packages\System.Memory.4.5.0-rc1\lib\netstandard2.0\System.Memory.dll"
+#r @"..\..\..\..\packages\NETStandard.Library.NETFramework.2.0.0-preview2-25405-01\build\net461\ref\netstandard.dll"
+
+#nowarn "9"
+#nowarn "51"
+
+namespace System.Runtime.CompilerServices
+
+    open System
+    open System.Runtime.CompilerServices
+    open System.Runtime.InteropServices
+    [<AttributeUsage(AttributeTargets.All,AllowMultiple=false)>]
+    [<Sealed>]
+    type IsReadOnlyAttribute() =
+        inherit System.Attribute()
+
+    [<AttributeUsage(AttributeTargets.All,AllowMultiple=false)>]
+    [<Sealed>]
+    type IsByRefLikeAttribute() =
+        inherit System.Attribute()
+
+namespace Tests
+
+open System
+
+// NOT POST INFERENCE CHECKS
+#if NEGATIVE
+    module ForEachDeferenceSpanElementCheck =
+        let doSomething (s: Span<int>) =
+            for x in s do
+                x <- 5
+                ()
+#endif

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -250,6 +250,19 @@ module CoreTests =
             //testOkFile.CheckExists()
         end
 
+        begin
+            use testOkFile = fileguard cfg "test3.ok"
+
+            fsc cfg "%s -o:test3.exe -g" cfg.fsc_flags ["test3.fsx"]
+
+            singleNegTest cfg "test3"
+
+            // Execution is disabled until we can be sure .NET 4.7.2 is on the machine
+            //exec cfg ("." ++ "test.exe") ""
+
+            //testOkFile.CheckExists()
+        end
+
     [<Test>]
     let asyncStackTraces () = 
         let cfg = testConfig "core/asyncStackTraces"


### PR DESCRIPTION
This should resolve the issue: https://github.com/Microsoft/visualfsharp/issues/5269

Before, this expression:
```fsharp
        let doSomething (s: Span<int>) =
            for x in s do
                x <- 5
                ()
```
`x` would be not be implicitly dereferenced which makes the existing design a bit inconsistent with how we do implicit dereference of return byrefs.

With this being implicitely dereferenced, `x` should give a typecheck error saying that it is not mutable.

Need to do a few things before this can come in. I don't know if we can get this in 15.8 since this really isn't a bug, but it could hurt folks who start to use Span in F# if we don't settle on a design.

- [x] Add a few more tests
- [x] Follow up with @dsyme
- [x] Need to add syntax to give the ability to not implicitly dereference, `for &x in s do` ? (vNext)

If we settle on a design where we don't do this, then this PR is moot.

