### PR TITLE
Set compiler libraries to netstandard2.0"

### DIFF
--- a/FSharp.Profiles.props
+++ b/FSharp.Profiles.props
@@ -20,9 +20,7 @@
     <DefineConstants>$(DefineConstants);FX_NO_CORHOST_SIGNER</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_EVENTWAITHANDLE_IDISPOSABLE</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_EXIT_CONTEXT_FLAGS</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_HEAPTERMINATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_LINKEDRESOURCES</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_LOADER_OPTIMIZATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_PARAMETERIZED_THREAD_START</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_PDB_READER</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_PDB_WRITER</DefineConstants>

--- a/FSharp.Profiles.props
+++ b/FSharp.Profiles.props
@@ -11,7 +11,6 @@
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-    <DefineConstants>$(DefineConstants);NETSTANDARD1_6</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_APP_DOMAINS</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_ARRAY_LONG_LENGTH</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_BEGINEND_READWRITE</DefineConstants>

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ build: proto restore
 	$(DotNetExe) build-server shutdown
 	$(DotNetExe) build -c $(Configuration) -f netstandard1.6 src/fsharp/FSharp.Core/FSharp.Core.fsproj
 	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Build/FSharp.Build.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netstandard1.6 src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
 	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.1 src/fsharp/fsc/fsc.fsproj
-	$(DotNetExe) build -c $(Configuration) -f netstandard1.6 src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
+	$(DotNetExe) build -c $(Configuration) -f netstandard2.0 src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
 	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.1 src/fsharp/fsi/fsi.fsproj
 	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.0 tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
 	$(DotNetExe) build -c $(Configuration) -f netcoreapp2.0 tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj

--- a/fcs/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
+++ b/fcs/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharp.Compiler.SourceCodeServices
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD
 open System.Runtime.Serialization.Json
 open System.Runtime
 open System.Diagnostics
@@ -60,7 +60,7 @@ type ProjectCracker =
         let enableLogging = defaultArg enableLogging true
 
                 
