### PR TITLE
Stop UnifyTypes recovery in TcDelayed

### DIFF
--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -8448,7 +8448,7 @@ and TcDelayed cenv overallTy env tpenv mExpr expr exprty (atomicFlag:ExprAtomicF
     match delayed with 
     | []  
     | DelayedDot :: _ -> 
-        UnifyTypesAndRecover cenv env mExpr overallTy exprty
+        UnifyTypes cenv env mExpr overallTy exprty
         expr.Expr, tpenv
     // expr.M(args) where x.M is a .NET method or index property 
     // expr.M<tyargs>(args) where x.M is a .NET method or index property 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2394,6 +2394,9 @@ module TypecheckTests =
     let ``type check neg107`` () = singleNegTest (testConfig "typecheck/sigs") "neg107"
 
     [<Test>]
+    let ``type check neg108`` () = singleNegTest (testConfig "typecheck/sigs") "neg108"
+
+    [<Test>]
     let ``type check neg103`` () = singleNegTest (testConfig "typecheck/sigs") "neg103"
 
     [<Test>]

--- a/tests/fsharp/typecheck/sigs/neg108.bsl
+++ b/tests/fsharp/typecheck/sigs/neg108.bsl
@@ -1,0 +1,5 @@
+
+neg108.fs(4,19,4,23): typecheck error FS0001: This expression was expected to have type
+    'Test'    
+but here has type
+    'Unit -> Test'    

--- a/tests/fsharp/typecheck/sigs/neg108.fs
+++ b/tests/fsharp/typecheck/sigs/neg108.fs
@@ -1,0 +1,7 @@
+module Neg108
+
+type Test = Test of Unit
+let test : Test = Test
+
+
+


### PR DESCRIPTION
This is to resolve this issue: https://github.com/Microsoft/visualfsharp/issues/5468
And it does not regress this issue: https://github.com/Microsoft/visualfsharp/issues/629

I'm not 100% sure how this code works yet, but I do know this change fixes the issue.