### PR TITLE
Fix #4946  --- Update FSC and FSI to recognize upto .net framework 472

### DIFF
--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -9,6 +9,7 @@
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);COMPILER</DefineConstants>
+    <DefineConstants>$(DefineConstants);MSBUILD_AT_LEAST_15</DefineConstants>
     <OtherFlags>$(OtherFlags) --warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <UseFSharpProductVersion>true</UseFSharpProductVersion>
     <UseAssetTargetFallback>true</UseAssetTargetFallback>

--- a/src/fsharp/MSBuildReferenceResolver.fs
+++ b/src/fsharp/MSBuildReferenceResolver.fs
@@ -67,19 +67,28 @@ module internal Microsoft.FSharp.Compiler.MSBuildReferenceResolver
     [<Literal>]    
     let private Net451 = "v4.5.1"
 
-    /// The list of supported .NET Framework version numbers, using the monikers of the Reference Assemblies folder.
-    let SupportedNetFrameworkVersions = set [ Net20; Net30; Net35; Net40; Net45; Net451; (*SL only*) "v5.0" ]
-    
-    //[<Literal>]    
-    //let private Net452 = "v4.5.2" // not available in Dev15 MSBuild version
+    [<Literal>]    
+    let private Net452 = "v4.5.2" // not available in Dev15 MSBuild version
 
-#if MSBUILD_AT_LEAST_14
     [<Literal>]    
     let private Net46 = "v4.6"
 
     [<Literal>]    
     let private Net461 = "v4.6.1"
-#endif
+
+    [<Literal>]    
+    let private Net462 = "v4.6.2"
+
+    [<Literal>]    
+    let private Net47 = "v4.7"
+
+    [<Literal>]    
+    let private Net471 = "v4.7.1"
+
+    [<Literal>]    
+    let private Net472 = "v4.7.2"
+
+    let SupportedNetFrameworkVersions = set [ Net20; Net30; Net35; Net40; Net45; Net451; Net452; Net46; Net461; Net462; Net47; Net471; Net472; ]
 
     /// Get the path to the .NET Framework implementation assemblies by using ToolLocationHelper.GetPathToDotNetFramework.
     /// This is only used to specify the "last resort" path for assembly resolution.
@@ -93,10 +102,14 @@ module internal Microsoft.FSharp.Compiler.MSBuildReferenceResolver
             | Net40 ->  Some TargetDotNetFrameworkVersion.Version40
             | Net45 ->  Some TargetDotNetFrameworkVersion.Version45
             | Net451 -> Some TargetDotNetFrameworkVersion.Version451
-#if MSBUILD_AT_LEAST_14
-            //| Net452 -> Some TargetDotNetFrameworkVersion.Version452 // not available in Dev15 MSBuild version
+            | Net452 -> Some TargetDotNetFrameworkVersion.Version452
             | Net46 -> Some TargetDotNetFrameworkVersion.Version46
             | Net461 -> Some TargetDotNetFrameworkVersion.Version461
+#if MSBUILD_AT_LEAST_15
+            | Net462 -> Some TargetDotNetFrameworkVersion.Version462
+            | Net47 -> Some TargetDotNetFrameworkVersion.Version47
+            | Net471 -> Some TargetDotNetFrameworkVersion.Version471
+            | Net472 -> Some TargetDotNetFrameworkVersion.Version472
 #endif
             | _ -> assert false; None
         match v with
@@ -121,17 +134,21 @@ module internal Microsoft.FSharp.Compiler.MSBuildReferenceResolver
     /// Use MSBuild to determine the version of the highest installed framework.
     let HighestInstalledNetFrameworkVersion() =
       try
-#if MSBUILD_AT_LEAST_14
-        if box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version461)) <> null then Net461
-        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version46)) <> null then Net46
-        // 4.5.2 enumeration is not available in Dev15 MSBuild version
-        //elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version452)) <> null then Net452 
-        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version451)) <> null then Net451 
+// The Mono build still uses an ancient version of msbuild from around Dev 14
+#if MSBUILD_AT_LEAST_15
+        if box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version472)) <> null then Net472
+        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version471)) <> null then Net471
+        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version47)) <> null then Net47
+        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version462)) <> null then Net462
+        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version461)) <> null then Net461
 #else
-        if box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version451)) <> null then Net451 
+        if box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version461)) <> null then Net461
 #endif
-        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version45)) <> null then Net45 
-        else Net45 // version is 4.5 assumed since this code is running. 
+        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version46)) <> null then Net46
+        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version452)) <> null then Net452
+        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version451)) <> null then Net451
+        elif box (ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version45)) <> null then Net45
+        else Net45 // version is 4.5 assumed since this code is running.
       with _ -> Net45
 
     /// Derive the target framework directories.        

--- a/src/utils/reshapedmsbuild.fs
+++ b/src/utils/reshapedmsbuild.fs
@@ -85,6 +85,10 @@ module internal MsBuildAdapters =
     | Version46 = 7
     | Version461 = 8
     | Version452 = 9
