### PR TITLE
Small Language Service refactoring

### DIFF
--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -50,6 +50,9 @@
     <Compile Include="LanguageService\IProjectSite.fs" />
     <Compile Include="LanguageService\ProjectSitesAndFiles.fs" />
     <Compile Include="LanguageService\ProvideFSharpVersionRegistrationAttribute.fs" />
+    <Compile Include="LanguageService\FSharpCheckerProvider.fs" />
+    <Compile Include="LanguageService\FSharpProjectOptionsManager.fs" />
+    <Compile Include="LanguageService\LegacyProjectWorkspaceMap.fs" />
     <Compile Include="LanguageService\LanguageService.fs" />
     <Compile Include="LanguageService\AssemblyContentProvider.fs" />
     <Compile Include="LanguageService\SymbolHelpers.fs" />
@@ -152,7 +155,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="$(MicrosoftVisualStudioTextManagerInterop120PackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsPackageVersion)"  PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTuplePackageVersion)" />

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpCheckerProvider.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpCheckerProvider.fs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.ComponentModel.Composition
+open System.Diagnostics
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Diagnostics
+open Microsoft.FSharp.Compiler.SourceCodeServices
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.LanguageServices
+open Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+open FSharp.NativeInterop
+
+#nowarn "9" // NativePtr.toNativeInt
+
+// Exposes FSharpChecker as MEF export
+[<Export(typeof<FSharpCheckerProvider>); Composition.Shared>]
+type internal FSharpCheckerProvider 
+    [<ImportingConstructor>]
+    (
+        analyzerService: IDiagnosticAnalyzerService,
+        [<Import(typeof<VisualStudioWorkspace>)>] workspace: VisualStudioWorkspaceImpl,
+        settings: EditorOptions
+    ) =
+
+    let tryGetMetadataSnapshot (path, timeStamp) = 
+        try
+            let metadataReferenceProvider = workspace.Services.GetService<VisualStudioMetadataReferenceManager>()
+            let md = metadataReferenceProvider.GetMetadata(path, timeStamp)
+            let amd = (md :?> AssemblyMetadata)
+            let mmd = amd.GetModules().[0]
+            let mmr = mmd.GetMetadataReader()
+
+            // "lifetime is timed to Metadata you got from the GetMetadata(...). As long as you hold it strongly, raw 
+            // memory we got from metadata reader will be alive. Once you are done, just let everything go and 
+            // let finalizer handle resource rather than calling Dispose from Metadata directly. It is shared metadata. 
+            // You shouldn't dispose it directly."
+
+            let objToHold = box md
+
+            // We don't expect any ilread WeakByteFile to be created when working in Visual Studio
+            Debug.Assert((Microsoft.FSharp.Compiler.AbstractIL.ILBinaryReader.GetStatistics().weakByteFileCount = 0), "Expected weakByteFileCount to be zero when using F# in Visual Studio. Was there a problem reading a .NET binary?")
+
+            Some (objToHold, NativePtr.toNativeInt mmr.MetadataPointer, mmr.MetadataLength)
+        with ex -> 
+            // We catch all and let the backup routines in the F# compiler find the error
+            Assert.Exception(ex)
+            None 
+
+
+    let checker = 
+        lazy
+            let checker = 
+                FSharpChecker.Create(
+                    projectCacheSize = settings.LanguageServicePerformance.ProjectCheckCacheSize, 
+                    keepAllBackgroundResolutions = false,
+                    // Enabling this would mean that if devenv.exe goes above 2.3GB we do a one-off downsize of the F# Compiler Service caches
+                    (* , MaxMemory = 2300 *) 
+                    legacyReferenceResolver=Microsoft.FSharp.Compiler.MSBuildReferenceResolver.Resolver,
+                    tryGetMetadataSnapshot = tryGetMetadataSnapshot)
+
+            // This is one half of the bridge between the F# background builder and the Roslyn analysis engine.
+            // When the F# background builder refreshes the background semantic build context for a file,
+            // we request Roslyn to reanalyze that individual file.
+            checker.BeforeBackgroundFileCheck.Add(fun (fileName, _extraProjectInfo) ->  
+                async {
+                    try 
+                        let solution = workspace.CurrentSolution
+                        let documentIds = solution.GetDocumentIdsWithFilePath(fileName)
+                        if not documentIds.IsEmpty then 
+                            let documentIdsFiltered = documentIds |> Seq.filter workspace.IsDocumentOpen |> Seq.toArray
+                            for documentId in documentIdsFiltered do
+                                Trace.TraceInformation("{0:n3} Requesting Roslyn reanalysis of {1}", DateTime.Now.TimeOfDay.TotalSeconds, documentId)
+                            if documentIdsFiltered.Length > 0 then 
+                                analyzerService.Reanalyze(workspace,documentIds=documentIdsFiltered)
+                    with ex -> 
+                        Assert.Exception(ex)
+                } |> Async.StartImmediate
+            )
+            checker
+
+    member this.Checker = checker.Value
+

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.Collections.Concurrent
+open System.Collections.Immutable
+open System.ComponentModel.Composition
+open System.IO
+open System.Linq
+open Microsoft.CodeAnalysis
+open Microsoft.FSharp.Compiler.CompileOps
+open Microsoft.FSharp.Compiler.SourceCodeServices
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.FSharp.Editor.SiteProvider
+open Microsoft.VisualStudio.LanguageServices
+open Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+open Microsoft.VisualStudio.Shell
+
+/// Exposes FCS FSharpProjectOptions information management as MEF component.
+//
+// This service allows analyzers to get an appropriate FSharpProjectOptions value for a project or single file.
+// It also allows a 'cheaper' route to get the project options relevant to parsing (e.g. the #define values).
+// The main entrypoints are TryGetOptionsForDocumentOrProject and TryGetOptionsForEditingDocumentOrProject.
+[<Export(typeof<FSharpProjectOptionsManager>); Composition.Shared>]
+type internal FSharpProjectOptionsManager
+    [<ImportingConstructor>]
+    (
+        checkerProvider: FSharpCheckerProvider,
+        [<Import(typeof<VisualStudioWorkspace>)>] workspace: VisualStudioWorkspaceImpl,
+        [<Import(typeof<SVsServiceProvider>)>] serviceProvider: System.IServiceProvider,
+        settings: EditorOptions
+    ) =
+
+    // A table of information about projects, excluding single-file projects.
+    let projectOptionsTable = FSharpProjectOptionsTable()
+
+    // A table of information about single-file projects.  Currently we only need the load time of each such file, plus
+    // the original options for editing
+    let singleFileProjectTable = ConcurrentDictionary<ProjectId, DateTime * FSharpParsingOptions * FSharpProjectOptions>()
+
+    let tryGetOrCreateProjectId (projectFileName:string) =
+        let projectDisplayName = projectDisplayNameOf projectFileName
+        Some (workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName))
+
+    /// Retrieve the projectOptionsTable
+    member __.FSharpOptions = projectOptionsTable
+
+    /// Clear a project from the project table
+    member this.ClearInfoForProject(projectId:ProjectId) = projectOptionsTable.ClearInfoForProject(projectId)
+
+    /// Clear a project from the single file project table
+    member this.ClearInfoForSingleFileProject(projectId) =
+        singleFileProjectTable.TryRemove(projectId) |> ignore
+
+    /// Update a project in the single file project table
+    member this.AddOrUpdateSingleFileProject(projectId, data) = singleFileProjectTable.[projectId] <- data
+
+    /// Get the exact options for a single-file script
+    member this.ComputeSingleFileOptions (tryGetOrCreateProjectId, fileName, loadTime, fileContents) =
+        async {
+            let extraProjectInfo = Some(box workspace)
+            if SourceFile.MustBeSingleFileProject(fileName) then 
+                // NOTE: we don't use a unique stamp for single files, instead comparing options structurally.
+                // This is because we repeatedly recompute the options.
+                let optionsStamp = None 
+                let! options, _diagnostics = checkerProvider.Checker.GetProjectOptionsFromScript(fileName, fileContents, loadTime, [| |], ?extraProjectInfo=extraProjectInfo, ?optionsStamp=optionsStamp) 
+                // NOTE: we don't use FCS cross-project references from scripts to projects.  THe projects must have been
+                // compiled and #r will refer to files on disk
+                let referencedProjectFileNames = [| |] 
+                let site = ProjectSitesAndFiles.CreateProjectSiteForScript(fileName, referencedProjectFileNames, options)
+                let deps, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, site, serviceProvider, (tryGetOrCreateProjectId fileName), fileName, options.ExtraProjectInfo, Some projectOptionsTable)
+                let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)
+                return (deps, parsingOptions, projectOptions)
+            else
+                let site = ProjectSitesAndFiles.ProjectSiteOfSingleFile(fileName)
+                let deps, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, site, serviceProvider, (tryGetOrCreateProjectId fileName), fileName, extraProjectInfo, Some projectOptionsTable)
+                let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)
+                return (deps, parsingOptions, projectOptions)
+        }
+
+    /// Update the info for a project in the project table
+    member this.UpdateProjectInfo(tryGetOrCreateProjectId, projectId, site, userOpName, invalidateConfig) =
+        Logger.Log LogEditorFunctionId.LanguageService_UpdateProjectInfo
+        projectOptionsTable.AddOrUpdateProject(projectId, (fun isRefresh ->
+            let extraProjectInfo = Some(box workspace)
+            let referencedProjects, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, site, serviceProvider, Some(projectId), site.ProjectFileName, extraProjectInfo,  Some projectOptionsTable)
+            if invalidateConfig then checkerProvider.Checker.InvalidateConfiguration(projectOptions, startBackgroundCompileIfAlreadySeen = not isRefresh, userOpName = userOpName + ".UpdateProjectInfo")
+            let referencedProjectIds = referencedProjects |> Array.choose tryGetOrCreateProjectId
+            let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)
+            referencedProjectIds, parsingOptions, Some site, projectOptions))
+
+    /// Get compilation defines relevant for syntax processing.  
+    /// Quicker then TryGetOptionsForDocumentOrProject as it doesn't need to recompute the exact project 
+    /// options for a script.
+    member this.GetCompilationDefinesForEditingDocument(document:Document) = 
+        let projectOptionsOpt = this.TryGetOptionsForProject(document.Project.Id)  
+        let parsingOptions = 
+            match projectOptionsOpt with 
+            | Some (parsingOptions, _site, _projectOptions) -> parsingOptions
+            | _ -> { FSharpParsingOptions.Default with IsInteractive = IsScript document.Name }
+        CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
+
+    /// Try and get the Options for a project 
+    member this.TryGetOptionsForProject(projectId:ProjectId) = projectOptionsTable.TryGetOptionsForProject(projectId)
+
+    /// Get the exact options for a document or project
+    member this.TryGetOptionsForDocumentOrProject(document: Document) =
+        async { 
+            let projectId = document.Project.Id
+
+            // The options for a single-file script project are re-requested each time the file is analyzed.  This is because the
+            // single-file project may contain #load and #r references which are changing as the user edits, and we may need to re-analyze
+            // to determine the latest settings.  FCS keeps a cache to help ensure these are up-to-date.
+            match singleFileProjectTable.TryGetValue(projectId) with
+            | true, (loadTime, _, _) ->
+                try
+                    let fileName = document.FilePath
+                    let! cancellationToken = Async.CancellationToken
+                    let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
+                    // NOTE: we don't use FCS cross-project references from scripts to projects.  The projects must have been
+                    // compiled and #r will refer to files on disk.
+                    let tryGetOrCreateProjectId _ = None 
+                    let! _referencedProjectFileNames, parsingOptions, projectOptions = this.ComputeSingleFileOptions (tryGetOrCreateProjectId, fileName, loadTime, sourceText.ToString())
+                    this.AddOrUpdateSingleFileProject(projectId, (loadTime, parsingOptions, projectOptions))
+                    return Some (parsingOptions, None, projectOptions)
+                with ex -> 
+                    Assert.Exception(ex)
+                    return None
+            | _ -> return this.TryGetOptionsForProject(projectId)
+        }
+
+    /// Get the options for a document or project relevant for syntax processing.
+    /// Quicker then TryGetOptionsForDocumentOrProject as it doesn't need to recompute the exact project options for a script.
+    member this.TryGetOptionsForEditingDocumentOrProject(document:Document) = 
+        let projectId = document.Project.Id
+        match singleFileProjectTable.TryGetValue(projectId) with 
+        | true, (_loadTime, parsingOptions, originalOptions) -> Some (parsingOptions, originalOptions)
+        | _ -> this.TryGetOptionsForProject(projectId) |> Option.map(fun (parsingOptions, _, projectOptions) -> parsingOptions, projectOptions)
+
+    /// get a siteprovider
+    member this.ProvideProjectSiteProvider(project:Project) = provideProjectSiteProvider(workspace, project, serviceProvider, Some projectOptionsTable)
+
+    /// Tell the checker to update the project info for the specified project id
+    member this.UpdateProjectInfoWithProjectId(projectId:ProjectId, userOpName, invalidateConfig) =
+        let hier = workspace.GetHierarchy(projectId)
+        match hier with
+        | null -> ()
+        | h when (h.IsCapabilityMatch("CPS")) ->
+            let project = workspace.CurrentSolution.GetProject(projectId)
+            if not (isNull project) then
+                let siteProvider = this.ProvideProjectSiteProvider(project)
+                let projectSite = siteProvider.GetProjectSite()
+                if projectSite.CompilationSourceFiles.Length <> 0 then
+                    this.UpdateProjectInfo(tryGetOrCreateProjectId, projectId, projectSite, userOpName, invalidateConfig)
+        | _ -> ()
+
+    /// Tell the checker to update the project info for the specified project id
+    member this.UpdateDocumentInfoWithProjectId(projectId:ProjectId, documentId:DocumentId, userOpName, invalidateConfig) =
+        if workspace.IsDocumentOpen(documentId) then
+            this.UpdateProjectInfoWithProjectId(projectId, userOpName, invalidateConfig)
+
+    [<Export>]
+    /// This handles commandline change notifications from the Dotnet Project-system
+    /// Prior to VS 15.7 path contained path to project file, post 15.7 contains target binpath
+    /// binpath is more accurate because a project file can have multiple in memory projects based on configuration
+    member this.HandleCommandLineChanges(path:string, sources:ImmutableArray<CommandLineSourceFile>, references:ImmutableArray<CommandLineReference>, options:ImmutableArray<string>) =
+        use _logBlock = Logger.LogBlock(LogEditorFunctionId.LanguageService_HandleCommandLineArgs)
+
+        let projectId =
+            match workspace.ProjectTracker.TryGetProjectByBinPath(path) with
+            | true, project -> project.Id
+            | false, _ -> workspace.ProjectTracker.GetOrCreateProjectIdForPath(path, projectDisplayNameOf path)
+        let project =  workspace.ProjectTracker.GetProject(projectId)
+        let path = project.ProjectFilePath
+        let fullPath p =
+            if Path.IsPathRooted(p) || path = null then p
+            else Path.Combine(Path.GetDirectoryName(path), p)
+        let sourcePaths = sources |> Seq.map(fun s -> fullPath s.Path) |> Seq.toArray
+        let referencePaths = references |> Seq.map(fun r -> fullPath r.Reference) |> Seq.toArray
+
+        projectOptionsTable.SetOptionsWithProjectId(projectId, sourcePaths, referencePaths, options.ToArray())
+        this.UpdateProjectInfoWithProjectId(projectId, "HandleCommandLineChanges", invalidateConfig=true)
+
+    member __.Checker = checkerProvider.Checker

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -170,7 +170,7 @@ type internal FSharpPackage() as this =
             GetToolWindowAsITestVFSI().GetMostRecentLines(n)
 
 [<Guid(FSharpConstants.languageServiceGuidString)>]
