### PR TITLE
Fixes #5504 - 15.8 Internal MSBuild Error

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
@@ -3250,12 +3250,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 this.SetHostObject("CoreCompile", "Fsc", this);
 
                 // Do the actual Build
-                var loggerList = new System.Collections.Generic.List<Microsoft.Build.Framework.ILogger>(this.buildEngine.Loggers);
-                if (buildLogger != null)
-                    loggerList.Add(buildLogger);
-                if (myDebugLogger != null)
-                    loggerList.Add(myDebugLogger);
-
+                var loggerList = new System.Collections.Generic.List<Microsoft.Build.Framework.ILogger>();
+                if (buildLogger != null) loggerList.Add(buildLogger);
+                if (myDebugLogger != null) loggerList.Add(myDebugLogger);
                 loggers = loggerList.ToArray();
 
                 var ba = new BuildAccessorAccess(buildKind, accessor);


### PR DESCRIPTION
The FSharp project system incorrectly copied Loggers from the Global ProjectCollection.  A recent addition to that collection was not resilient to being copied in each compiled project, which highlighted our error.

/cc @paulvick, @brettfo, @cartermp @kevinpi



