### PR TITLE
Cherry pick:        Fix ngen of compiler to Dev15.8

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Compiler/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Compiler/Files.swr
@@ -4,30 +4,38 @@ package name=Microsoft.FSharp.Compiler
         version=$(FSharpPackageVersion)
 
 folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp"
-  file source="$(BinariesFolder)\net40\bin\fsc.exe" vs.file.ngen=yes
+
+  file source=$(BinariesFolder)\net40\bin\fsc.exe vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2 vs.file.ngenApplication="[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\fsc.exe"
   file source="$(BinariesFolder)\net40\bin\fsc.exe.config"
-  file source="$(BinariesFolder)\net40\bin\FSharp.Build.dll" vs.file.ngen=yes
-  file source="$(BinariesFolder)\net40\bin\FSharp.Compiler.Interactive.Settings.dll" vs.file.ngen=yes
-  file source="$(BinariesFolder)\net40\bin\FSharp.Compiler.Private.dll" vs.file.ngen=yes
-  file source="$(BinariesFolder)\net40\bin\FSharp.Compiler.Server.Shared.dll" vs.file.ngen=yes
-  file source="$(BinariesFolder)\net40\bin\FSharp.Core.dll" vs.file.ngen=yes
+
+  file source=$(BinariesFolder)\net40\bin\fsi.exe vs.file.ngen=yes vs.file.ngenArchitecture=X86 vs.file.ngenPriority=2 vs.file.ngenApplication="[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\fsi.exe"
+  file source="$(BinariesFolder)\net40\bin\fsi.exe.config"
+
+  file source="$(BinariesFolder)\net40\bin\fsiAnyCpu.exe" vs.file.ngen=yes vs.file.ngenArchitecture=X64 vs.file.ngenPriority=2 vs.file.ngenApplication="[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\fsiAnyCpu.exe"
+  file source="$(BinariesFolder)\net40\bin\fsiAnyCpu.exe.config"
+
+  file source="$(BinariesFolder)\net40\bin\FSharp.Compiler.Interactive.Settings.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
+  file source="$(BinariesFolder)\net40\bin\FSharp.Compiler.Private.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
+  file source="$(BinariesFolder)\net40\bin\FSharp.Compiler.Server.Shared.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
+
+  file source="$(BinariesFolder)\net40\bin\FSharp.Core.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
   file source="$(BinariesFolder)\net40\bin\FSharp.Core.optdata"
   file source="$(BinariesFolder)\net40\bin\FSharp.Core.sigdata"
-  file source="$(PackagesFolder)\Microsoft.VisualFSharp.Type.Providers.Redist.$(MicrosoftVisualFSharpTypeProvidersRedistPackageVersion)\content\4.3.0.0\FSharp.Data.TypeProviders.dll" vs.file.ngen=yes
-  file source="$(BinariesFolder)\net40\bin\fsi.exe" vs.file.ngen=yes
-  file source="$(BinariesFolder)\net40\bin\fsi.exe.config"
-  file source="$(BinariesFolder)\net40\bin\fsiAnyCpu.exe" vs.file.ngen=yes
-  file source="$(BinariesFolder)\net40\bin\fsiAnyCpu.exe.config"
+
+  file source="$(BinariesFolder)\net40\bin\FSharp.Build.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
+
+  file source="$(PackagesFolder)\Microsoft.VisualFSharp.Type.Providers.Redist.$(MicrosoftVisualFSharpTypeProvidersRedistPackageVersion)\content\4.3.0.0\FSharp.Data.TypeProviders.dll"
   file source="$(BinariesFolder)\net40\bin\Microsoft.Build.Conversion.Core.dll"
   file source="$(BinariesFolder)\net40\bin\Microsoft.Build.dll"
   file source="$(BinariesFolder)\net40\bin\Microsoft.Build.Engine.dll"
   file source="$(BinariesFolder)\net40\bin\Microsoft.Build.Framework.dll"
   file source="$(BinariesFolder)\net40\bin\Microsoft.Build.Tasks.Core.dll"
   file source="$(BinariesFolder)\net40\bin\Microsoft.Build.Utilities.Core.dll"
