### PR TITLE
Treat pinvokes like abstract methods for debugging

### DIFF
--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -2526,7 +2526,8 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
                 SequencePoints=seqpoints }
           cenv.AddCode code
           addr
-      | MethodBody.Abstract ->
+      | MethodBody.Abstract
+      | MethodBody.PInvoke _ ->
           // Now record the PDB record for this method - we write this out later. 
           if cenv.generatePdb then 
             cenv.pdbinfo.Add  


### PR DESCRIPTION
We need a row to be recorded in the MethodDebugInformation table.
Fixes #4637