### PR TITLE
Disallow byref-likes types within anonymous records

### DIFF
--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -352,7 +352,8 @@ let rec CheckTypeDeep (cenv: cenv) ((visitTy,visitTyconRefOpt,visitAppTyOpt,visi
     | TType_anon (anonInfo,tys) -> 
         if not (cenv.anonRecdTypes.ContainsKey anonInfo.Stamp) then 
              cenv.anonRecdTypes <- cenv.anonRecdTypes.Add(anonInfo.Stamp, anonInfo)
-        CheckTypesDeep cenv f g env tys
+
+        CheckTypesDeepNoInner cenv f g env tys
 
     | TType_ucase (_,tinst) -> CheckTypesDeep cenv f g env tinst
     | TType_tuple (_,tys) -> CheckTypesDeep cenv f g env tys


### PR DESCRIPTION
Fixes #6104

Note that it's still a little funky if you declare an anonymous record as the type for an input parameter:

![image](https://user-images.githubusercontent.com/6309070/51346519-b9e5db00-1a52-11e9-9d8e-b5a2994b2b6e.png)

Ideally we'd have the error in the declaration itself, not at the use site.