### PR TITLE
Always emit conditional attributes in FCS

### DIFF
--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -366,6 +366,9 @@ type TcConfigBuilder =
 
       /// if true - 'let mutable x = Span.Empty', the value 'x' is a stack referring span. Used for internal testing purposes only until we get true stack spans.
       mutable internalTestSpanStackReferring : bool
+
+      /// Prevent erasure of conditional attributes and methods so tooling is able analyse them.
+      mutable noConditionalErasure: bool
     }
 
     static member Initial: TcConfigBuilder

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -858,7 +858,7 @@ let editorSpecificFlags (tcConfigB: TcConfigBuilder) =
     CompilerOption("gccerrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.GccErrors), None, None) 
     CompilerOption("exename", tagNone, OptionString (fun s -> tcConfigB.exename <- Some(s)), None, None)
     CompilerOption("maxerrors", tagInt, OptionInt (fun n -> tcConfigB.maxErrors <- n), None, None)
-    CompilerOption("noConditionalErasure", tagNone, OptionUnit (fun () -> tcConfigB.noConditionalErasure <- true), None, None) ]
+    CompilerOption("noconditionalerasure", tagNone, OptionUnit (fun () -> tcConfigB.noConditionalErasure <- true), None, None) ]
 
 let internalFlags (tcConfigB:TcConfigBuilder) =
   [

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -848,8 +848,8 @@ let testFlag tcConfigB =
                                             | str                -> warning(Error(FSComp.SR.optsUnknownArgumentToTheTestSwitch(str),rangeCmdArgs))), None,
                            None)
 
