### PR TITLE
clean up version number computation

### DIFF
--- a/build/targets/AssemblyVersions.props
+++ b/build/targets/AssemblyVersions.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <!-- Put build number 0 and today's date if this was a local build -->
     <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd.0))</BUILD_BUILDNUMBER>
+    <!-- Remove '.DRAFT' suffix if it exists -->
+    <BUILD_BUILDNUMBER>$(BUILD_BUILDNUMBER.Replace(".DRAFT", ""))</BUILD_BUILDNUMBER>
 
     <!--
     Given $(BUILD_BUILDNUMBER) = '20161225.1'
@@ -22,7 +24,10 @@
     <FSCoreVersion>4.4.3.0</FSCoreVersion>
     <FSProductVersion>10.1.1.0</FSProductVersion>
     <FSPackageVersion>10.1.4</FSPackageVersion>
-    <VSAssemblyVersion>15.7.0.0</VSAssemblyVersion>
+    <VSMajorVersion>15</VSMajorVersion>
+    <VSMinorVersion>7</VSMinorVersion>
+    <VSGeneralVersion>$(VSMajorVersion).0</VSGeneralVersion>
+    <VSAssemblyVersion>$(VSMajorVersion).$(VSMinorVersion).0.0</VSAssemblyVersion>
     <MicroBuildAssemblyVersion Condition="'$(MicroBuildAssemblyVersion)' == ''">$(FSCoreVersion)</MicroBuildAssemblyVersion>
 
     <!-- certain delivered F# VS assemblies use a specific MicroBuildAssemblyVersion, otherwise use FSCoreVersion -->

--- a/setup/FSharp.Setup.props
+++ b/setup/FSharp.Setup.props
@@ -13,13 +13,8 @@
     <Import Project="$(MSBuildThisFileDirectory)..\build\targets\AssemblyVersions.props" />
 
     <PropertyGroup>
-        <!-- This number should only be two parts, e.g., '15.6'. -->
-        <FSharpProductVersion>$(VSAssemblyVersion.Split('.')[0]).$(VSAssemblyVersion.Split('.')[1])</FSharpProductVersion>
-        <!-- BUILD_BUILDNUMBER is passed from Microbuild. Replace by today's date and (0) if it was a local build -->
-        <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd.0))</BUILD_BUILDNUMBER>
-        <!-- Remove .DRAFT suffix if it exists in the build number -->
-        <FSharpPackageVersion>$(FSharpProductVersion).$(BUILD_BUILDNUMBER.Replace(".DRAFT", ""))</FSharpPackageVersion>
-        <!-- FSharpPackageVersion should be {F# version}.{today's date}.{build number}. Example: 15.6.20160901.3 -->
+        <!-- FSharpPackageVersion should be {VS version}.{today's date}.{build number}. Example: 15.6.20160901.3 -->
+        <FSharpPackageVersion>$(VSMajorVersion).$(VSMinorVersion).$(BUILD_BUILDNUMBER)</FSharpPackageVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
@@ -3,7 +3,7 @@ use vs
 package name=Microsoft.FSharp.Dependencies
         version=$(FSharpPackageVersion)
 
-folder "InstallDir:MSBuild\Microsoft\VisualStudio\v15.0\FSharp"
+folder "InstallDir:MSBuild\Microsoft\VisualStudio\v$(VSGeneralVersion)\FSharp"
   file "Microsoft.FSharp.targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.Shim.targets"
   file "Microsoft.Portable.FSharp.targets" source="$(BinariesFolder)\setup\resources\Microsoft.Portable.FSharp.Shim.targets"
   file "Microsoft.FSharp.NetSdk.targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.NetSdk.Shim.targets"

--- a/setup/Swix/Microsoft.FSharp.Dependencies/Microsoft.FSharp.Dependencies.swixproj
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/Microsoft.FSharp.Dependencies.swixproj
@@ -21,6 +21,7 @@
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);BinariesFolder=$(BinariesFolder)</PackagePreprocessorDefinitions>
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);PackagesFolder=$(PackagesFolder)</PackagePreprocessorDefinitions>
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);FSharpPackageVersion=$(FSharpPackageVersion)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);VSGeneralVersion=$(VSGeneralVersion)</PackagePreprocessorDefinitions>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +31,7 @@
 
   <Target Name="CheckPropertiesArePassed">
     <Error Condition="'$(FSharpPackageVersion)' == ''" Text="A 'FSharpPackageVersion' property must be passed to the project." />
+    <Error Condition="'$(VSGeneralVersion)' == ''" Text="A 'VSGeneralVersion' property must be passed to the project." />
   </Target>
 
   <Target Name="SignFiles">

--- a/setup/fsharp-setup-build.proj
+++ b/setup/fsharp-setup-build.proj
@@ -45,7 +45,7 @@
                  Properties="Configuration=$(Configuration);IsLangPack=%(VsixProjects.IsLangPack);FSharpPackageVersion=$(FSharpPackageVersion);OutputPath=$(VsixBuildLocation);DisableOutputPathCopying=true;$(CustomProps)" />
         <MSBuild Projects="%(SwixSetupProjects.ProjectPath)"
                  Targets="Build"
