### PR TITLE
Re-enable end-2-end tests in build ci_part3

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -285,6 +285,7 @@ if /i "%ARG%" == "ci_part3" (
     set BUILD_NET40=1
     set TEST_CORECLR_FSHARP_SUITE=1
     set TEST_CORECLR_COREUNIT_SUITE=1
+    set TEST_END_2_END=1
     set CI=1
 )
 

--- a/tests/EndToEndBuildTests/BasicProvider/TestBasicProvider.cmd
+++ b/tests/EndToEndBuildTests/BasicProvider/TestBasicProvider.cmd
@@ -18,16 +18,16 @@ rem
 if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\BasicProvider /s /q
 taskkill /F /IM dotnet.exe
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40 -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
 rem
@@ -35,17 +35,18 @@ rem Build typeprovider package with coreclr compiler
 rem Test it with both desktop and coreclr compilers
 rem
 if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\BasicProvider /s /q
+taskkill /F /IM dotnet.exe
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack BasicProvider\BasicProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
+@echo%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test BasicProvider.Tests\BasicProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
 :success

--- a/tests/EndToEndBuildTests/ComboProvider/TestComboProvider.cmd
+++ b/tests/EndToEndBuildTests/ComboProvider/TestComboProvider.cmd
@@ -17,16 +17,16 @@ rem
 if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\ComboProvider /s /q
 taskkill /F /IM dotnet.exe
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40 -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=net40
 @if ERRORLEVEL 1 echo Error: ComboProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
 @if ERRORLEVEL 1 echo Error: ComboProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr
 @if ERRORLEVEL 1 echo Error: ComboProviderProvider failed  && goto :failure
 
 rem
@@ -34,17 +34,18 @@ rem Build typeprovider package with coreclr compiler
 rem Test it with both desktop and coreclr compilers
 rem
 if not '%NUGET_PACKAGES%' == '' rd %NUGET_PACKAGES%\ComboProvider /s /q
+taskkill /F /IM dotnet.exe
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe pack ComboProvider\ComboProvider\ComboProvider.fsproj -o %~dp0artifacts -c release -v minimal -p:FSharpTestCompilerVersion=coreclr
 @if ERRORLEVEL 1 echo Error: ComboProviderProvider failed  && goto :failure
 
-@echo%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40 -nr=false
+@echo%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=net461 -p:FSharpTestCompilerVersion=net40
 @if ERRORLEVEL 1 echo Error: TestBasicProvider failed  && goto :failure
 
-@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
-%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr -nr=false
+@echo %__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr
+%__scriptpath%..\..\..\artifacts\toolset\dotnet\dotnet.exe test ComboProvider\ComboProvider.Tests\ComboProvider.Tests.fsproj -c release -v minimal -p:TestTargetFramework=netcoreapp2.0 -p:FSharpTestCompilerVersion=coreclr
 @if ERRORLEVEL 1 echo Error: ComboProvider failed  && goto :failure
 
 :success


### PR DESCRIPTION
The TypeProvider end-2-end tests weren't running and were broken.

Fixes them and runs them as part of ci_part3.