### PR TITLE
Add F#+ to the test suite

### DIFF
--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -189,22 +189,17 @@ let config configurationName envVars =
             | [||] -> failwithf "Could not find any 'FSharp.Compiler.Tools' inside '%s'" packagesDir
             | [| dir |] -> Path.Combine(dir, "tools", "fsi.exe")
             | _ -> failwithf "Found more than one 'FSharp.Compiler.Tools' inside '%s', please clean up." packagesDir
-    // let toolsDir = SCRIPT_ROOT ++ ".." ++ ".." ++ "Tools"
+    let toolsDir = SCRIPT_ROOT ++ ".." ++ ".." ++ "Tools"
     let dotNetExe =
-        let dotnetPath =
+        if File.Exists(toolsDir ++ "dotnetcli" ++ "dotnet.exe") then
+            toolsDir ++ "dotnetcli" ++ "dotnet.exe"
+        else
             let path = envVars.["Path"].Split(';')
-            let res =
-                path
-                |> Array.filter(fun path -> path.Contains("dotnetcli"))
-                |> Array.tryFind(fun path -> File.Exists(path ++ "dotnet.exe"))
-            match res with
-            | Some dotnetpath -> dotnetpath
-            | None -> 
+            let dotnetPath =
                 path
                 |> Array.filter(fun path -> path.Contains("dotnet"))
                 |> Array.find(fun path -> File.Exists(path ++ "dotnet.exe"))
-        dotnetPath ++ "dotnet.exe"
-        // toolsDir ++ "dotnetcli" ++ "dotnet.exe"
+            dotnetPath ++ "dotnet.exe"
     // ildasm requires coreclr.dll to run which has already been restored to the packages directory
     File.Copy(coreclrdll, Path.GetDirectoryName(ILDASM) ++ "coreclr.dll", overwrite=true)
 

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -192,9 +192,17 @@ let config configurationName envVars =
     // let toolsDir = SCRIPT_ROOT ++ ".." ++ ".." ++ "Tools"
     let dotNetExe =
         let dotnetPath =
-            envVars.["Path"].Split(';')
-            |> Array.filter(fun path -> path.Contains("dotnet"))
-            |> Array.find(fun path -> File.Exists(path ++ "dotnet.exe"))
+            let path = envVars.["Path"].Split(';')
+            let res =
+                path
+                |> Array.filter(fun path -> path.Contains("dotnetcli"))
+                |> Array.tryFind(fun path -> File.Exists(path ++ "dotnet.exe"))
+            match res with
+            | Some dotnetpath -> dotnetpath
+            | None -> 
+                path
+                |> Array.filter(fun path -> path.Contains("dotnet"))
+                |> Array.find(fun path -> File.Exists(path ++ "dotnet.exe"))
         dotnetPath ++ "dotnet.exe"
         // toolsDir ++ "dotnetcli" ++ "dotnet.exe"
     // ildasm requires coreclr.dll to run which has already been restored to the packages directory

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -125,6 +125,11 @@ module Commands =
         printfn "Executing git."
         exec gitExe args
 
+    let nunit exec nunitExe workdir args =
+        let args = (sprintf "%s --work:\"%s\"" (args |> Seq.ofList |> String.concat " ") workdir)
+        printfn "Running external nunit tests."
+        exec nunitExe args
+
 type TestConfig = 
     { EnvironmentVariables : Map<string, string>
       CSC : string
@@ -143,7 +148,8 @@ type TestConfig =
       Directory: string 
       DotNetExe: string
       DefaultPlatform: string
-      GitExe: string }
+      GitExe: string 
+      NunitConsoleRunner: string }
 
 
 module WindowsPlatform = 
@@ -203,6 +209,9 @@ let config configurationName envVars =
     let gitExe =
         let gitPath = envVars.["GIT"]
         Path.Combine(gitPath, "git.exe")
+    let nunitExe =
+        packagesDir ++ "NUnit.Console.3.0.0" ++ "tools" ++ "nunit3-console.exe"
+
     let defaultPlatform = 
         match Is64BitOperatingSystem with 
 //        | PlatformID.MacOSX, true -> "osx.10.10-x64"
@@ -227,7 +236,8 @@ let config configurationName envVars =
       Directory="" 
       DotNetExe = dotNetExe
       DefaultPlatform = defaultPlatform
