### PR TITLE
[WIP] replace sprintf to string.format for FSharp.Core.UnitTests

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/ComparersRegression.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/ComparersRegression.fs
@@ -1742,7 +1742,7 @@ module ComparersRegression =
             make_result_set f items (Some expected) |> ignore
         with
         | ValidationException(lhs=lhs; rhs=rhs; expected=expected; received=received) ->
-            failwith <| sprintf "args(%O, %O) Expected=%O. Received=%O." lhs rhs expected received
+            failwith <| String.Format("args({0}, {1}) Expected={2}. Received={3}.", lhs, rhs, expected, received)
 
 open ComparersRegression
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule2.fs
@@ -165,7 +165,7 @@ type ArrayModule2() =
         Assert.AreEqual(105, resultIntAcc)
 
         // string array
-        let funcStr acc (x:string) = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), sprintf "%s%s" acc x
+        let funcStr acc (x:string) = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), String.Format("{0}{1}", acc, x)
         let resultStr,resultStrAcc = Array.mapFold funcStr "" [| "";"BB";"C";"" |]
         if resultStr <> [| "empty";"bb";"c";"empty" |] then Assert.Fail()
         Assert.AreEqual("BBC", resultStrAcc)
@@ -190,7 +190,7 @@ type ArrayModule2() =
         Assert.AreEqual(106, resultIntAcc)
 
         // string array
-        let funcStr (x:string) acc = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), sprintf "%s%s" acc x
+        let funcStr (x:string) acc = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), String.Format("{0}{1}", acc, x)
         let resultStr,resultStrAcc = Array.mapFoldBack funcStr [| "";"BB";"C";"" |] ""
         if resultStr <> [| "empty";"bb";"c";"empty" |] then Assert.Fail()
         Assert.AreEqual("CBB", resultStrAcc)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/CollectionModulesConsistency.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/CollectionModulesConsistency.fs
@@ -15,8 +15,8 @@ let smallerSizeCheck testable = Check.One({ Config.QuickThrowOnFailure with EndS
 
 /// helper function that creates labeled FsCheck properties for equality comparisons
 let consistency name sqs ls arr =
-    (sqs = arr) |@ (sprintf  "Seq.%s = '%A', Array.%s = '%A'" name sqs name arr) .&. 
-    (ls  = arr) |@ (sprintf "List.%s = '%A', Array.%s = '%A'" name ls name arr)
+    (sqs = arr) |@ (String.Format("Seq.{0} = '{1}', Array.{0} = '{2}'", name, sqs, arr)) .&. 
+    (ls  = arr) |@ (String.Format("List.{0} = '{1}', Array.{0} = '{2}'", name, ls, arr))
 
 
 let allPairs<'a when 'a : equality> (xs : list<'a>) (xs2 : list<'a>) =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/CollectionModulesConsistency.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/CollectionModulesConsistency.fs
@@ -15,9 +15,8 @@ let smallerSizeCheck testable = Check.One({ Config.QuickThrowOnFailure with EndS
 
 /// helper function that creates labeled FsCheck properties for equality comparisons
 let consistency name sqs ls arr =
-    (sqs = arr) |@ (String.Format("Seq.{0} = '{1}', Array.{0} = '{2}'", name, sqs, arr)) .&. 
-    (ls  = arr) |@ (String.Format("List.{0} = '{1}', Array.{0} = '{2}'", name, ls, arr))
-
+    (sqs = arr) |@ (sprintf  "Seq.%s = '%A', Array.%s = '%A'" name sqs name arr) .&. 
+    (ls  = arr) |@ (sprintf "List.%s = '%A', Array.%s = '%A'" name ls name arr)
 
 let allPairs<'a when 'a : equality> (xs : list<'a>) (xs2 : list<'a>) =
     let s = xs |> Seq.allPairs xs2 |> Seq.toArray

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule2.fs
@@ -228,7 +228,7 @@ type ListModule02() =
         Assert.AreEqual(101, resultIntAcc)
 
         // string List
-        let funcStr acc (x:string) = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), sprintf "%s%s" acc x
+        let funcStr acc (x:string) = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), String.Format("{0}{1}", acc, x)
         let resultStr,resultStrAcc = List.mapFold funcStr "" ["";"BB";"C";""]
         Assert.AreEqual(["empty";"bb";"c";"empty"], resultStr)
         Assert.AreEqual("BBC", resultStrAcc)
@@ -254,7 +254,7 @@ type ListModule02() =
         Assert.AreEqual(102, resultIntAcc)
 
         // string List
-        let funcStr (x:string) acc = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), sprintf "%s%s" acc x
+        let funcStr (x:string) acc = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), String.Format("{0}{1}", acc, x)
         let resultStr,resultStrAcc = List.mapFoldBack funcStr ["";"BB";"C";""] ""
         Assert.AreEqual(["empty";"bb";"c";"empty"], resultStr)
         Assert.AreEqual("CBB", resultStrAcc)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule.fs