-type internal FSharpLanguageService(package : FSharpPackage, solution: IVsSolution) as this =
+type internal FSharpLanguageService(package : FSharpPackage, solution: IVsSolution) =
     inherit AbstractLanguageService<FSharpPackage, FSharpLanguageService>(package)
 
     let projectInfoManager = package.ComponentModel.DefaultExportProvider.GetExport<FSharpProjectOptionsManager>().Value
@@ -192,7 +192,7 @@ type internal FSharpLanguageService(package : FSharpPackage, solution: IVsSoluti
         let projectDisplayName = projectDisplayNameOf projectFileName
         Some (workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName))
 
-    let legacyProjectWorkspaceMap = LegacyProjectWorkspaceMap(this.Workspace, solution, projectInfoManager, package.ComponentModel.GetService<IWorkspaceProjectContextFactory>(), this.SystemServiceProvider)
+    let mutable legacyProjectWorkspaceMap = Unchecked.defaultof<LegacyProjectWorkspaceMap>
 
     override this.Initialize() = 
         base.Initialize()
@@ -202,6 +202,7 @@ type internal FSharpLanguageService(package : FSharpPackage, solution: IVsSoluti
 
         this.Workspace.DocumentClosed.Add <| fun args -> tryRemoveSingleFileProject args.Document.Project.Id
 
+        legacyProjectWorkspaceMap <- LegacyProjectWorkspaceMap(this.Workspace, solution, projectInfoManager, package.ComponentModel.GetService<IWorkspaceProjectContextFactory>(), this.SystemServiceProvider)
         legacyProjectWorkspaceMap.Initialize()
 
         let theme = package.ComponentModel.DefaultExportProvider.GetExport<ISetThemeColors>().Value

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -33,248 +33,13 @@ open Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 open Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 open Microsoft.VisualStudio.LanguageServices.ProjectSystem
 open Microsoft.VisualStudio.Shell
+open Microsoft.VisualStudio.Shell.Events
 open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.ComponentModelHost
 open Microsoft.VisualStudio.Text.Outlining
 open FSharp.NativeInterop
 
 #nowarn "9" // NativePtr.toNativeInt
-
-// Exposes FSharpChecker as MEF export
-[<Export(typeof<FSharpCheckerProvider>); Composition.Shared>]
-type internal FSharpCheckerProvider 
-    [<ImportingConstructor>]
-    (
-        analyzerService: IDiagnosticAnalyzerService,
-        [<Import(typeof<VisualStudioWorkspace>)>] workspace: VisualStudioWorkspaceImpl,
-        settings: EditorOptions
-    ) =
-
-    let tryGetMetadataSnapshot (path, timeStamp) = 
-        try
-            let metadataReferenceProvider = workspace.Services.GetService<VisualStudioMetadataReferenceManager>()
-            let md = metadataReferenceProvider.GetMetadata(path, timeStamp)
-            let amd = (md :?> AssemblyMetadata)
-            let mmd = amd.GetModules().[0]
-            let mmr = mmd.GetMetadataReader()
-
-            // "lifetime is timed to Metadata you got from the GetMetadata(...). As long as you hold it strongly, raw 
-            // memory we got from metadata reader will be alive. Once you are done, just let everything go and 
-            // let finalizer handle resource rather than calling Dispose from Metadata directly. It is shared metadata. 
-            // You shouldn't dispose it directly."
-
-            let objToHold = box md
-
-            // We don't expect any ilread WeakByteFile to be created when working in Visual Studio
-            Debug.Assert((Microsoft.FSharp.Compiler.AbstractIL.ILBinaryReader.GetStatistics().weakByteFileCount = 0), "Expected weakByteFileCount to be zero when using F# in Visual Studio. Was there a problem reading a .NET binary?")
-
-            Some (objToHold, NativePtr.toNativeInt mmr.MetadataPointer, mmr.MetadataLength)
-        with ex -> 
-            // We catch all and let the backup routines in the F# compiler find the error
-            Assert.Exception(ex)
-            None 
-
-
-    let checker = 
-        lazy
-            let checker = 
-                FSharpChecker.Create(
-                    projectCacheSize = settings.LanguageServicePerformance.ProjectCheckCacheSize, 
-                    keepAllBackgroundResolutions = false,
-                    // Enabling this would mean that if devenv.exe goes above 2.3GB we do a one-off downsize of the F# Compiler Service caches
-                    (* , MaxMemory = 2300 *) 
-                    legacyReferenceResolver=Microsoft.FSharp.Compiler.MSBuildReferenceResolver.Resolver,
-                    tryGetMetadataSnapshot = tryGetMetadataSnapshot)
-
-            // This is one half of the bridge between the F# background builder and the Roslyn analysis engine.
-            // When the F# background builder refreshes the background semantic build context for a file,
-            // we request Roslyn to reanalyze that individual file.
-            checker.BeforeBackgroundFileCheck.Add(fun (fileName, _extraProjectInfo) ->  
-                async {
-                    try 
-                        let solution = workspace.CurrentSolution
-                        let documentIds = solution.GetDocumentIdsWithFilePath(fileName)
-                        if not documentIds.IsEmpty then 
-                            let documentIdsFiltered = documentIds |> Seq.filter workspace.IsDocumentOpen |> Seq.toArray
-                            for documentId in documentIdsFiltered do
-                                Trace.TraceInformation("{0:n3} Requesting Roslyn reanalysis of {1}", DateTime.Now.TimeOfDay.TotalSeconds, documentId)
-                            if documentIdsFiltered.Length > 0 then 
-                                analyzerService.Reanalyze(workspace,documentIds=documentIdsFiltered)
-                    with ex -> 
-                        Assert.Exception(ex)
-                } |> Async.StartImmediate
-            )
-            checker
-
-    member this.Checker = checker.Value
-
-
-/// Exposes FCS FSharpProjectOptions information management as MEF component.
-//
-// This service allows analyzers to get an appropriate FSharpProjectOptions value for a project or single file.
-// It also allows a 'cheaper' route to get the project options relevant to parsing (e.g. the #define values).
-// The main entrypoints are TryGetOptionsForDocumentOrProject and TryGetOptionsForEditingDocumentOrProject.
-[<Export(typeof<FSharpProjectOptionsManager>); Composition.Shared>]
-type internal FSharpProjectOptionsManager
-    [<ImportingConstructor>]
-    (
-        checkerProvider: FSharpCheckerProvider,
-        [<Import(typeof<VisualStudioWorkspace>)>] workspace: VisualStudioWorkspaceImpl,
-        [<Import(typeof<SVsServiceProvider>)>] serviceProvider: System.IServiceProvider,
-        settings: EditorOptions
-    ) =
-
-    // A table of information about projects, excluding single-file projects.
-    let projectOptionsTable = FSharpProjectOptionsTable()
-
-    // A table of information about single-file projects.  Currently we only need the load time of each such file, plus
-    // the original options for editing
-    let singleFileProjectTable = ConcurrentDictionary<ProjectId, DateTime * FSharpParsingOptions * FSharpProjectOptions>()
-
-    let tryGetOrCreateProjectId (projectFileName:string) =
-        let projectDisplayName = projectDisplayNameOf projectFileName
-        Some (workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName))
-
-    /// Retrieve the projectOptionsTable
-    member __.FSharpOptions = projectOptionsTable
-
-    /// Clear a project from the project table
-    member this.ClearInfoForProject(projectId:ProjectId) = projectOptionsTable.ClearInfoForProject(projectId)
-
-    /// Clear a project from the single file project table
-    member this.ClearInfoForSingleFileProject(projectId) =
-        singleFileProjectTable.TryRemove(projectId) |> ignore
-
-    /// Update a project in the single file project table
-    member this.AddOrUpdateSingleFileProject(projectId, data) = singleFileProjectTable.[projectId] <- data
-
-    /// Get the exact options for a single-file script
-    member this.ComputeSingleFileOptions (tryGetOrCreateProjectId, fileName, loadTime, fileContents) =
-        async {
-            let extraProjectInfo = Some(box workspace)
-            if SourceFile.MustBeSingleFileProject(fileName) then 
-                // NOTE: we don't use a unique stamp for single files, instead comparing options structurally.
-                // This is because we repeatedly recompute the options.
-                let optionsStamp = None 
-                let! options, _diagnostics = checkerProvider.Checker.GetProjectOptionsFromScript(fileName, fileContents, loadTime, [| |], ?extraProjectInfo=extraProjectInfo, ?optionsStamp=optionsStamp) 
-                // NOTE: we don't use FCS cross-project references from scripts to projects.  THe projects must have been
-                // compiled and #r will refer to files on disk
-                let referencedProjectFileNames = [| |] 
-                let site = ProjectSitesAndFiles.CreateProjectSiteForScript(fileName, referencedProjectFileNames, options)
-                let deps, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, site, serviceProvider, (tryGetOrCreateProjectId fileName), fileName, options.ExtraProjectInfo, Some projectOptionsTable)
-                let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)
-                return (deps, parsingOptions, projectOptions)
-            else
-                let site = ProjectSitesAndFiles.ProjectSiteOfSingleFile(fileName)
-                let deps, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, site, serviceProvider, (tryGetOrCreateProjectId fileName), fileName, extraProjectInfo, Some projectOptionsTable)
-                let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)
-                return (deps, parsingOptions, projectOptions)
-        }
-
-    /// Update the info for a project in the project table
-    member this.UpdateProjectInfo(tryGetOrCreateProjectId, projectId, site, userOpName, invalidateConfig) =
-        Logger.Log LogEditorFunctionId.LanguageService_UpdateProjectInfo
-        projectOptionsTable.AddOrUpdateProject(projectId, (fun isRefresh ->
-            let extraProjectInfo = Some(box workspace)
-            let referencedProjects, projectOptions = ProjectSitesAndFiles.GetProjectOptionsForProjectSite(settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences, site, serviceProvider, Some(projectId), site.ProjectFileName, extraProjectInfo,  Some projectOptionsTable)
-            if invalidateConfig then checkerProvider.Checker.InvalidateConfiguration(projectOptions, startBackgroundCompileIfAlreadySeen = not isRefresh, userOpName = userOpName + ".UpdateProjectInfo")
-            let referencedProjectIds = referencedProjects |> Array.choose tryGetOrCreateProjectId
-            let parsingOptions, _ = checkerProvider.Checker.GetParsingOptionsFromProjectOptions(projectOptions)
-            referencedProjectIds, parsingOptions, Some site, projectOptions))
-
-    /// Get compilation defines relevant for syntax processing.  
-    /// Quicker then TryGetOptionsForDocumentOrProject as it doesn't need to recompute the exact project 
-    /// options for a script.
-    member this.GetCompilationDefinesForEditingDocument(document:Document) = 
-        let projectOptionsOpt = this.TryGetOptionsForProject(document.Project.Id)  
-        let parsingOptions = 
-            match projectOptionsOpt with 
-            | Some (parsingOptions, _site, _projectOptions) -> parsingOptions
-            | _ -> { FSharpParsingOptions.Default with IsInteractive = IsScript document.Name }
-        CompilerEnvironment.GetCompilationDefinesForEditing parsingOptions
-
-    /// Try and get the Options for a project 
-    member this.TryGetOptionsForProject(projectId:ProjectId) = projectOptionsTable.TryGetOptionsForProject(projectId)
-
-    /// Get the exact options for a document or project
-    member this.TryGetOptionsForDocumentOrProject(document: Document) =
-        async { 
-            let projectId = document.Project.Id
-
-            // The options for a single-file script project are re-requested each time the file is analyzed.  This is because the
-            // single-file project may contain #load and #r references which are changing as the user edits, and we may need to re-analyze
-            // to determine the latest settings.  FCS keeps a cache to help ensure these are up-to-date.
-            match singleFileProjectTable.TryGetValue(projectId) with
-            | true, (loadTime, _, _) ->
-                try
-                    let fileName = document.FilePath
-                    let! cancellationToken = Async.CancellationToken
-                    let! sourceText = document.GetTextAsync(cancellationToken) |> Async.AwaitTask
-                    // NOTE: we don't use FCS cross-project references from scripts to projects.  The projects must have been
-                    // compiled and #r will refer to files on disk.
-                    let tryGetOrCreateProjectId _ = None 
-                    let! _referencedProjectFileNames, parsingOptions, projectOptions = this.ComputeSingleFileOptions (tryGetOrCreateProjectId, fileName, loadTime, sourceText.ToString())
-                    this.AddOrUpdateSingleFileProject(projectId, (loadTime, parsingOptions, projectOptions))
-                    return Some (parsingOptions, None, projectOptions)
-                with ex -> 
-                    Assert.Exception(ex)
-                    return None
-            | _ -> return this.TryGetOptionsForProject(projectId)
-        }
-
-    /// Get the options for a document or project relevant for syntax processing.
-    /// Quicker then TryGetOptionsForDocumentOrProject as it doesn't need to recompute the exact project options for a script.
-    member this.TryGetOptionsForEditingDocumentOrProject(document:Document) = 
-        let projectId = document.Project.Id
-        match singleFileProjectTable.TryGetValue(projectId) with 
-        | true, (_loadTime, parsingOptions, originalOptions) -> Some (parsingOptions, originalOptions)
-        | _ -> this.TryGetOptionsForProject(projectId) |> Option.map(fun (parsingOptions, _, projectOptions) -> parsingOptions, projectOptions)
-
-    /// get a siteprovider
-    member this.ProvideProjectSiteProvider(project:Project) = provideProjectSiteProvider(workspace, project, serviceProvider, Some projectOptionsTable)
-
-    /// Tell the checker to update the project info for the specified project id
-    member this.UpdateProjectInfoWithProjectId(projectId:ProjectId, userOpName, invalidateConfig) =
-        let hier = workspace.GetHierarchy(projectId)
-        match hier with
-        | null -> ()
-        | h when (h.IsCapabilityMatch("CPS")) ->
-            let project = workspace.CurrentSolution.GetProject(projectId)
-            if not (isNull project) then
-                let siteProvider = this.ProvideProjectSiteProvider(project)
-                let projectSite = siteProvider.GetProjectSite()
-                if projectSite.CompilationSourceFiles.Length <> 0 then
-                    this.UpdateProjectInfo(tryGetOrCreateProjectId, projectId, projectSite, userOpName, invalidateConfig)
-        | _ -> ()
-
-    /// Tell the checker to update the project info for the specified project id
-    member this.UpdateDocumentInfoWithProjectId(projectId:ProjectId, documentId:DocumentId, userOpName, invalidateConfig) =
-        if workspace.IsDocumentOpen(documentId) then
-            this.UpdateProjectInfoWithProjectId(projectId, userOpName, invalidateConfig)
-
-    [<Export>]
-    /// This handles commandline change notifications from the Dotnet Project-system
-    /// Prior to VS 15.7 path contained path to project file, post 15.7 contains target binpath
-    /// binpath is more accurate because a project file can have multiple in memory projects based on configuration
-    member this.HandleCommandLineChanges(path:string, sources:ImmutableArray<CommandLineSourceFile>, references:ImmutableArray<CommandLineReference>, options:ImmutableArray<string>) =
-        use _logBlock = Logger.LogBlock(LogEditorFunctionId.LanguageService_HandleCommandLineArgs)
-
-        let projectId =
-            match workspace.ProjectTracker.TryGetProjectByBinPath(path) with
-            | true, project -> project.Id
-            | false, _ -> workspace.ProjectTracker.GetOrCreateProjectIdForPath(path, projectDisplayNameOf path)
-        let project =  workspace.ProjectTracker.GetProject(projectId)
-        let path = project.ProjectFilePath
-        let fullPath p =
-            if Path.IsPathRooted(p) || path = null then p
-            else Path.Combine(Path.GetDirectoryName(path), p)
-        let sourcePaths = sources |> Seq.map(fun s -> fullPath s.Path) |> Seq.toArray
-        let referencePaths = references |> Seq.map(fun r -> fullPath r.Reference) |> Seq.toArray
-
-        projectOptionsTable.SetOptionsWithProjectId(projectId, sourcePaths, referencePaths, options.ToArray())
-        this.UpdateProjectInfoWithProjectId(projectId, "HandleCommandLineChanges", invalidateConfig=true)
-
-    member __.Checker = checkerProvider.Checker
 
 // Used to expose FSharpChecker/ProjectInfo manager to diagnostic providers
 // Diagnostic providers can be executed in environment that does not use MEF so they can rely only
