### PR TITLE
Fix # 5514

### DIFF
--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -217,31 +217,13 @@ module internal FSharpEnvironment =
             match probePoint with 
             | Some p when safeExists (Path.Combine(p,"FSharp.Core.dll")) -> Some p 
             | _ -> 
-
-            // On windows the location of the compiler is via a registry key
-
-            // Note: If the keys below change, be sure to update code in:
-            // Property pages (ApplicationPropPage.vb)
-            let keys = 
-                [| 
-                    @"Software\Microsoft\FSharp\10.1\Runtime\v4.0"; 
-                    @"Software\Microsoft\FSharp\4.1\Runtime\v4.0"; 
-                    @"Software\Microsoft\FSharp\4.0\Runtime\v4.0"
-                |]
-            let path = keys |> Seq.tryPick(fun k -> tryRegKey k)
-            match path with
-            | Some _ -> path
-            | None ->
-            // On Unix we let you set FSHARP_COMPILER_BIN. I've rarely seen this used and its not documented in the install instructions.
-            let result = 
-                let var = System.Environment.GetEnvironmentVariable("FSHARP_COMPILER_BIN")
-                if String.IsNullOrEmpty(var) then None
-                else Some(var)
-            match result with 
-            | Some _ -> result
-            | None -> 
-            // For the prototype compiler, we can just use the current domain
-            tryCurrentDomain()
+            // We let you set FSHARP_COMPILER_BIN. I've rarely seen this used and its not documented in the install instructions.
+            let result = System.Environment.GetEnvironmentVariable("FSHARP_COMPILER_BIN")
+            if not (String.IsNullOrEmpty(result)) then
+                Some result
+            else
+                // For the prototype compiler, we can just use the current domain
+                tryCurrentDomain()
         with e -> 
             System.Diagnostics.Debug.Assert(false, "Error while determining default location of F# compiler")
             None

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
@@ -49,8 +49,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Const INDEX_WINDOWSCLASSLIB As Integer = 2
         Protected Const INDEX_LAST As Integer = INDEX_WINDOWSCLASSLIB
         Public Const Const_TargetFrameworkMoniker As String = "TargetFrameworkMoniker"
-        Private m_v20FSharpRedistInstalled As Boolean = False
-        Private m_v40FSharpRedistInstalled As Boolean = False
 
         Friend WithEvents TargetFramework As System.Windows.Forms.ComboBox
         Friend WithEvents TargetFrameworkLabel As System.Windows.Forms.Label
@@ -74,12 +72,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             m_OutputTypeStringKeys(INDEX_WINDOWSAPP) = SR.GetString(SR.PPG_WindowsApp)
             m_OutputTypeStringKeys(INDEX_COMMANDLINEAPP) = SR.GetString(SR.PPG_CommandLineApp)
             m_OutputTypeStringKeys(INDEX_WINDOWSCLASSLIB) = SR.GetString(SR.PPG_WindowsClassLib)
-
-            Dim v20FSharpRedistKey As String = "HKEY_LOCAL_MACHINE\Software\Microsoft\FSharp\10.1\Runtime\v2.0"
-            Dim v40FSharpRedistKey As String = "HKEY_LOCAL_MACHINE\Software\Microsoft\FSharp\10.1\Runtime\v4.0"
-
-            m_v20FSharpRedistInstalled = Not (IsNothing(Microsoft.Win32.Registry.GetValue(v20FSharpRedistKey, Nothing, Nothing)))
-            m_v40FSharpRedistInstalled = Not (IsNothing(Microsoft.Win32.Registry.GetValue(v40FSharpRedistKey, Nothing, Nothing)))
 
             'Add any initialization after the InitializeComponent() call
             AddChangeHandlers()
@@ -587,18 +579,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If moniker.StartsWith(".NETCoreApp") OrElse moniker.StartsWith(".NETStandard") Then
                 Return True
             End If
-            If moniker.Contains("v2") Then
-                Return Me.m_v20FSharpRedistInstalled
-            End If
-            If moniker.Contains("v3.0") Then
-                Return Me.m_v20FSharpRedistInstalled
-            End If
-            If moniker.Contains("v3.5") Then
-                Return Me.m_v20FSharpRedistInstalled
-            End If
-            '' Is this cheating?
-            If moniker.Contains("v4") Then
-                Return Me.m_v40FSharpRedistInstalled
+            ' With the latest tooling, if we have editors the redist is installed by definition
+            If moniker.Contains("v2") Or moniker.Contains("v3.0") Or moniker.Contains("v3.5") Or moniker.Contains("v4") Then
+                Return True
             End If
             Return False
         End Function


### PR DESCRIPTION
F# projects don't show Target Framework after upgrading to 15.8.0

It should look like this:

![image](https://user-images.githubusercontent.com/5175830/44176186-b1e9cf80-a09d-11e8-910f-90ed5641ccb4.png)

The fix is to stop relying on the registry keys for anything.
