### PR TITLE
Use public sign

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -42,7 +42,10 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(FSharpSourcesRoot)\fsharp\msft.pubkey</AssemblyOriginatorKeyFile>
     <StrongNames>true</StrongNames>
-    <DelaySign>true</DelaySign>
+    <DelaySign>false</DelaySign>
+    <PublicSign>true</PublicSign>
+    <GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
+    <NoCompilerStandardLib Condition="'$(TargetFramework)' == 'netstandard1.6'">true</NoCompilerStandardLib>
   </PropertyGroup>
   <PropertyGroup Condition="'$(MonoPackaging)' == 'true'">
     <AssemblyOriginatorKeyFile>$(FSharpSourcesRoot)\fsharp\test.snk</AssemblyOriginatorKeyFile>

--- a/src/update.cmd
+++ b/src/update.cmd
@@ -44,13 +44,6 @@ set SN64="%WINSDKNETFXTOOLS_x64%sn.exe"
 set NGEN32=%windir%\Microsoft.NET\Framework\v4.0.30319\ngen.exe
 set NGEN64=%windir%\Microsoft.NET\Framework64\v4.0.30319\ngen.exe
 
-rem Disable strong-name validation for binaries that are delay-signed with the microsoft key
-%SN32% -q -Vr *,b03f5f7f11d50a3a
-
-if /i "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
-    %SN64% -q -Vr *,b03f5f7f11d50a3a
-)
-
 if /i "%1" == "signonly" goto :eof
 if /i "%1" == "debug" set NGEN_FLAGS=/Debug
 

--- a/vsintegration/update-vsintegration.cmd
+++ b/vsintegration/update-vsintegration.cmd
@@ -267,46 +267,6 @@ if "%DEPLOY%" == "yes" if "!ISADMIN!" == "yes" (
     REG ADD "HKLM\SOFTWARE\Microsoft\.NETFramework\v4.0.30319\AssemblyFoldersEx\F# !FSHARPVERSION! Core Assemblies (Open Source)" /ve /t REG_SZ /f /d "!X86_PROGRAMFILES!\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.!FSHARPVERSION!.0\
     REG ADD "HKLM\SOFTWARE\Microsoft\.NETFramework\v4.0.50709\AssemblyFoldersEx\F# !FSHARPVERSION! Core Assemblies (Open Source)" /ve /t REG_SZ /f /d "!X86_PROGRAMFILES!\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.!FSHARPVERSION!.0\
 
-    rem Disable strong-name validation for F# binaries built from open source that are signed with the microsoft key
-    echo.
-    CALL :colorEcho 02 "[!ACTION!] Removing strong-name validation of F# binaries" & echo.
-    !SN32! -Vr FSharp.Core,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.Build,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.Compiler.Interactive.Settings,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr HostedCompilerServer,b03f5f7f11d50a3a 1>NUL 2>NUL
-
-    !SN32! -Vr FSharp.Compiler,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.Compiler.Server.Shared,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.Editor,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.LanguageService,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.LanguageService.Base,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.ProjectSystem.Base,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.ProjectSystem.FSharp,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.ProjectSystem.PropertyPages,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr FSharp.VS.FSI,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr VisualFSharp.UnitTests,b03f5f7f11d50a3a 1>NUL 2>NUL
-    !SN32! -Vr VisualFSharp.Salsa,b03f5f7f11d50a3a 1>NUL 2>NUL
-
-    REM Do this *in addition* to the above for x64 systems
-    if /i "!PROCESSOR_ARCHITECTURE!"=="AMD64" (
-        !SN64! -Vr FSharp.Core,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.Build,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.Compiler.Interactive.Settings,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr HostedCompilerServer,b03f5f7f11d50a3a 1>NUL 2>NUL
-
-        !SN64! -Vr FSharp.Compiler,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.Compiler.Server.Shared,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.Editor,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.LanguageService,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.LanguageService.Base,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.ProjectSystem.Base,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.ProjectSystem.FSharp,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.ProjectSystem.PropertyPages,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr FSharp.VS.FSI,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr VisualFSharp.UnitTests,b03f5f7f11d50a3a 1>NUL 2>NUL
-        !SN64! -Vr VisualFSharp.Salsa,b03f5f7f11d50a3a 1>NUL 2>NUL
-    )
-
     rem NGen fsc, fsi, fsiAnyCpu, and FSharp.Build.dll
     
     echo.


### PR DESCRIPTION
Use PublicSign instead of DelaySign, for cases where the latter was used in developer builds.

This addresses the assembly strong naming limitations involved in #6032.