### PR TITLE
fix doc comment issues that prevented proper XML parsing

### DIFF
--- a/src/fsharp/FSharp.Core/async.fsi
+++ b/src/fsharp/FSharp.Core/async.fsi
@@ -427,7 +427,6 @@ namespace Microsoft.FSharp.Control
         /// The default is used if this parameter is not provided.</param>
         /// <returns>A <c>System.Threading.Tasks.Task</c> that will be completed
         /// in the corresponding state once the computation terminates (produces the result, throws exception or gets canceled)</returns>
-        /// </returns> 
         static member StartImmediateAsTask: 
             computation:Async<'T> * ?cancellationToken:CancellationToken-> Task<'T>
 

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -808,7 +808,7 @@ namespace Microsoft.FSharp.Core
 #endif
     type byref<'T, 'Kind> = (# "!0&" #)
 
-    /// <summary>Represents a managed pointer in F# code. For F# 4.5+ this is considered equivalent to <c>byref&lt'T, ByRefKinds.InOut&gt</c></summary>
+    /// <summary>Represents a managed pointer in F# code. For F# 4.5+ this is considered equivalent to <c>byref&lt;'T, ByRefKinds.InOut&gt;</c></summary>
     type byref<'T> = (# "!0&" #)
 
     /// Represents the types of byrefs in F# 4.5+
@@ -1850,7 +1850,7 @@ namespace Microsoft.FSharp.Core
     ///
     /// <remarks>Use the constructors <c>ValueSome</c> and <c>ValueNone</c> to create values of this type.
     /// Use the values in the <c>ValueOption</c> module to manipulate values of this type,
-    /// or pattern match against the values directly.
+    /// or pattern match against the values directly.</remarks>
     [<StructuralEquality; StructuralComparison>]
     [<CompiledName("FSharpValueOption`1")>]
     [<Struct>]
@@ -1870,7 +1870,7 @@ namespace Microsoft.FSharp.Core
     ///
     /// <remarks>Use the constructors <c>ValueSome</c> and <c>ValueNone</c> to create values of this type.
     /// Use the values in the <c>ValueOption</c> module to manipulate values of this type,
-    /// or pattern match against the values directly.
+    /// or pattern match against the values directly.</remarks>
     and 'T voption = ValueOption<'T>
 
     /// <summary>Helper type for error handling without exceptions.</summary>


### PR DESCRIPTION
This will enable the doc team to automagically suck in our doc comments, currently they are broken by our rubbish xml