### PR TITLE
Do we really need to keep resolving after we already found a type?

### DIFF
--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3830,28 +3830,28 @@ let TryToResolveLongIdentAsType (ncenv: NameResolver) (nenv: NameResolutionEnv) 
     | Some id ->
         // Look for values called 'id' that accept the dot-notation 
         let ty, isItemVal = 
-            (match nenv.eUnqualifiedItems |> Map.tryFind id with
+            match nenv.eUnqualifiedItems |> Map.tryFind id with
                // v.lookup : member of a value
-             | Some v ->
-                 match v with 
-                 | Item.Value x -> 
-                     let ty = x.Type
-                     let ty = if x.BaseOrThisInfo = CtorThisVal && isRefCellTy g ty then destRefCellTy g ty else ty
-                     Some ty, true
-                 | _ -> None, false
-             | None -> None, false)
+            | Some v ->
+                match v with 
+                | Item.Value x -> 
+                    let ty = x.Type
+                    let ty = if x.BaseOrThisInfo = CtorThisVal && isRefCellTy g ty then destRefCellTy g ty else ty
+                    Some ty, true
+                | _ -> None, false
+            | None -> None, false
         
-        if isItemVal then ty
-        else
-            (ty, LookupTypeNameInEnvNoArity OpenQualified id nenv)
-            ||> List.fold (fun resTy tcref ->
-                // type.lookup : lookup a static something in a type
-                match resTy with
-                | Some _ -> resTy
-                | None ->
-                    let tcref = ResolveNestedTypeThroughAbbreviation ncenv tcref m
-                    let ty = FreshenTycon ncenv m tcref
-                    Some ty) 
+        if isItemVal then ty else
+
+        match ty with
+        | Some _ -> ty
+        | _ ->
+            // type.lookup : lookup a static something in a type
+            LookupTypeNameInEnvNoArity OpenQualified id nenv
+            |> List.tryHead
+            |> Option.map (fun tcref ->
+                let tcref = ResolveNestedTypeThroughAbbreviation ncenv tcref m
+                FreshenTycon ncenv m tcref) 
     | _ -> None
 
 /// allowObsolete - specifies whether we should return obsolete types & modules 

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3845,14 +3845,13 @@ let TryToResolveLongIdentAsType (ncenv: NameResolver) (nenv: NameResolutionEnv) 
         else
             (ty, LookupTypeNameInEnvNoArity OpenQualified id nenv)
             ||> List.fold (fun resTy tcref ->
-                // type.lookup : lookup a static something in a type 
-                let tcref = ResolveNestedTypeThroughAbbreviation ncenv tcref m
-                let ty = FreshenTycon ncenv m tcref
-                let resTy =
-                    match resTy with
-                    | Some _ -> resTy
-                    | None -> Some ty
-                resTy) 
+                // type.lookup : lookup a static something in a type
+                match resTy with
+                | Some _ -> resTy
+                | None ->
+                    let tcref = ResolveNestedTypeThroughAbbreviation ncenv tcref m
+                    let ty = FreshenTycon ncenv m tcref
+                    Some ty) 
     | _ -> None
 
 /// allowObsolete - specifies whether we should return obsolete types & modules 

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -3829,7 +3829,7 @@ let TryToResolveLongIdentAsType (ncenv: NameResolver) (nenv: NameResolutionEnv) 
     match List.tryLast plid with
     | Some id ->
         // Look for values called 'id' that accept the dot-notation 
-        let ty, isItemVal = 
+        let ty = 
             match nenv.eUnqualifiedItems |> Map.tryFind id with
                // v.lookup : member of a value
             | Some v ->
@@ -3837,11 +3837,9 @@ let TryToResolveLongIdentAsType (ncenv: NameResolver) (nenv: NameResolutionEnv) 
                 | Item.Value x -> 
                     let ty = x.Type
                     let ty = if x.BaseOrThisInfo = CtorThisVal && isRefCellTy g ty then destRefCellTy g ty else ty
-                    Some ty, true
-                | _ -> None, false
-            | None -> None, false
-        
-        if isItemVal then ty else
+                    Some ty
+                | _ -> None
+            | None -> None
 
         match ty with
         | Some _ -> ty


### PR DESCRIPTION
It looks like we call ResolveNestedTypeThroughAbbreviation for all elements in the list, but we olny return the first one.