### PR TITLE
[WIP, Prototype] Disallowing byref extension methods to be reference types

### DIFF
--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
@@ -4351,7 +4351,7 @@ type internal SR private() =
     /// Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
     /// (Originally from ..\FSComp.txt:1441)
     static member tastCantTakeAddressOfExpression() = (3236, GetStringFunc("tastCantTakeAddressOfExpression",",,,") )
-    /// Cannot call the byref extension method '%s' as the first parameter requires the value to be mutable or a non-readonly byref type.
+    /// Cannot call the byref extension method '%s. The first parameter requires the value to be mutable or a non-readonly byref type.
     /// (Originally from ..\FSComp.txt:1442)
     static member tcCannotCallExtensionMethodInrefToByref(a0 : System.String) = (3237, GetStringFunc("tcCannotCallExtensionMethodInrefToByref",",,,%s,,,") a0)
     /// Byref types are not allowed to have optional type extensions.

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
@@ -4351,12 +4351,15 @@ type internal SR private() =
     /// Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
     /// (Originally from ..\FSComp.txt:1441)
     static member tastCantTakeAddressOfExpression() = (3236, GetStringFunc("tastCantTakeAddressOfExpression",",,,") )
-    /// Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
+    /// Cannot call the byref extension method '%s' as the first parameter requires the value to be mutable or a non-readonly byref type.
     /// (Originally from ..\FSComp.txt:1442)
-    static member tcCannotCallExtensionMemberInrefToByref() = (3237, GetStringFunc("tcCannotCallExtensionMemberInrefToByref",",,,") )
+    static member tcCannotCallExtensionMethodInrefToByref(a0 : System.String) = (3237, GetStringFunc("tcCannotCallExtensionMethodInrefToByref",",,,%s,,,") a0)
     /// Byref types are not allowed to have optional type extensions.
     /// (Originally from ..\FSComp.txt:1443)
     static member tcByrefsMayNotHaveTypeExtensions() = (3238, GetStringFunc("tcByrefsMayNotHaveTypeExtensions",",,,") )
+    /// Cannot partially apply the extension method '%s' because the first parameter is a byref type.
+    /// (Originally from ..\FSComp.txt:1444)
+    static member tcCannotPartiallyApplyExtensionMethodForByref(a0 : System.String) = (3239, GetStringFunc("tcCannotPartiallyApplyExtensionMethodForByref",",,,%s,,,") a0)
 
     /// Call this method once to validate that all known resources are valid; throws if not
     static member RunStartupValidation() =
@@ -5772,6 +5775,7 @@ type internal SR private() =
         ignore(GetString("chkNoSpanLikeVariable"))
         ignore(GetString("chkNoSpanLikeValueFromExpression"))
         ignore(GetString("tastCantTakeAddressOfExpression"))
-        ignore(GetString("tcCannotCallExtensionMemberInrefToByref"))
+        ignore(GetString("tcCannotCallExtensionMethodInrefToByref"))
         ignore(GetString("tcByrefsMayNotHaveTypeExtensions"))
+        ignore(GetString("tcCannotPartiallyApplyExtensionMethodForByref"))
         ()

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
@@ -4355,7 +4355,7 @@
     <value>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</value>
   </data>
   <data name="tcCannotCallExtensionMethodInrefToByref" xml:space="preserve">
-    <value>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</value>
+    <value>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</value>
   </data>
   <data name="tcByrefsMayNotHaveTypeExtensions" xml:space="preserve">
     <value>Byref types are not allowed to have optional type extensions.</value>

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
@@ -4354,10 +4354,13 @@
   <data name="tastCantTakeAddressOfExpression" xml:space="preserve">
     <value>Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</value>
   </data>
-  <data name="tcCannotCallExtensionMemberInrefToByref" xml:space="preserve">
-    <value>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</value>
+  <data name="tcCannotCallExtensionMethodInrefToByref" xml:space="preserve">
+    <value>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</value>
   </data>
   <data name="tcByrefsMayNotHaveTypeExtensions" xml:space="preserve">
     <value>Byref types are not allowed to have optional type extensions.</value>
+  </data>
+  <data name="tcCannotPartiallyApplyExtensionMethodForByref" xml:space="preserve">
+    <value>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</value>
   </data>
 </root>

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1442,3 +1442,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3237,tcCannotCallExtensionMethodInrefToByref,"Cannot call the byref extension method '%s. The first parameter requires the value to be mutable or a non-readonly byref type."
 3238,tcByrefsMayNotHaveTypeExtensions,"Byref types are not allowed to have optional type extensions."
 3239,tcCannotPartiallyApplyExtensionMethodForByref,"Cannot partially apply the extension method '%s' because the first parameter is a byref type."
