### PR TITLE
Use hashes for language service cache keys

### DIFF
--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -2629,7 +2629,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
 
                     match incrementalBuildersCache.TryGetAny (ctok, options) with
                     | Some (Some builder, creationErrors, _) ->
-                        match bc.GetCachedCheckFileResult(builder, filename, sourceText.GetHashCode(), options) with
+                        match bc.GetCachedCheckFileResult(builder, filename, sourceText, options) with
                         | Some (_, checkResults) -> return Some (builder, creationErrors, Some (FSharpCheckFileAnswer.Succeeded checkResults))
                         | _ -> return Some (builder, creationErrors, None)
                     | _ -> return None // the builder wasn't ready
@@ -2669,7 +2669,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                 | None -> return FSharpCheckFileAnswer.Succeeded (MakeCheckFileResultsEmpty(filename, creationErrors))
                 | Some builder -> 
                     // Check the cache. We can only use cached results when there is no work to do to bring the background builder up-to-date
-                    let cachedResults = bc.GetCachedCheckFileResult(builder, filename, sourceText.GetHashCode(), options)
+                    let cachedResults = bc.GetCachedCheckFileResult(builder, filename, sourceText, options)
 
                     match cachedResults with
                     | Some (_, checkResults) -> return FSharpCheckFileAnswer.Succeeded checkResults
@@ -2706,7 +2706,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
                     return (parseResults, FSharpCheckFileAnswer.Aborted)
 
                 | Some builder -> 
-                    let cachedResults = bc.GetCachedCheckFileResult(builder, filename, sourceText.GetHashCode(), options)
+                    let cachedResults = bc.GetCachedCheckFileResult(builder, filename, sourceText, options)
 
                     match cachedResults with 
                     | Some (parseResults, checkResults) -> 

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -27,8 +27,6 @@ type ISourceText =
 
     abstract CopyTo : sourceIndex: int * destination: char [] * destinationIndex: int * count: int -> unit
 
-    abstract GetHashCode : unit -> int
-
 [<Sealed>]
 type StringText(str: string) =
 
@@ -97,8 +95,6 @@ type StringText(str: string) =
 
         member __.CopyTo(sourceIndex, destination, destinationIndex, count) =
             str.CopyTo(sourceIndex, destination, destinationIndex, count)
-
-        member this.GetHashCode() = this.GetHashCode()
 
 module SourceText =
 

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -25,7 +25,7 @@ type ISourceText =
 
     abstract ContentEquals : sourceText: ISourceText -> bool
 
-    abstract CopyTo : sourceIndex: int * destination: char [] * destinationIndex: int * count: int -> unit  
+    abstract CopyTo : sourceIndex: int * destination: char [] * destinationIndex: int * count: int -> unit
 
     abstract GetHashCode : unit -> int
 
@@ -52,6 +52,9 @@ type StringText(str: string) =
         lazy getLines str
 
     member __.String = str
+    
+    override __.GetHashCode() = str.GetHashCode()
+    override __.Equals(obj: obj) = str.Equals(obj)
 
     interface ISourceText with
     
@@ -95,7 +98,7 @@ type StringText(str: string) =
         member __.CopyTo(sourceIndex, destination, destinationIndex, count) =
             str.CopyTo(sourceIndex, destination, destinationIndex, count)
 
-        member __.GetHashCode() = str.GetHashCode()
+        member this.GetHashCode() = this.GetHashCode()
 
 module SourceText =
 

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -27,6 +27,8 @@ type ISourceText =
 
     abstract CopyTo : sourceIndex: int * destination: char [] * destinationIndex: int * count: int -> unit  
 
+    abstract GetHashCode : unit -> int
+
 [<Sealed>]
 type StringText(str: string) =
 
@@ -92,6 +94,8 @@ type StringText(str: string) =
 
         member __.CopyTo(sourceIndex, destination, destinationIndex, count) =
             str.CopyTo(sourceIndex, destination, destinationIndex, count)
+
+        member __.GetHashCode() = str.GetHashCode()
 
 module SourceText =
 

--- a/src/utils/prim-lexing.fsi
+++ b/src/utils/prim-lexing.fsi
@@ -25,8 +25,6 @@ type ISourceText =
 
     abstract CopyTo : sourceIndex: int * destination: char [] * destinationIndex: int * count: int -> unit
 
-    abstract GetHashCode : unit -> int
-
 module SourceText =
 
     val ofString : string -> ISourceText

--- a/src/utils/prim-lexing.fsi
+++ b/src/utils/prim-lexing.fsi
@@ -23,7 +23,9 @@ type ISourceText =
 
     abstract ContentEquals : sourceText: ISourceText -> bool
 
