### PR TITLE
Dev 16.0 new F# template fails

### DIFF
--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharpFull.csproj
@@ -22,11 +22,6 @@
       <Link>License.txt</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(FSharpSourcesRoot)\..\packages\System.ValueTuple.4.4.0\System.ValueTuple.4.4.0.nupkg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>packages\System.ValueTuple.4.4.0.nupkg</Link>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="$(FSharpSourcesRoot)\..\packages\Microsoft.VisualFSharp.Type.Providers.Redist\$(MicrosoftVisualFSharpTypeProvidersRedistPackageVersion)\content\4.3.0.0\FSharp.Data.TypeProviders.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>FSharp.Data.TypeProviders.dll</Link>


### PR DESCRIPTION
Dev 16.0 new files dialog fails to create new F# TEmplate.

This was fixed in 15.9, somehow the merge back to master was not correct and we lost half the fix.

Anyway this is the fix.
