### PR TITLE
Fixed hard crash in VS when specific F# code is used.

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1598,7 +1598,7 @@ module internal Parser =
                 let isExe = options.IsExe
                 try Some (ParseInput(lexfun, errHandler.ErrorLogger, lexbuf, None, fileName, (isLastCompiland, isExe)))
                 with e ->
-                    stopProcessingRecovery e Range.range0 // don't re-raise any exceptions, we must return None.
+                    errHandler.ErrorLogger.StopProcessingRecovery e Range.range0 // don't re-raise any exceptions, we must return None.
                     None)
         errHandler.CollectedDiagnostics, parseResult, errHandler.AnyErrors
 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -1598,7 +1598,7 @@ module internal Parser =
                 let isExe = options.IsExe
                 try Some (ParseInput(lexfun, errHandler.ErrorLogger, lexbuf, None, fileName, (isLastCompiland, isExe)))
                 with e ->
-                    errHandler.ErrorLogger.ErrorR(e)
+                    stopProcessingRecovery e Range.range0 // don't re-raise any exceptions, we must return None.
                     None)
         errHandler.CollectedDiagnostics, parseResult, errHandler.AnyErrors
 


### PR DESCRIPTION
Resolves this issue: https://github.com/Microsoft/visualfsharp/issues/5615
This fixes a hard crash in VS by simply not re-raising exceptions when parsing in our service layer.