+3240,chkByrefExtensionMethodMustBeAStruct,"The first parameter of the byref extension method '%s' must be a value type or a generic type constrained to struct."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1439,6 +1439,6 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3234,chkNoSpanLikeVariable,"The Span or IsByRefLike variable '%s' cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
 3235,chkNoSpanLikeValueFromExpression,"A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope."
 3236,tastCantTakeAddressOfExpression,"Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address."
-3237,tcCannotCallExtensionMethodInrefToByref,"Cannot call the byref extension method '%s' as the first parameter requires the value to be mutable or a non-readonly byref type."
+3237,tcCannotCallExtensionMethodInrefToByref,"Cannot call the byref extension method '%s. The first parameter requires the value to be mutable or a non-readonly byref type."
 3238,tcByrefsMayNotHaveTypeExtensions,"Byref types are not allowed to have optional type extensions."
 3239,tcCannotPartiallyApplyExtensionMethodForByref,"Cannot partially apply the extension method '%s' because the first parameter is a byref type."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1439,5 +1439,6 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3234,chkNoSpanLikeVariable,"The Span or IsByRefLike variable '%s' cannot be used at this point. This is to ensure the address of the local value does not escape its scope."
 3235,chkNoSpanLikeValueFromExpression,"A Span or IsByRefLike value returned from the expression cannot be used at ths point. This is to ensure the address of the local value does not escape its scope."
 3236,tastCantTakeAddressOfExpression,"Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address."
-3237,tcCannotCallExtensionMemberInrefToByref,"Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref."
+3237,tcCannotCallExtensionMethodInrefToByref,"Cannot call the byref extension method '%s' as the first parameter requires the value to be mutable or a non-readonly byref type."
 3238,tcByrefsMayNotHaveTypeExtensions,"Byref types are not allowed to have optional type extensions."
+3239,tcCannotPartiallyApplyExtensionMethodForByref,"Cannot partially apply the extension method '%s' because the first parameter is a byref type."

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -599,7 +599,7 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
             //     If so, make sure we don't allow readonly/immutable values to be passed byref from an extension member. 
             //     An inref will work though.
             if isReadOnly && mustTakeAddress && minfo.IsExtensionMember then
-                minfo.TryHeadObjArgsByrefType(amap, m, minfo.FormalMethodInst)
+                minfo.TryObjArgByrefType(amap, m, minfo.FormalMethodInst)
                 |> Option.iter (fun ty ->
                     if not (isInByrefTy g ty) then
                         errorR(Error(FSComp.SR.tcCannotCallExtensionMethodInrefToByref(minfo.DisplayName), m)))

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -599,7 +599,7 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
             //     If so, make sure we don't allow readonly/immutable values to be passed byref from an extension member. 
             //     An inref will work though.
             if isReadOnly && mustTakeAddress && minfo.IsExtensionMember then
-                minfo.TryHeadObjArgsAsByrefType(amap, m, minfo.FormalMethodInst)
+                minfo.TryHeadObjArgsByrefType(amap, m, minfo.FormalMethodInst)
                 |> Option.iter (fun ty ->
                     if not (isInByrefTy g ty) then
                         errorR(Error(FSComp.SR.tcCannotCallExtensionMethodInrefToByref(minfo.DisplayName), m)))

--- a/src/fsharp/MethodCalls.fs
+++ b/src/fsharp/MethodCalls.fs
@@ -598,28 +598,12 @@ let TakeObjAddrForMethodCall g amap (minfo:MethInfo) isMutable m objArgs f =
             // Check to see if the extension member uses the extending type as a byref.
             //     If so, make sure we don't allow readonly/immutable values to be passed byref from an extension member. 
             //     An inref will work though.