@@ -935,7 +935,7 @@ type SeqModule() =
         Assert.AreEqual("E", foldStr)
         
         // single element
-        let funcStr2 elem acc = sprintf "%s%s" elem acc
+        let funcStr2 elem acc = String.Format("{0}{1}", elem, acc)
         let strSeq2 = seq [ "A" ]
         let foldStr2 = Seq.foldBack funcStr2 strSeq2 "X"
         Assert.AreEqual("AX", foldStr2)
@@ -965,7 +965,7 @@ type SeqModule() =
         Assert.AreEqual(164, resultInt)
 
         // string Seq
-        let funcStr = sprintf "%s%s%s"
+        let funcStr x y z = String.Format("{0}{1}{2}", x, y, z)
         let strSeq = seq [ "A"; "B"; "C"; "D" ]
         let resultStr = Seq.foldBack2  funcStr strSeq (seq [ "a"; "b"; "c"; "d"]) "*"
         Assert.AreEqual("AaBbCcDd*", resultStr)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
@@ -470,7 +470,7 @@ type SeqModule2() =
         Assert.AreEqual(105, resultIntAcc)
 
         // string Seq
-        let funcStr acc (x:string) = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), sprintf "%s%s" acc x
+        let funcStr acc (x:string) = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), String.Format("{0}{1}", acc, x)
         let resultStr,resultStrAcc = Seq.mapFold funcStr "" <| seq [ "";"BB";"C";"" ]
         VerifySeqsEqual (seq [ "empty";"bb";"c";"empty" ]) resultStr
         Assert.AreEqual("BBC", resultStrAcc)
@@ -495,7 +495,7 @@ type SeqModule2() =
         Assert.AreEqual(106, resultIntAcc)
 
         // string Seq
-        let funcStr (x:string) acc = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), sprintf "%s%s" acc x
+        let funcStr (x:string) acc = match x.Length with 0 -> "empty", acc | _ -> x.ToLower(), String.Format("{0}{1}", acc, x)
         let resultStr,resultStrAcc = Seq.mapFoldBack funcStr (seq [ "";"BB";"C";"" ]) ""
         VerifySeqsEqual (seq [ "empty";"bb";"c";"empty" ]) resultStr
         Assert.AreEqual("CBB", resultStrAcc)
@@ -1021,7 +1021,7 @@ type SeqModule2() =
         Assert.AreEqual("E", reduceStr)
         
         // string Seq
-        let funcStr2 elem acc = sprintf "%s%s" elem acc
+        let funcStr2 elem acc = String.Format("{0}{1}", elem, acc)
         let strSeq2 = seq [ "A" ]
         let reduceStr2 = Seq.reduceBack  funcStr2 strSeq2
         Assert.AreEqual("A", reduceStr2)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -112,7 +112,7 @@ module ChoiceUtils =
             verifyIndex index
             match ops.[index] with
             | SomeResultAfter timeout -> Assert.AreEqual(getMinTime(), timeout)
