### PR TITLE
Move SourceText: Microsoft.FSharp -> FSharp

### DIFF
--- a/fcs/samples/EditorService/Program.fs
+++ b/fcs/samples/EditorService/Program.fs
@@ -8,7 +8,7 @@ open FSharp.Compiler.QuickParse
 let checker = FSharpChecker.Create()
 
 let parseWithTypeInfo (file, input) = 
-    let input = Microsoft.FSharp.Compiler.Text.SourceText.ofString input
+    let input = FSharp.Compiler.Text.SourceText.ofString input
     let checkOptions, _errors = checker.GetProjectOptionsFromScript(file, input) |> Async.RunSynchronously
     let parsingOptions, _errors = checker.GetParsingOptionsFromProjectOptions(checkOptions)
     let untypedRes = checker.ParseFile(file, input, parsingOptions) |> Async.RunSynchronously

--- a/fcs/samples/UntypedTree/Program.fs
+++ b/fcs/samples/UntypedTree/Program.fs
@@ -11,7 +11,7 @@ let checker = FSharpChecker.Create()
 // Get untyped tree for a specified input
 let getUntypedTree (file, input) = 
   let parsingOptions = { FSharpParsingOptions.Default with SourceFiles = [| file |] }
-  let untypedRes = checker.ParseFile(file, Microsoft.FSharp.Compiler.Text.SourceText.ofString input, parsingOptions) |> Async.RunSynchronously
+  let untypedRes = checker.ParseFile(file, FSharp.Compiler.Text.SourceText.ofString input, parsingOptions) |> Async.RunSynchronously
   match untypedRes.ParseTree with
   | Some tree -> tree
   | None -> failwith "Something went wrong during parsing!"

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -44,8 +44,7 @@ open FSharp.Compiler.TypeChecker
 open FSharp.Compiler.Tast
 open FSharp.Compiler.Tastops
 open FSharp.Compiler.TcGlobals
-
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 
 #if !NO_EXTENSIONTYPING
 open FSharp.Compiler.ExtensionTyping

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -17,7 +17,7 @@ open FSharp.Compiler.Ast
 open FSharp.Compiler.ErrorLogger
 open FSharp.Compiler.Tast
 open FSharp.Compiler.TcGlobals
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 open Microsoft.FSharp.Core.CompilerServices
 #if !NO_EXTENSIONTYPING
 open FSharp.Compiler.ExtensionTyping

--- a/src/fsharp/NameResolution.fs
+++ b/src/fsharp/NameResolution.fs
@@ -23,7 +23,7 @@ open FSharp.Compiler.AccessibilityLogic
 open FSharp.Compiler.AttributeChecking
 open FSharp.Compiler.InfoReader
 open FSharp.Compiler.PrettyNaming
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 open System.Collections.Generic
 
 #if !NO_EXTENSIONTYPING

--- a/src/fsharp/NameResolution.fsi
+++ b/src/fsharp/NameResolution.fsi
@@ -14,7 +14,7 @@ open FSharp.Compiler.Tastops
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.PrettyNaming
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 
 /// A NameResolver is a context for name resolution. It primarily holds an InfoReader.
 type NameResolver =

--- a/src/fsharp/UnicodeLexing.fsi
+++ b/src/fsharp/UnicodeLexing.fsi
@@ -2,7 +2,7 @@
 
 module internal FSharp.Compiler.UnicodeLexing
 
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 open Microsoft.FSharp.Text
 open Internal.Utilities.Text.Lexing
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -50,7 +50,7 @@ open FSharp.Compiler.Tastops
 open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.ReferenceResolver
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 
 open Internal.Utilities
 open Internal.Utilities.Collections

--- a/src/fsharp/service/ServiceXmlDocParser.fs
+++ b/src/fsharp/service/ServiceXmlDocParser.fs
@@ -4,7 +4,7 @@ namespace FSharp.Compiler.SourceCodeServices
 
 open FSharp.Compiler
 open FSharp.Compiler.AbstractIL.Internal.Library
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 
 /// Represent an Xml documentation block in source code
 type XmlDocable =

