### PR TITLE
Fixed extension members that extend a type using a byref to be called with an immutable value

### DIFF
--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
@@ -4327,33 +4327,33 @@ type internal SR private() =
     /// The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
     /// (Originally from ..\FSComp.txt:1433)
     static member chkNoByrefAddressOfValueFromExpression() = (3228, GetStringFunc("chkNoByrefAddressOfValueFromExpression",",,,") )
-    /// The Span or IsByRefLike expression cannot be returned from this function or method, because it is composed using elements that may escape their scope.
-    /// (Originally from ..\FSComp.txt:1434)
-    static member chkNoReturnOfLimitedSpan() = (3229, GetStringFunc("chkNoReturnOfLimitedSpan",",,,") )
     /// This value can't be assigned because the target '%s' may refer to non-stack-local memory, while the expression being assigned is assessed to potentially refer to stack-local memory. This is to help prevent pointers to stack-bound memory escaping their scope.
-    /// (Originally from ..\FSComp.txt:1435)
-    static member chkNoWriteToLimitedSpan(a0 : System.String) = (3230, GetStringFunc("chkNoWriteToLimitedSpan",",,,%s,,,") a0)
+    /// (Originally from ..\FSComp.txt:1434)
+    static member chkNoWriteToLimitedSpan(a0 : System.String) = (3229, GetStringFunc("chkNoWriteToLimitedSpan",",,,%s,,,") a0)
     /// A value defined in a module must be mutable in order to take its address, e.g. 'let mutable x = ...'
-    /// (Originally from ..\FSComp.txt:1436)
-    static member tastValueMustBeLocal() = (3231, GetStringFunc("tastValueMustBeLocal",",,,") )
+    /// (Originally from ..\FSComp.txt:1435)
+    static member tastValueMustBeLocal() = (3230, GetStringFunc("tastValueMustBeLocal",",,,") )
     /// A type annotated with IsReadOnly must also be a struct. Consider adding the [<Struct>] attribute to the type.
+    /// (Originally from ..\FSComp.txt:1436)
+    static member tcIsReadOnlyNotStruct() = (3231, GetStringFunc("tcIsReadOnlyNotStruct",",,,") )
+    /// Struct members cannot return the address of fields of the struct by reference
     /// (Originally from ..\FSComp.txt:1437)
-    static member tcIsReadOnlyNotStruct() = (3232, GetStringFunc("tcIsReadOnlyNotStruct",",,,") )
-    /// Struct members cannot return 'this' or fields by reference
-    /// (Originally from ..\FSComp.txt:1438)
-    static member chkStructsMayNotReturnAddressesOfContents() = (3234, GetStringFunc("chkStructsMayNotReturnAddressesOfContents",",,,") )
+    static member chkStructsMayNotReturnAddressesOfContents() = (3232, GetStringFunc("chkStructsMayNotReturnAddressesOfContents",",,,") )
     /// The function or method call cannot be used at this point, because one argument that is a byref of a non-stack-local Span or IsByRefLike type is used with another argument that is a stack-local Span or IsByRefLike type. This is to ensure the address of the local value does not escape its scope.
-    /// (Originally from ..\FSComp.txt:1439)
-    static member chkNoByrefLikeFunctionCall() = (3235, GetStringFunc("chkNoByrefLikeFunctionCall",",,,") )
+    /// (Originally from ..\FSComp.txt:1438)
+    static member chkNoByrefLikeFunctionCall() = (3233, GetStringFunc("chkNoByrefLikeFunctionCall",",,,") )
     /// The Span or IsByRefLike variable '%s' cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
-    /// (Originally from ..\FSComp.txt:1440)
-    static member chkNoSpanLikeVariable(a0 : System.String) = (3236, GetStringFunc("chkNoSpanLikeVariable",",,,%s,,,") a0)
+    /// (Originally from ..\FSComp.txt:1439)
+    static member chkNoSpanLikeVariable(a0 : System.String) = (3234, GetStringFunc("chkNoSpanLikeVariable",",,,%s,,,") a0)
     /// A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope.