-            if mustTakeAddress && isReadOnly && minfo.IsExtensionMember then
-                let tyOpt =
-                    match minfo with
-                    // For F# defined methods.
-                    | FSMeth(_, _, vref, _) ->
-                        let ty, _ = destFunTy g vref.Type
-                        Some(ty)
-
-                    // For IL methods, defined outside of F#.
-                    | ILMeth(_, info, _) ->
-                        let paramTypes = info.GetRawArgTypes(amap, m, minfo.FormalMethodInst)
-                        match paramTypes with
-                        | [] -> failwith "impossible"
-                        | ty :: _ -> Some(ty)
-
-                    | _ -> None
-                
-                match tyOpt with
-                | Some(ty) ->
-                    if isByrefTy g ty && not (isInByrefTy g ty) then
-                        errorR(Error(FSComp.SR.tcCannotCallExtensionMemberInrefToByref(), m))
-                | _ -> ()
+            if isReadOnly && mustTakeAddress && minfo.IsExtensionMember then
+                minfo.TryHeadObjArgsAsByrefType(amap, m, minfo.FormalMethodInst)
+                |> Option.iter (fun ty ->
+                    if not (isInByrefTy g ty) then
+                        errorR(Error(FSComp.SR.tcCannotCallExtensionMethodInrefToByref(minfo.DisplayName), m)))
+                        
 
             wrap, [objArgExpr'] 
 

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -1778,7 +1778,7 @@ let CheckModuleBinding cenv env (TBind(v,e,_) as bind) =
 
             if v.IsExtensionMethod then
                 let minfo = FSMeth(g, generalizedTyconRef tcref, mkLocalValRef v, Some 0UL)
-                minfo.TryHeadObjArgsByrefType(cenv.amap, v.Range, minfo.FormalMethodInst)
+                minfo.TryObjArgByrefType(cenv.amap, v.Range, minfo.FormalMethodInst)
                 |> Option.iter (fun ty ->
                     let hasStructOrStructConstraint =
                         match destByrefTy g ty with

--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -1776,8 +1776,6 @@ let CheckModuleBinding cenv env (TBind(v,e,_) as bind) =
                            MethInfosEquivByNameAndSig EraseAll true g cenv.amap v.Range minfo1 minfo2 then 
                             errorR(Duplicate(kind,v.DisplayName,v.Range)))
 
-
-
             // Properties get 'get_X', only if there are no args
             // Properties get 'get_X'
             match v.ValReprInfo with 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -9808,10 +9808,11 @@ and TcMethodApplication
     let objArgPreBinder, objArgs = 
         match objArgs, lambdaVars with 
         | [objArg], Some _   -> 
+            if  finalCalledMethInfo.IsExtensionMember && finalCalledMethInfo.ObjArgNeedsAddress(cenv.amap, mMethExpr) then
+                error(Error(FSComp.SR.tcCannotPartiallyApplyExtensionMethodForByref(finalCalledMethInfo.DisplayName), mMethExpr))
             let objArgTy = tyOfExpr cenv.g objArg
             let v, ve = mkCompGenLocal mMethExpr "objectArg" objArgTy
             (fun body -> mkCompGenLet mMethExpr v objArg body), [ve]
-
         | _ -> 
             emptyPreBinder, objArgs
 

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1595,8 +1595,8 @@ type MethInfo =
             | _ -> 
                 x.DeclaringTyconRef.Typars(m)
 
-    /// Tries to get the head of the argument type list if it's a byref type.
-    member x.TryHeadObjArgsByrefType(amap, m, minst) =
+    /// Tries to get the object arg type if it's a byref type.
+    member x.TryObjArgByrefType(amap, m, minst) =
         x.GetObjArgTypes(amap, m, minst)
         |> List.tryHead
         |> Option.bind (fun ty ->

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1596,7 +1596,7 @@ type MethInfo =
                 x.DeclaringTyconRef.Typars(m)
 
     /// Tries to get the head of the argument type list if it's a byref type.
-    member x.TryHeadObjArgsAsByrefType(amap, m, minst) =
+    member x.TryHeadObjArgsByrefType(amap, m, minst) =
         x.GetObjArgTypes(amap, m, minst)
         |> List.tryHead
         |> Option.bind (fun ty ->

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -1595,6 +1595,14 @@ type MethInfo =
             | _ -> 
                 x.DeclaringTyconRef.Typars(m)
 
+    /// Tries to get the head of the argument type list if it's a byref type.
+    member x.TryHeadObjArgsAsByrefType(amap, m, minst) =
+        x.GetObjArgTypes(amap, m, minst)
+        |> List.tryHead
+        |> Option.bind (fun ty ->
+            if isByrefTy x.TcGlobals ty then Some(ty)
+            else None)
+
 //-------------------------------------------------------------------------
 // ILFieldInfo
 

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -124,133 +124,137 @@ type ValFlags(flags:int64) =
     new (recValInfo, baseOrThis, isCompGen, inlineInfo, isMutable, isModuleOrMemberBinding, isExtensionMember, isIncrClassSpecialMember, isTyFunc, allowTypeInst, isGeneratedEventVal) =
         let flags = 
                      (match baseOrThis with
-                                        | BaseVal ->                         0b0000000000000000000L
-                                        | CtorThisVal ->                     0b0000000000000000010L
-                                        | NormalVal ->                       0b0000000000000000100L
-                                        | MemberThisVal ->                   0b0000000000000000110L) |||
-                     (if isCompGen then                                      0b0000000000000001000L 
-                      else                                                   0b00000000000000000000L) |||
+                                        | BaseVal ->                         0b00000000000000000000L
+                                        | CtorThisVal ->                     0b00000000000000000010L
+                                        | NormalVal ->                       0b00000000000000000100L
+                                        | MemberThisVal ->                   0b00000000000000000110L) |||
+                     (if isCompGen then                                      0b00000000000000001000L 
+                      else                                                   0b000000000000000000000L) |||
                      (match inlineInfo with
-                                        | ValInline.PseudoVal ->             0b0000000000000000000L
-                                        | ValInline.Always ->                0b0000000000000010000L
-                                        | ValInline.Optional ->              0b0000000000000100000L
-                                        | ValInline.Never ->                 0b0000000000000110000L) |||
+                                        | ValInline.PseudoVal ->             0b00000000000000000000L
+                                        | ValInline.Always ->                0b00000000000000010000L
+                                        | ValInline.Optional ->              0b00000000000000100000L
+                                        | ValInline.Never ->                 0b00000000000000110000L) |||
                      (match isMutable with
-                                        | Immutable ->                       0b0000000000000000000L
-                                        | Mutable   ->                       0b0000000000001000000L) |||
+                                        | Immutable ->                       0b00000000000000000000L
+                                        | Mutable   ->                       0b00000000000001000000L) |||
 
                      (match isModuleOrMemberBinding with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000000000010000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000000000010000000L) |||
                      (match isExtensionMember with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000000000100000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000000000100000000L) |||
                      (match isIncrClassSpecialMember with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000000001000000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000000001000000000L) |||
                      (match isTyFunc with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000000010000000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000000010000000000L) |||
 
                      (match recValInfo with
-                                     | ValNotInRecScope     ->               0b0000000000000000000L
-                                     | ValInRecScope true   ->               0b0000000100000000000L
-                                     | ValInRecScope false  ->               0b0000001000000000000L) |||
+                                     | ValNotInRecScope     ->               0b00000000000000000000L
+                                     | ValInRecScope true   ->               0b00000000100000000000L
+                                     | ValInRecScope false  ->               0b00000001000000000000L) |||
 
                      (match allowTypeInst with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0000100000000000000L) |||
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00000100000000000000L) |||
 
                      (match isGeneratedEventVal with
-                                        | false     ->                       0b0000000000000000000L
-                                        | true      ->                       0b0100000000000000000L)                                        
+                                        | false     ->                       0b00000000000000000000L
+                                        | true      ->                       0b00100000000000000000L)                                        
 
         ValFlags(flags)
 
     member x.BaseOrThisInfo = 