--- a/src/fsharp/service/ServiceXmlDocParser.fsi
+++ b/src/fsharp/service/ServiceXmlDocParser.fsi
@@ -5,7 +5,7 @@ namespace FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler
 open FSharp.Compiler.Range
 open FSharp.Compiler.Ast
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 
 /// Represent an Xml documentation block in source code
 type public XmlDocable =

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -41,8 +41,8 @@ open FSharp.Compiler.Infos
 open FSharp.Compiler.InfoReader
 open FSharp.Compiler.NameResolution
 open FSharp.Compiler.TypeChecker
+open FSharp.Compiler.Text
 open FSharp.Compiler.SourceCodeServices.SymbolHelpers
-open Microsoft.FSharp.Compiler.Text
 
 open Internal.Utilities
 open Internal.Utilities.Collections

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -26,7 +26,7 @@ open FSharp.Compiler.Infos
 open FSharp.Compiler.InfoReader
 open FSharp.Compiler.Tast
 open FSharp.Compiler.Tastops
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 
 /// Represents the reason why the GetDeclarationLocation operation failed.
 [<RequireQualifiedAccess>]

--- a/src/utils/prim-lexing.fs
+++ b/src/utils/prim-lexing.fs
@@ -2,7 +2,7 @@
 
 #nowarn "47" // recursive initialization of LexBuffer
 
-namespace Microsoft.FSharp.Compiler.Text
+namespace FSharp.Compiler.Text
 
 open System
 open System.IO
@@ -103,8 +103,8 @@ module SourceText =
 
 namespace Internal.Utilities.Text.Lexing
 
+    open FSharp.Compiler.Text
     open Microsoft.FSharp.Core
-    open Microsoft.FSharp.Compiler.Text
     open Microsoft.FSharp.Collections
     open System.Collections.Generic
 

--- a/src/utils/prim-lexing.fsi
+++ b/src/utils/prim-lexing.fsi
@@ -3,7 +3,7 @@
 // LexBuffers are for use with automatically generated lexical analyzers,
 // in particular those produced by 'fslex'.
 
-namespace Microsoft.FSharp.Compiler.Text
+namespace FSharp.Compiler.Text
 
 type ISourceText =
 
@@ -36,7 +36,7 @@ module SourceText =
 namespace Internal.Utilities.Text.Lexing
 
 open System.Collections.Generic
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 open Microsoft.FSharp.Core
 open Microsoft.FSharp.Control
 

--- a/tests/FSharp.Compiler.UnitTests/Compiler.fs
+++ b/tests/FSharp.Compiler.UnitTests/Compiler.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open System
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 open FSharp.Compiler.SourceCodeServices
 
 open NUnit.Framework

--- a/tests/FSharp.Compiler.UnitTests/SourceTextTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/SourceTextTests.fs
@@ -5,7 +5,7 @@ namespace FSharp.Compiler.UnitTests
 open System
 open NUnit.Framework
 
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 
 [<TestFixture>]
 module SourceTextTests =

--- a/tests/service/AssemblyContentProviderTests.fs
+++ b/tests/service/AssemblyContentProviderTests.fs
@@ -43,7 +43,7 @@ let (=>) (source: string) (expected: string list) =
                // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak
                yield "" |]
 
-    let _, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, 0, Microsoft.FSharp.Compiler.Text.SourceText.ofString source, projectOptions) |> Async.RunSynchronously
+    let _, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, 0, FSharp.Compiler.Text.SourceText.ofString source, projectOptions) |> Async.RunSynchronously
     
     let checkFileResults =
         match checkFileAnswer with

