### PR TITLE
Update microsoft build version for build task

### DIFF
--- a/src/fsharp/FSharp.Build/project.json
+++ b/src/fsharp/FSharp.Build/project.json
@@ -1,9 +1,9 @@
 {
     "dependencies": {
-        "Microsoft.Build": "15.1.548",
-        "Microsoft.Build.Framework": "15.1.548",
-        "Microsoft.Build.Tasks.Core": "15.1.548",
-        "Microsoft.Build.Utilities.Core": "15.1.548",
+        "Microsoft.Build": "15.6.85",
+        "Microsoft.Build.Framework": "15.6.85",
+        "Microsoft.Build.Tasks.Core": "15.6.85",
+        "Microsoft.Build.Utilities.Core": "15.6.85",
         "Microsoft.NETCore.Platforms": "1.1.0",
         "Microsoft.Win32.Registry": {
             "version": "4.3.0",


### PR DESCRIPTION
We recently updated the msbuild version referenced by F#.

This updates the coreclr build task for F#.