-                                  match (flags       &&&                     0b0000000000000000110L) with 
-                                                             |               0b0000000000000000000L -> BaseVal
-                                                             |               0b0000000000000000010L -> CtorThisVal
-                                                             |               0b0000000000000000100L -> NormalVal
-                                                             |               0b0000000000000000110L -> MemberThisVal
+                                  match (flags       &&&                     0b00000000000000000110L) with 
+                                                             |               0b00000000000000000000L -> BaseVal
+                                                             |               0b00000000000000000010L -> CtorThisVal
+                                                             |               0b00000000000000000100L -> NormalVal
+                                                             |               0b00000000000000000110L -> MemberThisVal
                                                              | _          -> failwith "unreachable"
 
 
 
-    member x.IsCompilerGenerated =      (flags       &&&                     0b0000000000000001000L) <> 0x0L
+    member x.IsCompilerGenerated =      (flags       &&&                     0b00000000000000001000L) <> 0x0L
 
     member x.SetIsCompilerGenerated(isCompGen) = 
-            let flags =                 (flags       &&&                  ~~~0b0000000000000001000L) |||
+            let flags =                 (flags       &&&                  ~~~0b00000000000000001000L) |||
                                         (match isCompGen with
-                                          | false           ->               0b0000000000000000000L
-                                          | true            ->               0b0000000000000001000L)
+                                          | false           ->               0b00000000000000000000L
+                                          | true            ->               0b00000000000000001000L)
             ValFlags(flags)
 
     member x.InlineInfo = 
