### PR TITLE
Make .NET Desktop fsi.exe 32-bit again and make fsiAnyCpu.exe (64-bit) the default to launch in VS

### DIFF
--- a/build/config/AssemblySignToolData.json
+++ b/build/config/AssemblySignToolData.json
@@ -49,8 +49,7 @@
       "certificate": "NuGet",
       "strongName": null,
       "values": [
-        "artifacts\\*.nupkg",
-        "artifacts\\*\\*.nupkg"
+        "packages\\*\\*.nupkg"
       ]
     }
   ],

--- a/fsharp.proj
+++ b/fsharp.proj
@@ -28,7 +28,6 @@
     <BuildFCS Condition="'$(BUILD_FCS)' == '1'">true</BuildFCS>
     <BuildNuget Condition="'$(BUILD_NUGET)' == '1' or '$(BUILD_SETUP)' == '1'">true</BuildNuget>
     <BuildSetup Condition="'$(BUILD_SETUP)' == '1'">true</BuildSetup>
-    <BuildNuget Condition="'$(BUILD_NUGET)' == '1'">true</BuildNuget>
 
     <TestCompiler Condition="'$(TEST_NET40_COMPILERUNIT_SUITE)' == '1'">true</TestCompiler>
     <TestCompiler Condition="'$(TEST_CORECLR_COREUNIT_SUITE)' == '1'">true</TestCompiler>
@@ -91,10 +90,10 @@
       <Projects Include="$(MSBuildThisFileDirectory)vsintegration\Utils\LanguageServiceProfiling\LanguageServiceProfiling.fsproj" />
       <Projects Include="$(MSBuildThisFileDirectory)vsintegration\fsharp-vsintegration-item-templates-build.proj" />
       <Projects Include="$(MSBuildThisFileDirectory)vsintegration\fsharp-vsintegration-project-templates-build.proj" />
-      <Projects Include="$(MSBuildThisFileDirectory)vsintegration\fsharp-vsintegration-vsix-build.proj" />
+      <VsixProjects Include="$(MSBuildThisFileDirectory)vsintegration\fsharp-vsintegration-vsix-build.proj" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(BuildCompiler)' == 'true' OR '$(BuildNuget)' == 'true' OR '$(BuildVS)' == 'true' OR'$(_RunningRestore)' == 'true'">
+    <ItemGroup Condition="'$(BuildCompiler)' == 'true' OR '$(BuildNuget)' == 'true' OR '$(BuildVS)' == 'true' OR '$(_RunningRestore)' == 'true'">
       <NugetProjects Include="src\fsharp\FSharp.Core\FSharp.Core.fsproj" />
     </ItemGroup>
 
@@ -111,7 +110,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(BuildSetup)' == 'true' OR '$(_RunningRestore)' == 'true'">
-      <Projects Include="$(MSBuildThisFileDirectory)setup\fsharp-setup-build.csproj" />
+      <SetupProjects Include="$(MSBuildThisFileDirectory)setup\fsharp-setup-build.csproj" />
     </ItemGroup>
 
     <!-- test binaries -->
@@ -155,21 +154,25 @@
   </Target>
 
   <Target Name="Build" DependsOnTargets="CollectProjects">
-    <!-- Nuget projects need to be built before the vsix stuff, so that the vsix build -->
+    <MSBuild Projects="@(NugetProjects);@(Projects)" Targets="Build" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
     <MSBuild Projects="@(NugetProjects)" Targets="Pack" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
-    <MSBuild Projects="@(Projects);@(NugetProjects)" Targets="Build" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
+    <MSBuild Projects="@(VsixProjects)" Targets="Build" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
+    <MSBuild Projects="@(SetupProjects)" Targets="Build" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
   </Target>
 
   <Target Name="Rebuild" DependsOnTargets="CollectProjects">