+    | Version462 = 10
+    | Version47 = 11
+    | Version471 = 12
+    | Version472 = 13
     | VersionLatest = 8  //TargetDotNetFrameworkVersion.Version461
 
     /// <summary>

--- a/tests/fsharpqa/Source/CodeGen/EmittedIL/Tuples/ValueTupleAliasConstructor.il.bsl.net47
+++ b/tests/fsharpqa/Source/CodeGen/EmittedIL/Tuples/ValueTupleAliasConstructor.il.bsl.net47
@@ -1,0 +1,83 @@
+
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+
+
+
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly extern FSharp.Core
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:5:0:0
+}
+.assembly ValueTupleAliasConstructor
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32,
+                                                                                                      int32,
+                                                                                                      int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 01 00 00 00 00 00 ) 
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.mresource public FSharpSignatureData.ValueTupleAliasConstructor
+{
+  // Offset: 0x00000000 Length: 0x000001EA
+}
+.mresource public FSharpOptimizationData.ValueTupleAliasConstructor
+{
+  // Offset: 0x000001F0 Length: 0x00000061
+}
+.module ValueTupleAliasConstructor.exe
+// MVID: {5C136441-E59F-7FAD-A745-03834164135C}
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x01150000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public abstract auto ansi sealed ValueTupleAliasConstructor
+       extends [mscorlib]System.Object
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+} // end of class ValueTupleAliasConstructor
+
+.class private abstract auto ansi sealed '<StartupCode$ValueTupleAliasConstructor>'.$ValueTupleAliasConstructor
+       extends [mscorlib]System.Object
+{
+  .field static assembly int32 init@
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public static void  main@() cil managed
+  {
+    .entrypoint
+    // Code size       9 (0x9)
+    .maxstack  8
+    .language '{AB4F38C9-B6E6-43BA-BE3B-58080B2CCCE3}', '{994B45C4-E6E9-11D2-903F-00C04FA302A1}', '{5A869D0B-6611-11D3-BD2A-0000F80849BD}'
+    .line 3,3 : 9,22 'c:\\kevinransom\\visualfsharp\\tests\\fsharpqa\\Source\\CodeGen\\EmittedIL\\Tuples\\ValueTupleAliasConstructor.fs'
+    IL_0000:  ldc.i4.2
+    IL_0001:  ldc.i4.2
+    IL_0002:  newobj     instance void valuetype [mscorlib]System.ValueTuple`2<int32,int32>::.ctor(!0,
+                                                                                                   !1)
+    IL_0007:  pop
+    IL_0008:  ret
+  } // end of method $ValueTupleAliasConstructor::main@
+
+} // end of class '<StartupCode$ValueTupleAliasConstructor>'.$ValueTupleAliasConstructor
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/tests/fsharpqa/testenv/src/ILComparer/Program.fs
+++ b/tests/fsharpqa/testenv/src/ILComparer/Program.fs
@@ -3,9 +3,6 @@ open System.IO
 
 [<EntryPoint>]
 let main (argv : string array) =
-    let fn1 = argv.[0]
-    let fn2 = argv.[1]
-
     // Read file into an array
     let File2List (filename:string) = 
         use s = new StreamReader(filename)
@@ -15,9 +12,6 @@ let main (argv : string array) =
             let isblank_or_comment = Regex.IsMatch(line, @"^[ \t]*//") || Regex.IsMatch(line, @"^[ \t]*$")
             if not isblank_or_comment then l <- List.append l ( line :: [])
         l
-
-    let f1 = File2List fn1
-    let f2 = File2List fn2
 
     let rec compareAux (f1:string list) (f2:string list) i =
         match f1, f2 with 
@@ -73,4 +67,22 @@ let main (argv : string array) =
             printfn "%s" (e.ToString())
             false
 
-    exit (if compare f1 f2 then 0 else 1)
+    let fn1 = argv.[0]
+    let fn2 = argv.[1]
+    let fn3 = argv.[0] + ".net47"
+
+    let f2 = File2List fn2
+
+    // Check to see if fn1+".net47" exists, if so check this baseline first if not equal then check fn1 baseline
+    // the fn1 + ".net47" baseline exists in the rare case where il produced has changed for example valuetuple moved form system.valuetuple.dll to mscorlib.dll, making baselines tricky
+    let result =
+        if File.Exists(fn3) then 
+            let f3 = File2List fn3
+            if compare f3 f2 then 0 else 1
+        else
+            1
+    if result = 0 then
+        exit 0
+    else
+        let f1 = File2List fn1
+        exit (if compare f1 f2 then 0 else 1)


### PR DESCRIPTION
Fixes #4946 



I note that Don submitted a similar PR, however this one as well as enabling the higher frameworks.  Updates the HighestInstalledNetFrameworkVersion api, to return the highest supported framework.

/cc @brettfo   This fixes the issue we were seeing with Dev 16.0