-                                  match (flags       &&&                     0b0000000000000110000L) with 
-                                                             |               0b0000000000000000000L -> ValInline.PseudoVal
-                                                             |               0b0000000000000010000L -> ValInline.Always
-                                                             |               0b0000000000000100000L -> ValInline.Optional
-                                                             |               0b0000000000000110000L -> ValInline.Never
+                                  match (flags       &&&                     0b00000000000000110000L) with 
+                                                             |               0b00000000000000000000L -> ValInline.PseudoVal
+                                                             |               0b00000000000000010000L -> ValInline.Always
+                                                             |               0b00000000000000100000L -> ValInline.Optional
+                                                             |               0b00000000000000110000L -> ValInline.Never
                                                              | _          -> failwith "unreachable"
 
     member x.MutabilityInfo = 
-                                  match (flags       &&&                     0b0000000000001000000L) with 
-                                                             |               0b0000000000000000000L -> Immutable
-                                                             |               0b0000000000001000000L -> Mutable
+                                  match (flags       &&&                     0b00000000000001000000L) with 
+                                                             |               0b00000000000000000000L -> Immutable
+                                                             |               0b00000000000001000000L -> Mutable
                                                              | _          -> failwith "unreachable"
 
 
     member x.IsMemberOrModuleBinding = 
-                                  match (flags       &&&                     0b0000000000010000000L) with 
-                                                             |               0b0000000000000000000L -> false
-                                                             |               0b0000000000010000000L -> true
+                                  match (flags       &&&                     0b00000000000010000000L) with 
+                                                             |               0b00000000000000000000L -> false
+                                                             |               0b00000000000010000000L -> true
                                                              | _          -> failwith "unreachable"
 
 
-    member x.WithIsMemberOrModuleBinding = ValFlags(flags |||                0b0000000000010000000L)
+    member x.WithIsMemberOrModuleBinding = ValFlags(flags |||                0b00000000000010000000L)
 
 
-    member x.IsExtensionMember        = (flags       &&&                     0b0000000000100000000L) <> 0L
+    member x.IsExtensionMember        = (flags       &&&                     0b00000000000100000000L) <> 0L
 
-    member x.IsIncrClassSpecialMember = (flags       &&&                     0b0000000001000000000L) <> 0L
+    member x.IsIncrClassSpecialMember = (flags       &&&                     0b00000000001000000000L) <> 0L
 
-    member x.IsTypeFunction           = (flags       &&&                     0b0000000010000000000L) <> 0L
+    member x.IsTypeFunction           = (flags       &&&                     0b00000000010000000000L) <> 0L
 
-    member x.RecursiveValInfo =   match (flags       &&&                     0b0000001100000000000L) with 
-                                                             |               0b0000000000000000000L -> ValNotInRecScope
-                                                             |               0b0000000100000000000L -> ValInRecScope(true)
-                                                             |               0b0000001000000000000L -> ValInRecScope(false)
+    member x.RecursiveValInfo =   match (flags       &&&                     0b00000001100000000000L) with 
+                                                             |               0b00000000000000000000L -> ValNotInRecScope
+                                                             |               0b00000000100000000000L -> ValInRecScope(true)
+                                                             |               0b00000001000000000000L -> ValInRecScope(false)
                                                              | _                   -> failwith "unreachable"
 
     member x.WithRecursiveValInfo(recValInfo) = 
             let flags = 
-                     (flags       &&&                                     ~~~0b0000001100000000000L) |||
+                     (flags       &&&                                     ~~~0b00000001100000000000L) |||
                      (match recValInfo with
-                                     | ValNotInRecScope     ->               0b0000000000000000000L
-                                     | ValInRecScope(true)  ->               0b0000000100000000000L
-                                     | ValInRecScope(false) ->               0b0000001000000000000L) 
+                                     | ValNotInRecScope     ->               0b00000000000000000000L
+                                     | ValInRecScope(true)  ->               0b00000000100000000000L
+                                     | ValInRecScope(false) ->               0b00000001000000000000L) 
             ValFlags(flags)
 
-    member x.MakesNoCriticalTailcalls         =                   (flags &&& 0b0000010000000000000L) <> 0L
+    member x.MakesNoCriticalTailcalls         =                   (flags &&& 0b00000010000000000000L) <> 0L
 
-    member x.WithMakesNoCriticalTailcalls =               ValFlags(flags ||| 0b0000010000000000000L)
+    member x.WithMakesNoCriticalTailcalls =               ValFlags(flags ||| 0b00000010000000000000L)
 