-      GitExe = gitExe }
+      GitExe = gitExe
+      NunitConsoleRunner = nunitExe }
 
 let logConfig (cfg: TestConfig) =
     log "---------------------------------------------------------------"
@@ -466,6 +476,7 @@ let mkdir cfg = Commands.mkdir_p cfg.Directory
 let copy_y cfg f = Commands.copy_y cfg.Directory f >> checkResult
 let dotnet cfg flag args = Commands.dotnet cfg.Directory (exec cfg) cfg.DotNetExe flag args
 let git cfg x = Commands.git (exec cfg) (cfg.GitExe) x
+let nunit cfg x = Commands.nunit (exec cfg) (cfg.NunitConsoleRunner) (cfg.Directory) x
 
 let diff normalize path1 path2 =
     let result = System.Text.StringBuilder()

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -207,7 +207,10 @@ let config configurationName envVars =
     let FSCOREDLLPATH = "" 
 #endif
     let gitExe =
-        let gitPath = envVars.["GIT"]
+        let gitPath =
+            envVars.["Path"].Split(';')
+            |> Array.filter(fun s -> s.Contains("Git"))
+            |> Array.find(fun s -> System.IO.File.Exists(System.IO.Path.Combine(s, "git.exe")))
         Path.Combine(gitPath, "git.exe")
     let nunitExe =
         packagesDir ++ "NUnit.Console.3.0.0" ++ "tools" ++ "nunit3-console.exe"

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -28,6 +28,33 @@ let FSI_BASIC = FSI_FILE
 // ^^^^^^^^^^^^ To run these tests in F# Interactive , 'build net40', then send this chunk, then evaluate body of a test ^^^^^^^^^^^^
 
 module CoreTests = 
+    open TestFramework
+    
+    [<Test>]
+    let testFSharpPlusBuild () =
+        let cfg = testConfig ""
+        mkdir cfg "repos"
+        
+        if Commands.directoryExists cfg.Directory "repos/FSharpPlus" |> Option.isNone then
+            let cfg = testConfig "repos"
+            git cfg ["clone"; "http://github.com/fsprojects/FSharpPlus"; "FSharpPlus"]
+
+        let cfg2 = testConfig "repos/FSharpPlus"
+
+        // git cfg2 ["reset"; "--hard"; "fcb507bc8734362f4f6d40c08a4bc011e50e5d56"]
+
+        // Reference the freshly built compiler
+        let fullPath = cfg2.FSCBinPath |> getFullPath
+
+        let cfg3 = testConfig "repos/FSharpPlus/src/FSharpPlus"
+
+        dotnet cfg3 "msbuild" 
+            [ "FSharpPlus.fsproj" 
+              "/p:CompilerTest=true"
+              sprintf "/p:FSC_ToolPathCompilerBuild=%s" fullPath
+              sprintf "/p:FSC_ExePathCompilerBuild=%s" (fullPath ++ "fsc.exe")
+            ]
+
     // These tests are enabled for .NET Framework and .NET Core
     [<Test>]
     let ``access-FSC_BASIC``() = singleTestBuildAndRun "core/access" FSC_BASIC

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -63,6 +63,7 @@ module CoreTests =
             "FSharpPlus.fsproj"
             "/p:Configuration=Release"
             "/p:CompilerTest=true"
+            "/p:TargetFramework=net45"
             sprintf "/p:FSC_ToolPathCompilerBuild=%s" fullPath
             sprintf "/p:FSC_ExePathCompilerBuild=%s" (fullPath ++ "fsc.exe")
         ]
@@ -87,6 +88,7 @@ module CoreTests =
             "FSharpPlus.Tests.fsproj"
             "/p:Configuration=Release"
             "/p:CompilerTest=true"
+            "/p:TargetFramework=net45"
             sprintf "/p:FSC_ToolPathCompilerBuild=%s" fullPath
             sprintf "/p:FSC_ExePathCompilerBuild=%s" (fullPath ++ "fsc.exe")
         ]

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -99,7 +99,7 @@ module CoreTests =
 
         nunit cfg [
             "--verbose"
-            "./bin/Release/FSharpPlus.Tests.dll"
+            (cfg.Directory ++ "./bin/Release/net45/FSharpPlus.Tests.dll" |> getFullPath)
         ]
 
     // These tests are enabled for .NET Framework and .NET Core

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -41,7 +41,9 @@ module CoreTests =
 
         let cfg2 = testConfig "repos/FSharpPlus"
 
