### PR TITLE
Fix: 5655 by removing FSharp.Core from VS/PublicAssembliesDirectory

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/Files.swr
@@ -10,10 +10,5 @@ folder "InstallDir:MSBuild\Microsoft\VisualStudio\v$(VSGeneralVersion)\FSharp"
   file "Microsoft.FSharp.Overrides.NetSdk.targets" source="$(SetupShimsDir)\Microsoft.FSharp.Overrides.NetSdk.Shim.targets"
   file "Microsoft.FSharp.NetSdk.props" source="$(SetupShimsDir)\Microsoft.FSharp.NetSdk.Shim.props"
 
-folder "InstallDir:Common7\IDE\PublicAssemblies"
-  file source="$(BinariesFolder)\FSharp.Core\$(Configuration)\net45\FSharp.Core.dll" vs.file.ngen=yes
-  file source="$(BinariesFolder)\FSharp.Core\$(Configuration)\net45\FSharp.Core.optdata"
-  file source="$(BinariesFolder)\FSharp.Core\$(Configuration)\net45\FSharp.Core.sigdata"
-
 folder "InstallDir:Common7\Tools\VsDevCmd\Ext"
   file source="fsharp.bat"


### PR DESCRIPTION
Fixes #5655 & #6014