### PR TITLE
Update map.fs

### DIFF
--- a/src/fsharp/FSharp.Core/map.fs
+++ b/src/fsharp/FSharp.Core/map.fs
@@ -558,7 +558,7 @@ namespace Microsoft.FSharp.Collections
             for (KeyValue(x,y)) in this do
                 res <- combineHash res (hash x)
                 res <- combineHash res (Unchecked.hash y)
-            abs res
+            res
 
         override this.Equals(that) = 
             match that with 


### PR DESCRIPTION
Fixes #6068, where you could cause a `System.OverFlowException` by using a key and value that leads to calling `abs` on `Int32.MinValue`. This is invalid on .NET. The fix is to not call `abs`, since there's really no reason to make a hash code always positive.