-  file source="$(BinariesFolder)\net40\bin\Microsoft.FSharp.NetSdk.props"
-  file source="$(BinariesFolder)\net40\bin\Microsoft.FSharp.NetSdk.targets"
-  file source="$(BinariesFolder)\net40\bin\Microsoft.FSharp.Targets"
   file source="$(BinariesFolder)\net40\bin\Microsoft.Portable.FSharp.Targets"
   file source="$(BinariesFolder)\net40\bin\System.Collections.Immutable.dll"
   file source="$(BinariesFolder)\net40\bin\System.Reflection.Metadata.dll"
   file source="$(BinariesFolder)\net40\bin\System.ValueTuple.dll"
+  file source="$(BinariesFolder)\net40\bin\Microsoft.FSharp.NetSdk.props"
+  file source="$(BinariesFolder)\net40\bin\Microsoft.FSharp.NetSdk.targets"
+  file source="$(BinariesFolder)\net40\bin\Microsoft.FSharp.Overrides.NetSdk.targets"
+  file source="$(BinariesFolder)\net40\bin\Microsoft.FSharp.Targets"

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -36,6 +36,9 @@
       <Name>FSharp.Build</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj">
@@ -43,6 +46,9 @@
       <Name>FSharp.Compiler.Interactive.Settings</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Server.Shared\FSharp.Compiler.Server.Shared.fsproj">
@@ -50,6 +56,9 @@
       <Name>FSharp.Compiler.Server.Shared</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj">
@@ -57,6 +66,9 @@
       <Name>FSharp.Compiler.Private</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj">
@@ -64,6 +76,9 @@
       <Name>FSharp.Core</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\src\fsharp\fsiAnyCpu\FsiAnyCPU.fsproj">
@@ -71,6 +86,10 @@
       <Name>FsiAnyCPU</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenApplication>[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\fsiAnyCpu.exe</NgenApplication>
+      <NgenArchitecture>X64</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\src\fsharp\fsi\Fsi.fsproj">
@@ -78,6 +97,10 @@
       <Name>Fsi</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenApplication>[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\fsi.exe</NgenApplication>
+      <NgenArchitecture>X86</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\..\src\fsharp\Fsc\Fsc.fsproj">
@@ -85,6 +108,10 @@
       <Name>fsc</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenApplication>[installDir]\Common7\IDE\CommonExtensions\Microsoft\FSharp\fsc.exe</NgenApplication>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.Editor\FSharp.Editor.fsproj">
@@ -92,6 +119,9 @@
       <Name>FSharp.Editor</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.UIResources\FSharp.UIResources.csproj">
@@ -106,6 +136,9 @@
       <Name>FSharp.LanguageService.Base</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.LanguageService\FSharp.LanguageService.fsproj">
@@ -113,6 +146,9 @@
       <Name>FSharp.LanguageService</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.ProjectSystem.Base\Project\ProjectSystem.Base.csproj">
@@ -120,6 +156,9 @@
       <Name>ProjectSystem.Base</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.ProjectSystem.FSharp\ProjectSystem.fsproj">
@@ -127,6 +166,9 @@
       <Name>ProjectSystem</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.ProjectSystem.PropertyPages\FSharp.PropertiesPages.vbproj">
@@ -134,6 +176,9 @@
       <Name>FSharp.PropertiesPages</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\src\FSharp.VS.FSI\FSharp.VS.FSI.fsproj">
@@ -141,8 +186,12 @@
       <Name>FSharp.VS.FSI</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bPkgDefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <Ngen>true</Ngen>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>2</NgenPriority>
       <Private>True</Private>
     </ProjectReference>
+
     <ProjectReference Include="$(FSharpSourcesRoot)\..\vsintegration\ItemTemplates\AppConfig\AppConfig.csproj">
       <Project>{6ba13aa4-c25f-480f-856b-8e8000299a72}</Project>
       <Name>AppConfig</Name>


### PR DESCRIPTION
This fixes

The BuildTools Sku ngens the FSharp binaries, however, the dependencies don't match the ones realized at run time, due to ngen using the VS binding redirects.
Fixed by configuring ngen to use the fsc.exe.config and fsi.exe.config in the build tools.
FSharp assemblies are not ngen'd for for Enterprise, Professional and Community Skus
The fix is to add the necessary metadata in the VisualFSharpFull project to the project references to enable ngen.
BuildTools sku failed to deploy the Microsoft.FSharp.Overrides.NetSdk.targets

//cc @jmarolf, @brettfo