### PR TITLE
Rename output overrides file

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
@@ -7,7 +7,7 @@ folder "InstallDir:MSBuild\Microsoft\VisualStudio\v$(VSGeneralVersion)\FSharp"
   file "Microsoft.FSharp.targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.Shim.targets"
   file "Microsoft.Portable.FSharp.targets" source="$(BinariesFolder)\setup\resources\Microsoft.Portable.FSharp.Shim.targets"
   file "Microsoft.FSharp.NetSdk.targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.NetSdk.Shim.targets"
-  file "Microsoft.FSharp.NetSdk.Overrides.targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.Overrides.NetSdk.Shim.targets"
+  file "Microsoft.FSharp.Overrides.NetSdk.targets" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.Overrides.NetSdk.Shim.targets"
   file "Microsoft.FSharp.NetSdk.props" source="$(BinariesFolder)\setup\resources\Microsoft.FSharp.NetSdk.Shim.props"
 
 folder "InstallDir:Common7\IDE\PublicAssemblies"


### PR DESCRIPTION
VS deploys Microsoft.FSharp.Overrides.NetSdk.Shim.targets to the wrong file name it needs to be: Microsoft.FSharp.Overrides.NetSdk.targets.

The wrong name breaks AssemblyInfo generation when compiling under VS.