-#if NETSTANDARD1_6
+#if NETSTANDARD
         let arguments = [|
             yield projectFileName
             yield enableLogging.ToString()

--- a/fcs/samples/FscExe/FscMain.fs
+++ b/fcs/samples/FscExe/FscMain.fs
@@ -288,9 +288,7 @@ module Driver =
             for error in errors do eprintfn "%s" (error.ToString())
             exitCode
 
-#if !FX_NO_DEFAULT_DEPENDENCY_TYPE
 [<Dependency("FSharp.Compiler",LoadHint.Always)>] 
-#endif
 do ()
 
 [<EntryPoint>]

--- a/fsharp.proj
+++ b/fsharp.proj
@@ -62,14 +62,14 @@
         <AdditionalProperties Condition="'$(BuildDesktop)' == 'true'">TargetFramework=net46</AdditionalProperties>
       </Projects>
       <Projects Include="$(MSBuildThisFileDirectory)src\fsharp\FSharp.Compiler.Private\FSharp.Compiler.Private.fsproj">
-        <AdditionalProperties Condition="'$(BuildNetcore)' == 'true'">TargetFramework=netstandard1.6</AdditionalProperties>
+        <AdditionalProperties Condition="'$(BuildNetcore)' == 'true'">TargetFramework=netstandard2.0</AdditionalProperties>
         <AdditionalProperties Condition="'$(BuildDesktop)' == 'true'">TargetFramework=net46</AdditionalProperties>
       </Projects>
       <Projects Include="$(MSBuildThisFileDirectory)src\fsharp\FSharp.Compiler.Server.Shared\FSharp.Compiler.Server.Shared.fsproj">
         <AdditionalProperties Condition="'$(BuildDesktop)' == 'true'">TargetFramework=net46</AdditionalProperties>
       </Projects>
       <Projects Include="$(MSBuildThisFileDirectory)src\fsharp\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj">
-        <AdditionalProperties Condition="'$(BuildNetcore)' == 'true'">TargetFramework=netstandard1.6</AdditionalProperties>
+        <AdditionalProperties Condition="'$(BuildNetcore)' == 'true'">TargetFramework=netstandard2.0</AdditionalProperties>
         <AdditionalProperties Condition="'$(BuildDesktop)' == 'true'">TargetFramework=net46</AdditionalProperties>
       </Projects>
       <Projects Include="$(MSBuildThisFileDirectory)src\fsharp\fsc\fsc.fsproj">

--- a/src/buildfromsource/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
+++ b/src/buildfromsource/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>FSharp.Compiler.Interactive.Settings</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1182;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>

--- a/src/buildfromsource/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/buildfromsource/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>FSharp.Compiler.Private</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2819,7 +2819,7 @@ type TcConfig private (data : TcConfigBuilder, validate:bool) =
     // FUTURE: remove this, we only read the binary for the exception it raises
     let fsharpBinariesDirValue = 
 // NOTE: It's not clear why this behaviour has been changed for the NETSTANDARD compilations of the F# compiler
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD
         ignore ilGlobals
         data.defaultFSharpBinariesDir
 #else
@@ -2983,7 +2983,7 @@ type TcConfig private (data : TcConfigBuilder, validate:bool) =
 
             | None -> 
 // "there is no really good notion of runtime directory on .NETCore"
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD
                 let runtimeRoot = Path.GetDirectoryName(typeof<System.Object>.Assembly.Location)
 #else
                 let runtimeRoot = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -50,10 +50,6 @@ open FSharp.Compiler.ExtensionTyping
 open Microsoft.FSharp.Core.CompilerServices
 #endif
 
-#if FX_RESHAPED_REFLECTION
-open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
 #if DEBUG
 [<AutoOpen>]
 module internal CompilerService =
@@ -2646,7 +2642,7 @@ let OpenILBinary(filename, reduceMemoryUsage, ilGlobals, pdbDirPath, shadowCopyR
             tryGetMetadataSnapshot = tryGetMetadataSnapshot } 
                       
       let location =
-#if !FX_RESHAPED_REFLECTION // shadow copy not supported
+#if FX_NO_APP_DOMAINS
           // In order to use memory mapped files on the shadow copied version of the Assembly, we `preload the assembly
           // We swallow all exceptions so that we do not change the exception contract of this API
           if shadowCopyReferences then 

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -21,17 +21,11 @@ open FSharp.Compiler.Lib
 open FSharp.Compiler.Range
 open FSharp.Compiler.IlxGen
 
-#if FX_RESHAPED_REFLECTION
-open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
 module Attributes = 
     open System.Runtime.CompilerServices
 
     //[<assembly: System.Security.SecurityTransparent>]
-#if !FX_NO_DEFAULT_DEPENDENCY_TYPE
     [<Dependency("FSharp.Core",LoadHint.Always)>] 
-#endif
     do()
 
 //----------------------------------------------------------------------------

--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -18,10 +18,6 @@ module internal ExtensionTyping =
     open FSharp.Compiler.AbstractIL.Diagnostics // dprintfn
     open FSharp.Compiler.AbstractIL.Internal.Library // frontAndBack
 
-#if FX_RESHAPED_REFLECTION
-    open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
     type TypeProviderDesignation = TypeProviderDesignation of string
 
     exception ProvidedTypeResolution of range * System.Exception 
@@ -371,20 +367,11 @@ module internal ExtensionTyping =
 
     [<AllowNullLiteral; Sealed>]
     type ProvidedType (x:System.Type, ctxt: ProvidedTypeContext) =
-#if FX_RESHAPED_REFLECTION
-        inherit ProvidedMemberInfo(x.GetTypeInfo(), ctxt)
-#if FX_NO_CUSTOMATTRIBUTEDATA
-        let provide () = ProvidedCustomAttributeProvider.Create (fun provider -> provider.GetMemberCustomAttributesData(x.GetTypeInfo()) :> _)
-#else
-        let provide () = ProvidedCustomAttributeProvider.Create (fun _provider -> x.GetTypeInfo().CustomAttributes)
-#endif
-#else
         inherit ProvidedMemberInfo(x, ctxt)
 #if FX_NO_CUSTOMATTRIBUTEDATA
         let provide () = ProvidedCustomAttributeProvider.Create (fun provider -> provider.GetMemberCustomAttributesData(x) :> _)
 #else
         let provide () = ProvidedCustomAttributeProvider.Create (fun _provider -> x.CustomAttributes)
-#endif
 #endif
         interface IProvidedCustomAttributeProvider with 
             member __.GetHasTypeProviderEditorHideMethodsAttribute(provider) = provide().GetHasTypeProviderEditorHideMethodsAttribute(provider)

--- a/src/fsharp/ExtensionTyping.fs
+++ b/src/fsharp/ExtensionTyping.fs
@@ -355,24 +355,14 @@ module internal ExtensionTyping =
                                   for KeyValue (st, tcref) in d2.Force() do dict.Add(st, f tcref)
                                   dict))
 
-#if FX_NO_CUSTOMATTRIBUTEDATA
-    type CustomAttributeData = Microsoft.FSharp.Core.CompilerServices.IProvidedCustomAttributeData
-    type CustomAttributeNamedArgument = Microsoft.FSharp.Core.CompilerServices.IProvidedCustomAttributeNamedArgument
-    type CustomAttributeTypedArgument = Microsoft.FSharp.Core.CompilerServices.IProvidedCustomAttributeTypedArgument
-#else
     type CustomAttributeData = System.Reflection.CustomAttributeData
     type CustomAttributeNamedArgument = System.Reflection.CustomAttributeNamedArgument
     type CustomAttributeTypedArgument = System.Reflection.CustomAttributeTypedArgument
-#endif
 
     [<AllowNullLiteral; Sealed>]
     type ProvidedType (x:System.Type, ctxt: ProvidedTypeContext) =
         inherit ProvidedMemberInfo(x, ctxt)
-#if FX_NO_CUSTOMATTRIBUTEDATA
-        let provide () = ProvidedCustomAttributeProvider.Create (fun provider -> provider.GetMemberCustomAttributesData(x) :> _)
-#else
         let provide () = ProvidedCustomAttributeProvider.Create (fun _provider -> x.CustomAttributes)
