### PR TITLE
Dive into types in type test expressions in AST visitor traverse

### DIFF
--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -66,11 +66,14 @@
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\TokenizerTests.fs">
       <Link>TokenizerTests.fs</Link>
     </Compile>
-    <Compile Include="$(FSharpSourcesRoot)\..\tests\service\Program.fs" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-      <Link>Program.fs</Link>
+    <Compile Include="$(FSharpSourcesRoot)\..\tests\service\ServiceUntypedParseTests.fs">
+      <Link>ServiceUntypedParseTests.fs</Link>
     </Compile>
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\TreeVisitorTests.fs">
       <Link>TreeVisitorTests.fs</Link>
+    </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\..\tests\service\Program.fs" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+      <Link>Program.fs</Link>
     </Compile>
     <None Include="App.config" />
   </ItemGroup>

--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -69,6 +69,9 @@
     <Compile Include="$(FSharpSourcesRoot)\..\tests\service\Program.fs" Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
       <Link>Program.fs</Link>
     </Compile>
+    <Compile Include="$(FSharpSourcesRoot)\..\tests\service\TreeVisitorTests.fs">
+      <Link>TreeVisitorTests.fs</Link>
+    </Compile>
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/fsharp/service/ServiceParseTreeWalk.fs
+++ b/src/fsharp/service/ServiceParseTreeWalk.fs
@@ -456,9 +456,12 @@ module public AstTraversal =
                      dive synExpr2 synExpr2.Range traverseSynExpr
                      dive synExpr3 synExpr3.Range traverseSynExpr]
                     |> pick expr
-                | SynExpr.TypeTest(synExpr, _synType, _range) -> traverseSynExpr synExpr
-                | SynExpr.Upcast(synExpr, _synType, _range) -> traverseSynExpr synExpr
-                | SynExpr.Downcast(synExpr, _synType, _range) -> traverseSynExpr synExpr
+                | SynExpr.TypeTest(synExpr, synType, _range)
+                | SynExpr.Upcast(synExpr, synType, _range)
+                | SynExpr.Downcast(synExpr, synType, _range) ->
+                    [dive synExpr synExpr.Range traverseSynExpr
+                     dive synType synType.Range traverseSynType]
+                    |> pick expr
                 | SynExpr.InferredUpcast(synExpr, _range) -> traverseSynExpr synExpr
                 | SynExpr.InferredDowncast(synExpr, _range) -> traverseSynExpr synExpr
                 | SynExpr.Null(_range) -> None

--- a/tests/service/InteractiveCheckerTests.fs
+++ b/tests/service/InteractiveCheckerTests.fs
@@ -54,11 +54,7 @@ let internal identsAndRanges (input: Ast.ParsedInput) =
     | Ast.ParsedInput.SigFile _ -> []
 
 let internal parseAndExtractRanges code =
