### PR TITLE
warnings as error again

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -21,6 +21,7 @@
     <ProtoOutputPath Condition="'$(OS)' != 'Unix'">$(ArtifactsBinDir)\fsc\Proto\net46</ProtoOutputPath>
     <ProtoOutputPath Condition="'$(OS)' == 'Unix'">$(ArtifactsBinDir)/fsc/Proto/netcoreapp2.1</ProtoOutputPath>
     <ValueTupleImplicitPackageVersion>4.4.0</ValueTupleImplicitPackageVersion>
+    <WarningsAsErrors>1182;0025;$(WarningsAsErrors)</WarningsAsErrors>
   </PropertyGroup>
 
   <!-- nuget -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,3 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('FSharp.Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <WarningsAsErrors>1182;0025;$(WarningsAsErrors)</WarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,3 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('FSharp.Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  <PropertyGroup>
-    <WarningsAsErrors>1182;0025;$(WarningsAsErrors)</WarningsAsErrors>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Turn warnings-as-errors back on for all the core F# projects.  This got lost somewhere along the way