-#endif
         interface IProvidedCustomAttributeProvider with 
             member __.GetHasTypeProviderEditorHideMethodsAttribute(provider) = provide().GetHasTypeProviderEditorHideMethodsAttribute(provider)
             member __.GetDefinitionLocationAttribute(provider) = provide().GetDefinitionLocationAttribute(provider)
@@ -501,12 +491,7 @@ module internal ExtensionTyping =
 
     and [<AllowNullLiteral; AbstractClass>] 
         ProvidedMemberInfo (x: System.Reflection.MemberInfo, ctxt) = 
-#if FX_NO_CUSTOMATTRIBUTEDATA
-        let provide () = ProvidedCustomAttributeProvider.Create (fun provider -> provider.GetMemberCustomAttributesData(x) :> _)
-#else
         let provide () = ProvidedCustomAttributeProvider.Create (fun _provider -> x.CustomAttributes)
-#endif
-
         member __.Name = x.Name
         /// DeclaringType can be null if MemberInfo belongs to Module, not to Type
         member __.DeclaringType = ProvidedType.Create ctxt x.DeclaringType
@@ -518,18 +503,10 @@ module internal ExtensionTyping =
 
     and [<AllowNullLiteral; Sealed>] 
         ProvidedParameterInfo (x: System.Reflection.ParameterInfo, ctxt) = 
-#if FX_NO_CUSTOMATTRIBUTEDATA
-        let provide () = ProvidedCustomAttributeProvider.Create (fun provider -> provider.GetParameterCustomAttributesData(x) :> _)
-#else
         let provide () = ProvidedCustomAttributeProvider.Create (fun _provider -> x.CustomAttributes)
-#endif
         member __.Name = x.Name
         member __.IsOut = x.IsOut
-#if FX_NO_ISIN_ON_PARAMETER_INFO 
-        member __.IsIn = not x.IsOut
-#else
         member __.IsIn = x.IsIn
-#endif
         member __.IsOptional = x.IsOptional
         member __.RawDefaultValue = x.RawDefaultValue
         member __.HasDefaultValue = x.Attributes.HasFlag(System.Reflection.ParameterAttributes.HasDefault)

--- a/src/fsharp/ExtensionTyping.fsi
+++ b/src/fsharp/ExtensionTyping.fsi
@@ -85,12 +85,6 @@ module internal ExtensionTyping =
 
         /// Map the TyconRef objects, if any
         member RemapTyconRefs : (obj -> obj) -> ProvidedTypeContext 
-           
-#if FX_NO_CUSTOMATTRIBUTEDATA
-    type CustomAttributeData = Microsoft.FSharp.Core.CompilerServices.IProvidedCustomAttributeData
-    type CustomAttributeNamedArgument = Microsoft.FSharp.Core.CompilerServices.IProvidedCustomAttributeNamedArgument
-    type CustomAttributeTypedArgument = Microsoft.FSharp.Core.CompilerServices.IProvidedCustomAttributeTypedArgument
-#endif
 
     type [<AllowNullLiteral; Sealed; Class>] 
         ProvidedType =

--- a/src/fsharp/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/fsharp/FSharp.Build/FSharpEmbedResourceText.fs
@@ -238,19 +238,9 @@ open Printf
     let StringBoilerPlate filename = @"
     // BEGIN BOILERPLATE
 
-    static let getCurrentAssembly () =
-    #if FX_RESHAPED_REFLECTION
-        typeof<SR>.GetTypeInfo().Assembly
-    #else
-        System.Reflection.Assembly.GetExecutingAssembly()
-    #endif
+    static let getCurrentAssembly () = System.Reflection.Assembly.GetExecutingAssembly()
 
-    static let getTypeInfo (t: System.Type) =
-    #if FX_RESHAPED_REFLECTION
-        t.GetTypeInfo()
-    #else
-        t
-    #endif
+    static let getTypeInfo (t: System.Type) = t
 
     static let resources = lazy (new System.Resources.ResourceManager(""" + filename + @""", getCurrentAssembly()))
 

--- a/src/fsharp/FSharp.Build/Fsc.fs
+++ b/src/fsharp/FSharp.Build/Fsc.fs
@@ -11,10 +11,6 @@ open Microsoft.Build.Framework
 open Microsoft.Build.Utilities
 open Internal.Utilities
 
-#if FX_RESHAPED_REFLECTION
-open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
 //There are a lot of flags on fsc.exe.
 //For now, not all of them are represented in the "Fsc class" object model.
 //The goal is to have the most common/important flags available via the Fsc class, and the

--- a/src/fsharp/FSharp.Build/Fsi.fs
+++ b/src/fsharp/FSharp.Build/Fsi.fs
@@ -11,10 +11,6 @@ open Microsoft.Build.Framework
 open Microsoft.Build.Utilities
 open Internal.Utilities
 
-#if FX_RESHAPED_REFLECTION
-open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
 //There are a lot of flags on fsi.exe.
 //For now, not all of them are represented in the "Fsi class" object model.
 //The goal is to have the most common/important flags available via the Fsi class, and the

