### PR TITLE
allow UTF-8 code page for test execution

### DIFF
--- a/tests/fsharpqa/Source/CompilerOptions/fsc/codepage/E_DefaultCodePage01.fsx
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/codepage/E_DefaultCodePage01.fsx
@@ -1,4 +1,0 @@
-// #Regression #NoMT #CompilerOptions 
-#load "FunctionalLibrary01.fs";;
-#q;;
-//<Expects status="error" span="(7,10)" id="FS0010">Unexpected character '\?' in type name$</Expects>

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/codepage/env.lst
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/codepage/env.lst
@@ -29,7 +29,6 @@
 	SOURCE=E_RequiresParameter01.fs   TAILFLAGS="--codepage" 	# E_RequiresParameter01.fs
 	SOURCE=E_RequiresParameter01.fs   TAILFLAGS="--codepage"  FSIMODE=EXEC 	# E_RequiresParameter01.fs-fsi
 
-	SOURCE=E_DefaultCodePage01.fsx     COMPILE_ONLY=1   FSIMODE=EXEC	# E_DefaultCodePage01.fsx
 	SOURCE=E_DefaultCodePage02.fsx     COMPILE_ONLY=1   			# E_DefaultCodePage02.fsx
 	SOURCE=MatchingCodePage01.fsx      COMPILE_ONLY=1  SCFLAGS="--codepage:1250" FSIMODE=EXEC	# MatchingCodePage01.fsx
 


### PR DESCRIPTION
This started failing when the internal build machine image changed the default code page from 437 to 65001.  Since this test doesn't test anything F# related that's not covered elsewhere, it's simply getting deleted.