### PR TITLE
Move nugets

### DIFF
--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.vstemplate
@@ -25,7 +25,7 @@
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
-    <packages repository="extension" repositoryId="VisualFSharp">
+    <packages repository="extension" repositoryId="VisualFSharpTemplates">
       <package id="System.ValueTuple" version="4.4.0" targetFramework="net40" />
       <package id="FSharp.Core" version="4.5.0" targetFramework="net40" />
      </packages>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.vstemplate
@@ -25,7 +25,7 @@
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
-    <packages repository="extension" repositoryId="VisualFSharp">
+    <packages repository="extension" repositoryId="VisualFSharpTemplates">
       <package id="System.ValueTuple" version="4.4.0" targetFramework="net40" />
       <package id="FSharp.Core" version="4.5.0" targetFramework="net40" />
     </packages>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.vstemplate
@@ -23,7 +23,7 @@
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
-    <packages repository="extension" repositoryId="VisualFSharp">
+    <packages repository="extension" repositoryId="VisualFSharpTemplates">
       <package id="System.ValueTuple" version="4.4.0" targetFramework="net40" />
       <package id="FSharp.Core" version="4.5.0" targetFramework="net40" />
      </packages>

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -23,16 +23,6 @@
       <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(FSharpSourcesRoot)\..\packages\FSharp.Core.4.5.0\FSharp.Core.4.5.0.nupkg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>packages\FSharp.Core.4.5.0.nupkg</Link>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0\System.ValueTuple.4.4.0.nupkg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>packages\System.ValueTuple.4.4.0.nupkg</Link>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="$(FSharpSourcesRoot)\..\packages\Microsoft.VisualFSharp.Type.Providers.Redist\$(MicrosoftVisualFSharpTypeProvidersRedistPackageVersion)\content\4.3.0.0\FSharp.Data.TypeProviders.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>FSharp.Data.TypeProviders.dll</Link>

--- a/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
+++ b/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
@@ -11,6 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="$(FSharpSourcesRoot)\..\packages\FSharp.Core.4.5.0\FSharp.Core.4.5.0.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>packages\FSharp.Core.4.5.0.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0\System.ValueTuple.4.4.0.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>packages\System.ValueTuple.4.4.0.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="Source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
We have started to see an error when creating an F# .NET framework project following install.  The issue seems to be a race in setting up the vsix'

Anyway … we were putting the templates in the VisualFSharpTemplates .vsix, and the SVT and FSharp.Core nupkgs in the VisualFSharp .nuget packages.

This change puts the .nupkgs where they actually belong in the same vsix as the Templates.


That way, as soon as the template vsix is set up, the system will be ready to create templates, and won't need the VisualFSharp vsix to be already configured.

