### PR TITLE
Always build FSharp.Core.UnitTests against the FSharp.Core in the repository

### DIFF
--- a/FSharpTests.Directory.Build.props
+++ b/FSharpTests.Directory.Build.props
@@ -1,9 +1,5 @@
 <Project>
 
-  <PropertyGroup>
-    <BUILD_IN_FSHARP_REPOSITORY>true</BUILD_IN_FSHARP_REPOSITORY>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(FSharpTestCompilerVersion)' == 'net40'">
     <DisableAutoSetFscCompilerPath>true</DisableAutoSetFscCompilerPath>
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
@@ -85,13 +85,8 @@
     <Content Include="**/*"  Exclude="**/*.bak;Directory.Build.Props;Directory.Build.targets" CopyToOutputDirectory="never" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BUILD_IN_FSHARP_REPOSITORY)' == 'true'">
+  <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core\FSharp.Core.fsproj" />
-    <PackageReference Include="FsCheck" Version="$(FsCheckPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(BUILD_IN_FSHARP_REPOSITORY)' != 'true'">
-    <PackageReference Include="FSharp.Core" Version="4.6.0" />
     <PackageReference Include="FsCheck" Version="3.0.0-alpha4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
This changes FSharp.Core.UnitTests to always build against the FSharp.Core library in the repository. This ensures that FSharp.Core changes are correctly tested by CI, and it's easier to build and test changes to the library via make/build.cmd.