@@ -394,7 +159,7 @@ type internal FSharpPackage() as this =
 
     override this.RoslynLanguageName = FSharpConstants.FSharpLanguageName
     override this.CreateWorkspace() = this.ComponentModel.GetService<VisualStudioWorkspaceImpl>()
-    override this.CreateLanguageService() = FSharpLanguageService(this)
+    override this.CreateLanguageService() = FSharpLanguageService(this, this.GetService(typeof<SVsSolution>) :?> IVsSolution)
     override this.CreateEditorFactories() = seq { yield FSharpEditorFactory(this) :> IVsEditorFactory }
     override this.RegisterMiscellaneousFilesWorkspaceInformation(_) = ()
 
@@ -405,7 +170,7 @@ type internal FSharpPackage() as this =
             GetToolWindowAsITestVFSI().GetMostRecentLines(n)
 
 [<Guid(FSharpConstants.languageServiceGuidString)>]
-type internal FSharpLanguageService(package : FSharpPackage) =
+type internal FSharpLanguageService(package : FSharpPackage, solution: IVsSolution) as this =
     inherit AbstractLanguageService<FSharpPackage, FSharpLanguageService>(package)
 
     let projectInfoManager = package.ComponentModel.DefaultExportProvider.GetExport<FSharpProjectOptionsManager>().Value
