### PR TITLE
Fixed match expression is evaluated twice if it returns a struct union

### DIFF
--- a/src/fsharp/PatternMatchCompilation.fs
+++ b/src/fsharp/PatternMatchCompilation.fs
@@ -907,6 +907,11 @@ let CompilePatternBasic
               else 
                   None,true)
 
+    and IsCopyableInputExpr origInputExpr = 
+        match origInputExpr with 
+        | Expr.Op (TOp.LValueOp (LByrefGet, v), [], [], _) when not v.IsMutable -> true 
+        | _ -> false
+
     and ChoosePreBinder simulSetOfEdgeDiscrims subexpr =
          match simulSetOfEdgeDiscrims with 
           // Very simple 'isinst' tests: put the result of 'isinst' in a local variable 
@@ -939,7 +944,7 @@ let CompilePatternBasic
              let argExpr = GetSubExprOfInput subexpr
              let argExpr = 
                  match argExpr, _origInputExprOpt with 
-                 | Expr.Val(v1, _, _), Some origInputExpr when valEq origInputVal v1.Deref -> origInputExpr
+                 | Expr.Val(v1, _, _), Some origInputExpr when valEq origInputVal v1.Deref && IsCopyableInputExpr origInputExpr -> origInputExpr
                  | _ -> argExpr
              let vOpt, addrExp, _readonly, _writeonly = mkExprAddrOfExprAux g true false NeverMutates argExpr None matchm
              match vOpt with 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/DiscrimantedUnionType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/DiscrimantedUnionType.fs
@@ -249,3 +249,10 @@ let [<Test>] ``can properly construct a struct union using FSharpValue.MakeUnion
     let c2 = (fieldVals.[1] :?> int)
     Assert.AreEqual (3456, c2)
 
+let [<Test>] ``struct unions does optimization correctly on pattern matching`` () =
+    let arr = ResizeArray()
+    match arr.Add(1); ValueSome () with
+    | ValueSome () -> ()
+    | ValueNone -> ()
+
+    Assert.AreEqual(1, arr.Count)


### PR DESCRIPTION
Resolves this bug: https://github.com/Microsoft/visualfsharp/issues/5689

@dsyme did the fix. I added the test. 