### PR TITLE
Use Framework valuetuple rather than netstandard1.0 one

### DIFF
--- a/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
+++ b/vsintegration/ProjectTemplates/ConsoleProject/Template/ConsoleApplication.fsproj
@@ -47,7 +47,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
+++ b/vsintegration/ProjectTemplates/LibraryProject/Template/Library.fsproj
@@ -43,7 +43,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/Tutorial.fsproj
@@ -50,7 +50,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
On Dev 16.0 the build doesn't seem to be able to find the valuetuple façade.  So setting the hintpath to net461.


I think there has been a change in the way Dev16, handles hintpaths on new project generation.

