### PR TITLE
Intall the dotnet cli preview and build fails

### DIFF
--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -84,7 +84,7 @@ Target "BuildVersion" (fun _ ->
 )
 
 Target "Build" (fun _ ->
-    runDotnet __SOURCE_DIRECTORY__ "build ../src/buildtools/buildtools.proj -v n -c Proto"
+    runDotnet __SOURCE_DIRECTORY__ "msbuild ../src/buildtools/buildtools.proj -verbosity:normal /p:Configuration=Proto"
     runDotnet __SOURCE_DIRECTORY__ "build FSharp.Compiler.Service.sln -v n -c release"
 )
 


### PR DESCRIPTION
When dotnet cli 3.0.0 preview 3 is installed on a pc the build fails with this error

The workaround is to build the project using ````dotnet msbuild proj```` instead of ````dotnet build proj````

````
     4>Done Building Project "c:\kevinransom\visualfsharp\src\buildtools\fsyacc\fsyacc.fsproj" (Restore target(s)).
     1>Done Building Project "c:\kevinransom\visualfsharp\src\buildtools\buildtools.proj" (Restore target(s)).
     5>Project "c:\kevinransom\visualfsharp\src\src\buildtools\buildtools.proj" on node 1 (Build target(s)).
     5>c:\kevinransom\visualfsharp\src\src\buildtools\buildtools.proj : error MSB4025: The project file could not be loaded. Could not find a part of the path 'c:\kevinransom\visualfsharp\src\src\buildtools\buildtools.proj'.
     5>Done Building Project "c:\kevinransom\visualfsharp\src\src\buildtools\buildtools.proj" (Build target(s)) -- FAILED.

Build FAILED.

       "c:\kevinransom\visualfsharp\src\src\buildtools\buildtools.proj" (Build target) (5) ->
         c:\kevinransom\visualfsharp\src\src\buildtools\buildtools.proj : error MSB4025: The project file could not be loaded. Could not find a part of the path 'c:\kevinransom\visualfsharp\src\src\buildtools\buildtools.proj'.

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:00.72
Running build failed.
````