### PR TITLE
Update mono props: support OSX and more .NET Framework versions

### DIFF
--- a/.vsts-pr.yaml
+++ b/.vsts-pr.yaml
@@ -6,10 +6,6 @@ jobs:
   strategy:
     maxParallel: 3
     matrix:
-      # we should be able to build the compiler for .net framework on *nix
-      mono:
-        _command: dotnet
-        _args: build -c release -f net46 src/fsharp/fsc/fsc.fsproj
       dotnet_sdk:
         _command: make
         _args: Configuration=release
@@ -33,10 +29,6 @@ jobs:
   strategy:
     maxParallel: 3
     matrix:
-      # we should be able to build the compiler for .net framework on *nix
-      mono:
-        _command: dotnet
-        _args: build -c release -f net46 src/fsharp/fsc/fsc.fsproj
       dotnet_sdk:
         _command: make
         _args: Configuration=release

--- a/.vsts-pr.yaml
+++ b/.vsts-pr.yaml
@@ -4,12 +4,15 @@ jobs:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 90
   strategy:
-    maxParallel: 2
+    maxParallel: 3
     matrix:
+      # we should be able to build the compiler for .net framework on *nix
+      mono:
+        _command: dotnet
+        _args: build -c release -f net46 src/fsharp/fsc/fsc.fsproj
       dotnet_sdk:
         _command: make
         _args: Configuration=release
-      # disabled until it can be properly fixed
       release_fcs:
         _command: ./fcs/build.sh
         _args: Build
@@ -19,6 +22,33 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults'
       ArtifactName: 'Linux $(_command) $(_args)'
+      publishLocation: Container
+    continueOnError: true
+    condition: failed()
+
+- job: MacOS
+  pool:
+    vmImage: macOS-10.13
+  timeoutInMinutes: 90
+  strategy:
+    maxParallel: 3
+    matrix:
+      # we should be able to build the compiler for .net framework on *nix
+      mono:
+        _command: dotnet
+        _args: build -c release -f net46 src/fsharp/fsc/fsc.fsproj
+      dotnet_sdk:
+        _command: make
+        _args: Configuration=release
+      release_fcs:
+        _command: ./fcs/build.sh
+        _args: Build
+  steps:
+  - script: $(_command) $(_args)
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults'
+      ArtifactName: 'MacOS $(_command) $(_args)'
       publishLocation: Container
     continueOnError: true
     condition: failed()

--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -44,9 +44,19 @@
 
   <!-- mono -->
   <PropertyGroup Condition="'$(OS)' == 'Unix'">
+    <MonoRoot Condition="'$(MonoRoot)' == '' and $([MSBuild]::IsOsPlatform('Linux'))">/usr</MonoRoot>
+    <MonoRoot Condition="'$(MonoRoot)' == '' and $([MSBuild]::IsOsPlatform('OSX'))">/Library/Frameworks/Mono.framework/Versions/Current</MonoRoot>
+    <MonoLibFolder>$(MonoRoot)/lib/mono</MonoLibFolder>
     <MonoPackaging Condition="$(TargetFramework.StartsWith('net4'))">true</MonoPackaging>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net45'">/usr/lib/mono/4.5-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net46'">/usr/lib/mono/4.6-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net45'">$(MonoLibFolder)/4.5-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net451'">$(MonoLibFolder)/4.5.1-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net452'">$(MonoLibFolder)/4.5.2-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net46'">$(MonoLibFolder)/4.6-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net461'">$(MonoLibFolder)/4.6.1-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net462'">$(MonoLibFolder)/4.6.2-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net47'">$(MonoLibFolder)/4.7-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net471'">$(MonoLibFolder)/4.7.1-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net472'">$(MonoLibFolder)/4.7.2-api</FrameworkPathOverride>
   </PropertyGroup>
 
   <!-- signing -->


### PR DESCRIPTION
A potential solve for #6180 that uses msbuild built-ins to determine the target OS and pivots off of that to set the FrameworkPathOverride.  I included a `MonoRoot` property to allow for easy integration into the build process that fsharp/fsharp uses, which allows for a 'floating' mono root.

Testing this locally on my OSX laptop seems to have the intended effect: for all TFMs below I can pivot to the correct -api folders, and supplying a `MonoRoot` via MSBuild parameter influences the search paths as expected.