@@ -423,207 +188,24 @@ type internal FSharpLanguageService(package : FSharpPackage) =
             project.Dispose()
         | _ -> ()
 
-    let invalidPathChars = set (Path.GetInvalidPathChars())
-    let isPathWellFormed (path: string) = not (String.IsNullOrWhiteSpace path) && path |> Seq.forall (fun c -> not (Set.contains c invalidPathChars))
-
     let tryGetOrCreateProjectId (workspace: VisualStudioWorkspaceImpl) (projectFileName: string) =
         let projectDisplayName = projectDisplayNameOf projectFileName
         Some (workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName))
 
-    let optionsAssociation = ConditionalWeakTable<IWorkspaceProjectContext, string[]>()
-
-    member private this.OnProjectAdded(projectId:ProjectId) = projectInfoManager.UpdateProjectInfoWithProjectId(projectId, "OnProjectAdded", invalidateConfig=true)
-    member private this.OnProjectReloaded(projectId:ProjectId) = projectInfoManager.UpdateProjectInfoWithProjectId(projectId, "OnProjectReloaded", invalidateConfig=true)
-    member private this.OnProjectRemoved(projectId) = projectInfoManager.ClearInfoForProject(projectId)
-    member private this.OnDocumentAdded(projectId:ProjectId, documentId:DocumentId) = projectInfoManager.UpdateDocumentInfoWithProjectId(projectId, documentId, "OnDocumentAdded", invalidateConfig=true)
-    member private this.OnDocumentReloaded(projectId:ProjectId, documentId:DocumentId) = projectInfoManager.UpdateDocumentInfoWithProjectId(projectId, documentId, "OnDocumentReloaded", invalidateConfig=true)
+    let legacyProjectWorkspaceMap = LegacyProjectWorkspaceMap(this.Workspace, solution, projectInfoManager, package.ComponentModel.GetService<IWorkspaceProjectContextFactory>(), this.SystemServiceProvider)
 
     override this.Initialize() = 
         base.Initialize()
 