-    <MSBuild Projects="@(Projects);@(NugetProjects)" Targets="Rebuild" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
+    <MSBuild Projects="@(NugetProjects);@(Projects)" Targets="Rebuild" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
+    <MSBuild Projects="@(NugetProjects)" Targets="Pack" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
+    <MSBuild Projects="@(VsixProjects)" Targets="Rebuild" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
+    <MSBuild Projects="@(SetupProjects)" Targets="Rebuild" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
   </Target>
 
   <Target Name="Clean" DependsOnTargets="CollectProjects">
-    <MSBuild Projects="@(Projects);@(NugetProjects)" Targets="Clean" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
+    <MSBuild Projects="@(Projects);@(NugetProjects);@(VsixProjects);@(SetupProjects)" Targets="Clean" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
   </Target>
 
   <Target Name="Restore" DependsOnTargets="_BeforeRestore;CollectProjects">
-    <MSBuild Projects="@(Projects);@(NugetProjects)" Targets="Restore" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
+    <MSBuild Projects="@(Projects);@(NugetProjects);@(VsixProjects);@(SetupProjects)" Targets="Restore" Properties="Configuration=$(Configuration);BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);$(CustomProps)" />
   </Target>
 
 </Project>

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PlatformTarget>x86</PlatformTarget>
     <DefineConstants>$(DefineConstants);FSI_SHADOW_COPY_REFERENCES;FSI_SERVER</DefineConstants>
   </PropertyGroup>
 

--- a/src/fsharp/service/IncrementalBuild.fs
+++ b/src/fsharp/service/IncrementalBuild.fs
@@ -1534,12 +1534,7 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     let stampedFileNamesNode        = Vector.Stamp "SourceFileTimeStamps" StampFileNameTask fileNamesNode
     let stampedReferencedAssembliesNode = Vector.Stamp "StampReferencedAssembly" StampReferencedAssemblyTask referencedAssembliesNode
     let initialTcAccNode            = Vector.Demultiplex "CombineImportedAssemblies" CombineImportedAssembliesTask stampedReferencedAssembliesNode
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    let parseTreesNode              = Vector.Map "ParseTrees" ParseTask stampedFileNamesNode
-    let tcStatesNode                = Vector.ScanLeft "TypeCheckingStates" TypeCheckTask initialTcAccNode stampedFileNamesNode
-#else
     let tcStatesNode                = Vector.ScanLeft "TypeCheckingStates" (fun ctok tcAcc n -> TypeCheckTask ctok tcAcc (ParseTask ctok n)) initialTcAccNode stampedFileNamesNode
-#endif
     let finalizedTypeCheckNode      = Vector.Demultiplex "FinalizeTypeCheck" FinalizeTypeCheckTask tcStatesNode
 
     // Outputs
@@ -1547,9 +1542,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
 
     do buildDescription.DeclareVectorOutput stampedFileNamesNode
     do buildDescription.DeclareVectorOutput stampedReferencedAssembliesNode
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    do buildDescription.DeclareVectorOutput parseTreesNode
-#endif
     do buildDescription.DeclareVectorOutput tcStatesNode
     do buildDescription.DeclareScalarOutput initialTcAccNode
     do buildDescription.DeclareScalarOutput finalizedTypeCheckNode
