### PR TITLE
We don't ever set the value FCS_RETAIN_BACKGROUND_PARSE_RESULTS

### DIFF
--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1534,12 +1534,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     let stampedFileNamesNode        = Vector.Stamp "SourceFileTimeStamps" StampFileNameTask fileNamesNode
     let stampedReferencedAssembliesNode = Vector.Stamp "StampReferencedAssembly" StampReferencedAssemblyTask referencedAssembliesNode
     let initialTcAccNode            = Vector.Demultiplex "CombineImportedAssemblies" CombineImportedAssembliesTask stampedReferencedAssembliesNode
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    let parseTreesNode              = Vector.Map "ParseTrees" ParseTask stampedFileNamesNode
-    let tcStatesNode                = Vector.ScanLeft "TypeCheckingStates" TypeCheckTask initialTcAccNode stampedFileNamesNode
-#else
     let tcStatesNode                = Vector.ScanLeft "TypeCheckingStates" (fun ctok tcAcc n -> TypeCheckTask ctok tcAcc (ParseTask ctok n)) initialTcAccNode stampedFileNamesNode
-#endif
     let finalizedTypeCheckNode      = Vector.Demultiplex "FinalizeTypeCheck" FinalizeTypeCheckTask tcStatesNode
 
     // Outputs
@@ -1547,9 +1542,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
 
     do buildDescription.DeclareVectorOutput stampedFileNamesNode
     do buildDescription.DeclareVectorOutput stampedReferencedAssembliesNode
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    do buildDescription.DeclareVectorOutput parseTreesNode
-#endif
     do buildDescription.DeclareVectorOutput tcStatesNode
     do buildDescription.DeclareScalarOutput initialTcAccNode
     do buildDescription.DeclareScalarOutput finalizedTypeCheckNode
@@ -1712,15 +1704,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     member builder.GetParseResultsForFile (ctok: CompilationThreadToken, filename) =
       cancellable {
         let slotOfFile = builder.GetSlotOfFileName filename
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-        match GetVectorResultBySlot(parseTreesNode, slotOfFile, partialBuild) with
-        | Some (results, _) -> return results
-        | None -> 
-            let! build = IncrementalBuild.EvalUpTo ctok SavePartialBuild (parseTreesNode, slotOfFile) partialBuild  
-            match GetVectorResultBySlot(parseTreesNode, slotOfFile, build) with
-            | Some (results, _) -> return results
-            | None -> return! failwith "Build was not evaluated, expected the results to be ready after 'Eval' (GetParseResultsForFile)."
-#else
         let! results = 
           cancellable {
             match GetVectorResultBySlot(stampedFileNamesNode, slotOfFile, partialBuild) with
@@ -1734,7 +1717,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
           }
         // re-parse on demand instead of retaining
         return ParseTask ctok results
-#endif
       }
 
     member __.SourceFiles  = sourceFiles  |> List.map (fun (_, f, _) -> f)

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5179,11 +5179,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     backgroundCheckCount.Value |> shouldEqual 0
     let checkResults1 = checker.CheckFileInProject(parseResults1, ProjectBig.fileNames.[5], 0, ProjectBig.fileSources2.[5], ProjectBig.options)  |> Async.RunSynchronously
     let pD, tD = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    backgroundParseCount.Value |> shouldEqual 10
-#else
     backgroundParseCount.Value |> shouldEqual 5
-#endif
     backgroundCheckCount.Value |> shouldEqual 5
     (pD - pC) |> shouldEqual 0
     (tD - tC) |> shouldEqual 1
@@ -5192,11 +5188,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     let pE, tE = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
     (pE - pD) |> shouldEqual 0
     (tE - tD) |> shouldEqual 1
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    backgroundParseCount.Value |> shouldEqual 10 // but note, the project does not get reparsed
-#else
     (backgroundParseCount.Value <= 8) |> shouldEqual true // but note, the project does not get reparsed
-#endif
     (backgroundCheckCount.Value <= 8) |> shouldEqual true // only two extra typechecks of files
 
     // A subsequent ParseAndCheck of identical source code doesn't do any more anything
@@ -5204,11 +5196,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     let pF, tF = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
     (pF - pE) |> shouldEqual 0  // note, no new parse of the file
     (tF - tE) |> shouldEqual 0  // note, no new typecheck of the file
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    backgroundParseCount.Value |> shouldEqual 10 // but note, the project does not get reparsed
-#else
     (backgroundParseCount.Value <= 8) |> shouldEqual true // but note, the project does not get reparsed
-#endif
     (backgroundCheckCount.Value <= 8) |> shouldEqual true // only two extra typechecks of files
 
     ()

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
@@ -4260,12 +4260,8 @@ let x = query { for bbbb in abbbbc(*D0*) do
         ReplaceFileInMemory file2 [""]
         SaveFileToDisk file2      
         TakeCoffeeBreak(this.VS)
-        
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-        gpatcc.AssertExactly(notAA[file2], notAA[file2;file3])
-#else
+
         gpatcc.AssertExactly(notAA[file2; file3], notAA[file2;file3])
-#endif
 
     /// FEATURE: References added to the project bring corresponding new .NET and F# items into scope.
     [<Test;Category("ReproX")>]


### PR DESCRIPTION
Removing dead test code