### PR TITLE
Cherrypick uithread from Dev15.8

### DIFF
--- a/vsintegration/src/FSharp.LanguageService.Base/DocumentTask.cs
+++ b/vsintegration/src/FSharp.LanguageService.Base/DocumentTask.cs
@@ -21,7 +21,8 @@ using IServiceProvider = System.IServiceProvider;
 using VsShell = Microsoft.VisualStudio.Shell.VsShellUtilities;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.VisualStudio.FSharp.LanguageService {
+namespace Microsoft.VisualStudio.FSharp.LanguageService
+{
     internal static class UIThread {
         static SynchronizationContext ctxt;
         static bool isUnitTestingMode = false;

--- a/vsintegration/src/FSharp.LanguageService.Base/LanguageService.cs
+++ b/vsintegration/src/FSharp.LanguageService.Base/LanguageService.cs
@@ -685,8 +685,8 @@ namespace Microsoft.VisualStudio.FSharp.LanguageService
         // Implemented in FSharpLanguageService.fs
         internal abstract BackgroundRequest_DEPRECATED CreateBackgroundRequest(int line, int col, TokenInfo info, string sourceText, ITextSnapshot snapshot, MethodTipMiscellany_DEPRECATED methodTipMiscellany, string fname, BackgroundRequestReason reason, IVsTextView view,AuthoringSink sink, ISource source, int timestamp, bool synchronous);
 
-		// Implemented in FSharpLanguageService.fs
-		internal abstract void OnParseFileOrCheckFileComplete(BackgroundRequest_DEPRECATED req);
+        // Implemented in FSharpLanguageService.fs
+        internal abstract void OnParseFileOrCheckFileComplete(BackgroundRequest_DEPRECATED req);
 
         internal void EnsureBackgroundThreadStarted()
         {

--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/IDEBuildLogger.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/IDEBuildLogger.cs
@@ -250,22 +250,22 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
             span.iEndLine = endLine < startLine ? span.iStartLine : endLine;
             span.iEndIndex = (endColumn < startColumn) && (span.iStartLine == span.iEndLine) ? span.iStartIndex : endColumn;
 
-			if (OutputWindowPane != null
-				&& (this.Verbosity != LoggerVerbosity.Quiet || errorEvent is BuildErrorEventArgs))
-			{
-				// Format error and output it to the output window
-				string message = this.FormatMessage(errorEvent.Message);
+            if (OutputWindowPane != null
+                && (this.Verbosity != LoggerVerbosity.Quiet || errorEvent is BuildErrorEventArgs))
+            {
+                // Format error and output it to the output window
+                string message = this.FormatMessage(errorEvent.Message);
                 DefaultCompilerError e = new DefaultCompilerError(file,
                                                 span.iStartLine,
                                                 span.iStartIndex,
                                                 span.iEndLine,
                                                 span.iEndIndex,
                                                 errorCode,
-					                            message);
-				e.IsWarning = isWarning;
+                                                message);
+                e.IsWarning = isWarning;
 
-				Output(GetFormattedErrorMessage(e));
-			}
+                Output(GetFormattedErrorMessage(e));
+            }
 
             UIThread.Run(delegate()
             {

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -200,7 +200,8 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                 resourceValue
 
             override this.Initialize() =
-                UIThread.CaptureSynchronizationContext()
+                Microsoft.VisualStudio.FSharp.LanguageService.UIThread.CaptureSynchronizationContext()
+                Microsoft.VisualStudio.FSharp.ProjectSystem.UIThread.CaptureSynchronizationContext()
 
                 base.Initialize()
 

--- a/vsintegration/tests/UnitTests/TestLib.Utils.fs
+++ b/vsintegration/tests/UnitTests/TestLib.Utils.fs
@@ -51,6 +51,7 @@ module Asserts =
 
 module UIStuff =
     let SetupSynchronizationContext() =
+        Microsoft.VisualStudio.FSharp.ProjectSystem.UIThread.InitUnitTestingMode()
         Microsoft.VisualStudio.FSharp.LanguageService.UIThread.InitUnitTestingMode()
         Microsoft.VisualStudio.FSharp.ProjectSystem.UIThread.InitUnitTestingMode()
 


### PR DESCRIPTION
With a developer build of F# from the master branch, when you load a legacy project and clean or rbuidl or build the project.  VS crashes.

This was already fixed in the dev15.8 branch with this commit:  https://github.com/Microsoft/visualfsharp/commit/91f490660c80f5c64fe930f7425275909f4c10d3

This merely cherrypicks and fixes the merge issues.
 
