### PR TITLE
Update DEVGUIDE.md

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -130,7 +130,8 @@ Testing the .NET Core version of the F# compiler on macOS and Linux is TBD.
 
 To build and test Visual F# IDE Tools, install these requirements:
 
-- [Visual Studio 2017](https://www.visualstudio.com/downloads/)
+- Download [Visual Studio 2017](https://www.visualstudio.com/downloads/)
+- Launch the Visual Studio Installer
   - Under the "Windows" workloads, select ".NET desktop development"
     - Select "F# desktop language support" under the optional components
   - Under the "Other Toolsets" workloads, select "Visual Studio extension development"


### PR DESCRIPTION
Explicitly mention that the optional components are found in the VS Installer, not somewhere on the downloads page (since that's all that was linked on the line before)