-            | op -> Assert.Fail <| sprintf "Should be 'Some' but got %A" op
+            | op -> Assert.Fail <| String.Format("Should be 'Some' but got {0}", op)
 
         | Choice1Of2 None ->
             Assert.True(ops |> List.forall (function NoneResultAfter _ -> true | _ -> false))
@@ -126,9 +126,9 @@ module ChoiceUtils =
             verifyIndex index
             match ops.[index] with
             | ExceptionAfter timeout -> Assert.AreEqual(getMinTime(), timeout)
-            | op -> Assert.Fail <| sprintf "Should be 'Exception' but got %A" op
+            | op -> Assert.Fail <| String.Format("Should be 'Exception' but got {0}", op)
 
-        | Choice2Of2 e -> Assert.Fail(sprintf "Unexpected exception %O" e)
+        | Choice2Of2 e -> Assert.Fail(String.Format("Unexpected exception {0}", e))
 
         // Step 3b. check that nested cancellation happens as expected
         if not <| List.isEmpty ops then
@@ -238,7 +238,7 @@ type AsyncModule() =
 
         let endTime = DateTime.UtcNow
         let delta = endTime - startTime
-        Assert.IsTrue(delta.TotalMilliseconds < 1100.0, sprintf "Expected faster timeout than %.0f ms" delta.TotalMilliseconds)
+        Assert.IsTrue(delta.TotalMilliseconds < 1100.0, String.Format("Expected faster timeout than {0:F0} ms", delta.TotalMilliseconds))
 
     [<Test>]
     member this.``AwaitWaitHandle.TimeoutWithCancellation``() = 
@@ -275,10 +275,10 @@ type AsyncModule() =
         let test = async {
             try
                 let! timeout = Async.AwaitWaitHandle wh
-                Assert.Fail(sprintf "Unexpected success %A" timeout)
+                Assert.Fail(String.Format("Unexpected success {0}", timeout))
             with
                 | :? ObjectDisposedException -> ()
-                | e -> Assert.Fail(sprintf "Unexpected error %A" e)
+                | e -> Assert.Fail(String.Format("Unexpected error {0}", e))
             }
         Async.RunSynchronously test
     

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Cancellation.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Cancellation.fs
@@ -280,7 +280,7 @@ type CancellationType() =
 
         try
             let res = t.Wait(1000)
-            Assert.Fail (sprintf "Excepted TimeoutException wrapped in an AggregateException, but got %A" res)
+            Assert.Fail (String.Format("Excepted TimeoutException wrapped in an AggregateException, but got {0}", res))
         with :? AggregateException as agg -> ()
 
     [<Test>]

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/EventModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/EventModule.fs
@@ -230,8 +230,8 @@ type EventModule() =
                                                           else          Choice2Of2(i.ToString(), i.ToString()))
                  
         let lastResult = ref ""
-        positiveEvent.Add(fun (msg, i)    -> lastResult := sprintf "Positive [%s][%d]" msg i)
-        negativeEvent.Add(fun (msg, msg2) -> lastResult := sprintf "Negative [%s][%s]" msg msg2)
+        positiveEvent.Add(fun (msg, i)    -> lastResult := String.Format("Positive [{0}][{1}]", msg, i))
+        negativeEvent.Add(fun (msg, msg2) -> lastResult := String.Format("Negative [{0}][{1}]", msg, msg2))
         
         numEvent.Trigger(10)
         Assert.AreEqual("Positive [10][10]", !lastResult)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/MailboxProcessorType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/MailboxProcessorType.fs
@@ -92,7 +92,7 @@ type MailboxProcessorType() =
 
                     while true do
                         let! (msg : int) = inbox.Receive ()
