### PR TITLE
Fixed IVT issue with Roslyn

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -200,7 +200,7 @@ type private FSharpProjectOptionsReactor (workspace: VisualStudioWorkspaceImpl, 
                     |> Seq.map (fun x -> "-r:" + project.Solution.GetProject(x.ProjectId).OutputFilePath)
                     |> Array.ofSeq
                     |> Array.append (
-                            project.MetadataReferences.OfType<VisualStudioMetadataReference.Snapshot>()
+                            project.MetadataReferences.OfType<PortableExecutableReference>()
                             |> Seq.map (fun x -> "-r:" + x.FilePath)
                             |> Array.ofSeq
                             |> Array.append (


### PR DESCRIPTION
The type used has changed and we should have been using `PortableExecutableReference` instead.

@cartermp @Pilchie This should get into preview3 as Roslyn made some changes and broke this specific IVT. // cc @jasonmalinowski 