### PR TITLE
Always build FSharp.Core.UnitTests against the FSharp.Core in the repository

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -3,6 +3,10 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\targets\Settings.props" />
 
+  <PropertyGroup>
+    <BUILD_IN_FSHARP_REPOSITORY>true</BUILD_IN_FSHARP_REPOSITORY>
+  </PropertyGroup>
+
   <!-- directory locations -->
   <PropertyGroup>
     <FSharpSourcesRoot>$(RepoRoot)src</FSharpSourcesRoot>

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -46,6 +46,7 @@ param (
     [switch][Alias('test')]$testDesktop,
     [switch]$testCoreClr,
     [switch]$testFSharpQA,
+    [switch]$testFSharpCore,
     [switch]$testVs,
     [switch]$testAll,
 
@@ -76,6 +77,7 @@ function Print-Usage() {
     Write-Host "  -testDesktop              Run tests against full .NET Framework"
     Write-Host "  -testCoreClr              Run tests against CoreCLR"
     Write-Host "  -testFSharpQA             Run F# Cambridge tests"
+    Write-Host "  -testFSharpCore           Run FSharpCore unit tests"
     Write-Host "  -testVs                   Run F# editor unit tests"
     Write-Host ""
     Write-Host "Advanced settings:"
@@ -270,6 +272,14 @@ try {
         Exec-Console $perlExe """$RepoRoot\tests\fsharpqa\testenv\bin\runall.pl"" -resultsroot ""$resultsRoot"" -results $resultsLog -log $errorLog -fail $failLog -cleanup:no -procs:$env:NUMBER_OF_PROCESSORS"
         Pop-Location
     }
+
+    if ($testFSharpCore) {
+        Write-Host "Environment Variables"
+        Get-Childitem Env:
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $desktopTargetFramework
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
+    }
+
 
     if ($testVs) {
         Write-Host "Environment Variables"


### PR DESCRIPTION
The PR: here #6360 correctly identifies that the new build uses FSharp.Core from nuget for the FSharp.Core unit tests.

Thanks @frassel for logging the issue, and providing a fix.

The fix is to ensure that the build correctly sets BUILD_IN_FSHARP_REPOSITORY to true

The place to ensure that is in FSharpBuild.Directory.Build.props

The value is also set in FSharpTest.Directory.Build.props.  I will review with @brettfo whether this props file is still necessary.  I can think of a couple of test cases that rely on it, but maybe it can now be made to disappear under arcade.

This pr also adds a --testFSharpCore for flag to run just the fsharp.core.unittests on desktop and coreclr.

/cc @frassel, @dsyme 