-    /// (Originally from ..\FSComp.txt:1441)
-    static member chkNoSpanLikeValueFromExpression() = (3237, GetStringFunc("chkNoSpanLikeValueFromExpression",",,,") )
+    /// (Originally from ..\FSComp.txt:1440)
+    static member chkNoSpanLikeValueFromExpression() = (3235, GetStringFunc("chkNoSpanLikeValueFromExpression",",,,") )
     /// Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+    /// (Originally from ..\FSComp.txt:1441)
+    static member tastCantTakeAddressOfExpression() = (3236, GetStringFunc("tastCantTakeAddressOfExpression",",,,") )
+    /// Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
     /// (Originally from ..\FSComp.txt:1442)
-    static member tastCantTakeAddressOfExpression() = (3238, GetStringFunc("tastCantTakeAddressOfExpression",",,,") )
+    static member tcCannotCallExtensionMemberInrefToByref() = (3237, GetStringFunc("tcCannotCallExtensionMemberInrefToByref",",,,") )
 
     /// Call this method once to validate that all known resources are valid; throws if not
     static member RunStartupValidation() =
@@ -5761,7 +5761,6 @@ type internal SR private() =
         ignore(GetString("tcByrefReturnImplicitlyDereferenced"))
         ignore(GetString("tcByRefLikeNotStruct"))
         ignore(GetString("chkNoByrefAddressOfValueFromExpression"))
-        ignore(GetString("chkNoReturnOfLimitedSpan"))
         ignore(GetString("chkNoWriteToLimitedSpan"))
         ignore(GetString("tastValueMustBeLocal"))
         ignore(GetString("tcIsReadOnlyNotStruct"))
@@ -5770,4 +5769,5 @@ type internal SR private() =
         ignore(GetString("chkNoSpanLikeVariable"))
         ignore(GetString("chkNoSpanLikeValueFromExpression"))
         ignore(GetString("tastCantTakeAddressOfExpression"))
+        ignore(GetString("tcCannotCallExtensionMemberInrefToByref"))
         ()

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
@@ -4330,9 +4330,6 @@
   <data name="chkNoByrefAddressOfValueFromExpression" xml:space="preserve">
     <value>The address of a value returned from the expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.</value>
   </data>
-  <data name="chkNoReturnOfLimitedSpan" xml:space="preserve">
-    <value>The Span or IsByRefLike expression cannot be returned from this function or method, because it is composed using elements that may escape their scope.</value>
-  </data>
   <data name="chkNoWriteToLimitedSpan" xml:space="preserve">
     <value>This value can't be assigned because the target '{0}' may refer to non-stack-local memory, while the expression being assigned is assessed to potentially refer to stack-local memory. This is to help prevent pointers to stack-bound memory escaping their scope.</value>
   </data>
@@ -4343,7 +4340,7 @@
     <value>A type annotated with IsReadOnly must also be a struct. Consider adding the [&lt;Struct&gt;] attribute to the type.</value>
   </data>
   <data name="chkStructsMayNotReturnAddressesOfContents" xml:space="preserve">
-    <value>Struct members cannot return 'this' or fields by reference</value>
+    <value>Struct members cannot return the address of fields of the struct by reference</value>
   </data>
   <data name="chkNoByrefLikeFunctionCall" xml:space="preserve">
     <value>The function or method call cannot be used at this point, because one argument that is a byref of a non-stack-local Span or IsByRefLike type is used with another argument that is a stack-local Span or IsByRefLike type. This is to ensure the address of the local value does not escape its scope.</value>
@@ -4356,5 +4353,8 @@
   </data>
   <data name="tastCantTakeAddressOfExpression" xml:space="preserve">
     <value>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</value>
+  </data>
+  <data name="tcCannotCallExtensionMemberInrefToByref" xml:space="preserve">
+    <value>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</value>
   </data>
 </root>

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1439,3 +1439,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3234,chkNoSpanLikeVariable,"The Span or IsByRefLike variable '%s' cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
 3235,chkNoSpanLikeValueFromExpression,"A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope."
 3236,tastCantTakeAddressOfExpression,"Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address."
+3237,tcCannotCallExtensionMemberInrefToByref,"Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1439,4 +1439,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3234,chkNoSpanLikeVariable,"The Span or IsByRefLike variable '%s' cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
 3235,chkNoSpanLikeValueFromExpression,"A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope."
 3236,tastCantTakeAddressOfExpression,"Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address."