--- a/tests/service/AssemblyReaderShim.fs
+++ b/tests/service/AssemblyReaderShim.fs
@@ -29,5 +29,5 @@ let x = 123
 """
 
     let fileName, options = Common.mkTestFileAndOptions source [| |]
-    Common.checker.ParseAndCheckFileInProject(fileName, 0, Microsoft.FSharp.Compiler.Text.SourceText.ofString source, options) |> Async.RunSynchronously |> ignore
+    Common.checker.ParseAndCheckFileInProject(fileName, 0, FSharp.Compiler.Text.SourceText.ofString source, options) |> Async.RunSynchronously |> ignore
     gotRequest |> should be True

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -57,13 +57,13 @@ type TempFile(ext, contents) =
 
 let getBackgroundParseResultsForScriptText (input) = 
     use file =  new TempFile("fsx", input)
-    let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file.Name, Microsoft.FSharp.Compiler.Text.SourceText.ofString input) |> Async.RunSynchronously
+    let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file.Name, FSharp.Compiler.Text.SourceText.ofString input) |> Async.RunSynchronously
     checker.GetBackgroundParseResultsForFileInProject(file.Name, checkOptions)  |> Async.RunSynchronously
 
 
 let getBackgroundCheckResultsForScriptText (input) = 
     use file =  new TempFile("fsx", input)
-    let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file.Name, Microsoft.FSharp.Compiler.Text.SourceText.ofString input) |> Async.RunSynchronously
+    let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file.Name, FSharp.Compiler.Text.SourceText.ofString input) |> Async.RunSynchronously
     checker.GetBackgroundCheckResultsForFileInProject(file.Name, checkOptions) |> Async.RunSynchronously
 
 
@@ -167,7 +167,7 @@ let mkTestFileAndOptions source additionalArgs =
     fileName, options
 
 let parseAndCheckFile fileName source options =
-    match checker.ParseAndCheckFileInProject(fileName, 0, Microsoft.FSharp.Compiler.Text.SourceText.ofString source, options) |> Async.RunSynchronously with
+    match checker.ParseAndCheckFileInProject(fileName, 0, FSharp.Compiler.Text.SourceText.ofString source, options) |> Async.RunSynchronously with
     | parseResults, FSharpCheckFileAnswer.Succeeded(checkResults) -> parseResults, checkResults
     | _ -> failwithf "Parsing aborted unexpectedly..."
 
@@ -181,11 +181,11 @@ let parseAndCheckScript (file, input) =
     let projectOptions = checker.GetProjectOptionsFromCommandLineArgs (projName, args)
 
 #else    
-    let projectOptions, _diagnostics = checker.GetProjectOptionsFromScript(file, Microsoft.FSharp.Compiler.Text.SourceText.ofString input) |> Async.RunSynchronously
+    let projectOptions, _diagnostics = checker.GetProjectOptionsFromScript(file, FSharp.Compiler.Text.SourceText.ofString input) |> Async.RunSynchronously
     printfn "projectOptions = %A" projectOptions
 #endif
 
-    let parseResult, typedRes = checker.ParseAndCheckFileInProject(file, 0, Microsoft.FSharp.Compiler.Text.SourceText.ofString input, projectOptions) |> Async.RunSynchronously
+    let parseResult, typedRes = checker.ParseAndCheckFileInProject(file, 0, FSharp.Compiler.Text.SourceText.ofString input, projectOptions) |> Async.RunSynchronously
     
     // if parseResult.Errors.Length > 0 then
     //     printfn "---> Parse Input = %A" input
@@ -203,7 +203,7 @@ let parseSourceCode (name: string, code: string) =
     let dllPath = Path.Combine(location, name + ".dll")
     let args = mkProjectCommandLineArgs(dllPath, [filePath])
     let options, errors = checker.GetParsingOptionsFromCommandLineArgs(List.ofArray args)
-    let parseResults = checker.ParseFile(filePath, Microsoft.FSharp.Compiler.Text.SourceText.ofString code, options) |> Async.RunSynchronously
+    let parseResults = checker.ParseFile(filePath, FSharp.Compiler.Text.SourceText.ofString code, options) |> Async.RunSynchronously
     parseResults.ParseTree
 
 /// Extract range info 

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -122,8 +122,8 @@ let ``Basic cancellation test`` () =
     let file = "/home/user/Test.fsx"
     async { 
         checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-        let! checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file, Microsoft.FSharp.Compiler.Text.SourceText.ofString input) 
-        let! parseResult, typedRes = checker.ParseAndCheckFileInProject(file, 0, Microsoft.FSharp.Compiler.Text.SourceText.ofString input, checkOptions) 
+        let! checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(file, FSharp.Compiler.Text.SourceText.ofString input) 
+        let! parseResult, typedRes = checker.ParseAndCheckFileInProject(file, 0, FSharp.Compiler.Text.SourceText.ofString input, checkOptions) 
         return parseResult, typedRes
     } |> Async.RunSynchronously
       |> ignore

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -913,7 +913,7 @@ let ``Type provider project references should not throw exceptions`` () =
     //printfn "options: %A" options
     let fileName = __SOURCE_DIRECTORY__ + @"/data/TypeProviderConsole/Program.fs"    
     let fileSource = File.ReadAllText(fileName)
-    let fileParseResults, fileCheckAnswer = checker.ParseAndCheckFileInProject(fileName, 0, Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource, options) |> Async.RunSynchronously
+    let fileParseResults, fileCheckAnswer = checker.ParseAndCheckFileInProject(fileName, 0, FSharp.Compiler.Text.SourceText.ofString fileSource, options) |> Async.RunSynchronously
     let fileCheckResults = 
         match fileCheckAnswer with
         | FSharpCheckFileAnswer.Succeeded(res) -> res
@@ -1010,7 +1010,7 @@ let ``Projects creating generated types should not utilize cross-project-referen
     //printfn "options: %A" options
     let fileName = __SOURCE_DIRECTORY__ + @"/data/TypeProvidersBug/TestConsole/Program.fs"    
     let fileSource = File.ReadAllText(fileName)
-    let fileParseResults, fileCheckAnswer = checker.ParseAndCheckFileInProject(fileName, 0, Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource, options) |> Async.RunSynchronously
+    let fileParseResults, fileCheckAnswer = checker.ParseAndCheckFileInProject(fileName, 0, FSharp.Compiler.Text.SourceText.ofString fileSource, options) |> Async.RunSynchronously
     let fileCheckResults = 
         match fileCheckAnswer with
         | FSharpCheckFileAnswer.Succeeded(res) -> res

--- a/tests/service/PerfTests.fs
+++ b/tests/service/PerfTests.fs
@@ -31,7 +31,7 @@ module internal Project1 =
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSources = [ for (i,f) in fileNamesI -> (f, "module M" + string i) ]
     for (f,text) in fileSources do File.WriteAllText(f, text)
-    let fileSources2 = [ for (i,f) in fileSources -> Microsoft.FSharp.Compiler.Text.SourceText.ofString f ]
+    let fileSources2 = [ for (i,f) in fileSources -> FSharp.Compiler.Text.SourceText.ofString f ]
 
     let fileNames = [ for (_,f) in fileNamesI -> f ]
     let args = mkProjectCommandLineArgs (dllName, fileNames)

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -39,7 +39,7 @@ let fff () = xxx + xxx
 
 type CAbbrev = C
     """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     File.WriteAllText(fileName1, fileSource1Text)
 
     let fileSource2Text = """
@@ -84,7 +84,7 @@ let mmmm1 : M.C = new M.C()             // note, these don't count as uses of CA
 let mmmm2 : M.CAbbrev = new M.CAbbrev() // note, these don't count as uses of C
 
     """