-    member x.PermitsExplicitTypeInstantiation =                   (flags &&& 0b0000100000000000000L) <> 0L
+    member x.PermitsExplicitTypeInstantiation =                   (flags &&& 0b00000100000000000000L) <> 0L
 
-    member x.HasBeenReferenced                =                   (flags &&& 0b0001000000000000000L) <> 0L
+    member x.HasBeenReferenced                =                   (flags &&& 0b00001000000000000000L) <> 0L
 
-    member x.WithHasBeenReferenced                     =  ValFlags(flags ||| 0b0001000000000000000L)
+    member x.WithHasBeenReferenced                     =  ValFlags(flags ||| 0b00001000000000000000L)
 
-    member x.IsCompiledAsStaticPropertyWithoutField =             (flags &&& 0b0010000000000000000L) <> 0L
+    member x.IsCompiledAsStaticPropertyWithoutField =             (flags &&& 0b00010000000000000000L) <> 0L
 
-    member x.WithIsCompiledAsStaticPropertyWithoutField = ValFlags(flags ||| 0b0010000000000000000L)
+    member x.WithIsCompiledAsStaticPropertyWithoutField = ValFlags(flags ||| 0b00010000000000000000L)
 
-    member x.IsGeneratedEventVal =                                (flags &&& 0b0100000000000000000L) <> 0L
+    member x.IsGeneratedEventVal =                                (flags &&& 0b00100000000000000000L) <> 0L
 
-    member x.IsFixed                                =             (flags &&& 0b1000000000000000000L) <> 0L
+    member x.IsFixed                                =             (flags &&& 0b01000000000000000000L) <> 0L
 
-    member x.WithIsFixed                               =  ValFlags(flags ||| 0b1000000000000000000L)
+    member x.WithIsFixed                               =  ValFlags(flags ||| 0b01000000000000000000L)
+
+    member x.IsExtensionMethod                                  = (flags &&& 0b10000000000000000000L) <> 0L
+
+    member x.WithIsExtensionMethod                      = ValFlags(flags ||| 0b10000000000000000000L)
 
     /// Get the flags as included in the F# binary metadata
     member x.PickledBits = 
@@ -258,7 +262,8 @@ type ValFlags(flags:int64) =
         // Clear the IsCompiledAsStaticPropertyWithoutField, only used to determine whether to use a true field for a value, and to eliminate the optimization info for observable bindings
         // Clear the HasBeenReferenced, only used to report "unreferenced variable" warnings and to help collect 'it' values in FSI.EXE
         // Clear the IsGeneratedEventVal, since there's no use in propagating specialname information for generated add/remove event vals
-                                                      (flags       &&&    ~~~0b0011001100000000000L) 
+        // Clear the IsExtensionMethod, only used in post inference checks for a defined extension method
+                                                      (flags       &&&    ~~~0b10011001100000000000L) 
 
 /// Represents the kind of a type parameter
 [<RequireQualifiedAccess; StructuredFormatDisplay("{DebugText}")>]
