### PR TITLE
Build a compiler dll with out a prerelease tag

### DIFF
--- a/build-nuget-packages.proj
+++ b/build-nuget-packages.proj
@@ -3,6 +3,7 @@
 
   <ItemGroup>
     <PackageProjects Include="src\fsharp\FSharp.Compiler.nuget\Microsoft.FSharp.Compiler.csproj" Condition="'$(BUILD_CORECLR)'=='1'" />
+    <PackageProjects Include="src\fsharp\FSharp.Compiler.nuget\Microsoft.FSharp.Compiler.Prerelease.csproj" Condition="'$(BUILD_CORECLR)'=='1'" />
     <PackageProjects Include="src\fsharp\FSharp.Core\FSharp.Core.fsproj" Condition="'$(BUILD_NUGET)'=='1'" />
   </ItemGroup>
 

--- a/build.cmd
+++ b/build.cmd
@@ -162,7 +162,6 @@ if /i "%ARG%" == "net40" (
 
 if /i "%ARG%" == "coreclr" (
     set _autoselect=0
-    set BUILD_PROTO_WITH_CORECLR_LKG=1
     set BUILD_CORECLR=1
     set BUILD_FROMSOURCE=1
 )
@@ -237,7 +236,7 @@ if /i "%ARG%" == "nuget" (
 
     set BUILD_PROTO=1
     set BUILD_NET40_FSHARP_CORE=1
-    set BUILD_PROTO_WITH_CORECLR_LKG=1
+    set BUILD_NET40=1
     set BUILD_CORECLR=1
     set BUILD_NUGET=1
 )

--- a/fsharp.proj
+++ b/fsharp.proj
@@ -11,6 +11,7 @@
     <BuildVS Condition="'$(BuildVS)' == ''">false</BuildVS>
     <BuildFCS Condition="'$(BuildFCS)' == ''">false</BuildFCS>
     <BuildSetup Condition="'$(BuildSetup)' == ''">false</BuildSetup>
+    <BuildNuget Condition="'$(BuildNuget)' == ''">false</BuildNuget>
 
     <TestCompiler Condition="'$(TestCompiler)' == ''">false</TestCompiler>
     <TestFSharpSuite Condition="'$(TestFSharpSuite)' == ''">false</TestFSharpSuite>
@@ -25,6 +26,7 @@
     <BuildCompiler Condition="'$(BUILD_CORECLR)' == '1'">true</BuildCompiler>
     <BuildVS Condition="'$(BUILD_VS)' == '1'">true</BuildVS>
     <BuildFCS Condition="'$(BUILD_FCS)' == '1'">true</BuildFCS>
+    <BuildNuget Condition="'$(BUILD_NUGET)' == '1' or '$(BUILD_SETUP)' == '1'">true</BuildNuget>
     <BuildSetup Condition="'$(BUILD_SETUP)' == '1'">true</BuildSetup>
 
     <TestCompiler Condition="'$(TEST_NET40_COMPILERUNIT_SUITE)' == '1'">true</TestCompiler>
@@ -98,8 +100,12 @@
       <Projects Include="$(MSBuildThisFileDirectory)fcs\FSharp.Compiler.Service.ProjectCrackerTool\FSharp.Compiler.Service.ProjectCrackerTool.fsproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(BuildSetup)' == 'true' OR '$(_RunningRestore)' == 'true'">
+    <ItemGroup Condition="'$(BuildNuget)' == 'true' OR '$(_RunningRestore)' == 'true'">
       <NugetProjects Include="$(MSBuildThisFileDirectory)src\fsharp\FSharp.Compiler.nuget\Microsoft.FSharp.Compiler.csproj" />
+      <NugetProjects Include="$(MSBuildThisFileDirectory)src\fsharp\FSharp.Compiler.nuget\Microsoft.FSharp.Compiler.Prerelease.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(BuildSetup)' == 'true' OR '$(_RunningRestore)' == 'true'">
       <Projects Include="$(MSBuildThisFileDirectory)setup\fsharp-setup-build.csproj" />
     </ItemGroup>
 

--- a/src/fsharp/FSharp.Compiler.nuget/Directory.Build.props
+++ b/src/fsharp/FSharp.Compiler.nuget/Directory.Build.props
@@ -6,8 +6,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <NuspecFile>Microsoft.FSharp.Compiler.nuspec</NuspecFile>
-    <PreReleaseSuffix Condition="'$(PreRelease)' != 'false'">-rtm-$(NuGetPackageVersionSuffix)</PreReleaseSuffix>
-    <PackageVersion>$(FSPackageVersion)$(PreReleaseSuffix)</PackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/fsharp/FSharp.Compiler.nuget/Directory.Build.targets
+++ b/src/fsharp/FSharp.Compiler.nuget/Directory.Build.targets
@@ -1,5 +1,10 @@
 <Project>
 
+  <PropertyGroup>
+    <PreReleaseSuffix Condition="'$(PreRelease)' != 'false'">-rtm-$(NuGetPackageVersionSuffix)</PreReleaseSuffix>
+    <PackageVersion>$(FSPackageVersion)$(PreReleaseSuffix)</PackageVersion>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Nuget.targets" />
 

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.Prerelease.csproj
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.Prerelease.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Testing.FSharp.Compiler</PackageId>
+    <PackageId>Microsoft.FSharp.Compiler</PackageId>
     <PreRelease>true</PreRelease>
   </PropertyGroup>
 

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.csproj
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.FSharp.Compiler</PackageId>
+    <PreRelease>false</PreRelease>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Slight tweaks to build cmd.  And add a build for a release version of the Microsoft.FSharp.Compiler package.

