### PR TITLE
Use hash code instead of full source text for language service caches

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -2998,7 +2998,7 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
     // background UI thread, not on the compiler thread.
     //
     // This cache is safe for concurrent access because there is no onDiscard action for the items in the cache.
-    let braceMatchCache = MruCache<AnyCallerThreadToken, _, _>(braceMatchCacheSize, areSimilar = AreSimilarForParsing, areSame = AreSameForParsing) 
+    let braceMatchCache = MruCache<AnyCallerThreadToken,_,_>(braceMatchCacheSize, areSimilar = AreSimilarForParsing, areSame = AreSameForParsing)
 
     let mutable maxMemoryReached = false
     let mutable maxMB = maxMBDefault

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -2998,7 +2998,7 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
     // background UI thread, not on the compiler thread.
     //
     // This cache is safe for concurrent access because there is no onDiscard action for the items in the cache.
-    let braceMatchCache = MruCache<AnyCallerThreadToken,_,_>(braceMatchCacheSize, areSimilar = AreSimilarForParsing, areSame = AreSameForParsing)
+    let braceMatchCache = MruCache<AnyCallerThreadToken,_,_>(braceMatchCacheSize, areSimilar = AreSimilarForParsing, areSame = AreSameForParsing) 
 
     let mutable maxMemoryReached = false
     let mutable maxMB = maxMBDefault


### PR DESCRIPTION
Not sure if this is the correct overall approach - but hopefully this can help encourage a better fix 🙂 

The following issues track large source files ultimately living on the large object heap, forcing horrible GC delays over time:

#5937 
#5936 
#5935 
#4881

But as mentioned in https://github.com/Microsoft/visualfsharp/issues/4881#issuecomment-388595261 the language service uses the full source text as a key for caches, making it more difficult to simply not pass around the full source text. This seeks to rectify that. It may also help the linked issues