### PR TITLE
Make .NET Desktop fsi.exe 32-bit again and make Desktop fsiAnyCpu.exe (64-bit) the default to launch in VS

### DIFF
--- a/build/targets/NGenOrCrossGen.targets
+++ b/build/targets/NGenOrCrossGen.targets
@@ -16,9 +16,9 @@
         NGen for both 32 and 64 bit product.
         If compiling use the app config file, if present.
     -->
-    <Exec Command='"$(PathToNGen64)" install "$(TargetPath)" /ExeConfig:$(TargetPath)' Condition = "Exists('$(PathToNGen64)') AND Exists('$(TargetPath).config') AND '$(IsAdministrator)' == 'true'"/>
+    <Exec Command='"$(PathToNGen64)" install "$(TargetPath)" /ExeConfig:$(TargetPath)' Condition = "Exists('$(PathToNGen64)') AND Exists('$(TargetPath).config') AND '$(IsAdministrator)' == 'true' AND '$(PlatformTarget)' != 'x86'"/>
     <Exec Command='"$(PathToNGen32)" install "$(TargetPath)" /ExeConfig:$(TargetPath)' Condition = "Exists('$(PathToNGen32)') AND Exists('$(TargetPath).config') AND '$(IsAdministrator)' == 'true'"/>
-    <Exec Command='"$(PathToNGen64)" install "$(TargetPath)"' Condition = " Exists('$(PathToNGen64)') AND (!Exists('$(TargetPath).config')) AND '$(IsAdministrator)' == 'true' "/>
+    <Exec Command='"$(PathToNGen64)" install "$(TargetPath)"' Condition = " Exists('$(PathToNGen64)') AND (!Exists('$(TargetPath).config')) AND '$(IsAdministrator)' == 'true' AND '$(PlatformTarget)' != 'x86' "/>
     <Exec Command='"$(PathToNGen32)" install "$(TargetPath)"' Condition = " Exists('$(PathToNGen32)') AND (!Exists('$(TargetPath).config')) AND '$(IsAdministrator)' == 'true' "/>
   </Target>
 

--- a/src/fsharp/fsi/fsi.fsproj
+++ b/src/fsharp/fsi/fsi.fsproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PlatformTarget>x86</PlatformTarget>
     <DefineConstants>$(DefineConstants);FSI_SHADOW_COPY_REFERENCES;FSI_SERVER</DefineConstants>
   </PropertyGroup>
 

--- a/vsintegration/src/FSharp.VS.FSI/sessions.fs
+++ b/vsintegration/src/FSharp.VS.FSI/sessions.fs
@@ -66,7 +66,7 @@ let timeoutApp descr timeoutMS (f : 'a -> 'b) (arg:'a) =
     !r
 
 module SessionsProperties = 
-    let mutable useAnyCpuVersion = false
+    let mutable useAnyCpuVersion = true // 64-bit by default
     let mutable fsiArgs = "--optimize"
     let mutable fsiShadowCopy = true
     let mutable fsiDebugMode = false


### PR DESCRIPTION
Fixes #6219

In addition, for dev16.0 I think it would make sense to make 64-bit the default when launching VS in Visual Studio for dev16.0. For example ML.NET only works with 64-bit, and F# Interactive in NET Core is 64-bit always. This PR makes this change too.