### PR TITLE
 Fixed internal error on struct tuple with struct constraint

### DIFF
--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1885,8 +1885,8 @@ and SolveTypeIsNonNullableValueType (csenv:ConstraintSolverEnv) ndeep m2 trace t
             return! AddConstraint csenv ndeep m2 trace destTypar (TyparConstraint.IsNonNullableStruct m)
         | _ ->
             let underlyingTy = stripTyEqnsAndMeasureEqns g ty
-            if isStructTy g underlyingTy && isAppTy g underlyingTy then
-                if tyconRefEq g g.system_Nullable_tcref (tcrefOfAppTy g underlyingTy) then
+            if isStructTy g underlyingTy then
+                if isAppTy g underlyingTy && tyconRefEq g g.system_Nullable_tcref (tcrefOfAppTy g underlyingTy) then
                     return! ErrorD (ConstraintSolverError(FSComp.SR.csTypeParameterCannotBeNullable(), m, m))
             else
                 return! ErrorD (ConstraintSolverError(FSComp.SR.csGenericConstructRequiresStructType(NicePrint.minimalStringOfType denv ty), m, m2))

--- a/src/fsharp/ConstraintSolver.fs
+++ b/src/fsharp/ConstraintSolver.fs
@@ -1885,7 +1885,7 @@ and SolveTypeIsNonNullableValueType (csenv:ConstraintSolverEnv) ndeep m2 trace t
             return! AddConstraint csenv ndeep m2 trace destTypar (TyparConstraint.IsNonNullableStruct m)
         | _ ->
             let underlyingTy = stripTyEqnsAndMeasureEqns g ty
-            if isStructTy g underlyingTy then
+            if isStructTy g underlyingTy && isAppTy g underlyingTy then
                 if tyconRefEq g g.system_Nullable_tcref (tcrefOfAppTy g underlyingTy) then
                     return! ErrorD (ConstraintSolverError(FSComp.SR.csTypeParameterCannotBeNullable(), m, m))
             else

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1986,6 +1986,12 @@ module TypecheckTests =
         peverify cfg "pos31.exe"
 
     [<Test>]
+    let ``sigs pos32`` () = 
+        let cfg = testConfig "typecheck/sigs"
+        fsc cfg "%s --target:exe -o:pos32.exe --warnaserror" cfg.fsc_flags ["pos32.fs"]
+        peverify cfg "pos32.exe"
+
+    [<Test>]
     let ``sigs pos23`` () = 
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos23.exe" cfg.fsc_flags ["pos23.fs"]

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2471,6 +2471,9 @@ module TypecheckTests =
     let ``type check neg114`` () = singleNegTest (testConfig "typecheck/sigs") "neg114"
 
     [<Test>] 
+    let ``type check neg115`` () = singleNegTest (testConfig "typecheck/sigs") "neg115"
+
+    [<Test>] 
     let ``type check neg_anon_1`` () = singleNegTest (testConfig "typecheck/sigs") "neg_anon_1"
 
     [<Test>] 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -1988,8 +1988,8 @@ module TypecheckTests =
     [<Test>]
     let ``sigs pos32`` () = 
         let cfg = testConfig "typecheck/sigs"
-        fsc cfg "%s --target:exe -o:pos32.exe --warnaserror" cfg.fsc_flags ["pos32.fs"]
-        peverify cfg "pos32.exe"
+        fsc cfg "%s --target:library -o:pos32.dll --warnaserror" cfg.fsc_flags ["pos32.fs"]
+        peverify cfg "pos32.dll"
 
     [<Test>]
     let ``sigs pos23`` () = 

--- a/tests/fsharp/typecheck/sigs/neg115.bsl
+++ b/tests/fsharp/typecheck/sigs/neg115.bsl
@@ -1,2 +1,2 @@
 
-neg115.fs(8,30,8,34): typecheck error FS0001: A generic construct requires that the type 'struct ('a * 'b)' is a CLI or F# struct type
+neg115.fs(8,30,8,34): typecheck error FS0001: Expecting a type supporting the operator 'get_Item1' but given a tuple type

--- a/tests/fsharp/typecheck/sigs/neg115.bsl
+++ b/tests/fsharp/typecheck/sigs/neg115.bsl
@@ -1,0 +1,2 @@
+
+neg115.fs(8,30,8,34): typecheck error FS0001: A generic construct requires that the type 'struct ('a * 'b)' is a CLI or F# struct type

--- a/tests/fsharp/typecheck/sigs/neg115.fs
+++ b/tests/fsharp/typecheck/sigs/neg115.fs
@@ -1,0 +1,9 @@
+
+module M
+
+    let inline test (arg: ^T when ^T : struct) = 
+        (^T : (member Item1: _) (arg))
+
+    let f () =
+        let a = test struct (1, 2)
+        ()

--- a/tests/fsharp/typecheck/sigs/pos32.fs
+++ b/tests/fsharp/typecheck/sigs/pos32.fs
@@ -1,0 +1,9 @@
+module Pos32
+
+    let inline test (arg: ^T when ^T : struct) = 
+        ()
+
+    let f () =
+        let a = test struct (1, 2)
+        ()
+    


### PR DESCRIPTION
Fixes this: https://github.com/Microsoft/visualfsharp/issues/6062

The reason was because the check on `isStructTy` assumed it would only pass on app types, then try to immediately deref the app type. Recently, we added a check for struct tuples in `isStructTy`, so that assumption does not hold anymore as struct tuples are not app types; therefore, we get an internal error.

However, before we made the change inside of `isStructTy`, the code in `SolveTypeIsNonNullableValueType` was still incorrect. It meant a struct tuple would fail on a struct constraint in general. This PR should also fix that, meaning this code will now compile:

```fsharp
let inline test (arg: ^T when ^T : struct) = 
    ()

let f () =
    let a = test struct (1, 2)
    ()
```