-        let workspaceChanged (args:WorkspaceChangeEventArgs) =
-            match args.Kind with
-            | WorkspaceChangeKind.ProjectAdded     -> this.OnProjectAdded(args.ProjectId)
-            | WorkspaceChangeKind.ProjectReloaded  -> this.OnProjectReloaded(args.ProjectId)
-            | WorkspaceChangeKind.ProjectRemoved   -> this.OnProjectRemoved(args.ProjectId)
-            | WorkspaceChangeKind.DocumentAdded    -> this.OnDocumentAdded(args.ProjectId, args.DocumentId)
-            | WorkspaceChangeKind.DocumentReloaded -> this.OnDocumentReloaded(args.ProjectId, args.DocumentId)
-            | WorkspaceChangeKind.DocumentRemoved
-            | WorkspaceChangeKind.AdditionalDocumentAdded
-            | WorkspaceChangeKind.AdditionalDocumentReloaded
-            | WorkspaceChangeKind.AdditionalDocumentRemoved
-            | WorkspaceChangeKind.AdditionalDocumentChanged
-            | WorkspaceChangeKind.DocumentInfoChanged
-            | WorkspaceChangeKind.DocumentChanged
-            | WorkspaceChangeKind.SolutionAdded
-            | WorkspaceChangeKind.SolutionChanged
-            | WorkspaceChangeKind.SolutionReloaded
-            | WorkspaceChangeKind.SolutionCleared
-            | _ -> ()
-
         this.Workspace.Options <- this.Workspace.Options.WithChangedOption(Completion.CompletionOptions.BlockForCompletionItems, FSharpConstants.FSharpLanguageName, false)
         this.Workspace.Options <- this.Workspace.Options.WithChangedOption(Shared.Options.ServiceFeatureOnOffOptions.ClosedFileDiagnostic, FSharpConstants.FSharpLanguageName, Nullable false)
