### PR TITLE
Fixed overloading for inref/outref/byref from passing

### DIFF
--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -2456,6 +2456,10 @@ type EventInfo =
 //-------------------------------------------------------------------------
 // Helpers associated with getting and comparing method signatures
 
+/// Strips inref and outref to be a byref.
+let stripByrefTy g ty =
+    if isByrefTy g ty then mkByrefTy g (destByrefTy g ty)
+    else ty
 
 /// Represents the information about the compiled form of a method signature. Used when analyzing implementation
 /// relations between members and abstract slots.
@@ -2479,7 +2483,8 @@ let CompiledSigOfMeth g amap m (minfo:MethInfo) =
             
     CompiledSig(vargtys,vrty,formalMethTypars,fmtpinst)
 
-/// Used to hide/filter members from super classes based on signature 
+/// Used to hide/filter members from super classes based on signature
+/// Inref and outref parameter types will be treated as a byref type for equivalency.
 let MethInfosEquivByNameAndPartialSig erasureFlag ignoreFinal g amap m (minfo:MethInfo) (minfo2:MethInfo) = 
     (minfo.LogicalName = minfo2.LogicalName) &&
     (minfo.GenericArity = minfo2.GenericArity) &&
@@ -2490,7 +2495,8 @@ let MethInfosEquivByNameAndPartialSig erasureFlag ignoreFinal g amap m (minfo:Me
     let fminst2 = generalizeTypars formalMethTypars2
     let argtys = minfo.GetParamTypes(amap, m, fminst)
     let argtys2 = minfo2.GetParamTypes(amap, m, fminst2)
-    (argtys,argtys2) ||> List.lengthsEqAndForall2 (List.lengthsEqAndForall2 (typeAEquivAux erasureFlag g (TypeEquivEnv.FromEquivTypars formalMethTypars formalMethTypars2)))
+    (argtys,argtys2) ||> List.lengthsEqAndForall2 (List.lengthsEqAndForall2 (fun ty1 ty2 ->
+        typeAEquivAux erasureFlag g (TypeEquivEnv.FromEquivTypars formalMethTypars formalMethTypars2) (stripByrefTy g ty1) (stripByrefTy g ty2)))
 
 /// Used to hide/filter members from super classes based on signature 
 let PropInfosEquivByNameAndPartialSig erasureFlag g amap m (pinfo:PropInfo) (pinfo2:PropInfo) = 

--- a/tests/fsharp/core/byrefs/test2.bsl
+++ b/tests/fsharp/core/byrefs/test2.bsl
@@ -28,3 +28,9 @@ test2.fsx(93,17,93,29): typecheck error FS0425: The type of a first-class functi
 test2.fsx(112,53,112,54): typecheck error FS3209: The address of the variable 'x' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
 test2.fsx(124,33,124,34): typecheck error FS3209: The address of the variable 'x' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
+
+test2.fsx(133,23,133,27): typecheck error FS0438: Duplicate method. The method 'Beef' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.
+
+test2.fsx(131,23,131,27): typecheck error FS0438: Duplicate method. The method 'Beef' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.
+
+test2.fsx(129,23,129,27): typecheck error FS0438: Duplicate method. The method 'Beef' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.

--- a/tests/fsharp/core/byrefs/test2.bsl
+++ b/tests/fsharp/core/byrefs/test2.bsl
@@ -29,8 +29,8 @@ test2.fsx(112,53,112,54): typecheck error FS3209: The address of the variable 'x
 
 test2.fsx(124,33,124,34): typecheck error FS3209: The address of the variable 'x' or a related expression cannot be used at this point. This is to ensure the address of the local value does not escape its scope.
 
-test2.fsx(133,23,133,27): typecheck error FS0438: Duplicate method. The method 'Beef' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.
+test2.fsx(133,23,133,33): typecheck error FS0438: Duplicate method. The method 'TestMethod' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.
 
-test2.fsx(131,23,131,27): typecheck error FS0438: Duplicate method. The method 'Beef' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.
+test2.fsx(131,23,131,33): typecheck error FS0438: Duplicate method. The method 'TestMethod' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.
 
-test2.fsx(129,23,129,27): typecheck error FS0438: Duplicate method. The method 'Beef' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.
+test2.fsx(129,23,129,33): typecheck error FS0438: Duplicate method. The method 'TestMethod' has the same name and signature as another method in type 'NegativeTests.TestNegativeOverloading'.

--- a/tests/fsharp/core/byrefs/test2.fsx
+++ b/tests/fsharp/core/byrefs/test2.fsx
@@ -126,11 +126,11 @@ module NegativeTests =
 
     type TestNegativeOverloading() =
 
-        static member Beef(dt: byref<int>) = ()
+        static member TestMethod(dt: byref<int>) = ()
 
-        static member Beef(dt: inref<int>) = ()
+        static member TestMethod(dt: inref<int>) = ()
 
-        static member Beef(dt: outref<int>) = ()
+        static member TestMethod(dt: outref<int>) = ()
 #endif
 
 module Tests =
@@ -148,11 +148,11 @@ module Tests =
 
     type TestPositiveOverloading() =
 
-        static member Beef(dt: byref<int>) = ()
+        static member TestMethod(dt: byref<int>) = ()
 
-        static member Beef(dt: inref<float32>) = ()
+        static member TestMethod(dt: inref<float32>) = ()
 
-        static member Beef(dt: outref<float>) = ()
+        static member TestMethod(dt: outref<float>) = ()
 
 let aa =
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 

--- a/tests/fsharp/core/byrefs/test2.fsx
+++ b/tests/fsharp/core/byrefs/test2.fsx
@@ -123,6 +123,14 @@ module NegativeTests =
         let mutable x = 1
         let f = Beef(fun () -> &x) // is not allowed
         ()
+
+    type TestNegativeOverloading() =
+
+        static member Beef(dt: byref<int>) = ()
+
+        static member Beef(dt: inref<int>) = ()
+
+        static member Beef(dt: outref<int>) = ()
 #endif
 
 module Tests =
@@ -137,6 +145,14 @@ module Tests =
             let y = &x // is allowed
             ()
         ()
+
+    type TestPositiveOverloading() =
+
+        static member Beef(dt: byref<int>) = ()
+
+        static member Beef(dt: inref<float32>) = ()
+
+        static member Beef(dt: outref<float>) = ()
 
 let aa =
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 


### PR DESCRIPTION
Fixes this issue: https://github.com/Microsoft/visualfsharp/issues/5446

The changes are simple. On method argument type equivalency, turn inref/outref type into a byref type.