### PR TITLE
Remove dependence on runfsc.cmd and runfsc.sh

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -55,9 +55,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Tailcalls Condition="'$(Tailcalls)' == '' ">true</Tailcalls>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' != '' " >
-    <FscToolPath Condition=" '$(FscToolPath)' == '' ">$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))</FscToolPath>
-    <FscToolExe Condition=" '$(FscToolExe)' == ''">$( [System.IO.Path]::GetFileName($(DOTNET_HOST_PATH)) )</FscToolExe>
+  <PropertyGroup Condition="'$(DOTNET_HOST_PATH)' != ''">
+    <FscToolPath Condition="'$(FscToolPath)' == ''">$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))</FscToolPath>
+    <FscToolExe Condition="'$(FscToolExe)' == ''">$([System.IO.Path]::GetFileName($(DOTNET_HOST_PATH)))</FscToolExe>
     <DotnetFscCompilerPath>"$(MSBuildThisFileDirectory)fsc.exe"</DotnetFscCompilerPath>
   </PropertyGroup>
 

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -55,14 +55,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <Tailcalls Condition="'$(Tailcalls)' == '' ">true</Tailcalls>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(OS)' != 'Unix' and Exists('$(MSBuildThisFileDirectory)\RunFsc.cmd')" >
-    <FscToolPath Condition=" '$(FscToolPath)' == '' ">$(MSBuildThisFileDirectory)</FscToolPath>
-    <FscToolExe Condition=" '$(FscToolExe)' == ''">RunFsc.cmd</FscToolExe>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(OS)' == 'Unix' and Exists('$(MSBuildThisFileDirectory)\RunFsc.sh')" >
-    <FscToolPath Condition=" '$(FscToolPath)' == '' ">$(MSBuildThisFileDirectory)</FscToolPath>
-    <FscToolExe Condition="'$(OS)' == 'Unix' and '$(FscToolExe)' == ''">RunFsc.sh</FscToolExe>
+  <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' != '' " >
+    <FscToolPath Condition=" '$(FscToolPath)' == '' ">$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))</FscToolPath>
+    <FscToolExe Condition=" '$(FscToolExe)' == ''">$( [System.IO.Path]::GetFileName($(DOTNET_HOST_PATH)) )</FscToolExe>
+    <DotnetFscCompilerPath>"$(MSBuildThisFileDirectory)fsc.exe"</DotnetFscCompilerPath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DisableImplicitSystemValueTupleReference)' != 'true'


### PR DESCRIPTION
The dotnet cli uses RunFsc.cmd and RunFsc.sh to execute the FSharp command in the build task using a single command.

There is an issue with this on those rare Linux packagings that don't have a bash shell configured.

This change, modifies the way the fsharp build task executes the fsharp compiler.

We now use the DotnetFscCompilerPath property to be the path to the F# compiler executable.
FscToolPath and FSCToolExe now point to the dotnet.exe specified in the guaranteed global property DOTNET_HOST_PATH.

What's nice about this, is that no sdk changes are necessary.