-        this.Workspace.WorkspaceChanged.Add(workspaceChanged)
+
         this.Workspace.DocumentClosed.Add <| fun args -> tryRemoveSingleFileProject args.Document.Project.Id
 
-        Events.SolutionEvents.OnAfterCloseSolution.Add <| fun _ ->
-            //checkerProvider.Checker.StopBackgroundCompile()
-
-            // FUTURE: consider enbling some or all of these to flush all caches and stop all background builds. However the operations
-            // are asynchronous and we need to decide if we stop everything synchronously.
-
-            //checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-            //checkerProvider.Checker.InvalidateAll()
-
-            singleFileProjects.Keys |> Seq.iter tryRemoveSingleFileProject
-
-        let ctx = System.Threading.SynchronizationContext.Current
-
-        let rec setupProjectsAfterSolutionOpen() =
-            async {
-                use openedProjects = MailboxProcessor.Start <| fun inbox ->
-                    async { 
-                        // waits for AfterOpenSolution and then starts projects setup
-                        do! Async.AwaitEvent Events.SolutionEvents.OnAfterOpenSolution |> Async.Ignore
-                        while true do
-                            let! siteProvider = inbox.Receive()
-                            do! Async.SwitchToContext ctx
-                            this.SetupProjectFile(siteProvider, this.Workspace, "SetupProjectsAfterSolutionOpen")
-                            do! Async.SwitchToThreadPool()
-                    }
-
-                use _ = Events.SolutionEvents.OnAfterOpenProject |> Observable.subscribe ( fun args ->
-                    match args.Hierarchy with
-                    | :? IProvideProjectSite as siteProvider -> openedProjects.Post(siteProvider)
-                    | _ -> () )
-
-                do! Async.AwaitEvent Events.SolutionEvents.OnAfterCloseSolution |> Async.Ignore
-                do! setupProjectsAfterSolutionOpen() 
-            }
-        setupProjectsAfterSolutionOpen() |> Async.StartImmediate
+        legacyProjectWorkspaceMap.Initialize()
 
         let theme = package.ComponentModel.DefaultExportProvider.GetExport<ISetThemeColors>().Value
         theme.SetColors()
