### PR TITLE
Update F# Banner text for F# 4.6

### DIFF
--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -12,7 +12,7 @@ open System.Runtime.InteropServices
 module internal FSharpEnvironment =
 
     /// The F# version reported in the banner
-    let FSharpBannerVersion = "10.4.0 for F# 4.5"
+    let FSharpBannerVersion = "10.4.0 for F# 4.6"
 
     let versionOf<'t> =
 #if FX_RESHAPED_REFLECTION


### PR DESCRIPTION
This was missed in #5890.

Not critical to get into Preview 2, so we'll just have to file a known issue that the banner text is incorrect.