### PR TITLE
[CompilerPerf] Starting refactoring of ConstraintSolver.fs

### DIFF
--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.fs
@@ -3190,10 +3190,10 @@ type internal SR private() =
     /// This operation accesses a mutable top-level value defined in another assembly in an unsupported way. The value cannot be accessed through its address. Consider copying the expression to a mutable local, e.g. 'let mutable x = ...', and if necessary assigning the value back after the completion of the operation
     /// (Originally from ..\FSComp.txt:1042)
     static member tastInvalidAddressOfMutableAcrossAssemblyBoundary() = (1188, GetStringFunc("tastInvalidAddressOfMutableAcrossAssemblyBoundary",",,,") )
-    /// Type parameters must be placed directly adjacent to the type name, e.g. \"type C<'T>\", not     type \"C   <'T>\"
+    /// Remove spaces between the type name and type parameter, e.g. \"type C<'T>\", not type \"C   <'T>\". Type parameters must be placed directly adjacent to the type name.
     /// (Originally from ..\FSComp.txt:1043)
     static member parsNonAdjacentTypars() = (1189, GetStringFunc("parsNonAdjacentTypars",",,,") )
-    /// Type arguments must be placed directly adjacent to the type name, e.g. \"C<'T>\", not \"C  <'T>\"
+    /// Remove spaces between the type name and type parameter, e.g. \"C<'T>\", not \"C <'T>\". Type parameters must be placed directly adjacent to the type name.
     /// (Originally from ..\FSComp.txt:1044)
     static member parsNonAdjacentTyargs() = (1190, GetStringFunc("parsNonAdjacentTyargs",",,,") )
     /// The use of the type syntax 'int C' and 'C  <int>' is not permitted here. Consider adjusting this type to be written in the form 'C<int>'

--- a/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSComp.resx
@@ -3082,7 +3082,7 @@
     <value>This number is outside the allowable range for 32-bit floats</value>
   </data>
   <data name="lexInvalidNumericLiteral" xml:space="preserve">
-    <value>This is not a valid numeric literal. Valid numeric literals include 1, 0x1, 0b0001 (int), 1u (uint32), 1L (int64), 1UL (uint64), 1s (int16), 1us (uint16), 1y (sbyte), 1uy (byte), 1.0 (float), 1.0f (float32), 1.0m (decimal), 1I (BigInteger).</value>
+    <value>This is not a valid numeric literal. Valid numeric literals include 1, 0x1, 0b0001 (int), 1u (uint32), 1L (int64), 1UL (uint64), 1s (int16), 1y (sbyte), 1uy (byte), 1.0 (float), 1.0f (float32), 1.0m (decimal), 1I (BigInteger).</value>
   </data>
   <data name="lexInvalidByteLiteral" xml:space="preserve">
     <value>This is not a valid byte literal</value>
@@ -3193,10 +3193,10 @@
     <value>This operation accesses a mutable top-level value defined in another assembly in an unsupported way. The value cannot be accessed through its address. Consider copying the expression to a mutable local, e.g. 'let mutable x = ...', and if necessary assigning the value back after the completion of the operation</value>
   </data>
   <data name="parsNonAdjacentTypars" xml:space="preserve">
-    <value>Type parameters must be placed directly adjacent to the type name, e.g. \"type C&lt;'T&gt;\", not     type \"C   &lt;'T&gt;\"</value>
+    <value>Remove spaces between the type name and type parameter, e.g. \"type C&lt;'T&gt;\", not type \"C   &lt;'T&gt;\". Type parameters must be placed directly adjacent to the type name.</value>
   </data>
   <data name="parsNonAdjacentTyargs" xml:space="preserve">
-    <value>Type arguments must be placed directly adjacent to the type name, e.g. \"C&lt;'T&gt;\", not \"C  &lt;'T&gt;\"</value>
+    <value>Remove spaces between the type name and type parameter, e.g. \"C&lt;'T&gt;\", not \"C &lt;'T&gt;\". Type parameters must be placed directly adjacent to the type name.</value>
   </data>
   <data name="parsNonAtomicType" xml:space="preserve">
     <value>The use of the type syntax 'int C' and 'C  &lt;int&gt;' is not permitted here. Consider adjusting this type to be written in the form 'C&lt;int&gt;'</value>

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -744,10 +744,8 @@ and solveTypMeetsTyparConstraints (csenv:ConstraintSolverEnv) ndeep m2 trace ty 
     let g = csenv.g
     // Propagate compat flex requirements from 'tp' to 'ty'
     do! SolveTypIsCompatFlex csenv trace r.IsCompatFlex ty
