### PR TITLE
Showing a better error message when trying to take an address of an operation

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -5863,19 +5863,22 @@ let rec mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress 
             let ty = tyOfExpr g expr
             if isStructTy g ty then 
                 match mut with 
+                | NeverMutates
+                | AddressOfOp -> ()
                 | DefinitelyMutates -> 
                     // Give a nice error message for mutating something we can't take the address of
                     errorR(Error(FSComp.SR.tastInvalidMutationOfConstant(), m))
                 | PossiblyMutates -> 
                     // Warn on defensive copy of something we can't take the address of
                     warning(DefensiveCopyWarning(FSComp.SR.tastValueHasBeenCopied(), m))
-                | _ -> ()
 
             match mut with
+            | NeverMutates
+            | DefinitelyMutates
+            | PossiblyMutates -> ()
             | AddressOfOp -> 
                 // we get an inref
                 errorR(Error(FSComp.SR.tastCantTakeAddressOfExpression(), m))
-            | _ -> ()
 
             // Take a defensive copy
             let tmp, _ = 

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -5863,16 +5863,20 @@ let rec mkExprAddrOfExprAux g mustTakeAddress useReadonlyForGenericArrayAddress 
             let ty = tyOfExpr g expr
             if isStructTy g ty then 
                 match mut with 
-                | NeverMutates -> ()
-                | AddressOfOp -> 
-                    // we get an inref
-                    errorR(Error(FSComp.SR.tastCantTakeAddressOfExpression(), m))
                 | DefinitelyMutates -> 
                     // Give a nice error message for mutating something we can't take the address of
                     errorR(Error(FSComp.SR.tastInvalidMutationOfConstant(), m))
                 | PossiblyMutates -> 
                     // Warn on defensive copy of something we can't take the address of
                     warning(DefensiveCopyWarning(FSComp.SR.tastValueHasBeenCopied(), m))
+                | _ -> ()
+
+            match mut with
+            | AddressOfOp -> 
+                // we get an inref
+                errorR(Error(FSComp.SR.tastCantTakeAddressOfExpression(), m))
+            | _ -> ()
+
             // Take a defensive copy
             let tmp, _ = 
                 match mut with 

--- a/tests/fsharp/core/byrefs/test.bsl
+++ b/tests/fsharp/core/byrefs/test.bsl
@@ -59,3 +59,11 @@ test.fsx(88,10,88,15): typecheck error FS3238: Byref types are not allowed to ha
 test.fsx(92,10,92,15): typecheck error FS3238: Byref types are not allowed to have optional type extensions.
 
 test.fsx(96,10,96,16): typecheck error FS3238: Byref types are not allowed to have optional type extensions.
+
+test.fsx(112,26,112,36): typecheck error FS0039: The value, constructor, namespace or type 'TrueForAll' is not defined.
+
+test.fsx(115,25,115,40): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
+test.fsx(115,25,115,40): typecheck error FS0001: The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
+
+test.fsx(120,21,120,29): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.

--- a/tests/fsharp/core/byrefs/test.bsl
+++ b/tests/fsharp/core/byrefs/test.bsl
@@ -60,10 +60,12 @@ test.fsx(92,10,92,15): typecheck error FS3238: Byref types are not allowed to ha
 
 test.fsx(96,10,96,16): typecheck error FS3238: Byref types are not allowed to have optional type extensions.
 
-test.fsx(112,26,112,36): typecheck error FS0039: The value, constructor, namespace or type 'TrueForAll' is not defined.
+test.fsx(114,21,114,36): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
-test.fsx(115,25,115,40): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+test.fsx(114,21,114,36): typecheck error FS0001: Type mismatch. Expecting a
+    'byref<float array>'    
+but given a
+    'inref<float array>'    
+The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
-test.fsx(115,25,115,40): typecheck error FS0001: The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
-
-test.fsx(120,21,120,29): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+test.fsx(119,21,119,29): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.

--- a/tests/fsharp/core/byrefs/test.fsx
+++ b/tests/fsharp/core/byrefs/test.fsx
@@ -96,6 +96,29 @@ module ByrefNegativeTests =
     type outref<'T> with
 
         member this.Test() = 1
