### PR TITLE
Avoid multiple dotnet cli downloads

### DIFF
--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -24,7 +24,14 @@ let isMono = false
 // Utilities
 // --------------------------------------------------------------------------------------
 
-let dotnetExePath = DotNetCli.InstallDotNetSDK "2.1.403"
+let dotnetExePath =
+    // Build.cmd normally downloads a dotnet cli to: <repo-root>\artifacts\toolset\dotnet
+    // check if there is one there to avoid downloading an additional one here
+    let pathToCli = Path.Combine(__SOURCE_DIRECTORY__, @"..\artifacts\toolset\dotnet\dotnet.exe")
+    if File.Exists(pathToCli) then
+        pathToCli
+    else
+        DotNetCli.InstallDotNetSDK "2.1.403"
 
 let runDotnet workingDir args =
     let result =


### PR DESCRIPTION
Whilst analyzing this: https://github.com/Microsoft/visualfsharp/pull/6271

I noticed and got irritated by the multiple dotnet clis we download, also the current script downloads a dotnet/cli, every single build when building fcs.

Anyway updated the script, to peek in the artifacts directory and see if dotnet cli has already been downloaded, if so then I use it.

Kevin