### PR TITLE
Always do TFM Attributes at front of compile list

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -394,8 +394,7 @@ this file.
             Overwrite="true"/>
 
         <ItemGroup>
-            <CompileBefore Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" Condition="'$(AdditionalSourcesText)' != '' AND ('$(OutputType)' == 'Exe' OR '$(OutputType)' == 'WinExe')"/>
-            <CompileAfter Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" Condition="'$(AdditionalSourcesText)' != '' AND '$(OutputType)' != 'Exe' AND '$(OutputType)' != 'WinExe'"/>
+            <CompileBefore Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" Condition="'$(AdditionalSourcesText)' != ''"/>
         </ItemGroup>
 
     </Target>


### PR DESCRIPTION
The Microsoft.FSharp.Targets file put the file containing TFM Attributes at the start of the list of source files when building an .exe, and after the list of files when building a dll.

When building tests a common pattern is to build a .dll with a main.  Which will generate an error:
````
c:\temp\foolib\Library.fs(9,9): error FS0433: A function labeled with the 'EntryPointAttribute' attribute must be the last declaration in the last file in the compilation sequence. [c:\temp\foolib\foolib.fsproj]
````
This error only occurs because some code appears after the main function, caused by the targets file.  This change always puts the attribute at the start where it can quite comfortably exist.