-        
-    /// Sync the Roslyn information for the project held in 'projectContext' to match the information given by 'site'.
-    /// Also sync the info in ProjectInfoManager if necessary.
-    member this.SyncProject(projectContext: IWorkspaceProjectContext, site: IProjectSite, workspace: VisualStudioWorkspaceImpl, forceUpdate, userOpName) =
-        let wellFormedFilePathSetIgnoreCase (paths: seq<string>) =
-            HashSet(paths |> Seq.filter isPathWellFormed |> Seq.map (fun s -> try Path.GetFullPath(s) with _ -> s), StringComparer.OrdinalIgnoreCase)
-
-        let mutable updated = forceUpdate
-
-        let project = workspace.CurrentSolution.Projects |> Seq.filter (fun p -> p.Name = projectContext.DisplayName) |> Seq.exactlyOne
-
-        // Sync the source files in projectContext.  Note that these source files are __not__ maintained in order in projectContext
-        // as edits are made. It seems this is ok because the source file list is only used to drive roslyn per-file checking.
-        let updatedFiles = site.CompilationSourceFiles |> wellFormedFilePathSetIgnoreCase
-        let originalFiles = project.Documents |> Seq.map (fun file -> file.FilePath) |> wellFormedFilePathSetIgnoreCase
-        
-        for file in updatedFiles do
-            if not(originalFiles.Contains(file)) then
-                projectContext.AddSourceFile(file)
-                updated <- true
-
-        for file in originalFiles do
-            if not(updatedFiles.Contains(file)) then
-                projectContext.RemoveSourceFile(file)
-                updated <- true
-
-        let updatedRefs = site.CompilationReferences |> wellFormedFilePathSetIgnoreCase
-        let originalRefs = project.MetadataReferences |> Enumerable.OfType<PortableExecutableReference> |> Seq.map (fun ref -> ref.FilePath) |> wellFormedFilePathSetIgnoreCase
-
-        for ref in updatedRefs do
-            if not(originalRefs.Contains(ref)) then
-                projectContext.AddMetadataReference(ref, MetadataReferenceProperties.Assembly)
-                updated <- true
-
-        for ref in originalRefs do
-            if not(updatedRefs.Contains(ref)) then
-                projectContext.RemoveMetadataReference(ref)
-                updated <- true
-
-        // Update the project options association
-        let ok,originalOptions = optionsAssociation.TryGetValue(projectContext)
-        let updatedOptions = site.CompilationOptions
-        if not ok || originalOptions <> updatedOptions then 
-
-            // OK, project options have changed, try to fake out Roslyn to convince it to reparse things.
-            // Calling SetOptions fails because the CPS project system being used by the F# project system 
-            // imlpementation at the moment has no command line parser installed, so we remove/add all the files 
-            // instead.  A change of flags doesn't happen very often and the remove/add is fast in any case.
-            //projectContext.SetOptions(String.concat " " updatedOptions)
-            for file in updatedFiles do
-                projectContext.RemoveSourceFile(file)
-                projectContext.AddSourceFile(file)
-
-            // Record the last seen options as an associated value
-            if ok then optionsAssociation.Remove(projectContext) |> ignore
-            optionsAssociation.Add(projectContext, updatedOptions)
-
-            updated <- true
-
-        // update the cached options
-        if updated then
-            projectInfoManager.UpdateProjectInfo(tryGetOrCreateProjectId workspace, project.Id, site, userOpName + ".SyncProject", invalidateConfig=true)
-
-    member this.SetupProjectFile(siteProvider: IProvideProjectSite, workspace: VisualStudioWorkspaceImpl, userOpName) =
-        let userOpName = userOpName + ".SetupProjectFile"
-        let  rec setup (site: IProjectSite) =
-            let projectGuid = Guid(site.ProjectGuid)
-            let projectFileName = site.ProjectFileName
-            let projectDisplayName = projectDisplayNameOf projectFileName
-
-            // This projectId is not guaranteed to be the same ProjectId that will actually be created once we call CreateProjectContext
-            // in Roslyn versions once https://github.com/dotnet/roslyn/pull/26931 is merged. Roslyn will still guarantee that once
-            // there is a project in the workspace with the same path, it'll return the ID of that. So this is sufficient to use
-            // in that case as long as we only use it to call GetProject.
-            let fakeProjectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName)
-
-            if isNull (workspace.ProjectTracker.GetProject fakeProjectId) then
-                let projectContextFactory = package.ComponentModel.GetService<IWorkspaceProjectContextFactory>();
-
-                let hierarchy =
-                    site.ProjectProvider
-                    |> Option.map (fun p -> p :?> IVsHierarchy)
-                    |> Option.toObj
-
-                // Roslyn is expecting site to be an IVsHierarchy.
-                // It just so happens that the object that implements IProvideProjectSite is also
-                // an IVsHierarchy. This assertion is to ensure that the assumption holds true.
-                Debug.Assert(not (isNull hierarchy), "About to CreateProjectContext with a non-hierarchy site")
-
-                let projectContext = 
-                    projectContextFactory.CreateProjectContext(
-                        FSharpConstants.FSharpLanguageName,
-                        projectDisplayName,
-                        projectFileName,
-                        projectGuid,
-                        hierarchy,
-                        Option.toObj site.CompilationBinOutputPath)
-                
-                // The real project ID that was actually added. See comments for fakeProjectId why this one is actually good.
-                let realProjectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName)
-
-                // Sync IProjectSite --> projectContext, and IProjectSite --> ProjectInfoManage
-                this.SyncProject(projectContext, site, workspace, forceUpdate=true, userOpName=userOpName)
-
-                site.BuildErrorReporter <- Some (projectContext :?> Microsoft.VisualStudio.Shell.Interop.IVsLanguageServiceBuildErrorReporter2)
-
-                // TODO: consider forceUpdate = false here.  forceUpdate=true may be causing repeated computation?
-                site.AdviseProjectSiteChanges(FSharpConstants.FSharpLanguageServiceCallbackName, 
-                                              AdviseProjectSiteChanges(fun () -> this.SyncProject(projectContext, site, workspace, forceUpdate=true, userOpName="AdviseProjectSiteChanges."+userOpName)))
-
-                site.AdviseProjectSiteClosed(FSharpConstants.FSharpLanguageServiceCallbackName, 
-                                             AdviseProjectSiteChanges(fun () -> 
-                                                projectInfoManager.ClearInfoForProject(realProjectId)
-                                                optionsAssociation.Remove(projectContext) |> ignore
-                                                projectContext.Dispose()))
-
-                for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites(Some realProjectId, site, this.SystemServiceProvider, Some (this.Workspace :>obj), Some projectInfoManager.FSharpOptions ) do
-                    setup referencedSite
-
-        setup (siteProvider.GetProjectSite()) 
 
     member this.SetupStandAloneFile(fileName: string, fileContents: string, workspace: VisualStudioWorkspaceImpl, hier: IVsHierarchy) =
         let loadTime = DateTime.Now
@@ -683,11 +265,10 @@ type internal FSharpLanguageService(package : FSharpPackage) =
                 //    CPS Projects, out-of-project file and script files don't
 
                 match hier with
-                | :? IProvideProjectSite as siteProvider when not (IsScript(filename)) ->
+                | :? IProvideProjectSite as _siteProvider when not (IsScript(filename)) ->
 
                     // This is the path for .fs/.fsi files in legacy projects
-
-                    this.SetupProjectFile(siteProvider, this.Workspace, "SetupNewTextView")
+                    ()
                 | h when not (isNull h) && not (IsScript(filename)) ->
                     let docId = this.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filename).FirstOrDefault()
                     match docId with

