### PR TITLE
CherryPick into dev15.8 (Fixes #5504 - 15.8 Internal MSBuild Error (#5557))

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/Project/ProjectNode.cs
@@ -3235,12 +3235,9 @@ namespace Microsoft.VisualStudio.FSharp.ProjectSystem
                 this.SetHostObject("CoreCompile", "Fsc", this);
 
                 // Do the actual Build
-                var loggerList = new System.Collections.Generic.List<Microsoft.Build.Framework.ILogger>(this.buildEngine.Loggers);
-                if (buildLogger != null)
-                    loggerList.Add(buildLogger);
-                if (myDebugLogger != null)
-                    loggerList.Add(myDebugLogger);
-
+                var loggerList = new System.Collections.Generic.List<Microsoft.Build.Framework.ILogger>();
+                if (buildLogger != null) loggerList.Add(buildLogger);
+                if (myDebugLogger != null) loggerList.Add(myDebugLogger);
                 loggers = loggerList.ToArray();
 
                 var ba = new BuildAccessorAccess(buildKind, accessor);


### PR DESCRIPTION
The issue is that when we do a build in the ide we copy all of the msbuild global loggers into the project.  This behavior is incorrect and causes them to be used multiple times during a build.  Those global loggers are not required or in some cases not designed to be reusable in that way.  Causing the internal error.

The resolution is to not use the Global Loggers in our design time build.

