### PR TITLE
allow norestore switch for regular workflow

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -22,6 +22,7 @@ param (
 
     # Actions
     [switch][Alias('r')]$restore,
+    [switch]$noRestore,
     [switch][Alias('b')]$build,
     [switch]$rebuild,
     [switch]$sign,
@@ -102,6 +103,10 @@ function Process-Arguments() {
         $script:testCoreClr = $True
         $script:testFSharpQA = $True
         $script:testVs = $True
+    }
+
+    if ($noRestore) {
+        $script:restore = $False;
     }
 
     foreach ($property in $properties) {

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -91,6 +91,9 @@ while [[ $# > 0 ]]; do
     --restore|-r)
       restore=true
       ;;
+    --norestore)
+      restore=false
+      ;;
     --build|-b)
       build=true
       ;;


### PR DESCRIPTION
Enable a faster code/build loop by passing `-noRestore` (case insensitive) or `--norestore` on Linux.