-3237,tcCannotCallExtensionMemberInrefToByref,"Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref."
+3237,tcCannotCallExtensionMemberInrefToByref,"Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref."

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -604,19 +604,19 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
                     // For F# defined methods.
                     | FSMeth(_, _, vref, _) ->
                         let ty, _ = destFunTy g vref.Type
-                        ValueSome(ty)
+                        Some(ty)
 
                     // For IL methods, defined outside of F#.
                     | ILMeth(_, info, _) ->
                         let paramTypes = info.GetRawArgTypes(amap, m, minfo.FormalMethodInst)
                         match paramTypes with
                         | [] -> failwith "impossible"
-                        | ty :: _ -> ValueSome(ty)
+                        | ty :: _ -> Some(ty)
 
-                    | _ -> ValueNone
+                    | _ -> None
                 
                 match tyOpt with
-                | ValueSome(ty) ->
+                | Some(ty) ->
                     if isByrefTy g ty && not (isInByrefTy g ty) then
                         errorR(Error(FSComp.SR.tcCannotCallExtensionMemberInrefToByref(), m))
                 | _ -> ()

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -585,7 +585,7 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
             let hasCallInfo = ccallInfo.IsSome
             let mustTakeAddress = hasCallInfo || minfo.ObjArgNeedsAddress(amap, m)
             let objArgTy = tyOfExpr g objArgExpr
-            let wrap, objArgExpr', readonly, _writeonly = mkExprAddrOfExpr g mustTakeAddress hasCallInfo isMutable objArgExpr None m
+            let wrap, objArgExpr', isReadOnly, _isWriteOnly = mkExprAddrOfExpr g mustTakeAddress hasCallInfo isMutable objArgExpr None m
             
             // Extension members and calls to class constraints may need a coercion for their object argument
             let objArgExpr' = 
@@ -598,7 +598,7 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
             // Check to see if the extension member uses the extending type as a byref.
             //     If so, make sure we don't allow readonly/immutable values to be passed byref from an extension member. 
             //     An inref will work though.
-            if mustTakeAddress && readonly && minfo.IsExtensionMember then
+            if mustTakeAddress && isReadOnly && minfo.IsExtensionMember then
                 let tyOpt =
                     match minfo with
                     // For F# defined methods.

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -585,7 +585,7 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
             let hasCallInfo = ccallInfo.IsSome
             let mustTakeAddress = hasCallInfo || minfo.ObjArgNeedsAddress(amap, m)
             let objArgTy = tyOfExpr g objArgExpr
-            let wrap, objArgExpr', _readonly, _writeonly = mkExprAddrOfExpr g mustTakeAddress hasCallInfo isMutable objArgExpr None m
+            let wrap, objArgExpr', readonly, _writeonly = mkExprAddrOfExpr g mustTakeAddress hasCallInfo isMutable objArgExpr None m
             
             // Extension members and calls to class constraints may need a coercion for their object argument
             let objArgExpr' = 
