### PR TITLE
Fixes: #4822 --- Support for arbitrary value in AssemblyInformationalVersionAttribute

### DIFF
--- a/build/targets/GenerateAssemblyAttributes.targets
+++ b/build/targets/GenerateAssemblyAttributes.targets
@@ -26,8 +26,6 @@
 
     <PropertyGroup>
       <GeneratedFSharpAssemblyVersionFile>$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyVersion$(DefaultLanguageSourceExtension)</GeneratedFSharpAssemblyVersionFile>
-      <!-- AssemblyInformationalVersionAttribute issues a by-design warning if the value passed isn't of the form #.#.#.#, but we specifically want to suppress this to allow the commit hash to be embedded. -->
-      <NoWarn Condition="'$(Language)' == 'F#'">2003;$(NoWarn)</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -17309,7 +17309,6 @@ let TypeCheckOneImplFile
                 try IL.parseILVersion version |> ignore; true
                 with _ -> false
             match attrName with
-            | "System.Reflection.AssemblyInformationalVersionAttribute"
             | "System.Reflection.AssemblyFileVersionAttribute" //TODO compile error like c# compiler?
             | "System.Reflection.AssemblyVersionAttribute" when not (isValid()) ->
                 warning(Error(FSComp.SR.fscBadAssemblyVersion(attrName, version), range))

--- a/tests/fsharp/core/versionAttributes/NoWarn2003.fs
+++ b/tests/fsharp/core/versionAttributes/NoWarn2003.fs
@@ -1,13 +1,12 @@
 namespace System
 open System.Reflection
 
-[<assembly: AssemblyVersionAttribute("5.0.0")>]
-
 do ()
 
 namespace System
 open System.Reflection
 #nowarn "2003"
 
-[<assembly: AssemblyInformationalVersion("5.0.0-beta024")>]
+[<assembly: AssemblyVersion("5.0.0-beta024")>]
+
 do ()

--- a/tests/fsharp/core/versionAttributes/out.stderr.bsl
+++ b/tests/fsharp/core/versionAttributes/out.stderr.bsl
@@ -6,12 +6,8 @@ Test 2=================================================
 NoWarn2003_2.fs(8,6): warning FS0988: Main module of program is empty: nothing will happen when it is run
 Test 3=================================================
 
-Warn2003_1.fs(5,42): warning FS2003: The attribute System.Reflection.AssemblyInformationalVersionAttribute specified version '5.0.0-beta024', but this value is invalid and has been ignored
-
 Warn2003_1.fs(7,6): warning FS0988: Main module of program is empty: nothing will happen when it is run
 Test 4=================================================
-
-Warn2003_2.fs(4,42): warning FS2003: The attribute System.Reflection.AssemblyInformationalVersionAttribute specified version '5.0.0-beta024', but this value is invalid and has been ignored
 
 Warn2003_2.fs(6,6): warning FS0988: Main module of program is empty: nothing will happen when it is run
 Test 5=================================================

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/AttributeUsage/X_AssemblyVersion01.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/AttributeUsage/X_AssemblyVersion01.fs
@@ -1,9 +1,7 @@
 // #Regression #Conformance #DeclarationElements #Attributes 
-//<Expects id="FS2003" status="warning">The attribute System.Reflection.AssemblyInformationalVersionAttribute specified version '6\.5\.4\.3\.2', but this value is invalid and has been ignored</Expects>
 //<Expects id="FS2003" status="warning">The attribute System.Reflection.AssemblyFileVersionAttribute specified version '9\.8\.7\.6\.5', but this value is invalid and has been ignored</Expects>
 
 [<assembly:System.Reflection.AssemblyVersion("1.2.3.4")>]
-[<assembly:System.Reflection.AssemblyInformationalVersion("6.5.4.3.2")>]
 [<assembly:System.Reflection.AssemblyFileVersion("9.8.7.6.5")>]
 do 
     ()

--- a/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/AttributeUsage/X_AssemblyVersion02.fs
+++ b/tests/fsharpqa/Source/Conformance/DeclarationElements/CustomAttributes/AttributeUsage/X_AssemblyVersion02.fs
@@ -1,9 +1,7 @@
 // #Regression #Conformance #DeclarationElements #Attributes 
-//<Expects id="FS2003" status="warning">The attribute System.Reflection.AssemblyInformationalVersionAttribute specified version '6\.5\.\*\.3', but this value is invalid and has been ignored</Expects>
 //<Expects id="FS2003" status="warning">The attribute System.Reflection.AssemblyFileVersionAttribute specified version '9\.8\.\*\.6', but this value is invalid and has been ignored</Expects>
 
 [<assembly:System.Reflection.AssemblyVersion("1.2.3.4")>]
-[<assembly:System.Reflection.AssemblyInformationalVersion("6.5.*.3")>]
 [<assembly:System.Reflection.AssemblyFileVersionAttribute("9.8.*.6")>]
 do 
     ()


### PR DESCRIPTION
Fix: #4822, #5052
The F# compiler erroneously validated that the AssemblyInformationalVersionAttribute started with a Version number.


This changes relaxes that requirement.

