### PR TITLE
Strip type equations when checking record field types

### DIFF
--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -540,7 +540,6 @@ let rec mkArgsForAppliedExpr isBaseCall argsl x =
 
 /// Check types occurring in the TAST.
 let CheckType permitByRefLike (cenv:cenv) env m ty =
-    let ty = stripTyEqns cenv.g ty
     if cenv.reportErrors then 
         let visitTyar (env,tp) = 
           if not (env.boundTypars.ContainsKey tp) then 

--- a/tests/fsharp/core/span/test2.bsl
+++ b/tests/fsharp/core/span/test2.bsl
@@ -64,3 +64,11 @@ test2.fsx(204,26,204,27): typecheck error FS0425: The type of a first-class func
 test2.fsx(204,26,204,27): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
 
 test2.fsx(204,26,204,27): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+test2.fsx(209,13,209,18): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+test2.fsx(208,14,208,18): typecheck error FS0437: A type would store a byref typed value. This is not permitted by Common IL.
+
+test2.fsx(214,13,214,18): typecheck error FS0412: A type instantiation involves a byref type. This is not permitted by the rules of Common IL.
+
+test2.fsx(213,14,213,19): typecheck error FS0437: A type would store a byref typed value. This is not permitted by Common IL.

--- a/tests/fsharp/core/span/test2.fsx
+++ b/tests/fsharp/core/span/test2.fsx
@@ -204,6 +204,16 @@ namespace Tests
                 for x in s do
                     yield x
             }
+            
+        type Nope = {
+            Funcn : ReadOnlySpan<byte> -> int
+            }
+
+        type FuncType = ReadOnlySpan<byte> -> int
+        type Nope2 = {
+            Funcn : FuncType
+            }
+
 #endif
 
         let should_work1 () =


### PR DESCRIPTION
This resolves https://github.com/Microsoft/visualfsharp/issues/5281 by stripping type equations when checking record field types.