### PR TITLE
Fixed cross project references again

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -92,14 +92,12 @@ module private FSharpProjectOptionsHelpers =
             p1.Version <> p2.Version
         )
 
-    let isProjectInvalidated (oldProject: Project) (newProject: Project) (settings: EditorOptions) cancellationToken =
-        async {
-            let hasProjectVersionChanged = hasProjectVersionChanged oldProject newProject
-            if settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences then
-                return hasProjectVersionChanged || hasDependentVersionChanged oldProject newProject
-            else
-                return hasProjectVersionChanged
-        }
+    let isProjectInvalidated (oldProject: Project) (newProject: Project) (settings: EditorOptions) =
+        let hasProjectVersionChanged = hasProjectVersionChanged oldProject newProject
+        if settings.LanguageServicePerformance.EnableInMemoryCrossProjectReferences then
+            hasProjectVersionChanged || hasDependentVersionChanged oldProject newProject
+        else
+            hasProjectVersionChanged
 
 [<RequireQualifiedAccess>]
 type private FSharpProjectOptionsMessage =
@@ -243,8 +241,7 @@ type private FSharpProjectOptionsReactor (workspace: VisualStudioWorkspaceImpl, 
                     return Some(parsingOptions, projectOptions)
   
             | true, (oldProject, parsingOptions, projectOptions) ->
-                let! isProjectInvalidated = isProjectInvalidated oldProject project settings cancellationToken
-                if isProjectInvalidated then
+                if isProjectInvalidated oldProject project settings then
                     cache.Remove(projectId) |> ignore
                     return! tryComputeOptions project cancellationToken
                 else


### PR DESCRIPTION
`GetDependentVersionAsync` is not what we wanted. Everytime we changed the current active document, the dependent version would change and invalidate on every key stroke; performance regressed massively.

What we really wanted to do is check if the project reference simply had their versions changed, so we look at each project reference and their version. This should be a fast operation, even if there were thousands of project references.

What is 🎺 ?