### PR TITLE
Improve coreclr init for build

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -38,8 +38,6 @@ if exist "%BUILD_TOOLS_SEMAPHORE%" (
   goto :DONE
 )
 
-if exist "%TOOLRUNTIME_DIR%" rmdir /S /Q "%TOOLRUNTIME_DIR%"
-
 :: Download Nuget.exe
 if NOT exist "%PACKAGES_DIR%NuGet.exe" (
   if NOT exist "%PACKAGES_DIR%" mkdir "%PACKAGES_DIR%"
@@ -63,6 +61,7 @@ if errorlevel 1 (
    set TOOLS_INIT_RETURN_CODE=1
    goto :DONE
 )
+echo "%DOTNET_TOOLS_VERSION% >> "%DOTNET_TOOLS_PATH%\sdk\%DOTNET_TOOLS_VERSION%"
 :afterdotnettoolsrestore
 
 set /p DOTNET_VERSION=< "%~dp0DotnetCLIVersion.txt"

--- a/scripts/dotnet-install.ps1
+++ b/scripts/dotnet-install.ps1
@@ -188,7 +188,7 @@ function GetHTTPResponse([Uri] $Uri)
             }
             # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
             # 10 minutes allows it to work over much slower connections.
-            $HttpClient.Timeout = New-TimeSpan -Minutes 10
+            $HttpClient.Timeout = New-TimeSpan -Minutes 20
             $Response = $HttpClient.GetAsync($Uri).Result
             if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode)))
             {


### PR DESCRIPTION
Caching for the dotnet cli during initialization for the coreclr build has been broken for quite a while.  This ensures the build downloads the dotnet cli a lot less than before.