-    let file = "Test"
-    let result = parseSourceCode (file, code)
-    match result with
-    | Some tree -> tree |> identsAndRanges
-    | None -> failwith "fail to parse..."
+    parseSource code |> identsAndRanges
 
 let input =
     """

--- a/tests/service/ServiceUntypedParseTests.fs
+++ b/tests/service/ServiceUntypedParseTests.fs
@@ -40,14 +40,12 @@ let private (=>) (source: string) (expected: CompletionContext option) =
     match markerPos with
     | None -> failwithf "Marker '%s' was not found in the source code" Marker
     | Some markerPos ->
-        match parseSourceCode("C:\\test.fs", source) with
-        | None -> failwith "No parse tree"
-        | Some parseTree ->
-            let actual = UntypedParseImpl.TryGetCompletionContext(markerPos, parseTree, lines.[Line.toZ markerPos.Line])
-            try Assert.AreEqual(expected, actual)
-            with e ->
-                printfn "ParseTree: %A" parseTree
-                reraise()
+        let parseTree = parseSource source
+        let actual = UntypedParseImpl.TryGetCompletionContext(markerPos, parseTree, lines.[Line.toZ markerPos.Line])
+        try Assert.AreEqual(expected, actual)
+        with e ->
+            printfn "ParseTree: %A" parseTree
+            reraise()
 
 module AttributeCompletion =
     [<Test>]

--- a/tests/service/StructureTests.fs
+++ b/tests/service/StructureTests.fs
@@ -40,23 +40,19 @@ let (=>) (source: string) (expectedRanges: (Range * Range) list) =
 
     let getRange (r: range) = (r.StartLine, r.StartColumn, r.EndLine, r.EndColumn)
 
-    let ast = parseSourceCode(fileName, source)
-
+    let tree = parseSource source
     try
-        match ast with
-        | Some tree ->
-            let actual =
-                Structure.getOutliningRanges lines tree
-                |> Seq.filter (fun sr -> sr.Range.StartLine <> sr.Range.EndLine)
-                |> Seq.map (fun sr -> getRange sr.Range, getRange sr.CollapseRange)
-                |> Seq.sort
-                |> List.ofSeq
-            let expected = List.sort expectedRanges
-            if actual <> expected then
-                failwithf "Expected %s, but was %s" (formatList expected) (formatList actual)
-        | None -> failwithf "Expected there to be a parse tree for source:\n%s" source
+        let actual =
+            Structure.getOutliningRanges lines tree
+            |> Seq.filter (fun sr -> sr.Range.StartLine <> sr.Range.EndLine)
+            |> Seq.map (fun sr -> getRange sr.Range, getRange sr.CollapseRange)
+            |> Seq.sort
+            |> List.ofSeq
+        let expected = List.sort expectedRanges
+        if actual <> expected then
+            failwithf "Expected %s, but was %s" (formatList expected) (formatList actual)
     with _ ->
-        printfn "AST:\n%+A" ast
+        printfn "AST:\n%+A" tree
         reraise()
 
 [<Test>]

--- a/tests/service/TreeVisitorTests.fs
+++ b/tests/service/TreeVisitorTests.fs
@@ -1,0 +1,22 @@
+module Tests.Service.TreeVisitorTests
+
+open FSharp.Compiler.Service.Tests.Common
+open Microsoft.FSharp.Compiler.Range
+open Microsoft.FSharp.Compiler.SourceCodeServices.AstTraversal
+open NUnit.Framework
+
+[<Test>]
+let ``Visit type`` () =
+    let visitor =
+        { new AstVisitorBase<_>() with
+            member x.VisitExpr(_, _, defaultTraverse, expr) = defaultTraverse expr
+            member x.VisitType(_, _) = Some () }
+
+    let source = "123 :? int"
+    let parseTree = parseSource source
+
+    Traverse(mkPos 1 11, parseTree, visitor)
+    |> Option.defaultWith (fun _ -> failwith "Did not visit type")
+
+    Traverse(mkPos 1 3, parseTree, visitor)
+    |> Option.map (fun _ -> failwith "Should not visit type") |> ignore

--- a/tests/service/TreeVisitorTests.fs
+++ b/tests/service/TreeVisitorTests.fs
@@ -6,7 +6,7 @@ open Microsoft.FSharp.Compiler.SourceCodeServices.AstTraversal
 open NUnit.Framework
 
 [<Test>]
-let ``Visit type`` () =
+let ``Visit type test`` () =
     let visitor =
         { new AstVisitorBase<_>() with
             member x.VisitExpr(_, _, defaultTraverse, expr) = defaultTraverse expr
@@ -19,4 +19,4 @@ let ``Visit type`` () =
     |> Option.defaultWith (fun _ -> failwith "Did not visit type")
 
     Traverse(mkPos 1 3, parseTree, visitor)
-    |> Option.map (fun _ -> failwith "Should not visit type") |> ignore
+    |> Option.iter (fun _ -> failwith "Should not visit type")

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -107,6 +107,9 @@
     <Compile Include="UnusedOpensTests.fs">
       <Link>CompilerService\UnusedOpensTests.fs</Link>
     </Compile>
+    <Compile Include="..\..\..\tests\service\TreeVisitorTests.fs">
+      <Link>CompilerService\TreeVisitorTests.fs</Link>
+    </Compile>
     <Compile Include="SyntacticColorizationServiceTests.fs">
       <Link>Roslyn\SyntacticColorizationServiceTests.fs</Link>
     </Compile>


### PR DESCRIPTION
Currently `AstTraversal.Traverse` goes into `expr` parts of type test expressions only and ignores `type` parts. This PR adds diving into `type` parts.

In the example below `System.String` will now be visited by `VisitType`.
```fsharp
"" :? System.String
```