@@ -594,6 +594,32 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
                   mkCoerceExpr(objArgExpr', minfo.ApparentEnclosingType, m, objArgTy)
               else
                   objArgExpr'
+
+            // Check to see if the extension member uses the extending type as a byref.
+            //     If so, make sure we don't allow readonly/immutable values to be passed byref from an extension member. 
+            //     An inref will work though.
+            if mustTakeAddress && readonly && minfo.IsExtensionMember then
+                let tyOpt =
+                    match minfo with
+                    // For F# defined methods.
+                    | FSMeth(_, _, vref, _) ->
+                        let ty, _ = destFunTy g vref.Type
+                        ValueSome(ty)
+
+                    // For IL methods, defined outside of F#.
+                    | ILMeth(_, info, _) ->
+                        let paramTypes = info.GetRawArgTypes(amap, m, minfo.FormalMethodInst)
+                        match paramTypes with
+                        | [] -> failwith "impossible"
+                        | ty :: _ -> ValueSome(ty)
+
+                    | _ -> ValueNone
+                
+                match tyOpt with
+                | ValueSome(ty) ->
+                    if isByrefTy g ty && not (isInByrefTy g ty) then
+                        errorR(Error(FSComp.SR.tcCannotCallExtensionMemberInrefToByref(), m))
+                | _ -> ()
 
             wrap, [objArgExpr'] 
 

--- a/src/fsharp/import.fs
+++ b/src/fsharp/import.fs
@@ -168,7 +168,6 @@ let rec ImportILType (env:ImportMap) m tinst ty =
         let inst = tspec.GenericArgs |> List.map (ImportILType env m tinst) 
         ImportTyconRefApp env tcref inst
 
-    | ILType.Modified(_,tref,ILType.Byref ty) when tref.Name = "System.Runtime.InteropServices.InAttribute" -> mkInByrefTy env.g (ImportILType env m tinst ty)
     | ILType.Byref ty -> mkByrefTy env.g (ImportILType env m tinst ty)
     | ILType.Ptr ILType.Void  when env.g.voidptr_tcr.CanDeref -> mkVoidPtrTy env.g
     | ILType.Ptr ty  -> mkNativePtrTy env.g (ImportILType env m tinst ty)

--- a/src/fsharp/symbols/Exprs.fs
+++ b/src/fsharp/symbols/Exprs.fs
@@ -1033,7 +1033,7 @@ module FSharpExprConvert =
                 // is not sufficient to resolve to a symbol unambiguously in these cases.
                 let argtys = [ ilMethRef.ArgTypes |> List.map (ImportILTypeFromMetadata cenv.amap m scoref tinst1 tinst2) ]
                 let rty = 
-                    match ImportReturnTypeFromMetaData cenv.amap m ilMethRef.ReturnType scoref tinst1 tinst2 with 
+                    match ImportReturnTypeFromMetadata cenv.amap m ilMethRef.ReturnType emptyILCustomAttrs scoref tinst1 tinst2 with 
                     | None -> if isCtor then  enclosingType else cenv.g.unit_ty
                     | Some ty -> ty
 

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">Adresa hodnoty vrácená výrazem nejde převzít. Před převzetím adresy přiřaďte vrácenou hodnotu hodnotě s vazbou na klauzuli Let.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">Die Adresse des über den Ausdruck zurückgegebenen Werts kann nicht abgerufen werden. Weisen Sie den zurückgegebenen Wert einem let-bound-Wert zu, bevor Sie die Adresse abrufen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -7057,6 +7057,11 @@
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">No se puede tomar la dirección del valor devuelto de la expresión. Asigne el valor devuelto a un valor enlazado con let antes de tomar la dirección.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">Impossible de prendre l'adresse de la valeur retournée par l'expression. Assignez la valeur retournée à une valeur liée à let avant de prendre l'adresse.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">Non è possibile accettare l'indirizzo del valore restituito dall'espressione. Assegnare il valore restituito a un valore associato a let prima di accettare l'indirizzo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">式から返された値のアドレスを取得できません。アドレスを取得する前に、let でバインドされた値に戻り値を割り当ててください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">식에서 반환된 값의 주소를 가져올 수 없습니다. 주소를 가져오기 전에 반환된 값을 let 바인딩 값에 할당하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">Nie można uzyskać adresu wartości zwróconej przez wyrażenie. Przypisz zwróconą wartość do wartości powiązanej za pomocą instrukcji let przed uzyskaniem adresu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">Não é possível obter o endereço do valor retornado da expressão. Atribua o valor retornado a um valor associado a let antes de obter o endereço.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">Невозможно получить адрес значения, возвращенного из выражения. Используйте возвращенное значение в качестве значения с привязкой let, прежде чем получить адрес.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">İfadeden döndürülen değerin adresi alınamaz. Adresi almadan önce, döndürülen değeri let ile bağlanmış bir değere atayın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">无法采用从表达式返回的地址值。在采用地址前将返回值分配给 let 绑定值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -7057,6 +7057,11 @@
         <target state="translated">無法使用運算式傳回值的位址。在使用位址前，先將傳回值指派給以 let 繫結的值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
+        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -7058,8 +7058,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.</target>
+        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
+        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/scripts/scriptlib.fsx
+++ b/src/scripts/scriptlib.fsx
@@ -159,9 +159,9 @@ module Scripting =
 
             match p.ExitCode with
             | 0 -> Success
-            | err -> 
+            | errCode -> 
                 let msg = sprintf "Error running command '%s' with args '%s' in directory '%s'.\n---- stdout below --- \n%s\n---- stderr below --- \n%s " exePath arguments workDir (out.ToString()) (err.ToString())
-                ErrorLevel (msg, err)
+                ErrorLevel (msg, errCode)
 
     type OutPipe (writer: TextWriter) =
         member x.Post (msg:string) = lock writer (fun () -> writer.WriteLine(msg))

--- a/tests/fsharp/core/byrefs/cslib3.cs
+++ b/tests/fsharp/core/byrefs/cslib3.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace CSharpLib3
+{
+    public static class Extensions
+    {
+        public static void Test(this in DateTime dt)
+        {
+
+        }
+
+        public static ref readonly DateTime Test2(this ref DateTime dt)
+        {
+            return ref dt;
+        }
+    }
+}

--- a/tests/fsharp/core/byrefs/test3.bsl
+++ b/tests/fsharp/core/byrefs/test3.bsl
@@ -1,5 +1,5 @@
 
-test3.fsx(39,18,39,28): typecheck error FS3237: Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.
+test3.fsx(39,18,39,28): typecheck error FS3237: Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
 
 test3.fsx(40,9,40,11): typecheck error FS0001: Type mismatch. Expecting a
     'byref<DateTime>'    
@@ -7,4 +7,8 @@ but given a
     'inref<DateTime>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-test3.fsx(44,9,44,20): typecheck error FS3237: Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.
+test3.fsx(44,9,44,20): typecheck error FS3237: Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
+
+test3.fsx(49,19,49,30): typecheck error FS3237: Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
+
+test3.fsx(55,9,55,21): typecheck error FS3237: Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.

--- a/tests/fsharp/core/byrefs/test3.bsl
+++ b/tests/fsharp/core/byrefs/test3.bsl
@@ -1,0 +1,10 @@
+
+test3.fsx(39,18,39,28): typecheck error FS3237: Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.
+
+test3.fsx(40,9,40,11): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<DateTime>'    
+but given a
+    'inref<DateTime>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+test3.fsx(44,9,44,20): typecheck error FS3237: Cannot call the extension member as it requires a value to be mutable or a byref due to the extending type being used as a byref.

--- a/tests/fsharp/core/byrefs/test3.fsx
+++ b/tests/fsharp/core/byrefs/test3.fsx
@@ -1,0 +1,72 @@
+#if TESTS_AS_APP
+module Core_byrefs
+#endif
+
+open System
+open System.Runtime.CompilerServices
+open CSharpLib3
+
+let failures = ref false
+let report_failure (s) = 
+  stderr.WriteLine ("NO: " + s); failures := true
+let test s b = if b then () else report_failure(s) 
+
+(* TEST SUITE FOR Int32 *)
+
+let out r (s:string) = r := !r @ [s]
+
+let check s actual expected = 
+    if actual = expected then printfn "%s: OK" s
+    else report_failure (sprintf "%s: FAILED, expected %A, got %A" s expected actual)
+
+let check2 s expected actual = check s actual expected
+
+// Test extension members for byrefs
+
+[<Extension>]
+type Ext() =
+    [<Extension>]
+    static member inline Change(dt: byref<DateTime>) = ()
+
+    [<Extension>]
+    static member inline NotChange(dt: inref<DateTime>) = ()
+
+#if NEGATIVE
+module Negatives =
+
+    let test1 () : byref<DateTime> =
+        let dt = DateTime.Now
+        let x = &dt.Test2() // should fail
+        &x // should fail
+
+    let test2 () =
+        let dt = DateTime.Now
+        dt.Change() // should fail
+
+#endif
+
+module Positives =
+
+    let test1 () =
+        let dt = DateTime.Now
+        dt.Test()
+
+    let test2 () =
+        let dt = DateTime.Now
+        dt.NotChange()
+
+    let test3 () =
+        let mutable dt = DateTime.Now
+        let _x = dt.Test2()
+        dt.Test()
+
+    let test4 () =
+        let mutable dt = DateTime.Now
+        dt.Change()
+        dt.NotChange()
+
+let aa =
+  if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
+  else (stdout.WriteLine "Test Passed"; 
+        System.IO.File.WriteAllText("test3.ok","ok"); 
+        exit 0)

--- a/tests/fsharp/core/byrefs/test3.fsx
+++ b/tests/fsharp/core/byrefs/test3.fsx
@@ -43,27 +43,48 @@ module Negatives =
         let dt = DateTime.Now
         dt.Change() // should fail
 
+    let test3 () =
+        let dt = DateTime.Now
+        let dtr = &dt
+        let _x = &dtr.Test2() // should fail
+        ()
+
+    let test4 () =
+        let dt = DateTime.Now
+        let dtr = &dt
+        dtr.Change() // should fail
+
 #endif
 
 module Positives =
 
     let test1 () =
         let dt = DateTime.Now
-        dt.Test()
+        let _x = dt.Test()
+        let dtr = &dt
+        dtr.Test()
 
     let test2 () =
         let dt = DateTime.Now
         dt.NotChange()
+        let dtr = &dt
+        dtr.NotChange()
 
     let test3 () =
         let mutable dt = DateTime.Now
         let _x = dt.Test2()
         dt.Test()
+        let dtr = &dt
+        let _x = dtr.Test2()
+        dtr.Test()
 
     let test4 () =
         let mutable dt = DateTime.Now
         dt.Change()
         dt.NotChange()
+        let dtr = &dt
+        dtr.Change()
+        dtr.NotChange()
 
 let aa =
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 

--- a/tests/fsharp/core/fsfromfsviacs/test.fsx
+++ b/tests/fsharp/core/fsfromfsviacs/test.fsx
@@ -166,12 +166,10 @@ module TestExtensions =
     check "dfeweeon1" (System.DateTime.Now.ExtendCSharpTypeWithInRefReturnExtension()).Date  x.Date
     check "dfeweeon2" (x.ExtendCSharpTypeWithInRefReturnExtension()).Date x.Date
 
-    check "dfeweeon3" (x.ExtendCSharpTypeWithRefReturnExtension()).Date x.Date
-
     let mutable mx = x
     check "dfeweeon4" (mx.ExtendCSharpTypeWithOutRefExtension(); mx) x.Date
 
-    check "dfeweeon5" (x.ExtendCSharpTypeWithInRefExtension()) x.Year
+    check "dfeweeon5" (mx.ExtendCSharpTypeWithInRefExtension()) x.Year
 
 
 let ToFSharpFunc() = 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -190,22 +190,6 @@ module CoreTests =
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
-            fsi cfg "" ["test.fsx"]
-
-            testOkFile.CheckExists()
-        end
-
-        begin
-
-            use testOkFile = fileguard cfg "test.ok"
-
-            fsiAnyCpu cfg "" ["test.fsx"]
-
-            testOkFile.CheckExists()
-        end
-
-        begin
             use testOkFile = fileguard cfg "test2.ok"
 
             fsc cfg "%s -o:test2.exe -g" cfg.fsc_flags ["test2.fsx"]
@@ -213,6 +197,20 @@ module CoreTests =
             singleNegTest cfg "test2"
 
             exec cfg ("." ++ "test2.exe") ""
+
+            testOkFile.CheckExists()
+        end
+
+        begin
+            csc cfg """/langversion:7.2 /nologo /target:library /out:cslib3.dll""" ["cslib3.cs"]
+
+            use testOkFile = fileguard cfg "test3.ok"
+
+            fsc cfg "%s -r:cslib3.dll -o:test3.exe -g" cfg.fsc_flags ["test3.fsx"]
+
+            singleNegTest { cfg with fsc_flags = sprintf "%s -r:cslib3.dll" cfg.fsc_flags } "test3"
+
+            exec cfg ("." ++ "test3.exe") ""
 
             testOkFile.CheckExists()
         end


### PR DESCRIPTION
This PR fixes two issues:

- Fixes https://github.com/Microsoft/visualfsharp/issues/5355 - prevents passing an immutable value `byref<_>` on an extension member.

- Fixes reading IL defined methods that have a `[IsReadOnly]` attribute on a parameter with type `byref<_>` that gets interpreted as `byref<_>` (should be `inref<_>`). We fix this by simply telling the type to be `inref<_>` on a parameter or return if it has a `[IsReadOnly]` attribute and it's a byref type.