-    let fileSource2 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource2Text
+    let fileSource2 = FSharp.Compiler.Text.SourceText.ofString fileSource2Text
     File.WriteAllText(fileName2, fileSource2Text)
 
     let fileNames = [fileName1; fileName2]
@@ -2429,7 +2429,7 @@ and F = { Field1 : int; Field2 : int }
 and G = Case1 | Case2 of int
 
     """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     File.WriteAllText(fileName1, fileSource1Text)
 
     let sigFileSource1Text = """
@@ -2451,7 +2451,7 @@ and F = { Field1 : int; Field2 : int }
 and G = Case1 | Case2 of int
 
     """
-    let sigFileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString sigFileSource1Text
+    let sigFileSource1 = FSharp.Compiler.Text.SourceText.ofString sigFileSource1Text
     File.WriteAllText(sigFileName1, sigFileSource1Text)
     let cleanFileName a = if a = fileName1 then "file1" elif a = sigFileName1 then "sig1"  else "??"
 
@@ -4514,7 +4514,7 @@ module internal Project35b =
 #r "System.dll"
 #r "notexist.dll"
 """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     File.WriteAllText(fileName1, fileSource1Text)
     let cleanFileName a = if a = fileName1 then "file1" else "??"
 
@@ -5158,7 +5158,7 @@ module internal ProjectBig =
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSources = [ for (i,f) in fileNamesI -> (f, "module M" + string i) ]
     for (f,text) in fileSources do File.WriteAllText(f, text)
