### PR TITLE
Add new implementation of IEnumerable<_> for dict

### DIFF
--- a/src/FSharp.Profiles.props
+++ b/src/FSharp.Profiles.props
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netcoreapp1.0'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants>$(DefineConstants);NETSTANDARD1_6</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_APP_DOMAINS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_ARRAY_LONG_LENGTH</DefineConstants>

--- a/src/FSharpSource.Profiles.targets
+++ b/src/FSharpSource.Profiles.targets
@@ -13,6 +13,7 @@
   <!-- These should be distinguished in the future -->
 
   <PropertyGroup Condition="'$(TargetDotnetProfile)'=='coreclr'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants>$(DefineConstants);NETSTANDARD1_6</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_APP_DOMAINS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_ARRAY_LONG_LENGTH</DefineConstants>


### PR DESCRIPTION
Fixes #5910 

The coreclr has a bug with SZGenericArrayEnumerators.  The bug causes it to not throw when accessing Current for an exhausted collection.  The Coreclr team will fix this bug, however.

This PR introduces a  correctly operating enumerator where we have a dependence on SZGenericArrayEnumerator.

We missed this in testing because we use an old version of the coreclr which doesn't have the bug.

This PR, continues to use the framework implementation on FSharp.Core.dll built for the NETFramework, because that code is correct and ngened in all scenarios.