--- a/src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
+++ b/src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>FSharp.Compiler.Interactive.Settings</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1182;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -226,7 +226,7 @@
     <Compile Include="..\..\absil\ilmorph.fs">
       <Link>AbsIL\ilmorph.fs</Link>
     </Compile>
-    <Compile Include="..\..\absil\ilsign.fs" Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <Compile Include="..\..\absil\ilsign.fs" Condition="$(TargetFramework.StartsWith(netstandard))">
       <Link>AbsIL\ilsign.fs</Link>
     </Compile>
     <Compile Include="..\..\absil\ilsupp.fsi">
@@ -677,7 +677,7 @@
     <PackageReference Include="System.IO.Compression" Version="$(SystemIoCompressionPackageVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+  <ItemGroup Condition="$(TargetFramework.Startswith('netstandard'))">
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderPackageVersion)" />
   </ItemGroup>
 

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>FSharp.Compiler.Private</AssemblyName>
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.netcore.nuspec
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.netcore.nuspec
@@ -36,6 +36,6 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="FSharp.Compiler.Private.dll"     target="lib\netstandard1.6" />
+        <file src="FSharp.Compiler.Private.dll"     target="lib\netstandard2.0" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
+++ b/src/fsharp/FSharp.Compiler.nuget/Microsoft.FSharp.Compiler.nuspec
@@ -54,19 +54,21 @@
             this approach gives a very small deployment. Which is kind of necessary.
         -->
         <!-- assemblies -->
-        <file src="$artifactsbindir$\fsc\$configuration$\netcoreapp2.1\fsc.exe"                                                                    target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\fsi\$configuration$\netcoreapp2.1\fsi.exe"                                                                    target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Core\$configuration$\netstandard1.6\FSharp.Core.dll"                                                   target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Compiler.Private\$configuration$\netstandard1.6\FSharp.Compiler.Private.dll"                           target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\FSharp.Build.dll"                                                 target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Compiler.Interactive.Settings\$configuration$\netstandard1.6\FSharp.Compiler.Interactive.Settings.dll" target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\fsc\$configuration$\netcoreapp2.1\fsc.exe"                                             target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\fsi\$configuration$\netcoreapp2.1\fsi.exe"                                             target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Core\$configuration$\netstandard1.6\FSharp.Core.dll"                            target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Compiler.Private\$configuration$\netstandard2.0\FSharp.Compiler.Private.dll"    target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\FSharp.Build.dll"                          target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Compiler.Interactive.Settings\$configuration$\netstandard2.0\FSharp.Compiler.Interactive.Settings.dll"
+                                                                                                                            target="lib\netcoreapp2.1" />
         <!-- symbols -->
-        <file src="$artifactsbindir$\fsc\$configuration$\netcoreapp2.1\fsc.pdb"                                                                    target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\fsi\$configuration$\netcoreapp2.1\fsi.pdb"                                                                    target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Core\$configuration$\netstandard1.6\FSharp.Core.pdb"                                                   target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Compiler.Private\$configuration$\netstandard1.6\FSharp.Compiler.Private.pdb"                           target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\FSharp.Build.pdb"                                                 target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Compiler.Interactive.Settings\$configuration$\netstandard1.6\FSharp.Compiler.Interactive.Settings.pdb" target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\fsc\$configuration$\netcoreapp2.1\fsc.pdb"                                             target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\fsi\$configuration$\netcoreapp2.1\fsi.pdb"                                             target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Core\$configuration$\netstandard1.6\FSharp.Core.pdb"                            target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Compiler.Private\$configuration$\netstandard2.0\FSharp.Compiler.Private.pdb"    target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\FSharp.Build.pdb"                          target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Compiler.Interactive.Settings\$configuration$\netstandard2.0\FSharp.Compiler.Interactive.Settings.pdb"
+                                                                                                                            target="lib\netcoreapp2.1" />
         <!-- additional files -->
         <file src="$artifactsbindir$\fsc\$configuration$\netcoreapp2.1\default.win32manifest"                               target="contentFiles\any\any" />
         <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\Microsoft.FSharp.Targets"                  target="contentFiles\any\any" />
@@ -74,10 +76,13 @@
         <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\Microsoft.FSharp.NetSdk.props"             target="contentFiles\any\any" />
         <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\Microsoft.FSharp.NetSdk.targets"           target="contentFiles\any\any" />
         <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\Microsoft.FSharp.Overrides.NetSdk.targets" target="contentFiles\any\any" />
+
         <!-- resources -->
-        <file src="$artifactsbindir$\FSharp.Core\$configuration$\netstandard1.6\**\FSharp.Core.resources.dll"                                                   target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Compiler.Private\$configuration$\netstandard1.6\**\FSharp.Compiler.Private.resources.dll"                           target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Compiler.Interactive.Settings\$configuration$\netstandard1.6\**\FSharp.Compiler.Interactive.Settings.resources.dll" target="lib\netcoreapp2.1" />
-        <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\**\FSharp.Build.resources.dll"                                                 target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Core\$configuration$\netstandard1.6\**\FSharp.Core.resources.dll"               target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Compiler.Private\$configuration$\netstandard2.0\**\FSharp.Compiler.Private.resources.dll"
+                                                                                                                            target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Compiler.Interactive.Settings\$configuration$\netstandard2.0\**\FSharp.Compiler.Interactive.Settings.resources.dll"
+                                                                                                                            target="lib\netcoreapp2.1" />
+        <file src="$artifactsbindir$\FSharp.Build\$configuration$\netstandard2.0\**\FSharp.Build.resources.dll"             target="lib\netcoreapp2.1" />
     </files>
 </package>

