### PR TITLE
Fix build for FsiAnyCPU

### DIFF
--- a/src/fsharp/fsiAnyCpu/fsiAnyCpu.fsproj
+++ b/src/fsharp/fsiAnyCpu/fsiAnyCpu.fsproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="..\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj" />
+    <ProjectReference Include="..\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj" />
     <ProjectReference Include="..\FSharp.Compiler.Server.Shared\FSharp.Compiler.Server.Shared.fsproj" />
   </ItemGroup>
 


### PR DESCRIPTION
FSI anyCPU build does not copy FSharp.Compiler.Interactive.Settings to the build directory.  Causing it to crash when run.

This fixes that.