-    abstract CopyTo : sourceIndex: int * destination: char [] * destinationIndex: int * count: int -> unit  
+    abstract CopyTo : sourceIndex: int * destination: char [] * destinationIndex: int * count: int -> unit
+
+    abstract GetHashCode : unit -> int
 
 module SourceText =
 

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -61,7 +61,6 @@ module private SourceText =
         let sourceText =
             { 
                 new Object() with
-                    member __.ToString() = sourceText.ToString()
                     override __.GetHashCode() =
                         let checksum = sourceText.GetChecksum()
                         let contentsHash = if not checksum.IsDefault then Hash.combineValues checksum else 0

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -59,67 +59,70 @@ module private SourceText =
 
     let create (sourceText: SourceText) =
         let sourceText =
-            { new ISourceText with
+            { 
+                new Object() with
+                    member __.ToString() = sourceText.ToString()
+                    override __.GetHashCode() =
+                        let checksum = sourceText.GetChecksum()
+                        let contentsHash = if not checksum.IsDefault then Hash.combineValues checksum else 0
+                        let encodingHash = if not (isNull sourceText.Encoding) then sourceText.Encoding.GetHashCode() else 0
+
+                        sourceText.ChecksumAlgorithm.GetHashCode()
+                        |> Hash.combine encodingHash
+                        |> Hash.combine contentsHash
+                        |> Hash.combine sourceText.Length
+
+                interface ISourceText with
             
-                member __.Item with get index = sourceText.[index]
+                    member __.Item with get index = sourceText.[index]
 
-                member __.GetLineString(lineIndex) =
-                    sourceText.Lines.[lineIndex].ToString()
+                    member __.GetLineString(lineIndex) =
+                        sourceText.Lines.[lineIndex].ToString()
 
-                member __.GetLineCount() =
-                    sourceText.Lines.Count
+                    member __.GetLineCount() =
+                        sourceText.Lines.Count
 
-                member __.GetLastCharacterPosition() =
-                    if sourceText.Lines.Count > 0 then
-                        (sourceText.Lines.Count, sourceText.Lines.[sourceText.Lines.Count - 1].Span.Length)
-                    else
-                        (0, 0)
-
-                member __.GetSubTextString(start, length) =
-                    sourceText.GetSubText(TextSpan(start, length)).ToString()
-
-                member __.SubTextEquals(target, startIndex) =
-                    if startIndex < 0 || startIndex >= sourceText.Length then
-                        invalidArg "startIndex" "Out of range."
-
-                    if String.IsNullOrEmpty(target) then
-                        invalidArg "target" "Is null or empty."
-
-                    let lastIndex = startIndex + target.Length
-                    if lastIndex <= startIndex || lastIndex >= sourceText.Length then
-                        invalidArg "target" "Too big."
-
-                    let mutable finished = false
-                    let mutable didEqual = true
-                    let mutable i = 0
-                    while not finished && i < target.Length do
-                        if target.[i] <> sourceText.[startIndex + i] then
-                            didEqual <- false
-                            finished <- true // bail out early                        
+                    member __.GetLastCharacterPosition() =
+                        if sourceText.Lines.Count > 0 then
+                            (sourceText.Lines.Count, sourceText.Lines.[sourceText.Lines.Count - 1].Span.Length)
                         else
-                            i <- i + 1
+                            (0, 0)
 
-                    didEqual
+                    member __.GetSubTextString(start, length) =
+                        sourceText.GetSubText(TextSpan(start, length)).ToString()
 
-                member __.ContentEquals(sourceText) =
-                    match sourceText with
-                    | :? SourceText as sourceText -> sourceText.ContentEquals(sourceText)
-                    | _ -> false
+                    member __.SubTextEquals(target, startIndex) =
+                        if startIndex < 0 || startIndex >= sourceText.Length then
+                            invalidArg "startIndex" "Out of range."
 
-                member __.Length = sourceText.Length
+                        if String.IsNullOrEmpty(target) then
+                            invalidArg "target" "Is null or empty."
 
-                member __.CopyTo(sourceIndex, destination, destinationIndex, count) =
-                    sourceText.CopyTo(sourceIndex, destination, destinationIndex, count)
+                        let lastIndex = startIndex + target.Length
+                        if lastIndex <= startIndex || lastIndex >= sourceText.Length then
+                            invalidArg "target" "Too big."
 
-                member __.GetHashCode() =
-                    let checksum = sourceText.GetChecksum()
-                    let contentsHash = if not checksum.IsDefault then Hash.combineValues checksum else 0
-                    let encodingHash = if not (isNull sourceText.Encoding) then sourceText.Encoding.GetHashCode() else 0
+                        let mutable finished = false
+                        let mutable didEqual = true
+                        let mutable i = 0
+                        while not finished && i < target.Length do
+                            if target.[i] <> sourceText.[startIndex + i] then
+                                didEqual <- false
+                                finished <- true // bail out early                        
+                            else
+                                i <- i + 1
 
-                    sourceText.ChecksumAlgorithm.GetHashCode()
-                    |> Hash.combine encodingHash
-                    |> Hash.combine contentsHash
-                    |> Hash.combine sourceText.Length
+                        didEqual
+
+                    member __.ContentEquals(sourceText) =
+                        match sourceText with
+                        | :? SourceText as sourceText -> sourceText.ContentEquals(sourceText)
+                        | _ -> false
+
+                    member __.Length = sourceText.Length
+
+                    member __.CopyTo(sourceIndex, destination, destinationIndex, count) =
+                        sourceText.CopyTo(sourceIndex, destination, destinationIndex, count)
             }
 
         sourceText


### PR DESCRIPTION
Fixes #6028 and is an evolved version of #5944

In #6001 we replaced strings with `ISourceText` in the language service, reducing huge amounts of allocations in VS. However, it did not address the issue that our language service caches still use the full text of source as keys. This PR continues what #5944 does, except it uses the same hashing algorithm that Roslyn uses for the actual Roslyn `SourceText` type.