@@ -1712,15 +1704,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     member builder.GetParseResultsForFile (ctok: CompilationThreadToken, filename) =
       cancellable {
         let slotOfFile = builder.GetSlotOfFileName filename
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-        match GetVectorResultBySlot(parseTreesNode, slotOfFile, partialBuild) with
-        | Some (results, _) -> return results
-        | None -> 
-            let! build = IncrementalBuild.EvalUpTo ctok SavePartialBuild (parseTreesNode, slotOfFile) partialBuild  
-            match GetVectorResultBySlot(parseTreesNode, slotOfFile, build) with
-            | Some (results, _) -> return results
-            | None -> return! failwith "Build was not evaluated, expected the results to be ready after 'Eval' (GetParseResultsForFile)."
-#else
         let! results = 
           cancellable {
             match GetVectorResultBySlot(stampedFileNamesNode, slotOfFile, partialBuild) with
@@ -1734,7 +1717,6 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
           }
         // re-parse on demand instead of retaining
         return ParseTask ctok results
-#endif
       }
 
     member __.SourceFiles  = sourceFiles  |> List.map (fun (_, f, _) -> f)

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5179,11 +5179,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     backgroundCheckCount.Value |> shouldEqual 0
     let checkResults1 = checker.CheckFileInProject(parseResults1, ProjectBig.fileNames.[5], 0, ProjectBig.fileSources2.[5], ProjectBig.options)  |> Async.RunSynchronously
     let pD, tD = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    backgroundParseCount.Value |> shouldEqual 10
-#else
     backgroundParseCount.Value |> shouldEqual 5
-#endif
     backgroundCheckCount.Value |> shouldEqual 5
     (pD - pC) |> shouldEqual 0
     (tD - tC) |> shouldEqual 1
@@ -5192,11 +5188,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     let pE, tE = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
     (pE - pD) |> shouldEqual 0
     (tE - tD) |> shouldEqual 1
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    backgroundParseCount.Value |> shouldEqual 10 // but note, the project does not get reparsed
-#else
     (backgroundParseCount.Value <= 8) |> shouldEqual true // but note, the project does not get reparsed
-#endif
     (backgroundCheckCount.Value <= 8) |> shouldEqual true // only two extra typechecks of files
 
     // A subsequent ParseAndCheck of identical source code doesn't do any more anything
@@ -5204,11 +5196,7 @@ let ``Test request for parse and check doesn't check whole project`` () =
     let pF, tF = FSharpChecker.GlobalForegroundParseCountStatistic, FSharpChecker.GlobalForegroundTypeCheckCountStatistic
     (pF - pE) |> shouldEqual 0  // note, no new parse of the file
     (tF - tE) |> shouldEqual 0  // note, no new typecheck of the file
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-    backgroundParseCount.Value |> shouldEqual 10 // but note, the project does not get reparsed
-#else
     (backgroundParseCount.Value <= 8) |> shouldEqual true // but note, the project does not get reparsed
-#endif
     (backgroundCheckCount.Value <= 8) |> shouldEqual true // only two extra typechecks of files
 
     ()

--- a/vsintegration/src/FSharp.VS.FSI/sessions.fs
+++ b/vsintegration/src/FSharp.VS.FSI/sessions.fs
@@ -66,7 +66,7 @@ let timeoutApp descr timeoutMS (f : 'a -> 'b) (arg:'a) =
     !r
 
 module SessionsProperties = 
-    let mutable useAnyCpuVersion = false
+    let mutable useAnyCpuVersion = true
     let mutable fsiArgs = "--optimize"
     let mutable fsiShadowCopy = true
     let mutable fsiDebugMode = false

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.Completion.fs
@@ -4260,12 +4260,8 @@ let x = query { for bbbb in abbbbc(*D0*) do
         ReplaceFileInMemory file2 [""]
         SaveFileToDisk file2      
         TakeCoffeeBreak(this.VS)
-        
-#if FCS_RETAIN_BACKGROUND_PARSE_RESULTS
-        gpatcc.AssertExactly(notAA[file2], notAA[file2;file3])
-#else
+
         gpatcc.AssertExactly(notAA[file2; file3], notAA[file2;file3])
-#endif
 
     /// FEATURE: References added to the project bring corresponding new .NET and F# items into scope.
     [<Test;Category("ReproX")>]


### PR DESCRIPTION
Fixes https://github.com/Microsoft/visualfsharp/issues/6219

In addition, for dev16.0 I think it would make sense to make 64-bit the default when launching VS in Visual Studio for dev16.0. For example ML.NET only works with 64-bit, and F# Interactive in NET Core is 64-bit always.  This PR makes this change too.



