### PR TITLE
Add decoded ILAttribute representation

### DIFF
--- a/src/absil/il.fs
+++ b/src/absil/il.fs
@@ -948,10 +948,29 @@ type ILAttribElem =
 type ILAttributeNamedArg =  (string * ILType * bool * ILAttribElem)
 
 [<StructuralEquality; StructuralComparison; StructuredFormatDisplay("{DebugText}")>]
-type ILAttribute = 
-    { Method: ILMethodSpec
-      Data: byte[] 
-      Elements: ILAttribElem list }
+type ILAttribute =
+    | Encoded of method: ILMethodSpec * data: byte[] * elements: ILAttribElem list
+    | Decoded of method: ILMethodSpec * fixedArgs: ILAttribElem list * namedArgs: ILAttributeNamedArg list
+
+    member x.Method =
+        match x with
+        | Encoded (method, _, _)
+        | Decoded (method, _, _) -> method
+
+    member x.Elements =
+        match x with
+        | Encoded (_, _, elements) -> elements
+        | Decoded (_, fixedArgs, namedArgs) -> fixedArgs @ (namedArgs |> List.map (fun (_, _, _, e) -> e))
+
+    member x.WithMethod(method: ILMethodSpec) =
+        match x with
+        | Encoded (_, data, elements) -> Encoded (method, data, elements)
+        | Decoded (_, fixedArgs, namedArgs) -> Decoded (method, fixedArgs, namedArgs)
+
+    member x.Data =
+        match x with
+        | Encoded (_, data, _) -> data
+        | _ -> failwithf "Getting encoded data from decoded attribute %O." x
 
     /// For debugging
     [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
@@ -3581,9 +3600,7 @@ let mkILCustomAttribMethRef (ilg: ILGlobals) (mspec:ILMethodSpec, fixedArgs: lis
          yield! u16AsBytes (uint16 namedArgs.Length) 
          for namedArg in namedArgs do 
              yield! encodeCustomAttrNamedArg ilg namedArg |]
-    { Method = mspec
-      Data = args
-      Elements = fixedArgs @ (namedArgs |> List.map(fun (_, _, _, e) -> e)) }
+    Encoded (mspec, args, fixedArgs @ (namedArgs |> List.map (fun (_, _, _, e) -> e)))
 
 let mkILCustomAttribute ilg (tref, argtys, argvs, propvs) = 
     mkILCustomAttribMethRef ilg (mkILNonGenericCtorMethSpec (tref, argtys), argvs, propvs)
@@ -3755,7 +3772,10 @@ type ILTypeSigParser(tstring : string) =
         ILAttribElem.Type(Some(ilty))
 
 let decodeILAttribData (ilg: ILGlobals) (ca: ILAttribute) = 
-    let bytes = ca.Data
+    match ca with
+    | Decoded (_, fixedArgs, namedArgs) -> fixedArgs, namedArgs
+    | Encoded (_, bytes, _) ->
+
     let sigptr = 0
     let bb0, sigptr = sigptr_get_byte bytes sigptr
     let bb1, sigptr = sigptr_get_byte bytes sigptr
@@ -3944,7 +3964,7 @@ and refs_of_token s x =
     | ILToken.ILMethod mr -> refs_of_mspec s mr
     | ILToken.ILField fr -> refs_of_fspec s fr
 
-and refs_of_custom_attr s x = refs_of_mspec s x.Method
+and refs_of_custom_attr s (cattr: ILAttribute) = refs_of_mspec s cattr.Method
     
 and refs_of_custom_attrs s (cas : ILAttributes) = List.iter (refs_of_custom_attr s) cas.AsList
 and refs_of_varargs s tyso = Option.iter (refs_of_tys s) tyso 

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -752,12 +752,19 @@ type ILAttribElem =
 /// Named args: values and flags indicating if they are fields or properties.
 type ILAttributeNamedArg = string * ILType * bool * ILAttribElem
 
-/// Custom attributes. See 'decodeILAttribData' for a helper to parse the byte[] to ILAttribElem's as best as possible.
+/// Custom attribute.
 type ILAttribute =
+    /// Attribute with args encoded to a binary blob according to ECMA-335 II.21 and II.23.3.
+    /// 'decodeILAttribData' is used to parse the byte[] blob to ILAttribElem's as best as possible.
     | Encoded of method: ILMethodSpec * data: byte[] * elements: ILAttribElem list
+
+    /// Attribute with args in decoded form.
     | Decoded of method: ILMethodSpec * fixedArgs: ILAttribElem list * namedArgs: ILAttributeNamedArg list
 
+    /// Attribute instance constructor.
     member Method: ILMethodSpec
+
+    /// Decoded arguments. May be empty in encoded attribute form.
     member Elements: ILAttribElem list
 
     member WithMethod: method: ILMethodSpec -> ILAttribute

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -752,12 +752,16 @@ type ILAttribElem =
 /// Named args: values and flags indicating if they are fields or properties.
 type ILAttributeNamedArg = string * ILType * bool * ILAttribElem
 
-/// Custom attributes.  See 'decodeILAttribData' for a helper to parse the byte[] 
-/// to ILAttribElem's as best as possible.  
+/// Custom attributes. See 'decodeILAttribData' for a helper to parse the byte[] to ILAttribElem's as best as possible.
 type ILAttribute =
-    { Method: ILMethodSpec  
-      Data: byte[] 
-      Elements: ILAttribElem list}
+    | Encoded of method: ILMethodSpec * data: byte[] * elements: ILAttribElem list
+    | Decoded of method: ILMethodSpec * fixedArgs: ILAttribElem list * namedArgs: ILAttributeNamedArg list
+
+    member Method: ILMethodSpec
+    member Elements: ILAttribElem list
+    member Data: byte[]
+
+    member WithMethod: method: ILMethodSpec -> ILAttribute
 
 [<NoEquality; NoComparison; Struct>]
 type ILAttributes =

--- a/src/absil/il.fsi
+++ b/src/absil/il.fsi
@@ -759,7 +759,6 @@ type ILAttribute =
 
     member Method: ILMethodSpec
     member Elements: ILAttribElem list
-    member Data: byte[]
 
     member WithMethod: method: ILMethodSpec -> ILAttribute
 
@@ -1685,6 +1684,8 @@ val mkILCustomAttribute:
        ILAttribElem list (* fixed args: values and implicit types *) * 
        ILAttributeNamedArg list (* named args: values and flags indicating if they are fields or properties *) 
          -> ILAttribute
+
+val getCustomAttrData: ILGlobals -> ILAttribute -> byte[]
 
 val mkPermissionSet: ILGlobals -> ILSecurityAction * (ILTypeRef * (string * ILType * ILAttribElem) list) list -> ILSecurityDecl
 

--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -136,7 +136,7 @@ let rec celem_ty2ty f celem =
 let cnamedarg_ty2ty f ((nm, ty, isProp, elem) : ILAttributeNamedArg)  =
     (nm, f ty, isProp, celem_ty2ty f elem) 
 
-let cattr_ty2ty ilg f c =
+let cattr_ty2ty ilg f (c: ILAttribute) =
     let meth = mspec_ty2ty (f, (fun _ -> f)) c.Method
     // dev11 M3 defensive coding: if anything goes wrong with attribute decoding or encoding, then back out.
     if morphCustomAttributeData then
@@ -146,9 +146,9 @@ let cattr_ty2ty ilg f c =
            let namedArgs = namedArgs |> List.map (cnamedarg_ty2ty f)
            IL.mkILCustomAttribMethRef ilg (meth, elems, namedArgs)       
         with _ -> 
-           { c with Method = meth }
+           c.WithMethod(meth)
     else
-        { c with Method = meth }
+        c.WithMethod(meth)
 
 
 let cattrs_ty2ty ilg f (cs: ILAttributes) =

--- a/src/absil/ilmorph.fs
+++ b/src/absil/ilmorph.fs
@@ -144,8 +144,8 @@ let cattr_ty2ty ilg f (c: ILAttribute) =
            let elems,namedArgs = IL.decodeILAttribData ilg c 
            let elems = elems |> List.map (celem_ty2ty f)
            let namedArgs = namedArgs |> List.map (cnamedarg_ty2ty f)
-           IL.mkILCustomAttribMethRef ilg (meth, elems, namedArgs)       
-        with _ -> 
+           mkILCustomAttribMethRef ilg (meth, elems, namedArgs)
+        with _ ->
            c.WithMethod(meth)
     else
         c.WithMethod(meth)

--- a/src/absil/ilprint.fs
+++ b/src/absil/ilprint.fs
@@ -469,7 +469,7 @@ let output_basic_type os x =
 let output_custom_attr_data os data = 
   output_string os " = "; output_parens output_bytes os data
       
-let goutput_custom_attr env os attr =
+let goutput_custom_attr env os (attr: ILAttribute) =
   output_string os " .custom "
   goutput_mspec env os attr.Method
   output_custom_attr_data os attr.Data

--- a/src/absil/ilprint.fs
+++ b/src/absil/ilprint.fs
@@ -30,13 +30,14 @@ let tyvar_generator =
 // Carry an environment because the way we print method variables 
 // depends on the gparams of the current scope. 
 type ppenv = 
-    { ppenvClassFormals: int;
+    { ilGlobals: ILGlobals
+      ppenvClassFormals: int;
       ppenvMethodFormals: int }
 let ppenv_enter_method  mgparams env = 
     {env with ppenvMethodFormals=mgparams}
 let ppenv_enter_tdef gparams env =
     {env with ppenvClassFormals=List.length gparams; ppenvMethodFormals=0}
-let mk_ppenv = { ppenvClassFormals=0; ppenvMethodFormals=0 }
+let mk_ppenv ilg = { ilGlobals = ilg; ppenvClassFormals = 0; ppenvMethodFormals = 0 }
 let debug_ppenv = mk_ppenv 
 let ppenv_enter_modul env = { env with  ppenvClassFormals=0; ppenvMethodFormals=0 }
 
@@ -472,7 +473,8 @@ let output_custom_attr_data os data =
 let goutput_custom_attr env os (attr: ILAttribute) =
   output_string os " .custom "
   goutput_mspec env os attr.Method
-  output_custom_attr_data os attr.Data
+  let data = getCustomAttrData env.ilGlobals attr
+  output_custom_attr_data os data
 
 let goutput_custom_attrs env os (attrs : ILAttributes) =
   List.iter (fun attr -> goutput_custom_attr env os attr;  output_string os "\n" ) attrs.AsList
@@ -1029,9 +1031,9 @@ let goutput_manifest env os m =
   output_string os " } \n"
 
 
-let output_module_fragment_aux _refs os  modul = 
+let output_module_fragment_aux _refs os (ilg: ILGlobals) modul =
   try 
-    let env = mk_ppenv 
+    let env = mk_ppenv ilg
     let env = ppenv_enter_modul env 
     goutput_tdefs false ([]) env os modul.TypeDefs;
     goutput_tdefs true ([]) env os modul.TypeDefs;
@@ -1039,9 +1041,9 @@ let output_module_fragment_aux _refs os  modul =
     output_string os "*** Error during printing : "; output_string os (e.ToString()); os.Flush();
     reraise()
 
-let output_module_fragment os  modul = 
+let output_module_fragment os (ilg: ILGlobals) modul =
   let refs = computeILRefs modul 
-  output_module_fragment_aux refs os  modul;
+  output_module_fragment_aux refs os ilg modul
   refs
 
 let output_module_refs os refs = 
@@ -1059,14 +1061,14 @@ let goutput_module_manifest env os modul =
   output_string os "\n";
   (output_option (goutput_manifest env)) os modul.Manifest
 
-let output_module os  modul = 
+let output_module os (ilg: ILGlobals) modul =
   try 
     let refs = computeILRefs modul 
-    let env = mk_ppenv 
+    let env = mk_ppenv ilg
     let env = ppenv_enter_modul env 
     output_module_refs  os refs;
     goutput_module_manifest env os modul;
-    output_module_fragment_aux refs os  modul;
+    output_module_fragment_aux refs os ilg modul;
   with e ->  
     output_string os "*** Error during printing : "; output_string os (e.ToString()); os.Flush();
     raise e

--- a/src/absil/ilprint.fsi
+++ b/src/absil/ilprint.fsi
@@ -9,6 +9,6 @@ open Microsoft.FSharp.Compiler.AbstractIL.Internal
 open System.IO
 
 #if DEBUG
-val public output_module      : TextWriter -> ILModuleDef -> unit
+val public output_module: TextWriter -> ilg: ILGlobals -> ILModuleDef -> unit
 #endif
 

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2567,12 +2567,13 @@ and seekReadCustomAttr ctxt (TaggedIndex(cat, idx), b) =
 
 and seekReadCustomAttrUncached ctxtH (CustomAttrIdx (cat, idx, valIdx)) = 
     let ctxt = getHole ctxtH
-    { Method=seekReadCustomAttrType ctxt (TaggedIndex(cat, idx))
-      Data=
+    let method = seekReadCustomAttrType ctxt (TaggedIndex(cat, idx))
+    let data =
         match readBlobHeapOption ctxt valIdx with
         | Some bytes -> bytes
-        | None -> Bytes.ofInt32Array [| |] 
-      Elements = [] }
+        | None -> Bytes.ofInt32Array [| |]
+    let elements = []
+    ILAttribute.Encoded (method, data, elements)
 
 and securityDeclsReader ctxtH tag = 
     mkILSecurityDeclsReader

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1414,7 +1414,7 @@ let emitMethodBody cenv modB emEnv ilG _name (mbody: ILLazyMethodBody) =
     | MethodBody.Native           -> failwith "emitMethodBody: native"               
     | MethodBody.NotAvailable     -> failwith "emitMethodBody: metadata only"
 
-let convCustomAttr cenv emEnv cattr =
+let convCustomAttr cenv emEnv (cattr: ILAttribute) =
     let methInfo = 
        match convConstructorSpec cenv emEnv cattr.Method with 
        | null -> failwithf "convCustomAttr: %+A" cattr.Method

--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -1419,7 +1419,7 @@ let convCustomAttr cenv emEnv (cattr: ILAttribute) =
        match convConstructorSpec cenv emEnv cattr.Method with 
        | null -> failwithf "convCustomAttr: %+A" cattr.Method
        | res -> res
-    let data = cattr.Data 
+    let data = getCustomAttrData cenv.ilg cattr
     (methInfo, data)
 
 let emitCustomAttr cenv emEnv add cattr  = add (convCustomAttr cenv emEnv cattr)

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -1384,6 +1384,7 @@ let rec GetCustomAttrDataAsBlobIdx cenv (data:byte[]) =
 
 and GetCustomAttrRow cenv hca (attr: ILAttribute) =
     let cat = GetMethodRefAsCustomAttribType cenv attr.Method.MethodRef
+    let data = getCustomAttrData cenv.ilg attr
     for element in attr.Elements do
         match element with
         | ILAttribElem.Type (Some ty) when ty.IsNominal -> GetTypeRefAsTypeRefIdx cenv ty.TypeRef |> ignore
@@ -1393,7 +1394,7 @@ and GetCustomAttrRow cenv hca (attr: ILAttribute) =
     UnsharedRow
             [| HasCustomAttribute (fst hca, snd hca);
                CustomAttributeType (fst cat, snd cat);
-               Blob (GetCustomAttrDataAsBlobIdx cenv attr.Data)
+               Blob (GetCustomAttrDataAsBlobIdx cenv data)
             |]
 
 and GenCustomAttrPass3Or4 cenv hca attr = 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -1382,7 +1382,7 @@ and GetMethodRefAsCustomAttribType cenv (mref:ILMethodRef) =
 let rec GetCustomAttrDataAsBlobIdx cenv (data:byte[]) = 
     if data.Length = 0 then 0 else GetBytesAsBlobIdx cenv data
 
-and GetCustomAttrRow cenv hca attr = 
+and GetCustomAttrRow cenv hca (attr: ILAttribute) =
     let cat = GetMethodRefAsCustomAttribType cenv attr.Method.MethodRef
     for element in attr.Elements do
         match element with

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1060,7 +1060,7 @@ type internal FsiDynamicCompiler
 #if DEBUG
         if fsiOptions.ShowILCode then 
             fsiConsoleOutput.uprintnfn "--------------------";
-            ILAsciiWriter.output_module outWriter mainmod3;
+            ILAsciiWriter.output_module outWriter ilGlobals mainmod3;
             fsiConsoleOutput.uprintnfn "--------------------"
 #else
         ignore(fsiOptions)


### PR DESCRIPTION
Allows passing decoded custom attributes when reading IL metadata.

One thing to consider is equality for this type as there're now two cases with different representations and structural equality cannot be used anymore. Are these attributes objects ever checked for equality?