### PR TITLE
Stop eagerly evaluating seqs (revert parts of #5348, #5370)

### DIFF
--- a/src/fsharp/FSharp.Core/seq.fs
+++ b/src/fsharp/FSharp.Core/seq.fs
@@ -1032,8 +1032,6 @@ namespace Microsoft.FSharp.Collections
         let inline groupByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (seq:seq<'T>) =
             checkNonNull "seq" seq
 
-            if isEmpty seq then empty else
-
             let dict = Dictionary<_,ResizeArray<_>> comparer
 
             // Previously this was 1, but I think this is rather stingy, considering that we are already paying
@@ -1087,7 +1085,6 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Distinct")>]
         let distinct source =
             checkNonNull "source" source
-            if isEmpty source then empty else
             seq { let hashSet = HashSet<'T>(HashIdentity.Structural<'T>)
                   for v in source do
                       if hashSet.Add(v) then
@@ -1096,7 +1093,6 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("DistinctBy")>]
         let distinctBy projection source =
             checkNonNull "source" source
-            if isEmpty source then empty else
             seq { let hashSet = HashSet<_>(HashIdentity.Structural<_>)
                   for v in source do
                     if hashSet.Add(projection v) then
@@ -1140,7 +1136,6 @@ namespace Microsoft.FSharp.Collections
 
         let inline countByImpl (comparer:IEqualityComparer<'SafeKey>) (keyf:'T->'SafeKey) (getKey:'SafeKey->'Key) (source:seq<'T>) =
             checkNonNull "source" source
-            if isEmpty source then empty else
 
             let dict = Dictionary comparer
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
@@ -52,8 +52,8 @@
       <HintPath Condition="'$(TargetDotnetProfile)' == 'net40'">$(FsCheckLibDir)\net452\FsCheck.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-        <HintPath>..\..\packages\System.ValueTuple.$(SystemValueTuplePackageVersion)\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
-        <Private>True</Private>
+      <HintPath>..\..\packages\System.ValueTuple.$(SystemValueTuplePackageVersion)\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -94,6 +94,7 @@
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\SeqProperties.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\CollectionModulesConsistency.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\StringModule.fs" />
+    <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\SeqMultipleIteration.fs" />
     <Compile Include="FSharp.Core\PrimTypes.fs" />
     <Compile Include="FSharp.Core\ComparersRegression.fs" />
     <Compile Include="FSharp.Core\DiscrimantedUnionType.fs" />

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqMultipleIteration.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqMultipleIteration.fs
@@ -1,0 +1,49 @@
+﻿namespace FSharp.Core.UnitTests.FSharp_Core.Microsoft_FSharp_Collections
+
+open NUnit.Framework
+
+[<TestFixture>]
+module SeqMultipleIteration =
+    let makeNewSeq () =
+        let haveCalled = false |> ref
+        seq {
+            if !haveCalled then failwith "Should not have iterated this sequence before"
+            haveCalled := true
+            yield 3
+        }, haveCalled
+
+    [<Test>]
+    let ``Seq.distinct only evaluates the seq once`` () =
+        let s, haveCalled = makeNewSeq ()
+        let distincts = Seq.distinct s
+        Assert.IsFalse !haveCalled
+        CollectionAssert.AreEqual (distincts |> Seq.toList, [3])
+        Assert.IsTrue !haveCalled
+
+    [<Test>]
+    let ``Seq.distinctBy only evaluates the seq once`` () =
+        let s, haveCalled = makeNewSeq ()
+        let distincts = Seq.distinctBy id s
+        Assert.IsFalse !haveCalled
+        CollectionAssert.AreEqual (distincts |> Seq.toList, [3])
+        Assert.IsTrue !haveCalled
+
+    [<Test>]
+    let ``Seq.groupBy only evaluates the seq once`` () =
+        let s, haveCalled = makeNewSeq ()
+        let distincts : seq<int * seq<int>> = Seq.groupBy id s
+        Assert.IsFalse !haveCalled
+        let distincts : list<int * seq<int>> = Seq.toList distincts
+        Assert.IsFalse !haveCalled
+        let distincts : list<int * list<int>> = distincts |> List.map (fun (i, s) -> (i, Seq.toList s))
+        CollectionAssert.AreEqual (distincts |> Seq.toList, [3, [3]])
+        Assert.IsTrue !haveCalled
+
+    [<Test>]
+    let ``Seq.countBy only evaluates the seq once`` () =
+        let s, haveCalled = makeNewSeq ()
+        let distincts : seq<int * int> = Seq.countBy id s
+        Assert.IsFalse !haveCalled
+        let distincts : list<int * int> = Seq.toList distincts
+        Assert.IsTrue !haveCalled
+        CollectionAssert.AreEqual (distincts |> Seq.toList, [(1, 3)])

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqMultipleIteration.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqMultipleIteration.fs
@@ -31,19 +31,19 @@ module SeqMultipleIteration =
     [<Test>]
     let ``Seq.groupBy only evaluates the seq once`` () =
         let s, haveCalled = makeNewSeq ()
-        let distincts : seq<int * seq<int>> = Seq.groupBy id s
+        let groups : seq<int * seq<int>> = Seq.groupBy id s
         Assert.IsFalse !haveCalled
-        let distincts : list<int * seq<int>> = Seq.toList distincts
+        let groups : list<int * seq<int>> = Seq.toList groups
         Assert.IsFalse !haveCalled
-        let distincts : list<int * list<int>> = distincts |> List.map (fun (i, s) -> (i, Seq.toList s))
-        CollectionAssert.AreEqual (distincts |> Seq.toList, [3, [3]])
+        let groups : list<int * list<int>> = groups |> List.map (fun (i, s) -> (i, Seq.toList s))
+        CollectionAssert.AreEqual (groups |> Seq.toList, [3, [3]])
         Assert.IsTrue !haveCalled
 
     [<Test>]
     let ``Seq.countBy only evaluates the seq once`` () =
         let s, haveCalled = makeNewSeq ()
-        let distincts : seq<int * int> = Seq.countBy id s
+        let counts : seq<int * int> = Seq.countBy id s
         Assert.IsFalse !haveCalled
-        let distincts : list<int * int> = Seq.toList distincts
+        let counts : list<int * int> = Seq.toList counts
         Assert.IsTrue !haveCalled
-        CollectionAssert.AreEqual (distincts |> Seq.toList, [(1, 3)])
+        CollectionAssert.AreEqual (counts |> Seq.toList, [(3, 1)])

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqMultipleIteration.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqMultipleIteration.fs
@@ -34,9 +34,7 @@ module SeqMultipleIteration =
         let groups : seq<int * seq<int>> = Seq.groupBy id s
         Assert.IsFalse !haveCalled
         let groups : list<int * seq<int>> = Seq.toList groups
-        Assert.IsFalse !haveCalled
-        let groups : list<int * list<int>> = groups |> List.map (fun (i, s) -> (i, Seq.toList s))
-        CollectionAssert.AreEqual (groups |> Seq.toList, [3, [3]])
+        // Seq.groupBy iterates the entire sequence as soon as it begins iteration.
         Assert.IsTrue !haveCalled
 
     [<Test>]


### PR DESCRIPTION
This is to fix https://github.com/Microsoft/visualfsharp/issues/5942 . (My first PR to VisualFSharp; let me know if I've done anything wrong.) I've left most of the changes introduced by the rogue PRs mentioned in that ticket; just reverted the Seq-specific changes.

I'm relying here on the continuous integration to actually run these tests, because my home setup remains unable to build the compiler.