### PR TITLE
Replace tick with quote in blacklisted characters for rename on type name

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -811,10 +811,10 @@ module internal Tokenizer =
         let isFixableIdentifier (s: string) = 
             not (String.IsNullOrEmpty s) && Lexhelp.Keywords.NormalizeIdentifierBackticks s |> isIdentifier
         
-        let forbiddenChars = [| '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '\'' |]
+        let forbiddenChars = [| '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '\"' |]
         
         let isTypeNameIdent (s: string) =
-            not (String.IsNullOrEmpty s) && s.IndexOfAny forbiddenChars = -1 && isFixableIdentifier s 
+            not (String.IsNullOrEmpty s) && s.IndexOfAny forbiddenChars = -1 && isFixableIdentifier s
         
         let isUnionCaseIdent (s: string) =
             isTypeNameIdent s && Char.IsUpper(s.Replace(doubleBackTickDelimiter, "").[0])


### PR DESCRIPTION
Fixes #5604

The previous code blacklisted `'`, but looking a [the ported VFPT code](https://github.com/fsprojects/VisualFSharpPowerTools/blob/ec16013d6a508dcc25dba24eea8fa770946edddc/src/FSharp.Editing/Common/IdentifierUtils.fs#L42), this may have been mistyped and `"` was intended.

This was never hit if the symbol was an identifier, since this set of forbidden characters is only checked if the symbol is a type name.

With this change, symbols like `DU'` are considered valid, and symbols like `DU"` are not.