--- a/src/fsharp/FSharp.Core/array2.fs
+++ b/src/fsharp/FSharp.Core/array2.fs
@@ -53,7 +53,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("ZeroCreateBased")>]
         let zeroCreateBased (base1:int) (base2:int) (length1:int) (length2:int) = 
             if (base1 = 0 && base2 = 0) then 
-#if NETSTANDARD1_6
+#if NETSTANDARD
                 zeroCreate length1 length2
 #else                
                 // Note: this overload is available on Compact Framework and Silverlight, but not Portable

--- a/src/fsharp/FSharp.Core/math/z.fs
+++ b/src/fsharp/FSharp.Core/math/z.fs
@@ -19,7 +19,7 @@ namespace System.Numerics
     // NOTE: 0 has two repns (+1,0) or (-1,0).
     [<Struct>]
     [<CustomEquality; CustomComparison>]
-#if !NETSTANDARD1_6
+#if !NETSTANDARD
     [<StructuredFormatDisplay("{StructuredDisplayString}I")>]
 #endif
     type BigInteger(signInt:int, v : BigNat) =

--- a/src/fsharp/FSharp.Core/reflect.fs
+++ b/src/fsharp/FSharp.Core/reflect.fs
@@ -447,11 +447,11 @@ module internal Impl =
         //   Item1, Item2, ..., Item<maxTuple-1>
         //   Item1, Item2, ..., Item<maxTuple-1>, Rest
         // The PropertyInfo may not come back in order, so ensure ordering here.
-#if !NETSTANDARD1_6
+#if !NETSTANDARD
         assert(maxTuple < 10) // Alphasort will only works for upto 9 items: Item1, Item10, Item2, Item3, ..., Item9, Rest
 #endif
         let props = props |> Array.sortBy (fun p -> p.Name) // they are not always in alphabetic order
