### PR TITLE
Re-add embed

### DIFF
--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -295,6 +295,10 @@ type public Fsc () as this =
         with get() = embedAllSources
         and  set(s) = embedAllSources <- s
 
+    member fsc.Embed
+        with get() = embeddedFiles
+        and set(e) = embeddedFiles <- e
+
     member fsc.EmbeddedFiles
         with get() = embeddedFiles
         and set(e) = embeddedFiles <- e

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -285,7 +285,7 @@ this file.
               DocumentationFile="$(DocumentationFile)"
               DotnetFscCompilerPath="$(DotnetFscCompilerPath)"
               EmbedAllSources="$(EmbedAllSources)"
-              EmbeddedFiles="@(EmbeddedFiles)"
+              Embed="@(EmbeddedFiles)"
               GenerateInterfaceFile="$(GenerateInterfaceFile)"
               HighEntropyVA="$(HighEntropyVA)"
               KeyFile="$(KeyOriginatorFile)"


### PR DESCRIPTION
Back in August we renamed Embed to EmbeddedFiles, this Build Property is used to specify to the build task what source files to embed in the PDB.  The property was renamed to align with the C# BuildTask since we did it first this seems slightly unfair, but hey …

However, there is a nasty side effect that sometimes now shows up.  Msbuild has a habit of re-using loaded assemblies, so it is possible for some solutions to actually use different versions of the F# compiler depending on installed versions, paths, etc.

This causes us to see occasionally under hard to diagnose circumstances, this error:

````
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.Targets(276,15): 
error MSB4064: The "Embed" parameter is not supported by the "Fsc" task. Verify the parameter exists on the task, and it is a settable public instance property. [D:\a\1\s\fcs\FSharp.Compiler.Service.ProjectCrackerTool\FSharp.Compiler.Service.ProjectCrackerTool.fsproj]
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.Targets(265,9): 
error MSB4063: The "Fsc" task could not be initialized with its input parameters.  [D:\a\1\s\fcs\FSharp.Compiler.Service.ProjectCrackerTool\FSharp.Compiler.Service.ProjectCrackerTool.fsproj]

````

The Fix here is to make the build task now support both Embed and EmbeddedFiles, so that now whichever Microsoft.FSharp.Targets file is in use we end up being able to support the property.

Also, we are switching back to using the old Task-property in Microsoft.FSharp.Targets, so that if the old build task was loaded first then it's will be used.

We will use the msbuild property EmbeddedFiles as input to the Embed buildtask property so that our project files look like the C# ones.


/cc @dsyme, @cartermp, brettfo

Kevin