### PR TITLE
use gcServer in fsiAnyCpu

### DIFF
--- a/src/fsharp/fsiAnyCpu/app.config
+++ b/src/fsharp/fsiAnyCpu/app.config
@@ -2,6 +2,7 @@
 <configuration>
   <runtime>
     <gcAllowVeryLargeObjects enabled="true" />
+    <gcServer enabled="true" />
     <legacyUnhandledExceptionPolicy enabled="true" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
This change increases GC throughput when doing parallel processing with fsi.
A simple test:
```
let nums = [|1..1000000|]

let isPrime n = 
    let upperBound = int (sqrt (float n))
    let hasDivisor =     
        [2..upperBound]
        |> List.exists (fun i -> n % i = 0)
    not hasDivisor

System.GC.Collect()

let finalDigitOfPrimes = 
        nums 
        |> PSeq.filter isPrime
        |> PSeq.groupBy (fun i -> i % 10)
        |> PSeq.map (fun (k, vs) -> (k, Seq.length vs))
        |> PSeq.toArray

// Timing for finalDigit of Primes only.
// Default GC: Real: 00:00:04.444, CPU: 00:00:14.812, GC gen0: 5117, gen1: 3, gen2: 0
// Changing to gcServer: Real: 00:00:02.536, CPU: 00:00:15.187, GC gen0: 205, gen1: 0, gen2: 0
```

This difference is small in this example, but on an 18 core cpu processing lots of data I saw this change result in computation time falling from ~ 40 minutes to 10 minutes.  This seems like an acceptable tradeoff when fsharp is being used interactively.