+
+    module CantTakeAddressOfExpressionReturningReferenceType =
+        open System.Collections.Concurrent
+        open System.Collections.Generic
+
+        let test1 () =
+            let aggregator = 
+                new ConcurrentDictionary<
+                        string, ConcurrentDictionary<string,array<float>>
+                        >()
+
+            for kvp in aggregator do
+            for kvpInner in kvp.Value do
+                if Array.TrueForAll(kvpInner.Value,(fun v -> v = 0.0) ) then
+                    kvp.Value.TryRemove(
+                        kvpInner.Key,
+                        &kvpInner.Value)
+                    |> ignore
+
+        let test2 () =
+            let x = KeyValuePair(1, [||])
+            let y = &x.Value
+            ()
 #endif
 
 // Test a simple ref  argument

--- a/tests/fsharp/core/byrefs/test.fsx
+++ b/tests/fsharp/core/byrefs/test.fsx
@@ -109,11 +109,10 @@ module ByrefNegativeTests =
 
             for kvp in aggregator do
             for kvpInner in kvp.Value do
-                if Array.TrueForAll(kvpInner.Value,(fun v -> v = 0.0) ) then
-                    kvp.Value.TryRemove(
-                        kvpInner.Key,
-                        &kvpInner.Value)
-                    |> ignore
+                kvp.Value.TryRemove(
+                    kvpInner.Key,
+                    &kvpInner.Value)
+                |> ignore
 
         let test2 () =
             let x = KeyValuePair(1, [||])

--- a/tests/fsharp/typecheck/sigs/neg106.bsl
+++ b/tests/fsharp/typecheck/sigs/neg106.bsl
@@ -149,6 +149,8 @@ The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(102,37,102,40): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(102,36,102,40): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(102,36,102,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
 but given a
@@ -162,6 +164,8 @@ but given a
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(112,39,112,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(112,38,112,42): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(112,38,112,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
@@ -177,6 +181,8 @@ The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(122,39,122,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(122,38,122,42): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(122,38,122,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
 but given a
@@ -191,6 +197,8 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(132,39,132,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(132,38,132,42): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(132,38,132,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -204,6 +212,8 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(142,39,142,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(142,38,142,42): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(142,38,142,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    

--- a/tests/fsharp/typecheck/sigs/neg106.vsbsl
+++ b/tests/fsharp/typecheck/sigs/neg106.vsbsl
@@ -149,6 +149,8 @@ The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(102,37,102,40): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(102,36,102,40): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(102,36,102,40): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
 but given a
@@ -162,6 +164,8 @@ but given a
 The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(112,39,112,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(112,38,112,42): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(112,38,112,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
@@ -177,6 +181,8 @@ The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(122,39,122,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(122,38,122,42): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(122,38,122,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    
 but given a
@@ -191,6 +197,8 @@ The type 'ByRefKinds.InOut' does not match the type 'ByRefKinds.In'
 
 neg106.fs(132,39,132,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
 
+neg106.fs(132,38,132,42): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
+
 neg106.fs(132,38,132,42): typecheck error FS0001: Type mismatch. Expecting a
     'byref<'a>'    
 but given a
@@ -204,6 +212,8 @@ but given a
 The type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'
 
 neg106.fs(142,39,142,42): typecheck error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.
+
+neg106.fs(142,38,142,42): typecheck error FS3236: Cannot take the address of the value returned from the expression. Assign the returned value to a let-bound value before taking the address.
 
 neg106.fs(142,38,142,42): typecheck error FS0001: Type mismatch. Expecting a
     'outref<'a>'    


### PR DESCRIPTION
As discussed here: https://github.com/Microsoft/visualfsharp/issues/5540

>So, this code, [KeyValuePair] `&kvpInner.Value` I think should have been illegal since the beginning of time, but it looks like it was allowed [even before 4.5]. You are actually not taking the address of the field from the KeyValuePair. Behind the scenes it's creating a local and assigning it the `kvpInner.Value` and getting the address of that local. The workaround I mentioned does the same thing, but is explicit.

> `&kvpInner.Value` will not work today regardless. Once you fix the type error, then post inference checks kicks in and throws an error saying a local has gone out of scope. So today, in 4.5, you can't do this, but the error message is wrong.

>Let me translate, consider this code:

>```fsharp 
>let y = &kvpInner.Value
>```
>This translates to:

>```fsharp
>let y =
>    let x = kvpInner.Value
>    &x
>```
>Which is illegal 4.5 due to our scoping rules, x can't go out of the scope of where it was declared.

The code fix was very simple. Before if the type was a value type and we were trying to take the address of an operation, then it would error. Now we do it on both value and reference types.