### PR TITLE
fix FCS issue with IsByRef

### DIFF
--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -475,7 +475,7 @@ and FSharpEntity(cenv: SymbolEnv, entity:EntityRef) =
 
     member __.IsByRef = 
         isResolved() &&
-        tyconRefEq cenv.g cenv.g.byref_tcr entity
+        isByrefTyconRef cenv.g entity
 
     member __.IsOpaque = 
         isResolved() &&


### PR DESCRIPTION
F# 4.5 introduced an issue with the `IsByRef` property on FSharpEntity in the F# Compiler Service API.

https://github.com/fsharp/FSharp.Compiler.Service/issues/876