### PR TITLE
Add symbol creation for an operator with a constraint

### DIFF
--- a/src/fsharp/symbols/Symbols.fs
+++ b/src/fsharp/symbols/Symbols.fs
@@ -290,6 +290,9 @@ type FSharpSymbol(cenv: SymbolEnv, item: (unit -> Item), access: (FSharpSymbol -
         | Item.ArgName(id, ty, _)  ->
              FSharpParameter(cenv, ty, {Attribs=[]; Name=Some id}, Some id.idRange, isParamArrayArg=false, isInArg=false, isOutArg=false, isOptionalArg=false) :> _
 
+        | Item.ImplicitOp(_, { contents = Some(TraitConstraintSln.FSMethSln(_, vref, _)) }) ->
+            FSharpMemberOrFunctionOrValue(cenv, V vref, item) :> _
+
         // TODO: the following don't currently return any interesting subtype
         | Item.ImplicitOp _
         | Item.ILField _ 


### PR DESCRIPTION
This addresses a situaltion where if you request a tooltip for an operator with a constraint no symbol is returned due to:

Item.ImplicitOp(_, { contents = Some(TraitConstraintSln.FSMethSln(_, vref, _)) })
Being turned into a vanilla FSharpSymbol which has no real information about the symbol that the IDE can use.

An corresponding issue was logged for ionide here: ionide/ionide-vscode-fsharp#1025

Corresponding PR at FCS: https://github.com/fsharp/FSharp.Compiler.Service/pull/896