-        
     // Propagate dynamic requirements from 'tp' to 'ty'
     do! SolveTypDynamicReq csenv trace r.DynamicReq ty
-
     // Propagate static requirements from 'tp' to 'ty' 
     do! SolveTypStaticReq csenv trace r.StaticReq ty
     
@@ -1012,12 +1010,12 @@ and SolveMemberConstraint (csenv:ConstraintSolverEnv) ignoreUnresolvedOverload p
     // Assert the object type if the constraint is for an instance member    
     if memFlags.IsInstance then 
         match tys, argtys with 
-            | [ty], (h :: _) -> do! SolveTypeEqualsTypeKeepAbbrevs csenv ndeep m2 trace h ty 
-            | _ -> do! ErrorD (ConstraintSolverError(FSComp.SR.csExpectedArguments(), m, m2))
+        | [ty], (h :: _) -> do! SolveTypeEqualsTypeKeepAbbrevs csenv ndeep m2 trace h ty 
+        | _ -> do! ErrorD (ConstraintSolverError(FSComp.SR.csExpectedArguments(), m, m2))
     // Trait calls are only supported on pseudo type (variables) 
     for e in tys do
       do! SolveTypStaticReq csenv trace HeadTypeStaticReq e
-        
+    
     let argtys = if memFlags.IsInstance then List.tail argtys else argtys
 
     let minfos = GetRelevantMethodsForTrait csenv permitWeakResolution nm traitInfo

--- a/src/fsharp/ErrorLogger.fs
+++ b/src/fsharp/ErrorLogger.fs
@@ -596,14 +596,32 @@ let rec Iterate2D f xs ys =
     | h1 :: t1, h2::t2 -> f h1 h2 ++ (fun () -> Iterate2D f t1 t2) 
     | _ -> failwith "Iterate2D"
 
+/// Keep the warnings, propagate the error to the exception continuation.
 let TryD f g = 
     match f() with
-    | ErrorResult(warns, err) ->  (OkResult(warns, ())) ++ (fun () -> g err)
+    | ErrorResult(warns, err) ->
+        trackErrors {
+            do! OkResult(warns, ())
+            return! g err
+        }
     | res -> res
 
 let rec RepeatWhileD ndeep body = body ndeep ++ (fun x -> if x then RepeatWhileD (ndeep+1) body else CompleteD) 
 let AtLeastOneD f l = MapD f l ++ (fun res -> ResultD (List.exists id res))
 
+
+[<RequireQualifiedAccess>]
+module OperationResult =
+    let inline ignore (res: OperationResult<'a>) =
+        match res with
+        | OkResult(warnings, _) -> OkResult(warnings, ())
+        | ErrorResult(warnings, err) -> ErrorResult(warnings, err)
+
+    // Alternative ignore
+    (* 
+    let inline ignore (res: OperationResult<'a>) : OperationResult<'a> =
+        res ++ (fun _ -> CompleteD)
+    *)
 
 // Code below is for --flaterrors flag that is only used by the IDE
 

--- a/src/fsharp/ErrorLogger.fs
+++ b/src/fsharp/ErrorLogger.fs
@@ -617,12 +617,6 @@ module OperationResult =
         | OkResult(warnings, _) -> OkResult(warnings, ())
         | ErrorResult(warnings, err) -> ErrorResult(warnings, err)
 
-    // Alternative ignore
-    (* 
-    let inline ignore (res: OperationResult<'a>) : OperationResult<'a> =
-        res ++ (fun _ -> CompleteD)
-    *)
-
 // Code below is for --flaterrors flag that is only used by the IDE
 
 let stringThatIsAProxyForANewlineInFlatErrors = new System.String [|char 29 |]


### PR DESCRIPTION
In this PR mostly all usage of the operator `++` is removed and replaced with the `trackErrors` CE such that the functionality is more readable and easier to change. 

Those changes should also clear the way for debugging capabilities of the constraint solver.
Another side effect of this refactoring is that the formatting of many lines is now more style conform.

Signed-off-by: realvictorprm <mueller.vpr@gmail.com>

EDIT:

The changes also include replacing most of the `IterateD` occurences to a for loop within `trackErrors`.