### PR TITLE
Fixed byref extension methods from not showing up in completions

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -2765,6 +2765,7 @@ let IsApplicableMethApprox g amap m (minfo:MethInfo) availObjTy =
         let minst = FreshenMethInfo m minfo
         match minfo.GetObjArgTypes(amap, m, minst) with
         | [reqdObjTy] -> 
+            let reqdObjTy = if isByrefTy g reqdObjTy then destByrefTy g reqdObjTy else reqdObjTy // This is to support byref extension methods.
             TryD (fun () -> SolveTypeSubsumesType csenv 0 m NoTrace None reqdObjTy availObjTy ++ (fun () -> ResultD true))
                  (fun _err -> ResultD false)
             |> CommitOperationResult

--- a/vsintegration/tests/UnitTests/CompletionProviderTests.fs
+++ b/vsintegration/tests/UnitTests/CompletionProviderTests.fs
@@ -602,6 +602,34 @@ module M2 =
 """
     VerifyCompletionList(fileContents, "    Ext", ["Extensions"; "ExtraTopLevelOperators"], [])
 
+[<Test>]
+let ``Byref Extension Methods`` () =
+    let fileContents = """
+module Extensions =
+    open System
+    open System.Runtime.CompilerServices
+
+    [<Struct>]
+    type Message = Message of String
+
+    [<Sealed; AbstractClass; Extension>]
+    type MessageExtensions private () =
+        let (|Message|) (Message message) = message
+
+        [<Extension>]
+        static member Print (Message message : Message) =
+            printfn "%s" message
+
+        [<Extension>]
+        static member PrintRef (Message message : inref<Message>) =
+            printfn "%s" message
+
+    let wrappedMessage = Message "Hello World"
+
+    wrappedMessage.
+"""
+    VerifyCompletionList(fileContents, "wrappedMessage.", ["PrintRef"], [])
+
 #if EXE
 ShouldDisplaySystemNamespace()
 #endif


### PR DESCRIPTION
Resolves this issue: https://github.com/Microsoft/visualfsharp/issues/5515

Fix was very simple. We just get the destination of the byref type and check it against our type we are trying to get completions for.