### PR TITLE
Checking assembly when checking for String.Concat in Optimizer

### DIFF
--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1767,19 +1767,19 @@ let TryDetectQueryQuoteAndRun cenv (expr:Expr) =
 let IsILMethodRefDeclaringTypeSystemString (ilg: ILGlobals) (mref: ILMethodRef) =
     mref.DeclaringTypeRef.Scope.IsAssemblyRef &&
     mref.DeclaringTypeRef.Scope.AssemblyRef.Name = ilg.typ_String.TypeRef.Scope.AssemblyRef.Name &&
-    mref.DeclaringTypeRef.FullName = ilg.typ_String.TypeRef.FullName
+    mref.DeclaringTypeRef.BasicQualifiedName = ilg.typ_String.BasicQualifiedName
                 
 let IsILMethodRefSystemStringConcatOverload (ilg: ILGlobals) (mref: ILMethodRef) =
     IsILMethodRefDeclaringTypeSystemString ilg mref &&
     mref.Name = "Concat" &&
-    mref.ReturnType.TypeRef.FullName = ilg.typ_String.TypeRef.FullName &&
-    mref.ArgCount >= 2 && mref.ArgCount <= 4 && mref.ArgTypes |> List.forall(fun ilty -> ilty.TypeRef.FullName = ilg.typ_String.TypeRef.FullName)
+    mref.ReturnType.BasicQualifiedName = ilg.typ_String.BasicQualifiedName &&
+    mref.ArgCount >= 2 && mref.ArgCount <= 4 && mref.ArgTypes |> List.forall(fun ilty -> ilty.BasicQualifiedName = ilg.typ_String.BasicQualifiedName)
 
 let IsILMethodRefSystemStringConcatArray (ilg: ILGlobals) (mref: ILMethodRef) =
     IsILMethodRefDeclaringTypeSystemString ilg mref &&
     mref.Name = "Concat" &&
-    mref.ReturnType.TypeRef.FullName = ilg.typ_String.TypeRef.FullName &&
-    mref.ArgCount = 1 && mref.ArgTypes.Head.TypeRef.FullName = "System.String[]"
+    mref.ReturnType.BasicQualifiedName = ilg.typ_String.BasicQualifiedName &&
+    mref.ArgCount = 1 && mref.ArgTypes.Head.BasicQualifiedName = "System.String[]"
     
 //-------------------------------------------------------------------------
 // The traversal

--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -1763,16 +1763,23 @@ let TryDetectQueryQuoteAndRun cenv (expr:Expr) =
     | _ -> 
         //printfn "Not eliminating because no Run found"
         None
-                
-let IsSystemStringConcatOverload (methRef: ILMethodRef) =
-    methRef.Name = "Concat" && methRef.DeclaringTypeRef.FullName = "System.String" && 
-    methRef.ReturnType.BasicQualifiedName = "System.String" &&
-    methRef.ArgTypes |> List.forall(fun ilty -> ilty.BasicQualifiedName = "System.String")
 
-let IsSystemStringConcatArray (methRef: ILMethodRef) =
-    methRef.Name = "Concat" && methRef.DeclaringTypeRef.FullName = "System.String" && 
-    methRef.ReturnType.BasicQualifiedName = "System.String" &&
-    methRef.ArgTypes.Length = 1 && methRef.ArgTypes.Head.BasicQualifiedName = "System.String[]"
+let IsILMethodRefDeclaringTypeSystemString (ilg: ILGlobals) (mref: ILMethodRef) =
+    mref.DeclaringTypeRef.Scope.IsAssemblyRef &&
+    mref.DeclaringTypeRef.Scope.AssemblyRef.Name = ilg.typ_String.TypeRef.Scope.AssemblyRef.Name &&
+    mref.DeclaringTypeRef.FullName = ilg.typ_String.TypeRef.FullName
+                
+let IsILMethodRefSystemStringConcatOverload (ilg: ILGlobals) (mref: ILMethodRef) =
+    IsILMethodRefDeclaringTypeSystemString ilg mref &&
+    mref.Name = "Concat" &&
+    mref.ReturnType.TypeRef.FullName = ilg.typ_String.TypeRef.FullName &&
+    mref.ArgCount >= 2 && mref.ArgCount <= 4 && mref.ArgTypes |> List.forall(fun ilty -> ilty.TypeRef.FullName = ilg.typ_String.TypeRef.FullName)
+
+let IsILMethodRefSystemStringConcatArray (ilg: ILGlobals) (mref: ILMethodRef) =
+    IsILMethodRefDeclaringTypeSystemString ilg mref &&
+    mref.Name = "Concat" &&
+    mref.ReturnType.TypeRef.FullName = ilg.typ_String.TypeRef.FullName &&
+    mref.ArgCount = 1 && mref.ArgTypes.Head.TypeRef.FullName = "System.String[]"
     
 //-------------------------------------------------------------------------
 // The traversal
