### PR TITLE
Fix codegen for StructValueTuple when aliased

### DIFF
--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -805,6 +805,8 @@ let argsOfAppTy   g ty = ty |> stripTyEqns g |> (function TType_app(_, tinst) ->
 let tryDestTyparTy g ty = ty |> stripTyEqns g |> (function TType_var v -> Some v | _ -> None)
 let tryDestFunTy   g ty = ty |> stripTyEqns g |> (function TType_fun (tyv, tau) -> Some(tyv, tau) | _ -> None)
 let tryDestAppTy   g ty = ty |> stripTyEqns g |> (function TType_app(tcref, _) -> Some tcref | _ -> None)
+let tryDestTupleInfo g ty = ty |> stripTyEqns g |> (function TType_tuple(tupinfo, _) -> Some tupinfo | _ -> None)
+
 let tryAnyParTy    g ty = ty |> stripTyEqns g |> (function TType_var v -> Some v | TType_measure unt when isUnitParMeasure g unt -> Some(destUnitParMeasure g unt) | _ -> None)
 let (|AppTy|_|) g ty = ty |> stripTyEqns g |> (function TType_app(tcref, tinst) -> Some (tcref, tinst) | _ -> None) 
 let (|RefTupleTy|_|) g ty = ty |> stripTyEqns g |> (function TType_tuple(tupInfo, tys) when not (evalTupInfoIsStruct tupInfo) -> Some tys | _ -> None)
@@ -1729,7 +1731,10 @@ let isStructTy g ty =
     | Some tcref -> 
         let tycon = tcref.Deref
         tycon.IsStructRecordOrUnionTycon || tycon.IsStructOrEnumTycon
-    | _ -> false
+    | _ -> 
+        match tryDestTupleInfo g ty with
+        | Some tupleInfo -> match tupleInfo with | TupInfo.Const b -> b
+        | None -> false
 
 let isRefTy g ty = 
     not (isStructOrEnumTyconTy g ty) &&

--- a/src/fsharp/TastOps.fs
+++ b/src/fsharp/TastOps.fs
@@ -805,7 +805,6 @@ let argsOfAppTy   g ty = ty |> stripTyEqns g |> (function TType_app(_, tinst) ->
 let tryDestTyparTy g ty = ty |> stripTyEqns g |> (function TType_var v -> Some v | _ -> None)
 let tryDestFunTy   g ty = ty |> stripTyEqns g |> (function TType_fun (tyv, tau) -> Some(tyv, tau) | _ -> None)
 let tryDestAppTy   g ty = ty |> stripTyEqns g |> (function TType_app(tcref, _) -> Some tcref | _ -> None)
-let tryDestTupleInfo g ty = ty |> stripTyEqns g |> (function TType_tuple(tupinfo, _) -> Some tupinfo | _ -> None)
 
 let tryAnyParTy    g ty = ty |> stripTyEqns g |> (function TType_var v -> Some v | TType_measure unt when isUnitParMeasure g unt -> Some(destUnitParMeasure g unt) | _ -> None)
 let (|AppTy|_|) g ty = ty |> stripTyEqns g |> (function TType_app(tcref, tinst) -> Some (tcref, tinst) | _ -> None) 
@@ -1731,10 +1730,7 @@ let isStructTy g ty =
     | Some tcref -> 
         let tycon = tcref.Deref
         tycon.IsStructRecordOrUnionTycon || tycon.IsStructOrEnumTycon
-    | _ -> 
-        match tryDestTupleInfo g ty with
-        | Some tupleInfo -> match tupleInfo with | TupInfo.Const b -> b
-        | None -> false
+    | _ -> isStructTupleTy g ty
 
 let isRefTy g ty = 
     not (isStructOrEnumTyconTy g ty) &&

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Tuples/ValueTupleAliasConstructor.fs
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Tuples/ValueTupleAliasConstructor.fs
@@ -1,0 +1,3 @@
+open System
+type Node = (struct (int* int))
+let _ = new Node(2,2)

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Tuples/ValueTupleAliasConstructor.il.bsl
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Tuples/ValueTupleAliasConstructor.il.bsl
@@ -1,0 +1,88 @@
+
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+
+
+
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly extern FSharp.Core
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:5:0:0
+}
+.assembly extern System.ValueTuple
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 4:0:1:0
+}
+.assembly ValueTupleAliasConstructor
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32,
+                                                                                                      int32,
+                                                                                                      int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 00 00 00 00 00 ) 
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.mresource public FSharpSignatureData.ValueTupleAliasConstructor
+{
+  // Offset: 0x00000000 Length: 0x000001EA
+}
+.mresource public FSharpOptimizationData.ValueTupleAliasConstructor
+{
+  // Offset: 0x000001F0 Length: 0x00000061
+}
+.module ValueTupleAliasConstructor.exe
+// MVID: {5B9C53DD-A8CF-BB34-A745-0383DD539C5B}
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x01B00000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public abstract auto ansi sealed ValueTupleAliasConstructor
+       extends [mscorlib]System.Object
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+} // end of class ValueTupleAliasConstructor
+
+.class private abstract auto ansi sealed '<StartupCode$ValueTupleAliasConstructor>'.$ValueTupleAliasConstructor
+       extends [mscorlib]System.Object
+{
+  .field static assembly int32 init@
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public static void  main@() cil managed
+  {
+    .entrypoint
+    // Code size       9 (0x9)
+    .maxstack  8
+    .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    .line 3,3 : 9,22 'c:\\kevinransom\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\Tuples\\ValueTupleAliasConstructor.fs'
+    IL_0000:  ldc.i4.2
+    IL_0001:  ldc.i4.2
+    IL_0002:  newobj     instance void valuetype [System.ValueTuple]System.ValueTuple`2<int32,int32>::.ctor(!0,
+                                                                                                            !1)
+    IL_0007:  pop
+    IL_0008:  ret
+  } // end of method $ValueTupleAliasConstructor::main@
+
+} // end of class '<StartupCode$ValueTupleAliasConstructor>'.$ValueTupleAliasConstructor
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Tuples/env.lst
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Tuples/env.lst
@@ -1,13 +1,14 @@
-			SOURCE=Tuple01.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple01.exe"			# Tuple01.fs
+	SOURCE=Tuple01.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple01.exe"		# Tuple01.fs
 	SOURCE=Tuple02.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple02.exe"		# Tuple02.fs -
 	SOURCE=Tuple03.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple03.exe"		# Tuple03.fs -
 	SOURCE=Tuple04.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple04.exe"		# Tuple04.fs -
 	SOURCE=Tuple05.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple05.exe"		# Tuple05.fs -
 	SOURCE=Tuple06.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple06.exe"		# Tuple06.fs -
 	SOURCE=Tuple07.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple07.exe"		# Tuple07.fs -
-
 	SOURCE=Tuple08.fs      SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Tuple08.exe"		# Tuple08.fs -
 
 	SOURCE=TupleMonster.fs SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize-" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd TupleMonster.exe"		# TupleMonster.fs -
 
 	SOURCE=TupleElimination.fs SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize+" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd TupleElimination.exe"		# TupleElimination.fs -
+
+	SOURCE=ValueTupleAliasConstructor.fs SCFLAGS="-g --test:EmitFeeFeeAs100001 --optimize+" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd ValueTupleAliasConstructor.exe"		# ValueTupleAliasConstructor.fs -


### PR DESCRIPTION
@TIHan, @cartermp,

and I were looking at an issue earlier where F# generates bad code when initializing a structtuple that has been aliased.

This code:
````
// Learn more about F# at http://fsharp.org
open System

type Node = ( struct (int* int))

[<EntryPoint>]
let main argv =
    let node = new Node(2,2)
    0 // return an integer exit code

````
Compiles fine, but when it runs it fails like with this message:
````
C:\Users\kevinr\source\repos\ConsoleApp10\ConsoleApp10>Program.exe

Unhandled Exception: System.TypeLoadException: Could not load type 'System.ValueTuple`2' from assembly 'Program, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' due to value type mismatch.
   at Program.main(String[] argv)

C:\Users\kevinr\source\repos\ConsoleApp10\ConsoleApp10>
````
The message is garbage because the referenced ValueTuple is in System.Runtime or mscorlib, depending on platform.


The issue is that here: https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/MethodCalls.fs#L615
Generates the call to the constructor with valu set to false.

The implementation of isStructTy here: https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/TastOps.fs#L1727

The update tries to get the tupleinfo, if tryDestAppTy can't find a tcref to check the structness.

It's late, I will add a regression test tomorrow.

@TIHan, @dsyme can you take a look and see if this is okay.



