### PR TITLE
preserve directory structure when recursively copying files

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -29,8 +29,8 @@
 
     <Message Text="Copying build artifacts to $(FinalOutputPath)" />
     <MakeDir Directories="$(FinalOutputPath);$(FinalIntermediateOutputPath)" />
-    <Copy SourceFiles="@(OutputFilesToCopy)" DestinationFolder="$(FinalOutputPath)" />
-    <Copy SourceFiles="@(IntermediateFilesToCopy)" DestinationFolder="$(FinalIntermediateOutputPath)" />
+    <Copy SourceFiles="@(OutputFilesToCopy)" DestinationFolder="$(FinalOutputPath)\%(RecursiveDir)" />
+    <Copy SourceFiles="@(IntermediateFilesToCopy)" DestinationFolder="$(FinalIntermediateOutputPath)\%(RecursiveDir)" />
   </Target>
 
   <Import Project="build\targets\AssemblyVersions.props" />


### PR DESCRIPTION
Prevent the flattening of directories when copying files; this removes a bunch of duplicate file writes during a build.

Fixes #5224.

**Edit:** Internal build has passed and the generated NuGet package was correct; it didn't have the duplicate copy of `FSharp.Core.resources.dll` in `lib\net45`.