@@ -2690,6 +2695,9 @@ and [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
     /// Indicates if the value is pinned/fixed
     member x.IsFixed = x.val_flags.IsFixed
 
+    /// Indiciates if the value is an extension method
+    member x.IsExtensionMethod = x.val_flags.IsExtensionMethod
+
     /// Indicates if this value allows the use of an explicit type instantiation (i.e. does it itself have explicit type arguments,
     /// or does it have a signature?)
     member x.PermitsExplicitTypeInstantiation = x.val_flags.PermitsExplicitTypeInstantiation
@@ -2912,6 +2920,8 @@ and [<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
     member x.SetIsCompiledAsStaticPropertyWithoutField() = x.val_flags <- x.val_flags.WithIsCompiledAsStaticPropertyWithoutField
 
     member x.SetIsFixed()                                = x.val_flags <- x.val_flags.WithIsFixed
+
+    member x.SetIsExtensionMethod()                      = x.val_flags <- x.val_flags.WithIsExtensionMethod
 
     member x.SetValReprInfo info                         = 
         match x.val_opt_data with

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">Adresa hodnoty vrácená výrazem nejde převzít. Před převzetím adresy přiřaďte vrácenou hodnotu hodnotě s vazbou na klauzuli Let.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">Die Adresse des über den Ausdruck zurückgegebenen Werts kann nicht abgerufen werden. Weisen Sie den zurückgegebenen Wert einem let-bound-Wert zu, bevor Sie die Adresse abrufen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -7057,14 +7057,19 @@
         <target state="new">Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">No se puede tomar la dirección del valor devuelto de la expresión. Asigne el valor devuelto a un valor enlazado con let antes de tomar la dirección.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">Impossible de prendre l'adresse de la valeur retournée par l'expression. Assignez la valeur retournée à une valeur liée à let avant de prendre l'adresse.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">Non è possibile accettare l'indirizzo del valore restituito dall'espressione. Assegnare il valore restituito a un valore associato a let prima di accettare l'indirizzo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">式から返された値のアドレスを取得できません。アドレスを取得する前に、let でバインドされた値に戻り値を割り当ててください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">식에서 반환된 값의 주소를 가져올 수 없습니다. 주소를 가져오기 전에 반환된 값을 let 바인딩 값에 할당하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">Nie można uzyskać adresu wartości zwróconej przez wyrażenie. Przypisz zwróconą wartość do wartości powiązanej za pomocą instrukcji let przed uzyskaniem adresu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">Não é possível obter o endereço do valor retornado da expressão. Atribua o valor retornado a um valor associado a let antes de obter o endereço.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">Невозможно получить адрес значения, возвращенного из выражения. Используйте возвращенное значение в качестве значения с привязкой let, прежде чем получить адрес.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">İfadeden döndürülen değerin adresi alınamaz. Adresi almadan önce, döndürülen değeri let ile bağlanmış bir değere atayın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">无法采用从表达式返回的地址值。在采用地址前将返回值分配给 let 绑定值。</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -7072,6 +7072,11 @@
         <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkByrefExtensionMethodMustBeAStruct">
+        <source>The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</source>
+        <target state="new">The first parameter of the byref extension method '{0}' must be a value type or a generic type constrained to struct.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -7063,8 +7063,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
-        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
-        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <source>Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}. The first parameter requires the value to be mutable or a non-readonly byref type.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -7057,14 +7057,19 @@
         <target state="translated">無法使用運算式傳回值的位址。在使用位址前，先將傳回值指派給以 let 繫結的值。</target>
         <note />
       </trans-unit>
-      <trans-unit id="tcCannotCallExtensionMemberInrefToByref">
-        <source>Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</source>
-        <target state="new">Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="tcByrefsMayNotHaveTypeExtensions">
         <source>Byref types are not allowed to have optional type extensions.</source>
         <target state="new">Byref types are not allowed to have optional type extensions.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotCallExtensionMethodInrefToByref">
+        <source>Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</source>
+        <target state="new">Cannot call the byref extension method '{0}' as the first parameter requires the value to be mutable or a non-readonly byref type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcCannotPartiallyApplyExtensionMethodForByref">
+        <source>Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</source>
+        <target state="new">Cannot partially apply the extension method '{0}' because the first parameter is a byref type.</target>
         <note />
       </trans-unit>
     </body>

--- a/tests/fsharp/core/byrefs/test3.bsl
+++ b/tests/fsharp/core/byrefs/test3.bsl
@@ -1,5 +1,5 @@
 
-test3.fsx(39,18,39,28): typecheck error FS3237: Cannot call the byref extension method 'Test2' as the first parameter requires the value to be mutable or a non-readonly byref type.
+test3.fsx(39,18,39,28): typecheck error FS3237: Cannot call the byref extension method 'Test2. The first parameter requires the value to be mutable or a non-readonly byref type.
 
 test3.fsx(40,9,40,11): typecheck error FS0001: Type mismatch. Expecting a
     'byref<DateTime>'    
@@ -7,11 +7,11 @@ but given a
     'inref<DateTime>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-test3.fsx(44,9,44,20): typecheck error FS3237: Cannot call the byref extension method 'Change' as the first parameter requires the value to be mutable or a non-readonly byref type.
+test3.fsx(44,9,44,20): typecheck error FS3237: Cannot call the byref extension method 'Change. The first parameter requires the value to be mutable or a non-readonly byref type.
 
-test3.fsx(49,19,49,30): typecheck error FS3237: Cannot call the byref extension method 'Test2' as the first parameter requires the value to be mutable or a non-readonly byref type.
+test3.fsx(49,19,49,30): typecheck error FS3237: Cannot call the byref extension method 'Test2. The first parameter requires the value to be mutable or a non-readonly byref type.
 
-test3.fsx(55,9,55,21): typecheck error FS3237: Cannot call the byref extension method 'Change' as the first parameter requires the value to be mutable or a non-readonly byref type.
+test3.fsx(55,9,55,21): typecheck error FS3237: Cannot call the byref extension method 'Change. The first parameter requires the value to be mutable or a non-readonly byref type.
 
 test3.fsx(59,17,59,29): typecheck error FS3239: Cannot partially apply the extension method 'NotChange' because the first parameter is a byref type.
 

--- a/tests/fsharp/core/byrefs/test3.bsl
+++ b/tests/fsharp/core/byrefs/test3.bsl
@@ -1,5 +1,5 @@
 
-test3.fsx(39,18,39,28): typecheck error FS3237: Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
+test3.fsx(39,18,39,28): typecheck error FS3237: Cannot call the byref extension method 'Test2' as the first parameter requires the value to be mutable or a non-readonly byref type.
 
 test3.fsx(40,9,40,11): typecheck error FS0001: Type mismatch. Expecting a
     'byref<DateTime>'    
@@ -7,8 +7,12 @@ but given a
     'inref<DateTime>'    
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-test3.fsx(44,9,44,20): typecheck error FS3237: Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
+test3.fsx(44,9,44,20): typecheck error FS3237: Cannot call the byref extension method 'Change' as the first parameter requires the value to be mutable or a non-readonly byref type.
 
-test3.fsx(49,19,49,30): typecheck error FS3237: Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
+test3.fsx(49,19,49,30): typecheck error FS3237: Cannot call the byref extension method 'Test2' as the first parameter requires the value to be mutable or a non-readonly byref type.
 
-test3.fsx(55,9,55,21): typecheck error FS3237: Cannot call the extension member as it requires the value to be mutable or a byref type due to the extending type being used as a byref.
+test3.fsx(55,9,55,21): typecheck error FS3237: Cannot call the byref extension method 'Change' as the first parameter requires the value to be mutable or a non-readonly byref type.
+
+test3.fsx(59,17,59,29): typecheck error FS3239: Cannot partially apply the extension method 'NotChange' because the first parameter is a byref type.
+
+test3.fsx(60,17,60,24): typecheck error FS3239: Cannot partially apply the extension method 'Test' because the first parameter is a byref type.

--- a/tests/fsharp/core/byrefs/test3.bsl
+++ b/tests/fsharp/core/byrefs/test3.bsl
@@ -16,3 +16,7 @@ test3.fsx(55,9,55,21): typecheck error FS3237: Cannot call the byref extension m
 test3.fsx(59,17,59,29): typecheck error FS3239: Cannot partially apply the extension method 'NotChange' because the first parameter is a byref type.
 
 test3.fsx(60,17,60,24): typecheck error FS3239: Cannot partially apply the extension method 'Test' because the first parameter is a byref type.
+
+test3.fsx(61,17,61,26): typecheck error FS3239: Cannot partially apply the extension method 'Change' because the first parameter is a byref type.
+
+test3.fsx(62,17,62,25): typecheck error FS3239: Cannot partially apply the extension method 'Test2' because the first parameter is a byref type.

--- a/tests/fsharp/core/byrefs/test3.fsx
+++ b/tests/fsharp/core/byrefs/test3.fsx
@@ -54,6 +54,12 @@ module Negatives =
         let dtr = &dt
         dtr.Change() // should fail
 
+    let test5 () =
+        let dt = DateTime.Now
+        let x = dt.NotChange // should fail
+        let y = dt.Test // should fail
+        ()
+
 #endif
 
 module Positives =

--- a/tests/fsharp/core/byrefs/test3.fsx
+++ b/tests/fsharp/core/byrefs/test3.fsx
@@ -58,6 +58,8 @@ module Negatives =
         let dt = DateTime.Now
         let x = dt.NotChange // should fail
         let y = dt.Test // should fail
+        let z = dt.Change // should fail
+        let w = dt.Test2 // should fail
         ()
 
 #endif


### PR DESCRIPTION
An extension from this PR: https://github.com/Microsoft/visualfsharp/pull/5492

This is still WIP and most likely just a prototype as we haven't made a decision on what we will do yet.

But essentially, we should probably disallow byref extension methods to be reference types, ex:
```fsharp
[<Extension>]
type Extensions =
    [<Extension>]
    static member Test<'T>(xs: byref<'T>) = printfn "%A" xs // will fail

    [<Extension>]
    static member Test2<'T when 'T : struct>(xs: byref<'T>) = printfn "%A" xs // will pass

    [<Extension>]
    static member Test3(xs: byref<obj>) = printfn "%A" xs // will fail
 
    [<Extension>]
    static member Test4(xs: byref<int>) = printfn "%A" xs // will pass
```
```
The first parameter of the byref extension method 'Test' must be a value type or a generic type constrained to struct.

The first parameter of the byref extension method 'Test3' must be a value type or a generic type constrained to struct.
```