### PR TITLE
Clear status bar after navigable symbol is resolved

### DIFF
--- a/vsintegration/src/FSharp.Editor/Navigation/NavigableSymbolsService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigableSymbolsService.fs
@@ -54,6 +54,7 @@ type internal FSharpNavigableSymbolSource(checkerProvider: FSharpCheckerProvider
                     try
                         // This call to Wait() is fine because we want to be able to provide the error message in the status bar.
                         gtdTask.Wait()
+                        statusBar.Clear()
 
                         if gtdTask.Status = TaskStatus.RanToCompletion && gtdTask.Result.IsSome then
                             let navigableItem, range = gtdTask.Result.Value
@@ -61,8 +62,6 @@ type internal FSharpNavigableSymbolSource(checkerProvider: FSharpCheckerProvider
                             let declarationTextSpan = RoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
                             let declarationSpan = Span(declarationTextSpan.Start, declarationTextSpan.Length)
                             let symbolSpan = SnapshotSpan(snapshot, declarationSpan)
-
-                            statusBar.Clear()
 
                             return FSharpNavigableSymbol(navigableItem, symbolSpan, gtd, statusBar) :> INavigableSymbol
                         else 

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigableSymbolsService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigableSymbolsService.fs
@@ -62,6 +62,8 @@ type internal FSharpNavigableSymbolSource(checkerProvider: FSharpCheckerProvider
                             let declarationSpan = Span(declarationTextSpan.Start, declarationTextSpan.Length)
                             let symbolSpan = SnapshotSpan(snapshot, declarationSpan)
 
+                            statusBar.Clear()
+
                             return FSharpNavigableSymbol(navigableItem, symbolSpan, gtd, statusBar) :> INavigableSymbol
                         else 
                             statusBar.TempMessage(SR.CannotDetermineSymbol())


### PR DESCRIPTION
Today, you can hover over a type while holding control and it will render as a link you can click to go to definition on. However, if you never go to definition, you will still have text in the VS status bar saying it is finding the symbol definition long after it has been found. This clears that text explicitly.