-        // git cfg2 ["reset"; "--hard"; "fcb507bc8734362f4f6d40c08a4bc011e50e5d56"]
+        git cfg2 ["reset"; "--hard"; "aba256430a86a4022941800f06421dda16aa4cb0"]
+
+        exec cfg2 "build.cmd" "restore"
 
         // Reference the freshly built compiler
         let fullPath = cfg2.FSCBinPath |> getFullPath
@@ -97,7 +99,7 @@ module CoreTests =
 
         nunit cfg [
             "--verbose"
-            "./bin/Debug/FSharpPlus.Tests.dll"
+            "./bin/Release/FSharpPlus.Tests.dll"
         ]
 
     // These tests are enabled for .NET Framework and .NET Core

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -48,12 +48,57 @@ module CoreTests =
 
         let cfg3 = testConfig "repos/FSharpPlus/src/FSharpPlus"
 
-        dotnet cfg3 "msbuild" 
-            [ "FSharpPlus.fsproj" 
-              "/p:CompilerTest=true"
-              sprintf "/p:FSC_ToolPathCompilerBuild=%s" fullPath
-              sprintf "/p:FSC_ExePathCompilerBuild=%s" (fullPath ++ "fsc.exe")
-            ]
+        // Debug build isn't working
+        //dotnet cfg3 "msbuild" [
+        //    "FSharpPlus.fsproj"
+        //    "/p:Configuration=Debug" 
+        //    "/p:CompilerTest=true"
+        //    sprintf "/p:FSC_ToolPathCompilerBuild=%s" fullPath
+        //    sprintf "/p:FSC_ExePathCompilerBuild=%s" (fullPath ++ "fsc.exe")
+        //]
+        
+        dotnet cfg3 "msbuild" [
+            "FSharpPlus.fsproj"
+            "/p:Configuration=Release"
+            "/p:CompilerTest=true"
+            sprintf "/p:FSC_ToolPathCompilerBuild=%s" fullPath
+            sprintf "/p:FSC_ExePathCompilerBuild=%s" (fullPath ++ "fsc.exe")
+        ]
+
+    [<Test>]
+    let testFSharpPlusTests () =
+        let cfg = testConfig "repos/FSharpPlus/tests/FSharpPlus.Tests"
+
+        // Reference the freshly built compiler
+        let fullPath = cfg.FSCBinPath |> getFullPath
+        
+        // Debug build isn't working
+        //dotnet cfg "msbuild" [
+        //    "FSharpPlus.Tests.fsproj"
+        //    "/p:Configuration=Debug" 
+        //    "/p:CompilerTest=true"
+        //    sprintf "/p:FSC_ToolPathCompilerBuild=%s" fullPath
+        //    sprintf "/p:FSC_ExePathCompilerBuild=%s" (fullPath ++ "fsc.exe")
+        //]
+        
+        dotnet cfg "msbuild" [
+            "FSharpPlus.Tests.fsproj"
+            "/p:Configuration=Release"
+            "/p:CompilerTest=true"
+            sprintf "/p:FSC_ToolPathCompilerBuild=%s" fullPath
+            sprintf "/p:FSC_ExePathCompilerBuild=%s" (fullPath ++ "fsc.exe")
+        ]
+        
+        // Debug build isn't working so no testing of it
+        //nunit cfg [
+        //    "--verbose"
+        //    "./bin/Debug/FSharpPlus.Tests.dll"
+        //]
+
+        nunit cfg [
+            "--verbose"
+            "./bin/Debug/FSharpPlus.Tests.dll"
+        ]
 
     // These tests are enabled for .NET Framework and .NET Core
     [<Test>]


### PR DESCRIPTION
As discussed in https://github.com/Microsoft/visualfsharp/issues/3814#issuecomment-433622188 this PR adds the build of F#+ to the test suit.

Left points are:
- [x] Reference correct commit of F#+
- [x] Run F#+ tests too

The changes include:

- The Git exe is retrieved from the Path environment variable
- A new directory `./tests/fsharp/repos/` is created.
- F#+ is cloned to this directory and reset to a specific commit
- Build of F#+.fsproj

Signed-off-by: realvictorprm <mueller.vpr@gmail.com>