-// not shown in fsc.exe help, no warning on use, motivation is for use from VS
-let vsSpecificFlags (tcConfigB: TcConfigBuilder) = 
+// Not shown in fsc.exe help, no warning on use, motivation is for use from tooling.
+let editorSpecificFlags (tcConfigB: TcConfigBuilder) = 
   [ CompilerOption("vserrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.VSErrors), None, None)
     CompilerOption("validate-type-providers", tagNone, OptionUnit (id), None, None)  // preserved for compatibility's sake, no longer has any effect
     CompilerOption("LCID", tagInt, OptionInt ignore, None, None)
@@ -857,7 +857,8 @@ let vsSpecificFlags (tcConfigB: TcConfigBuilder) =
     CompilerOption("sqmsessionguid", tagNone, OptionString ignore, None, None)
     CompilerOption("gccerrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.GccErrors), None, None) 
     CompilerOption("exename", tagNone, OptionString (fun s -> tcConfigB.exename <- Some(s)), None, None)
-    CompilerOption("maxerrors", tagInt, OptionInt (fun n -> tcConfigB.maxErrors <- n), None, None) ]
+    CompilerOption("maxerrors", tagInt, OptionInt (fun n -> tcConfigB.maxErrors <- n), None, None)
+    CompilerOption("noConditionalErasure", tagNone, OptionUnit (fun () -> tcConfigB.noConditionalErasure <- true), None, None) ]
 
 let internalFlags (tcConfigB:TcConfigBuilder) =
   [
@@ -896,7 +897,7 @@ let internalFlags (tcConfigB:TcConfigBuilder) =
     CompilerOption("alwayscallvirt",tagNone,OptionSwitch(callVirtSwitch tcConfigB),Some(InternalCommandLineOption("alwayscallvirt",rangeCmdArgs)), None)
     CompilerOption("nodebugdata",tagNone, OptionUnit (fun () -> tcConfigB.noDebugData<-true),Some(InternalCommandLineOption("--nodebugdata",rangeCmdArgs)), None)
     testFlag tcConfigB  ] @
-  vsSpecificFlags tcConfigB @
+  editorSpecificFlags tcConfigB @
   [ CompilerOption("jit", tagNone, OptionSwitch (jitoptimizeSwitch tcConfigB), Some(InternalCommandLineOption("jit", rangeCmdArgs)), None)
     CompilerOption("localoptimize", tagNone, OptionSwitch(localoptimizeSwitch tcConfigB),Some(InternalCommandLineOption("localoptimize", rangeCmdArgs)), None)
     CompilerOption("splitting", tagNone, OptionSwitch(splittingSwitch tcConfigB),Some(InternalCommandLineOption("splitting", rangeCmdArgs)), None)

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -10829,8 +10829,10 @@ and TcAttribute canFail cenv (env: TcEnv) attrTgt (synAttr: SynAttribute)  =
     let conditionalCallDefineOpt = TryFindTyconRefStringAttribute cenv.g mAttr cenv.g.attrib_ConditionalAttribute tcref 
 
     match conditionalCallDefineOpt with 
+#if !COMPILER_SERVICE_AS_DLL 
     | Some d when not (List.contains d cenv.conditionalDefines) -> 
         [], false
+#endif
     | _ ->
 
          // REVIEW: take notice of inherited? 

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -504,8 +504,8 @@ type cenv =
       /// Used to resolve names
       nameResolver: NameResolver
       
-      /// The set of active conditional defines
-      conditionalDefines: string list
+      /// The set of active conditional defines. The value is None when conditional erasure is disabled in tooling.
+      conditionalDefines: string list option
             
       isInternalTestSpanStackReferring: bool
     } 
@@ -3004,8 +3004,8 @@ let BuildPossiblyConditionalMethodCall cenv env isMutable m isProp minfo valUseF
 
     let conditionalCallDefineOpt = TryFindMethInfoStringAttribute cenv.g m cenv.g.attrib_ConditionalAttribute minfo 
 
-    match conditionalCallDefineOpt with 
-    | Some d when not (List.contains d cenv.conditionalDefines) -> 
+    match conditionalCallDefineOpt, cenv.conditionalDefines with 
+    | Some d, Some defines when not (List.contains d defines) -> 
 
         // Methods marked with 'Conditional' must return 'unit' 
         UnifyTypes cenv env m cenv.g.unit_ty (minfo.GetFSharpReturnTy(cenv.amap, m, minst))
@@ -10828,13 +10828,10 @@ and TcAttribute canFail cenv (env: TcEnv) attrTgt (synAttr: SynAttribute)  =
 
     let conditionalCallDefineOpt = TryFindTyconRefStringAttribute cenv.g mAttr cenv.g.attrib_ConditionalAttribute tcref 
 
-    match conditionalCallDefineOpt with 
-#if !COMPILER_SERVICE_AS_DLL 
-    | Some d when not (List.contains d cenv.conditionalDefines) -> 
+    match conditionalCallDefineOpt, cenv.conditionalDefines with 
+    | Some d, Some defines when not (List.contains d defines) -> 
         [], false
-#endif
     | _ ->
-
          // REVIEW: take notice of inherited? 
         let validOn, _inherited = 
             let validOnDefault = 0x7fff

--- a/src/fsharp/TypeChecker.fsi
+++ b/src/fsharp/TypeChecker.fsi
@@ -39,14 +39,14 @@ val EmptyTopAttrs : TopAttribs
 val CombineTopAttrs : TopAttribs -> TopAttribs -> TopAttribs
 
 val TypeCheckOneImplFile : 
-      TcGlobals * NiceNameGenerator * ImportMap * CcuThunk * (unit -> bool) * ConditionalDefines * NameResolution.TcResultsSink * bool
+      TcGlobals * NiceNameGenerator * ImportMap * CcuThunk * (unit -> bool) * ConditionalDefines option * NameResolution.TcResultsSink * bool
       -> TcEnv 
       -> Tast.ModuleOrNamespaceType option
       -> ParsedImplFileInput
       -> Eventually<TopAttribs * Tast.TypedImplFile * ModuleOrNamespaceType * TcEnv * bool>
 
 val TypeCheckOneSigFile : 
-      TcGlobals * NiceNameGenerator * ImportMap * CcuThunk  * (unit -> bool) * ConditionalDefines * NameResolution.TcResultsSink * bool
+      TcGlobals * NiceNameGenerator * ImportMap * CcuThunk  * (unit -> bool) * ConditionalDefines option * NameResolution.TcResultsSink * bool
       -> TcEnv                             
       -> ParsedSigFileInput
       -> Eventually<TcEnv * ModuleOrNamespaceType * bool>

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -115,8 +115,8 @@ type FooAttribute() =
 [<Foo>]
 let x = 123
 """
-        let fileName, options = mkTestFileAndOptions source [| "--noConditionalErasure" |]
-        let _, checkResults = parseAndCheckFile fileName source options    
+        let fileName, options = mkTestFileAndOptions source [| "--noconditionalerasure" |]
+        let _, checkResults = parseAndCheckFile fileName source options
 
         checkResults.GetAllUsesOfAllSymbolsInFile()
          |> Async.RunSynchronously

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -115,7 +115,7 @@ type FooAttribute() =
 [<Foo>]
 let x = 123
 """
-        let fileName, options = mkTestFileAndOptions source [| |]
+        let fileName, options = mkTestFileAndOptions source [| "--noConditionalErasure" |]
         let _, checkResults = parseAndCheckFile fileName source options    
 
         checkResults.GetAllUsesOfAllSymbolsInFile()

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -118,11 +118,9 @@ let x = 123
         let fileName, options = mkTestFileAndOptions source [| |]
         let _, checkResults = parseAndCheckFile fileName source options    
 
-        let xSymbol =
-            checkResults.GetAllUsesOfAllSymbolsInFile()
-             |> Async.RunSynchronously
-             |> Array.tryFind (fun su -> su.Symbol.DisplayName = "x")
-             |> Option.map (fun su -> su.Symbol :?> FSharpMemberOrFunctionOrValue)
-             |> Option.defaultWith (fun _ -> failwith "Could not get symbol")
-        
-        xSymbol.Attributes.Count |> shouldEqual 1
+        checkResults.GetAllUsesOfAllSymbolsInFile()
+         |> Async.RunSynchronously
+         |> Array.tryFind (fun su -> su.Symbol.DisplayName = "x")
+         |> Option.orElseWith (fun _ -> failwith "Could not get symbol")
+         |> Option.map (fun su -> su.Symbol :?> FSharpMemberOrFunctionOrValue)
+         |> Option.iter (fun symbol -> symbol.Attributes.Count |> shouldEqual 1)

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -100,4 +100,29 @@ module Mod2 =
          mod1val1.XmlDocSig |> shouldEqual "P:Mod1.val1"
          mod2func2.XmlDocSig |> shouldEqual "M:Mod1.Mod2.func2"
 
-                 
+
+module Attributes =
+    [<Test>]
+    let ``Emit conditional attributes`` () =
+        let source = """
+open System
+open System.Diagnostics
+
+[<Conditional("Bar")>]
+type FooAttribute() =
+    inherit Attribute()
+
+[<Foo>]
+let x = 123
+"""
+        let fileName, options = mkTestFileAndOptions source [| |]
+        let _, checkResults = parseAndCheckFile fileName source options    
+
+        let xSymbol =
+            checkResults.GetAllUsesOfAllSymbolsInFile()
+             |> Async.RunSynchronously
+             |> Array.tryFind (fun su -> su.Symbol.DisplayName = "x")
+             |> Option.map (fun su -> su.Symbol :?> FSharpMemberOrFunctionOrValue)
+             |> Option.defaultWith (fun _ -> failwith "Could not get symbol")
+        
+        xSymbol.Attributes.Count |> shouldEqual 1


### PR DESCRIPTION
Fixes #3890. We analyse conditionally erased attributes like `CanBeNull` or `NotNull` from [`JetBrains.Annotations`](https://www.nuget.org/packages/JetBrains.Annotations) package and need to see all attributes before erasure. Any objections to always doing it in the compiler service?