--- a/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
@@ -1,0 +1,196 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+#nowarn "40"
+
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.Diagnostics
+open System.IO
+open System.Linq
+open System.Runtime.CompilerServices
+open Microsoft.CodeAnalysis
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.FSharp.Editor.SiteProvider
+open Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+open Microsoft.VisualStudio.LanguageServices.ProjectSystem
+open Microsoft.VisualStudio.Shell.Interop
+
+[<Sealed>]
+type internal LegacyProjectWorkspaceMap(workspace: VisualStudioWorkspaceImpl, 
+                                        solution: IVsSolution, 
+                                        projectInfoManager: FSharpProjectOptionsManager,
+                                        projectContextFactory: IWorkspaceProjectContextFactory,
+                                        serviceProvider: IServiceProvider) =
+
+    let invalidPathChars = set (Path.GetInvalidPathChars())
+    let optionsAssociation = ConditionalWeakTable<IWorkspaceProjectContext, string[]>()
+    let isPathWellFormed (path: string) = not (String.IsNullOrWhiteSpace path) && path |> Seq.forall (fun c -> not (Set.contains c invalidPathChars))
+    let legacyProjectQueue = ConcurrentQueue()
+
+    let tryGetOrCreateProjectId (workspace: VisualStudioWorkspaceImpl) (projectFileName: string) =
+        let projectDisplayName = projectDisplayNameOf projectFileName
+        Some (workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName))
+
+    member this.Initialize() =
+        solution.AdviseSolutionEvents(this) |> ignore
+
+        workspace.WorkspaceChanged.Add <| fun args ->
+            match args.Kind with
+            | WorkspaceChangeKind.SolutionAdded ->
+                let mutable hier = Unchecked.defaultof<IVsHierarchy>
+                while legacyProjectQueue.TryDequeue(&hier) do
+                    match hier with
+                    | :? IProvideProjectSite as siteProvider ->
+                        this.SetupLegacyProjectFile(siteProvider, workspace, "LegacyProjectWorkspaceMap.Initialize")
+                    | _ -> ()
+            | _ -> ()
+
+    /// Sync the Roslyn information for the project held in 'projectContext' to match the information given by 'site'.
+    /// Also sync the info in ProjectInfoManager if necessary.
+    member this.SyncLegacyProject(projectContext: IWorkspaceProjectContext, site: IProjectSite, workspace: VisualStudioWorkspaceImpl, forceUpdate, userOpName) =
+        let wellFormedFilePathSetIgnoreCase (paths: seq<string>) =
+            HashSet(paths |> Seq.filter isPathWellFormed |> Seq.map (fun s -> try Path.GetFullPath(s) with _ -> s), StringComparer.OrdinalIgnoreCase)
+
+        let mutable updated = forceUpdate
+
+        let project = workspace.CurrentSolution.Projects |> Seq.filter (fun p -> p.Name = projectContext.DisplayName) |> Seq.exactlyOne
+
+        // Sync the source files in projectContext.  Note that these source files are __not__ maintained in order in projectContext
+        // as edits are made. It seems this is ok because the source file list is only used to drive roslyn per-file checking.
+        let updatedFiles = site.CompilationSourceFiles |> wellFormedFilePathSetIgnoreCase
+        let originalFiles = project.Documents |> Seq.map (fun file -> file.FilePath) |> wellFormedFilePathSetIgnoreCase
+        
+        for file in updatedFiles do
+            if not(originalFiles.Contains(file)) then
+                projectContext.AddSourceFile(file)
+                updated <- true
+
+        for file in originalFiles do
+            if not(updatedFiles.Contains(file)) then
+                projectContext.RemoveSourceFile(file)
+                updated <- true
+
+        let updatedRefs = site.CompilationReferences |> wellFormedFilePathSetIgnoreCase
+        let originalRefs = project.MetadataReferences |> Enumerable.OfType<PortableExecutableReference> |> Seq.map (fun ref -> ref.FilePath) |> wellFormedFilePathSetIgnoreCase
+
+        for ref in updatedRefs do
+            if not(originalRefs.Contains(ref)) then
+                projectContext.AddMetadataReference(ref, MetadataReferenceProperties.Assembly)
+                updated <- true
+
+        for ref in originalRefs do
+            if not(updatedRefs.Contains(ref)) then
+                projectContext.RemoveMetadataReference(ref)
+                updated <- true
+
+        // Update the project options association
+        let ok,originalOptions = optionsAssociation.TryGetValue(projectContext)
+        let updatedOptions = site.CompilationOptions
+        if not ok || originalOptions <> updatedOptions then 
+
+            // OK, project options have changed, try to fake out Roslyn to convince it to reparse things.
+            // Calling SetOptions fails because the CPS project system being used by the F# project system 
+            // imlpementation at the moment has no command line parser installed, so we remove/add all the files 
+            // instead.  A change of flags doesn't happen very often and the remove/add is fast in any case.
+            //projectContext.SetOptions(String.concat " " updatedOptions)
+            for file in updatedFiles do
+                projectContext.RemoveSourceFile(file)
+                projectContext.AddSourceFile(file)
+
+            // Record the last seen options as an associated value
+            if ok then optionsAssociation.Remove(projectContext) |> ignore
+            optionsAssociation.Add(projectContext, updatedOptions)
+
+            updated <- true
+
+        // update the cached options
+        if updated then
+            projectInfoManager.UpdateProjectInfo(tryGetOrCreateProjectId workspace, project.Id, site, userOpName + ".SyncProject", invalidateConfig=true)
+
+    member this.SetupLegacyProjectFile(siteProvider: IProvideProjectSite, workspace: VisualStudioWorkspaceImpl, userOpName) =
+        let userOpName = userOpName + ".SetupProjectFile"
+        let  rec setup (site: IProjectSite) =
+            let projectGuid = Guid(site.ProjectGuid)
+            let projectFileName = site.ProjectFileName
+            let projectDisplayName = projectDisplayNameOf projectFileName
+
+            // This projectId is not guaranteed to be the same ProjectId that will actually be created once we call CreateProjectContext
+            // in Roslyn versions once https://github.com/dotnet/roslyn/pull/26931 is merged. Roslyn will still guarantee that once
+            // there is a project in the workspace with the same path, it'll return the ID of that. So this is sufficient to use
+            // in that case as long as we only use it to call GetProject.
+            let fakeProjectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName)
+
+            if isNull (workspace.ProjectTracker.GetProject fakeProjectId) then
+                let hierarchy =
+                    site.ProjectProvider
+                    |> Option.map (fun p -> p :?> IVsHierarchy)
+                    |> Option.toObj
+
+                // Roslyn is expecting site to be an IVsHierarchy.
+                // It just so happens that the object that implements IProvideProjectSite is also
+                // an IVsHierarchy. This assertion is to ensure that the assumption holds true.
+                Debug.Assert(not (isNull hierarchy), "About to CreateProjectContext with a non-hierarchy site")
+
+                let projectContext = 
+                    projectContextFactory.CreateProjectContext(
+                        FSharpConstants.FSharpLanguageName,
+                        projectDisplayName,
+                        projectFileName,
+                        projectGuid,
+                        hierarchy,
+                        Option.toObj site.CompilationBinOutputPath)
+                
+                // The real project ID that was actually added. See comments for fakeProjectId why this one is actually good.
+                let realProjectId = workspace.ProjectTracker.GetOrCreateProjectIdForPath(projectFileName, projectDisplayName)
+
+                // Sync IProjectSite --> projectContext, and IProjectSite --> ProjectInfoManage
+                this.SyncLegacyProject(projectContext, site, workspace, forceUpdate=true, userOpName=userOpName)
+
+                site.BuildErrorReporter <- Some (projectContext :?> Microsoft.VisualStudio.Shell.Interop.IVsLanguageServiceBuildErrorReporter2)
+
+                // TODO: consider forceUpdate = false here.  forceUpdate=true may be causing repeated computation?
+                site.AdviseProjectSiteChanges(FSharpConstants.FSharpLanguageServiceCallbackName, 
+                                              AdviseProjectSiteChanges(fun () -> this.SyncLegacyProject(projectContext, site, workspace, forceUpdate=true, userOpName="AdviseProjectSiteChanges."+userOpName)))
+
+                site.AdviseProjectSiteClosed(FSharpConstants.FSharpLanguageServiceCallbackName, 
+                                             AdviseProjectSiteChanges(fun () -> 
+                                                projectInfoManager.ClearInfoForProject(realProjectId)
+                                                optionsAssociation.Remove(projectContext) |> ignore
+                                                projectContext.Dispose()))
+
+                for referencedSite in ProjectSitesAndFiles.GetReferencedProjectSites(Some realProjectId, site, serviceProvider, Some (workspace :>obj), Some projectInfoManager.FSharpOptions ) do
+                    setup referencedSite
+
+        setup (siteProvider.GetProjectSite()) 
+
+    interface IVsSolutionEvents with
+
+        member __.OnAfterCloseSolution(_) = VSConstants.S_OK
+
+        member __.OnAfterLoadProject(_, _) = VSConstants.S_OK
+
+        member __.OnAfterOpenProject(hier, _) = 
+            legacyProjectQueue.Enqueue(hier)
+            VSConstants.S_OK
+
+        member this.OnAfterOpenSolution(_, _) = 
+            VSConstants.S_OK
+
+        member __.OnBeforeCloseProject(_, _) = VSConstants.S_OK
+
+        member __.OnBeforeCloseSolution(_) = 
+            let mutable hier = Unchecked.defaultof<IVsHierarchy>
+            while legacyProjectQueue.TryDequeue(&hier) do () // clear
+            VSConstants.S_OK
+
+        member __.OnBeforeUnloadProject(_, _) = VSConstants.S_OK
+
+        member __.OnQueryCloseProject(_, _, _) = VSConstants.S_OK
+
+        member __.OnQueryCloseSolution(_, _) = VSConstants.S_OK
+
+        member __.OnQueryUnloadProject(_, _) = VSConstants.S_OK


### PR DESCRIPTION
This is one of the first steps for our language service refactoring/re-wiring; gets rid of listening to almost all workspace events. It also fixes a problem that we had in master with F# tools not working (highlighting, intellisense, etc.).

This can be merged into dev16.0 as well.