-    let fileSources2 = [ for (i,f) in fileSources -> Microsoft.FSharp.Compiler.Text.SourceText.ofString f ]
+    let fileSources2 = [ for (i,f) in fileSources -> FSharp.Compiler.Text.SourceText.ofString f ]
 
     let fileNames = [ for (_,f) in fileNamesI -> f ]
     let args = mkProjectCommandLineArgs (dllName, fileNames)
@@ -5246,7 +5246,7 @@ module M
 # 10 "Test.fsy"
 let x = (1 = 3.0)
     """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     File.WriteAllText(fileName1, fileSource1Text)
     let fileNames = [fileName1]
     let args = mkProjectCommandLineArgs (dllName, fileNames)
@@ -5287,7 +5287,7 @@ let ``ParseAndCheckFileResults contains ImplFile list if FSharpChecker is create
 type A(i:int) =
     member x.Value = i
 """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     File.WriteAllText(fileName1, fileSource1Text)
 
     let fileNames = [fileName1]
@@ -5378,7 +5378,7 @@ type UseTheThings(i:int) =
     member x.UseSomeUsedModuleContainingExtensionMember() = (3).Q
     member x.UseSomeUsedModuleContainingUnion() = A
 """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     File.WriteAllText(fileName1, fileSource1Text)
 
     let fileNames = [fileName1]
@@ -5451,7 +5451,7 @@ type UseTheThings(i:int) =
     member x.UseSomeUsedModuleContainingExtensionMember() = (3).Q
     member x.UseSomeUsedModuleContainingUnion() = A
 """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     File.WriteAllText(fileName1, fileSource1Text)
 
     let fileNames = [fileName1]
@@ -5524,7 +5524,7 @@ type UseTheThings(i:int) =
     member x.UseSomeUsedModuleContainingExtensionMember() = (3).Q
     member x.UseSomeUsedModuleContainingUnion() = A
 """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     File.WriteAllText(fileName1, fileSource1Text)
 
     let fileNames = [fileName1]

--- a/tests/service/ProjectOptionsTests.fs
+++ b/tests/service/ProjectOptionsTests.fs
@@ -508,7 +508,7 @@ let ``Test SourceFiles order for GetProjectOptionsFromScript`` () = // See #594
         let scriptPath = __SOURCE_DIRECTORY__ + @"/data/ScriptProject/" + scriptName + ".fsx"
         let scriptSource = File.ReadAllText scriptPath
         let projOpts, _diagnostics =
-            checker.GetProjectOptionsFromScript(scriptPath, Microsoft.FSharp.Compiler.Text.SourceText.ofString scriptSource)
+            checker.GetProjectOptionsFromScript(scriptPath, FSharp.Compiler.Text.SourceText.ofString scriptSource)
             |> Async.RunSynchronously
         projOpts.SourceFiles
         |> Array.map Path.GetFileNameWithoutExtension
@@ -534,12 +534,12 @@ module ImplFile
 let x = 42
 #endif
 """
-    let fileSource1 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource1Text
+    let fileSource1 = FSharp.Compiler.Text.SourceText.ofString fileSource1Text
     let fileSource2Text = """
 #load "Impl.fs"
 ImplFile.x
 """
-    let fileSource2 = Microsoft.FSharp.Compiler.Text.SourceText.ofString fileSource2Text
+    let fileSource2 = FSharp.Compiler.Text.SourceText.ofString fileSource2Text
     File.WriteAllText(fileName1, fileSource1Text)
     File.WriteAllText(fileName2, fileSource2Text)
 

--- a/vsintegration/Utils/LanguageServiceProfiling/Program.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Program.fs
@@ -42,7 +42,7 @@ Results look like this:
 *)
 
 open FSharp.Compiler
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 open FSharp.Compiler.SourceCodeServices
 open System
 open System.IO

--- a/vsintegration/src/FSharp.Editor/CodeFix/ReplaceWithSuggestion.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ReplaceWithSuggestion.fs
@@ -12,7 +12,6 @@ open FSharp.Compiler
 open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler.SourceCodeServices
-open Microsoft.FSharp.Compiler.Text
 
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = "ReplaceWithSuggestion"); Shared>]
 type internal FSharpReplaceWithSuggestionCodeFixProvider

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -8,7 +8,7 @@ open System.IO
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.Host
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 open FSharp.Compiler.Ast
 open FSharp.Compiler.SourceCodeServices
 

