### PR TITLE
Remove a ton of build warnings

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -557,10 +557,10 @@ echo.
 echo ---------------- Done with arguments, starting preparation -----------------
 rem set TargetFrameworkSDKToolsDirectory --- needed for sdk to find al.exe. 
 if not "%TargetFrameworkSDKToolsDirectory%" == "" ( goto have_TargetFrameworkSDKToolsDirectory ) 
-set TargetFrameworkSDKToolsDirectory=%WindowsSDK_ExecutablePath_x64% 
+set TargetFrameworkSDKToolsDirectory=%WindowsSDK_ExecutablePath_x64%
 
 if not "%TargetFrameworkSDKToolsDirectory%" == "" ( goto have_TargetFrameworkSDKToolsDirectory ) 
-set TargetFrameworkSDKToolsDirectory=%WindowsSDK_ExecutablePath_x86% 
+set TargetFrameworkSDKToolsDirectory=%WindowsSDK_ExecutablePath_x86%
 
 :have_TargetFrameworkSDKToolsDirectory 
 


### PR DESCRIPTION
A recent checkin gave us the benefit of about 170 build warnings.  This cuts it bask to 2 build warnings, a comes at the cost of deleting 2 space characters.

#feelingaccomplished