-                        addMsg (sprintf "Received %i" msg)
+                        addMsg (String.Format("Received {0}", msg))
                 }, cancellationToken = cts.Token)
 
         mb.Post 1
@@ -125,7 +125,7 @@ type MailboxProcessorType() =
 
                     while true do
                         let! (msg : int) = inbox.Receive (100000)
-                        addMsg (sprintf "Received %i" msg)
+                        addMsg (String.Format("Received {0}", msg))
                 }, cancellationToken = cts.Token)
 
         mb.Post 1
@@ -158,7 +158,7 @@ type MailboxProcessorType() =
 
                     while true do
                         let! (msg : int) = inbox.Scan (fun msg -> Some(async { return msg }) )
-                        addMsg (sprintf "Scanned %i" msg)
+                        addMsg (String.Format("Scanned {0}", msg))
                 }, cancellationToken = cts.Token)
 
         mb.Post 1

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/ObservableModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/ObservableModule.fs
@@ -278,8 +278,8 @@ type ObservableModule() =
                                                           else          Choice2Of2(i.ToString(), i.ToString()))
                  
         let lastResult = ref ""
-        positiveEvent.Add(fun (msg, i)    -> lastResult := sprintf "Positive [%s][%d]" msg i)
-        negativeEvent.Add(fun (msg, msg2) -> lastResult := sprintf "Negative [%s][%s]" msg msg2)
+        positiveEvent.Add(fun (msg, i)    -> lastResult := String.Format("Positive [{0}][{1}]", msg, i))
+        negativeEvent.Add(fun (msg, msg2) -> lastResult := String.Format("Negative [{0}][{1}]", msg, msg2))
         
         numEvent.Trigger(10)
         Assert.AreEqual("Positive [10][10]", !lastResult)

--- a/tests/FSharp.Core.UnitTests/LibraryTestFx.fs
+++ b/tests/FSharp.Core.UnitTests/LibraryTestFx.fs
@@ -15,10 +15,10 @@ open NUnit.Framework
 let CheckThrowsExn<'a when 'a :> exn> (f : unit -> unit) =
     try
         let _ = f ()
-        sprintf "Expected %O exception, got no exception" typeof<'a> |> Assert.Fail 
+        String.Format("Expected {0} exception, got no exception", typeof<'a>) |> Assert.Fail 
     with
     | :? 'a -> ()
-    | e -> sprintf "Expected %O exception, got: %O" typeof<'a> e |> Assert.Fail
+    | e -> String.Format("Expected {0} exception, got: {1}", typeof<'a>, e) |> Assert.Fail
 
 let private CheckThrowsExn2<'a when 'a :> exn> s (f : unit -> unit) =
     let funcThrowsAsExpected =
@@ -102,10 +102,10 @@ module SurfaceArea =
                 } |> Array.ofSeq
 
             getMembers t
-            |> Array.map (fun (ty, m) -> sprintf "%s: %s" (ty.ToString()) (m.ToString()))
+            |> Array.map (fun (ty, m) -> String.Format("{0}: {1}", ty, m))
 #else
             t.GetMembers()
-            |> Array.map (fun v -> sprintf "%s: %s" (v.ReflectedType.ToString()) (v.ToString()))
+            |> Array.map (fun v -> String.Format("{0}: {1}", v.ReflectedType, v))
 #endif
             
         let actual =
@@ -143,7 +143,7 @@ module SurfaceArea =
 
         let logFile =
             let workDir = TestContext.CurrentContext.WorkDirectory
-            sprintf "%s\\CoreUnit_%s_Xml.xml" workDir platform
+            String.Format("{0}\\CoreUnit_{1}_Xml.xml", workDir, platform)
 
         // The surface areas don't match; prepare an easily-readable output message.
         let msg =


### PR DESCRIPTION
Remove the use of sprintf for FSharp.Core.UnitTests

[#4954](https://github.com/Microsoft/visualfsharp/issues/4954)