--- a/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
+++ b/vsintegration/src/FSharp.LanguageService/BackgroundRequests.fs
@@ -94,7 +94,7 @@ type internal FSharpLanguageServiceBackgroundRequests_DEPRECATED
                         lazy // This portion is executed on the language service thread
                             let timestamp = if source=null then System.DateTime(2000,1,1) else source.OpenedTime // source is null in unit tests
                             let checker = getInteractiveChecker()
-                            let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(fileName,  Microsoft.FSharp.Compiler.Text.SourceText.ofString sourceText, timestamp, [| |]) |> Async.RunSynchronously
+                            let checkOptions, _diagnostics = checker.GetProjectOptionsFromScript(fileName,  FSharp.Compiler.Text.SourceText.ofString sourceText, timestamp, [| |]) |> Async.RunSynchronously
                             let referencedProjectFileNames = [| |]
                             let projectSite = ProjectSitesAndFiles.CreateProjectSiteForScript(fileName, referencedProjectFileNames, checkOptions)
                             { ProjectSite = projectSite

--- a/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
+++ b/vsintegration/src/FSharp.LanguageService/FSharpSource.fs
@@ -371,7 +371,7 @@ type internal FSharpSource_DEPRECATED(service:LanguageService_DEPRECATED, textLi
                   Stamp = None }
                 |> ic.GetParsingOptionsFromProjectOptions
 
-            ic.ParseFile(fileName,  Microsoft.FSharp.Compiler.Text.SourceText.ofString (source.GetText()), co) |> Async.RunSynchronously
+            ic.ParseFile(fileName,  FSharp.Compiler.Text.SourceText.ofString (source.GetText()), co) |> Async.RunSynchronously
 
         override source.GetCommentFormat() = 
             let mutable info = new CommentInfo()

--- a/vsintegration/tests/Salsa/salsa.fs
+++ b/vsintegration/tests/Salsa/salsa.fs
@@ -1101,7 +1101,7 @@ module internal Salsa =
             
             member file.GetFileName() = filename
             member file.GetProjectOptionsOfScript() = 
-                project.Solution.Vs.LanguageService.FSharpChecker.GetProjectOptionsFromScript(filename, Microsoft.FSharp.Compiler.Text.SourceText.ofString file.CombinedLines, System.DateTime(2000,1,1), [| |]) 
+                project.Solution.Vs.LanguageService.FSharpChecker.GetProjectOptionsFromScript(filename, FSharp.Compiler.Text.SourceText.ofString file.CombinedLines, System.DateTime(2000,1,1), [| |]) 
                 |> Async.RunSynchronously
                 |> fst // drop diagnostics
                  

--- a/vsintegration/tests/UnitTests/RoslynSourceTextTests.fs
+++ b/vsintegration/tests/UnitTests/RoslynSourceTextTests.fs
@@ -6,7 +6,7 @@ open System
 open NUnit.Framework
 
 open Microsoft.VisualStudio.FSharp.Editor
-open Microsoft.FSharp.Compiler.Text
+open FSharp.Compiler.Text
 open Microsoft.CodeAnalysis.Text
 
 [<TestFixture>]

--- a/vsintegration/tests/UnitTests/UnusedOpensTests.fs
+++ b/vsintegration/tests/UnitTests/UnusedOpensTests.fs
@@ -29,7 +29,7 @@ let private checker = FSharpChecker.Create()
 let (=>) (source: string) (expectedRanges: ((*line*)int * ((*start column*)int * (*end column*)int)) list) =
     let sourceLines = source.Split ([|"\r\n"; "\n"; "\r"|], StringSplitOptions.None)
 
-    let _, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, 0, Microsoft.FSharp.Compiler.Text.SourceText.ofString source, projectOptions) |> Async.RunSynchronously
+    let _, checkFileAnswer = checker.ParseAndCheckFileInProject(filePath, 0, FSharp.Compiler.Text.SourceText.ofString source, projectOptions) |> Async.RunSynchronously
     
     let checkFileResults =
         match checkFileAnswer with


### PR DESCRIPTION
Fix for the new type being defined in the old namespace.
Please merge it to `master`/`dev16.0` before FCS release containing SourceText.