### PR TITLE
void fix for TPSDK running in .NET Core tooling

### DIFF
--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -428,7 +428,7 @@ module internal ExtensionTyping =
         member __.GetGenericArguments() = x.GetGenericArguments() |> ProvidedType.CreateArray ctxt
         member __.ApplyStaticArguments(provider: ITypeProvider, fullTypePathAfterArguments, staticArgs: obj[]) = 
             provider.ApplyStaticArguments(x, fullTypePathAfterArguments,  staticArgs) |> ProvidedType.Create ctxt
-        member __.IsVoid = (typeof<System.Void>.Equals(x))
+        member __.IsVoid = (typeof<System.Void>.Equals(x) || (x.Namespace = "System" && x.Name = "Void"))
         member __.IsGenericParameter = x.IsGenericParameter
         member __.IsValueType = x.IsValueType
         member __.IsByRef = x.IsByRef


### PR DESCRIPTION
The F# compiler type provider API transacts System.Type/MethodInfo etc. object to describe the provided code.

The compiler (and compiler service) side of this has a few niggling warts which need really gnarly workarounds in the TPSDK . While we're still going to need to workaround these (in order for type providers to work with existing tooling), I'm going to try to push a few fixes into the compiler to make things slightly easier in the very long term.

This is the first such fix: the compiler hardwires a comparison with the _compiler-runtime_ `typeof<System.Void>` as opposed to the _target_ version of this type.  This is wrong and leads to nasty workaround in the TPSDK [here](https://github.com/fsprojects/FSharp.TypeProviders.SDK/blob/master/src/ProvidedTypes.fs#L7857), which itself only works on some code paths, since not all code paths go through the comparison in the compiler.  This is causing problems for type providers running in .NET Core tooling [here](https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/244#issue-346700724): 

    error FS1108: The type 'Void' is required here and is unavailable. You must add a reference to assembly 'System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'.  

(It didn't cause a problem for .NET Framework tooling because "Void" was always in "mscorlib" even at runtime.)

My belief is the easiest thing is to change the compiler to just use a string comparison on the `System.Void` type name here.  I've made it additional just for safety. The TPSDK is doing this anyway, and is the only feasible means of authoring type providers, so there is no compat issue.

There's no point testing this in this repo as it would be hard to arrange and effectively need an import of the whole TPSDK into this repo.