@@ -1887,10 +1894,10 @@ and OptimizeInterfaceImpl cenv env baseValOpt (ty, overrides) =
 and MakeOptimizedSystemStringConcatCall cenv env m args =
     let rec optimizeArg e accArgs =
         match e, accArgs with
-        | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, methRef, _, _, _), _, [ Expr.Op(TOp.Array, _, args, _) ], _), _ when IsSystemStringConcatArray methRef ->
+        | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, [ Expr.Op(TOp.Array, _, args, _) ], _), _ when IsILMethodRefSystemStringConcatArray cenv.g.ilg mref ->
             optimizeArgs args accArgs
 
-        | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, methRef, _, _, _), _, args, _), _ when IsSystemStringConcatOverload methRef ->
+        | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, args, _), _ when IsILMethodRefSystemStringConcatOverload cenv.g.ilg mref ->
             optimizeArgs args accArgs
 
         // Optimize string constants, e.g. "1" + "2" will turn into "12"
@@ -1920,7 +1927,7 @@ and MakeOptimizedSystemStringConcatCall cenv env m args =
             mkStaticCall_String_Concat_Array cenv.g m arg
 
     match e with
-    | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, methRef, _, _, _) as op, tyargs, args, m) when IsSystemStringConcatOverload methRef || IsSystemStringConcatArray methRef ->
+    | Expr.Op(TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _) as op, tyargs, args, m) when IsILMethodRefSystemStringConcatOverload cenv.g.ilg mref || IsILMethodRefSystemStringConcatArray cenv.g.ilg mref ->
         OptimizeExprOpReductions cenv env (op, tyargs, args, m)
     | _ ->
         OptimizeExpr cenv env e
@@ -1993,9 +2000,9 @@ and OptimizeExprOp cenv env (op, tyargs, args, m) =
     | TOp.ILAsm([], [ty]), _, [a] when typeEquiv cenv.g (tyOfExpr cenv.g a) ty -> OptimizeExpr cenv env a
 
     // Optimize calls when concatenating strings, e.g. "1" + "2" + "3" + "4" .. etc.
-    | TOp.ILCall(_, _, _, _, _, _, _, methRef, _, _, _), _, [ Expr.Op(TOp.Array, _, args, _) ] when IsSystemStringConcatArray methRef ->
+    | TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, [ Expr.Op(TOp.Array, _, args, _) ] when IsILMethodRefSystemStringConcatArray cenv.g.ilg mref ->
         MakeOptimizedSystemStringConcatCall cenv env m args
-    | TOp.ILCall(_, _, _, _, _, _, _, methRef, _, _, _), _, args when IsSystemStringConcatOverload methRef ->
+    | TOp.ILCall(_, _, _, _, _, _, _, mref, _, _, _), _, args when IsILMethodRefSystemStringConcatOverload cenv.g.ilg mref ->
         MakeOptimizedSystemStringConcatCall cenv env m args
 
     | _ -> 


### PR DESCRIPTION
This doesn't fix a reported issue, but since I've been looking types defined in `il.fs`, I thought about the `String.Concat` optimization I did. I realized I need to check the assembly of where the type came from as well. The reason is so that if someone uses a custom assembly that has `System.String` defined in the same namespace, we do not try to optimize it. We only want to optimize `System.String` from mscorlib or System.Runtime. Luckily, `ILGlobals` has this information.