### PR TITLE
Ignore CSharp project references

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -108,8 +108,14 @@ type private FSharpProjectOptionsReactor (workspace: VisualStudioWorkspaceImpl, 
             let referencedProjects =
                 if settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences then
                     project.ProjectReferences
-                    |> Seq.choose (fun projectReference ->
+                    |> Seq.choose (fun projectReference -> 
                         let referenceProject = project.Solution.GetProject(projectReference.ProjectId)
+                        if referenceProject.Language = FSharpConstants.FSharpLanguageName then
+                            Some(referenceProject)
+                        else
+                            None
+                    )
+                    |> Seq.choose (fun referenceProject ->
                         let result =
                             tryComputeOptions referenceProject
                             |> Option.map (fun (_, projectOptions) ->


### PR DESCRIPTION
@KevinRansom @Pilchie @brettfo @cartermp 

This should get into preview 1 asap.

A F# .NET SDK project referencing both a C# project will result in tooling not working because I forgot to ignore C# project references when computing options.