### PR TITLE
Fixed tooling issues when changing solutions

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/ProjectSitesAndFiles.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/ProjectSitesAndFiles.fs
@@ -225,7 +225,7 @@ type internal ProjectSitesAndFiles() =
         let getReferencesForSolutionService (solutionService:IVsSolution) =
             [|
                 match referencedProjects projectSite, extraProjectInfo with
-                | _, Some (:? VisualStudioWorkspaceImpl as workspace) when not (isNull workspace.CurrentSolution)->
+                | None, Some (:? VisualStudioWorkspaceImpl as workspace) when not (isNull workspace.CurrentSolution)->
                     let path = projectSite.ProjectFileName
                     if not (String.IsNullOrWhiteSpace(path)) then
                         match projectIdOpt with


### PR DESCRIPTION
I was a bit overzealous when fixing cross project referencing for legacy projects (https://github.com/Microsoft/visualfsharp/pull/5698) , by trying to fix referencing CPS style projects. Unfortunately, this causes issues when loading a second solution in VS. `workspace.CurrentSolution` is absolutely unreliable and we should never rely on it for dev15.9.