-                 Properties="LocaleCode=%(SwixSetupProjects.LocaleCode);LocaleId=%(SwixSetupProjects.LocaleId);LocaleParentId=%(SwixSetupProjects.LocaleParentId);LocaleParentCulture=%(SwixSetupProjects.LocaleParentCulture);LocaleSpecificCulture=%(SwixSetupProjects.LocaleSpecificCulture);IsLangPack=%(SwixSetupProjects.IsLangPack);FSharpPackageVersion=$(FSharpPackageVersion);$(CustomProps)"/>
+                 Properties="LocaleCode=%(SwixSetupProjects.LocaleCode);LocaleId=%(SwixSetupProjects.LocaleId);LocaleParentId=%(SwixSetupProjects.LocaleParentId);LocaleParentCulture=%(SwixSetupProjects.LocaleParentCulture);LocaleSpecificCulture=%(SwixSetupProjects.LocaleSpecificCulture);IsLangPack=%(SwixSetupProjects.IsLangPack);FSharpPackageVersion=$(FSharpPackageVersion);VSGeneralVersion=$(VSGeneralVersion);$(CustomProps)"/>
     </Target>
 
     <Target Name="CopyLocalizationResources" BeforeTargets="Build">

--- a/src/FSharpSource.Settings.targets
+++ b/src/FSharpSource.Settings.targets
@@ -18,61 +18,7 @@
     <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
   </PropertyGroup>
 
-  <!-- Version number computation -->
-  <PropertyGroup>
-    <FSCoreVersion>4.4.3.0</FSCoreVersion>
-    <FSProductVersion>10.1.1.0</FSProductVersion>
-    <FSPackageVersion>10.1.4</FSPackageVersion>
-    <VSAssemblyVersion>15.7.0.0</VSAssemblyVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- Put build number 0 and today's date if this was a local build -->
-    <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd.0))</BUILD_BUILDNUMBER>
-
-    <!--
-    Given $(BUILD_BUILDNUMBER) = '20161225.1'
-
-    Then $(_Build_Year) = 2016
-    Then $(_Build_Month) = 12
-    Then $(_Build_Day) = 25
-    Then $(_Build_Number) = 1
-    Then $(Build_FileVersion) = 2016.12.25.1
-    -->
-    <_Build_Year>$(BUILD_BUILDNUMBER.Substring(0, 4))</_Build_Year>
-    <_Build_Month>$(BUILD_BUILDNUMBER.Substring(4, 2))</_Build_Month>
-    <_Build_Day>$(BUILD_BUILDNUMBER.Substring(6, 2))</_Build_Day>
-    <_Build_Number>$(BUILD_BUILDNUMBER.Substring(9))</_Build_Number>
-    <Build_FileVersion>$(_Build_Year).$(_Build_Month).$(_Build_Day).$(_Build_Number)</Build_FileVersion>
-
-    <MicroBuildAssemblyVersion Condition="'$(MicroBuildAssemblyVersion)' == ''">$(FSCoreVersion)</MicroBuildAssemblyVersion>
-
-    <!-- certain delivered F# VS assemblies use a specific MicroBuildAssemblyVersion, otherwise use FSCoreVersion --> 
-    <MicroBuildAssemblyVersion Condition="'$(UseFSharpProductVersion)' == 'true'">$(FSProductVersion)</MicroBuildAssemblyVersion> 
-
-    <!-- certain delivered F# VS assemblies use a specific MicroBuildAssemblyVersion, otherwise use FSCoreVersion --> 
-    <MicroBuildAssemblyVersion Condition="'$(UseVsMicroBuildAssemblyVersion)' == 'true'">$(VSAssemblyVersion)</MicroBuildAssemblyVersion> 
-
-    <!--
-
-    Given $(BUILD_BUILDNUMBER) = '20161225.1'
-    Given $(MicroBuildAssemblyVersion) = '15.4.1.0'
-
-    Then $(BuildTimeStamp_Date) = 161225
-    Then $(BuildTimeStamp_Number) = 01
-    Then $(BuildTimeStamp) = 16122501
-    Then $(MicroBuildAssemblyVersion_WithoutRevision) = 15.4.1
-    Then $(VsixPackageVersion) = 15.4.1.16122501
-    Then $(NuGetPackageVersionSuffix) = 161225-01
-
-    -->
-    <BuildTimeStamp_Date>$(BUILD_BUILDNUMBER.Split('.')[0].Substring(2))</BuildTimeStamp_Date>
-    <BuildTimeStamp_Number>$(BUILD_BUILDNUMBER.Split('.')[1].PadLeft(2, '0'))</BuildTimeStamp_Number>
-    <BuildTimeStamp>$(BuildTimeStamp_Date)$(BuildTimeStamp_Number)</BuildTimeStamp>
-    <MicroBuildAssemblyVersion_WithoutRevision>$(MicroBuildAssemblyVersion.Substring(0, $(MicroBuildAssemblyVersion.LastIndexOf('.'))))</MicroBuildAssemblyVersion_WithoutRevision>
-    <VsixPackageVersion>$(MicroBuildAssemblyVersion_WithoutRevision).$(BuildTimeStamp)</VsixPackageVersion>
-    <NuGetPackageVersionSuffix>$(BuildTimeStamp_Date)-$(BuildTimeStamp_Number)</NuGetPackageVersionSuffix>
-  </PropertyGroup>
+  <Import Project="..\build\targets\AssemblyVersions.props" />
 
   <PropertyGroup>
     <!-- Settings used all the time -->


### PR DESCRIPTION
The value `v15.0` is hard-coded into `setup/Swix/Microsoft.FSharp.Dependencies/Files.swr` which is inflexible.  In the process of parameterizing that value, I condensed and (hopefully) simplified our version number calculations.