### PR TITLE
Ensure that compiler path is set during Design Time build

### DIFF
--- a/vsintegration/src/FSharp.Editor/Build/SetGlobalPropertiesForSdkProjects.fs
+++ b/vsintegration/src/FSharp.Editor/Build/SetGlobalPropertiesForSdkProjects.fs
@@ -13,7 +13,7 @@ open Microsoft.VisualStudio.ProjectSystem.Build
 
 // We can't use well-known constants here because `string + string` isn't a valid constant expression in F#.
 [<AppliesTo("FSharp&LanguageService")>]
-[<ExportBuildGlobalPropertiesProvider>]
+[<ExportBuildGlobalPropertiesProvider(designTimeBuildProperties = true)>]
 type internal SetGlobalPropertiesForSdkProjects
     [<ImportingConstructor>]
     (

--- a/vsintegration/src/FSharp.Editor/Build/SetGlobalPropertiesForSdkProjects.fs
+++ b/vsintegration/src/FSharp.Editor/Build/SetGlobalPropertiesForSdkProjects.fs
@@ -14,6 +14,7 @@ open Microsoft.VisualStudio.ProjectSystem.Build
 // We can't use well-known constants here because `string + string` isn't a valid constant expression in F#.
 [<AppliesTo("FSharp&LanguageService")>]
 [<ExportBuildGlobalPropertiesProvider(designTimeBuildProperties = true)>]
+[<ExportBuildGlobalPropertiesProvider(designTimeBuildProperties = false)>]
 type internal SetGlobalPropertiesForSdkProjects
     [<ImportingConstructor>]
     (


### PR DESCRIPTION
In order to deploy the compiler with the VS tools VSIX, the IDE sets a build global variable:  FSharpCompilerPath, the build targets then use this to target the correct compiler.

The design time build wasn't picking up this value, and therefore using the compiler shipped with VS for Intellisense etc.  The end result was that MSBuild was using the old version of the FSharp.Build build task.

Because MsBuild was then reused for the re-build when doing a rebuild with the correct compiler tools path, msbuild silently used the already loaded FSharp.Build task, and failed to correctly bind to the EmbeddedFiles property.

Fortunately the Fix was trivial, and we now know a small amount more about the BuildTargets.

Kevin