### PR TITLE
[dev15.9] update nightly package publish options

### DIFF
--- a/.vsts-signed.yaml
+++ b/.vsts-signed.yaml
@@ -34,7 +34,7 @@ steps:
   inputs:
     scriptName: 'setup\publish-assets.ps1'
     arguments: '-binariesPath $(MSBuildConfiguration) -branchName $(Build.SourceBranch) -apiKey $(FSharp.MyGetApiKey)'
-  condition: and(succeeded(), contains(variables['PB_PublishType'], 'myget'), in(variables['Build.SourceBranchName'], 'master', 'dev15.7', 'dev15.8'))
+  condition: and(succeeded(), contains(variables['PB_PublishType'], 'myget'))
 
 # Publish packages to Azure Blob Storage
 - task: MSBuild@1

--- a/setup/publish-assets.ps1
+++ b/setup/publish-assets.ps1
@@ -30,11 +30,8 @@ try {
         "master" {
             $requestUrl = "https://dotnet.myget.org/F/fsharp/vsix/upload"
         }
-        "dev15.7" {
+        "dev15.9" {
             $requestUrl = "https://dotnet.myget.org/F/fsharp-preview/vsix/upload"
-        }
-        "dev15.8" {
-            $requestUrl = "https://dotnet.myget.org/F/fsharp-dev15-8-preview/vsix/upload"
         }
         default {
             Write-Host "Branch [$branchName] is not supported for publishing."


### PR DESCRIPTION
Remove the branch filtering in the `.yaml` file since the `.ps1` script handles that appropriately.