-#if !NETSTANDARD1_6  
+#if !NETSTANDARD
         assert(props.Length <= maxTuple)
         assert(let haveNames   = props |> Array.map (fun p -> p.Name)
                let expectNames = Array.init props.Length (fun i -> let j = i+1 // index j = 1,2,..,props.Length <= maxTuple
@@ -469,11 +469,11 @@ module internal Impl =
         //   Item1, Item2, ..., Item<maxTuple-1>
         //   Item1, Item2, ..., Item<maxTuple-1>, Rest
         // The PropertyInfo may not come back in order, so ensure ordering here.
-#if !NETSTANDARD1_6
+#if !NETSTANDARD
         assert(maxTuple < 10) // Alphasort will only works for upto 9 items: Item1, Item10, Item2, Item3, ..., Item9, Rest
 #endif
         let fields = fields |> Array.sortBy (fun fi -> fi.Name) // they are not always in alphabetic order
-#if !NETSTANDARD1_6  
+#if !NETSTANDARD
         assert(fields.Length <= maxTuple)
         assert(let haveNames   = fields |> Array.map (fun fi -> fi.Name)
                let expectNames = Array.init fields.Length (fun i -> let j = i+1 // index j = 1,2,..,fields.Length <= maxTuple
@@ -707,12 +707,11 @@ type UnionCaseInfo(typ: System.Type, tag:int) =
         props
 
     member __.GetCustomAttributes() = getMethInfo().GetCustomAttributes(false)
-    
+
     member __.GetCustomAttributes(attributeType) = getMethInfo().GetCustomAttributes(attributeType,false)
 
-#if !FX_NO_CUSTOMATTRIBUTEDATA
     member __.GetCustomAttributesData() = getMethInfo().CustomAttributes |> Seq.toArray :> System.Collections.Generic.IList<_>
-#endif    
+
     member __.Tag = tag
     override x.ToString() = typ.Name + "." + x.Name
     override x.GetHashCode() = typ.GetHashCode() + tag

--- a/src/fsharp/FSharp.Core/reflect.fsi
+++ b/src/fsharp/FSharp.Core/reflect.fsi
@@ -29,12 +29,9 @@ type UnionCaseInfo =
     /// <returns>An array of custom attributes.</returns>
     member GetCustomAttributes: attributeType:System.Type -> obj[]
 
-#if !FX_NO_CUSTOMATTRIBUTEDATA
     /// <summary>Returns the custom attributes data associated with the case.</summary>
     /// <returns>An list of custom attribute data items.</returns>
     member GetCustomAttributesData: unit -> System.Collections.Generic.IList<CustomAttributeData>
-
-#endif
 
     /// <summary>The fields associated with the case, represented by a PropertyInfo.</summary>
     /// <returns>The fields associated with the case.</returns>

--- a/src/fsharp/MSBuildReferenceResolver.fs
+++ b/src/fsharp/MSBuildReferenceResolver.fs
@@ -6,9 +6,6 @@ module internal FSharp.Compiler.MSBuildReferenceResolver
     open System.IO
     open System.Reflection
 
-#if FX_RESHAPED_REFLECTION
-    open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
 #if FX_RESHAPED_MSBUILD
     open FSharp.Compiler.MsBuildAdapters
     open FSharp.Compiler.ToolLocationHelper
@@ -19,6 +16,11 @@ module internal FSharp.Compiler.MSBuildReferenceResolver
     open Microsoft.Build.Tasks
     open Microsoft.Build.Utilities
     open Microsoft.Build.Framework
+
+    // Reflection wrapper for properties
+    type System.Object with
+        member this.GetPropertyValue(propName) =
+            this.GetType().GetProperty(propName, BindingFlags.Public).GetValue(this, null)
 
     /// Get the Reference Assemblies directory for the .NET Framework on Window.
     let DotNetFrameworkReferenceAssembliesRootDirectory = 
@@ -129,7 +131,7 @@ module internal FSharp.Compiler.MSBuildReferenceResolver
                 else Net45 // version is 4.5 assumed since this code is running.
             with _ -> Net45
 
-#if !FX_RESHAPED_REFLECTION
+#if !FX_RESHAPED_MSBUILD
         // 1.   First look to see if we can find the highest installed set of dotnet reference assemblies, if yes then select that framework
         // 2.   Otherwise ask msbuild for the highestinstalled framework
         let checkFrameworkForReferenceAssemblies (dotNetVersion:string) =
@@ -336,9 +338,6 @@ module internal FSharp.Compiler.MSBuildReferenceResolver
                                      FindSerializationAssemblies=false, Assemblies=assemblies, 
                                      SearchPaths=searchPaths, 
                                      AllowedAssemblyExtensions= [| ".dll" ; ".exe" |])
-#if FX_RESHAPED_REFLECTION
-        ignore targetProcessorArchitecture // Not implemented in reshapedmsbuild.fs
-#else
         rar.TargetProcessorArchitecture <- targetProcessorArchitecture
         let targetedRuntimeVersionValue = typeof<obj>.Assembly.ImageRuntimeVersion
 #if ENABLE_MONO_SUPPORT
@@ -351,7 +350,6 @@ module internal FSharp.Compiler.MSBuildReferenceResolver
         rar.TargetedRuntimeVersion <- targetedRuntimeVersionValue
         rar.CopyLocalDependenciesWhenParentReferenceInGac <- true
 #endif
-#endif        
         
         let succeeded = rar.Execute()
         

--- a/src/fsharp/MSBuildReferenceResolver.fs
+++ b/src/fsharp/MSBuildReferenceResolver.fs
@@ -99,7 +99,7 @@ module internal FSharp.Compiler.MSBuildReferenceResolver
         | _ -> []
 
     let GetPathToDotNetFrameworkReferenceAssemblies(version) = 
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD
         ignore version
         let r : string list = []
         r

--- a/src/fsharp/PrettyNaming.fs
+++ b/src/fsharp/PrettyNaming.fs
@@ -19,10 +19,6 @@ module public FSharp.Compiler.PrettyNaming
     open Internal.Utilities.StructuredFormat
     open Internal.Utilities.StructuredFormat.LayoutOps
 
-#if FX_RESHAPED_REFLECTION
-    open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
     //------------------------------------------------------------------------
     // Operator name compilation
     //-----------------------------------------------------------------------

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1665,10 +1665,6 @@ let GetStrongNameSigner signingInfo =
 // CopyFSharpCore
 //----------------------------------------------------------------------------
 
-#if FX_RESHAPED_REFLECTION
-type private TypeInThisAssembly (_dummy:obj) = class end
-#endif
-
 // If the --nocopyfsharpcore switch is not specified, this will:
 // 1) Look into the referenced assemblies, if FSharp.Core.dll is specified, it will copy it to output directory.
 // 2) If not, but FSharp.Core.dll exists beside the compiler binaries, it will copy it to output directory.
@@ -1685,11 +1681,7 @@ let CopyFSharpCore(outFile: string, referencedDlls: AssemblyReference list) =
     | Some referencedFsharpCoreDll -> copyFileIfDifferent referencedFsharpCoreDll.Text fsharpCoreDestinationPath
     | None ->
         let executionLocation =
-#if FX_RESHAPED_REFLECTION
-            TypeInThisAssembly(null).GetType().GetTypeInfo().Assembly.Location
-#else
             Assembly.GetExecutingAssembly().Location
-#endif
         let compilerLocation = Path.GetDirectoryName(executionLocation)
         let compilerFsharpCoreDllPath = Path.Combine(compilerLocation, fsharpCoreAssemblyName)
         if File.Exists(compilerFsharpCoreDllPath) then

--- a/src/fsharp/fscmain.fs
+++ b/src/fsharp/fscmain.fs
@@ -20,13 +20,7 @@ open FSharp.Compiler.CompileOps
 open FSharp.Compiler.AbstractIL.Internal.Library 
 open Internal.Utilities
 
-#if FX_RESHAPED_REFLECTION
-open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
-#if !FX_NO_DEFAULT_DEPENDENCY_TYPE
 [<Dependency("FSharp.Compiler.Private",LoadHint.Always)>] 
-#endif
 do ()
 
 
@@ -83,10 +77,8 @@ let main(argv) =
     System.Runtime.GCSettings.LatencyMode <- System.Runtime.GCLatencyMode.Batch
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parameter
 
-#if !FX_NO_HEAPTERMINATION
     if not runningOnMono then Lib.UnmanagedProcessExecutionOptions.EnableHeapTerminationOnCorruption() (* SDL recommendation *)
     Lib.UnmanagedProcessExecutionOptions.EnableHeapTerminationOnCorruption() (* SDL recommendation *)
-#endif
 
     try 
         Driver.main(Array.append [| "fsc.exe" |] argv)

--- a/src/fsharp/fsi/console.fs
+++ b/src/fsharp/fsi/console.fs
@@ -13,18 +13,9 @@ open Internal.Utilities
 /// Fixes to System.Console.ReadKey may break this code around, hence the option here.
 module internal ConsoleOptions =
 
-#if FX_NO_WIN_REGISTRY
-  let fixupRequired = false
-#else
-  // Bug 4254 was fixed in Dev11 (Net4.5), so this flag tracks making this fix up version specific.
-  let fixupRequired = not FSharpEnvironment.IsRunningOnNetFx45OrAbove
-#endif
-
-  let fixNonUnicodeSystemConsoleReadKey = ref fixupRequired
   let readKeyFixup (c:char) =
 #if FX_NO_SERVERCODEPAGES
 #else
-    if !fixNonUnicodeSystemConsoleReadKey then
       // Assumes the c:char is actually a byte in the System.Console.InputEncoding.
       // Convert it to a Unicode char through the encoding.
       if 0 <= int c && int c <= 255 then
@@ -36,10 +27,8 @@ module internal ConsoleOptions =
           c // no fix up
       else
         assert("readKeyFixHook: given char is outside the 0..255 byte range" = "")
-        c // no fix up
-    else
 #endif
-      c
+        c
 
 type internal Style = Prompt | Out | Error
 

--- a/src/fsharp/fsi/fsimain.fs
+++ b/src/fsharp/fsi/fsimain.fs
@@ -316,9 +316,7 @@ let evaluateSession(argv: string[]) =
 // Mark the main thread as STAThread since it is a GUI thread
 [<EntryPoint>]
 [<STAThread()>]    
-#if !FX_NO_LOADER_OPTIMIZATION
 [<LoaderOptimization(LoaderOptimization.MultiDomainHost)>]     
-#endif
 let MainMain argv = 
     ignore argv
     let argv = System.Environment.GetCommandLineArgs()

--- a/src/fsharp/fsi/fsimain.fs
+++ b/src/fsharp/fsi/fsimain.fs
@@ -28,21 +28,13 @@ open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.Interactive
 open FSharp.Compiler.Interactive.Shell.Settings
 
-#if FX_RESHAPED_REFLECTION
-open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
 #nowarn "55"
 #nowarn "40" // let rec on value 'fsiConfig'
 
 
-
 // Hardbinding dependencies should we NGEN fsi.exe
-#if !FX_NO_DEFAULT_DEPENDENCY_TYPE
 [<Dependency("FSharp.Compiler.Private",LoadHint.Always)>] do ()
 [<Dependency("FSharp.Core",LoadHint.Always)>] do ()
-#endif
-
 // Standard attributes
 [<assembly: System.Runtime.InteropServices.ComVisible(false)>]
 [<assembly: System.CLSCompliant(true)>]  
@@ -202,7 +194,7 @@ let evaluateSession(argv: string[]) =
 //#if USE_FSharp_Compiler_Interactive_Settings
         let fsiObjOpt = 
             let defaultFSharpBinariesDir =
-#if FX_RESHAPED_REFLECTION
+#if FX_NO_APP_DOMAINS
                 System.AppContext.BaseDirectory
 #else
                 System.AppDomain.CurrentDomain.BaseDirectory

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -20,10 +20,6 @@ open Microsoft.FSharp.Core.Printf
 open FSharp.Compiler.ExtensionTyping
 #endif
 
-#if FX_RESHAPED_REFLECTION
-open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
 //-------------------------------------------------------------------------
 // From IL types to F# types
 //-------------------------------------------------------------------------

--- a/src/fsharp/lib.fs
+++ b/src/fsharp/lib.fs
@@ -526,9 +526,6 @@ module UnmanagedProcessExecutionOptions =
     [<System.Security.Permissions.SecurityPermission(System.Security.Permissions.SecurityAction.Assert,UnmanagedCode = true)>] 
 #endif
     let EnableHeapTerminationOnCorruption() =
-#if FX_NO_HEAPTERMINATION
-        ()
-#else
         if (System.Environment.OSVersion.Version.Major >= 6 && // If OS is Vista or higher
             System.Environment.Version.Major < 3) then         // and CLR not 3.0 or higher 
             // "The flag HeapSetInformation sets is available in Windows XP SP3 and later.
@@ -547,5 +544,4 @@ module UnmanagedProcessExecutionOptions =
                             "Unable to enable unmanaged process execution option TerminationOnCorruption. " + 
                             "HeapSetInformation() returned FALSE; LastError = 0x" + 
                             GetLastError().ToString("X").PadLeft(8,'0') + "."))
-#endif
 

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -47,10 +47,6 @@ open Internal.Utilities
 open Internal.Utilities.Collections
 open FSharp.Compiler.Layout.TaggedTextOps
 
-#if FX_RESHAPED_REFLECTION
-open Microsoft.FSharp.Core.ReflectionAdapters
-#endif
-
 type internal Layout = StructuredFormat.Layout
 
 [<AutoOpen>]

--- a/src/fsharp/sr.fs
+++ b/src/fsharp/sr.fs
@@ -11,13 +11,7 @@ namespace FSharp.Compiler
     open System.Reflection 
 
     module internal SR =
-#if FX_RESHAPED_REFLECTION
-        open System.Reflection
-        type private TypeInThisAssembly = class end
-        let private resources = lazy (new System.Resources.ResourceManager("fsstrings", typeof<TypeInThisAssembly>.GetTypeInfo().Assembly))
-#else
         let private resources = lazy (new System.Resources.ResourceManager("fsstrings", System.Reflection.Assembly.GetExecutingAssembly()))
-#endif
 
         let GetString(name:string) =
             let s = resources.Force().GetString(name, System.Globalization.CultureInfo.CurrentUICulture)
@@ -33,11 +27,6 @@ namespace FSharp.Compiler
         open Microsoft.FSharp.Reflection
         open System.Reflection
         open Internal.Utilities.StructuredFormat
-
-#if FX_RESHAPED_REFLECTION
-        open PrimReflectionAdapters
-        open ReflectionAdapters
-#endif
 
         let mkFunctionValue (tys: System.Type[]) (impl:obj->obj) = 
             FSharpValue.MakeFunction(FSharpType.MakeFunctionType(tys.[0],tys.[1]), impl)

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -2022,12 +2022,8 @@ and Construct =
                 st.PApplyWithProvider((fun (st, provider) -> 
                     let findAttrib (ty:System.Type) (a:CustomAttributeData) = (a.Constructor.DeclaringType.FullName = ty.FullName)  
                     let ty = st.RawSystemType
-#if FX_NO_CUSTOMATTRIBUTEDATA
-                    provider.GetMemberCustomAttributesData(ty) 
-#else
                     ignore provider
                     ty.CustomAttributes
-#endif
                         |> Seq.exists (findAttrib typeof<Microsoft.FSharp.Core.MeasureAttribute>)), m)
                   .PUntaintNoFailure(fun x -> x)
             if isMeasure then TyparKind.Measure else TyparKind.Type

--- a/src/fsharp/tast.fs
+++ b/src/fsharp/tast.fs
@@ -2022,9 +2022,6 @@ and Construct =
                 st.PApplyWithProvider((fun (st, provider) -> 
                     let findAttrib (ty:System.Type) (a:CustomAttributeData) = (a.Constructor.DeclaringType.FullName = ty.FullName)  
                     let ty = st.RawSystemType
-#if FX_RESHAPED_REFLECTION
-                    let ty = ty.GetTypeInfo()
-#endif
 #if FX_NO_CUSTOMATTRIBUTEDATA
                     provider.GetMemberCustomAttributesData(ty) 
 #else

--- a/src/utils/sformat.fs
+++ b/src/utils/sformat.fs
@@ -1196,7 +1196,7 @@ namespace Microsoft.FSharp.Text.StructuredPrintfImpl
 
                               // massively reign in deep printing of properties 
                               let nDepth = depthLim/10
-#if NETSTANDARD1_6 || NETSTANDARD2_0 
+#if NETSTANDARD
                               Array.Sort((propsAndFields),{ new IComparer<MemberInfo> with member this.Compare(p1,p2) = compare (p1.Name) (p2.Name) } );
 #else                              
                               Array.Sort((propsAndFields :> Array),{ new System.Collections.IComparer with member this.Compare(p1,p2) = compare ((p1 :?> MemberInfo).Name) ((p2 :?> MemberInfo).Name) } );

--- a/tests/fsharp/test-framework.fs
+++ b/tests/fsharp/test-framework.fs
@@ -167,7 +167,7 @@ let config configurationName envVars =
     let fsiArchitecture = "netcoreapp2.1"
     let fsharpCoreArchitecture = "netstandard1.6"
     let fsharpBuildArchitecture = "netstandard2.0"
-    let fsharpCompilerInteractiveSettingsArchitecture = "netstandard1.6"
+    let fsharpCompilerInteractiveSettingsArchitecture = "netstandard2.0"
 #endif
     let repoRoot = SCRIPT_ROOT ++ ".." ++ ".."
     let artifactsPath = repoRoot ++ "artifacts"


### PR DESCRIPTION
FSharp.Compiler.Private.dll and FSharp.Compiler.Interactive.Settings.dll still built against netstandard1.6.

Updating to 2.0.  Since we never deploy recent builds on netcoreapp1.* any longer.