### PR TITLE
Re-enable ngen for desktop compiler builds

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="eng\targets\NuGet.targets" />
+  <Import Project="eng\targets\NGenBinaries.targets" />
   <Import Project="FSharp.Profiles.props" />
 
   <PropertyGroup Condition="'$(UseAssetTargetFallback)' == 'true'">

--- a/eng/targets/NGenBinaries.targets
+++ b/eng/targets/NGenBinaries.targets
@@ -26,7 +26,7 @@
 
   <!-- Amazingly the net session command returns 0 if in an administrator session and > 0 if not --> 
   <Target Name="CheckAdministratorPrivilege" 
-          BeforeTargets="BeforeCompile"
+          BeforeTargets="CoreCompile"
           Condition="'$(OS)' != 'Unix'">
     <Exec Command="NET SESSION  &lt;nul 2&lt;nul" ContinueOnError="true" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode"/>

--- a/eng/targets/NGenBinaries.targets
+++ b/eng/targets/NGenBinaries.targets
@@ -1,0 +1,41 @@
+<Project>
+  <Target Name="NGenWindowsBinaries"
+          AfterTargets="AfterBuild"
+          DependsOnTargets="CheckAdministratorPrivilege"
+          Condition="'$(OS)' != 'Unix' AND
+                     $(TargetFramework.StartsWith('net4')) AND 
+                     '$(NGenBinary)' == 'true' AND
+                     Exists('$(TargetPath)') ">
+    <PropertyGroup>
+      <PathToNGen64>$(windir)\Microsoft.NET\Framework64\v4.0.30319\ngen.exe</PathToNGen64>
+      <PathToNGen32>$(windir)\Microsoft.NET\Framework\v4.0.30319\ngen.exe</PathToNGen32>
+      <PathToSN32>$(WindowsSDK_ExecutablePath_x86)sn.exe</PathToSN32>
+    </PropertyGroup>
+
+    <!-- 
+        Enable Skip Verification and then NGen for both 32 and 64 bit product.
+        If compiling use the app config file, if present.
+    -->
+    <Exec Command='"$(PathToSN32)" /Vr "$(TargetPath)"' Condition = "Exists('$(PathToSN32)') AND Exists('$(TargetPath)') AND '$(IsAdministrator)' == 'true'"/>
+
+    <Exec Command='"$(PathToNGen64)" install "$(TargetPath)" /ExeConfig:$(TargetPath)' Condition = "Exists('$(PathToNGen64)') AND '$(PlatformTarget)' != 'x86' AND Exists('$(TargetPath).config') AND '$(IsAdministrator)' == 'true'"/>
+    <Exec Command='"$(PathToNGen32)" install "$(TargetPath)" /ExeConfig:$(TargetPath)' Condition = "Exists('$(PathToNGen32)') AND '$(PlatformTarget)' != 'x64' AND Exists('$(TargetPath).config') AND '$(IsAdministrator)' == 'true'"/>
+    <Exec Command='"$(PathToNGen64)" install "$(TargetPath)"' Condition = " Exists('$(PathToNGen64)') AND '$(PlatformTarget)' != 'x86' AND (!Exists('$(TargetPath).config')) AND '$(IsAdministrator)' == 'true' "/>
+    <Exec Command='"$(PathToNGen32)" install "$(TargetPath)"' Condition = " Exists('$(PathToNGen32)') AND '$(PlatformTarget)' != 'x64' AND (!Exists('$(TargetPath).config')) AND '$(IsAdministrator)' == 'true' "/>
+  </Target>
+
+  <!-- Amazingly the net session command returns 0 if in an administrator session and > 0 if not --> 
+  <Target Name="CheckAdministratorPrivilege" 
+          BeforeTargets="BeforeCompile"
+          Condition="'$(OS)' != 'Unix'">
+    <Exec Command="NET SESSION  &lt;nul 2&lt;nul" ContinueOnError="true" IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="ErrorCode"/>
+     </Exec>
+    <PropertyGroup>
+      <IsAdministrator Condition="'$(ErrorCode)' == '0'">true</IsAdministrator>
+      <IsAdministrator Condition="'$(ErrorCode)' != '0'">false</IsAdministrator>
+      <DelaySign Condition="'$(IsAdministrator)' == 'true'">true</DelaySign>
+      <PublicSign Condition="'$(IsAdministrator)' == 'true'">false</PublicSign>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/eng/targets/NGenBinaries.targets
+++ b/eng/targets/NGenBinaries.targets
@@ -1,7 +1,14 @@
 <Project>
+
+  <!-- Windows permissions means that users can't even see the directory $(SystemRoot)System32\config -->
+  <PropertyGroup Condition="'$(OS)' != 'Unix' AND Exists('$(SystemRoot)\System32\config\system')">
+    <IsAdministrator>true</IsAdministrator>
+    <DelaySign>true</DelaySign>
+    <PublicSign>false</PublicSign>
+  </PropertyGroup>
+
   <Target Name="NGenWindowsBinaries"
           AfterTargets="AfterBuild"
-          DependsOnTargets="CheckAdministratorPrivilege"
           Condition="'$(OS)' != 'Unix' AND
                      $(TargetFramework.StartsWith('net4')) AND 
                      '$(NGenBinary)' == 'true' AND
@@ -22,20 +29,5 @@
     <Exec Command='"$(PathToNGen32)" install "$(TargetPath)" /ExeConfig:$(TargetPath)' Condition = "Exists('$(PathToNGen32)') AND '$(PlatformTarget)' != 'x64' AND Exists('$(TargetPath).config') AND '$(IsAdministrator)' == 'true'"/>
     <Exec Command='"$(PathToNGen64)" install "$(TargetPath)"' Condition = " Exists('$(PathToNGen64)') AND '$(PlatformTarget)' != 'x86' AND (!Exists('$(TargetPath).config')) AND '$(IsAdministrator)' == 'true' "/>
     <Exec Command='"$(PathToNGen32)" install "$(TargetPath)"' Condition = " Exists('$(PathToNGen32)') AND '$(PlatformTarget)' != 'x64' AND (!Exists('$(TargetPath).config')) AND '$(IsAdministrator)' == 'true' "/>
-  </Target>
-
-  <!-- Amazingly the net session command returns 0 if in an administrator session and > 0 if not --> 
-  <Target Name="CheckAdministratorPrivilege" 
-          BeforeTargets="CoreCompile"
-          Condition="'$(OS)' != 'Unix'">
-    <Exec Command="NET SESSION  &lt;nul 2&lt;nul" ContinueOnError="true" IgnoreExitCode="true">
-      <Output TaskParameter="ExitCode" PropertyName="ErrorCode"/>
-     </Exec>
-    <PropertyGroup>
-      <IsAdministrator Condition="'$(ErrorCode)' == '0'">true</IsAdministrator>
-      <IsAdministrator Condition="'$(ErrorCode)' != '0'">false</IsAdministrator>
-      <DelaySign Condition="'$(IsAdministrator)' == 'true'">true</DelaySign>
-      <PublicSign Condition="'$(IsAdministrator)' == 'true'">false</PublicSign>
-    </PropertyGroup>
   </Target>
 </Project>

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -10,6 +10,7 @@
     <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <OtherFlags>$(OtherFlags) --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
+    <NGenBinary>true</NGenBinary>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
+++ b/src/fsharp/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
@@ -10,6 +10,7 @@
     <NoWarn>$(NoWarn);45;55;62;75;1182;1204</NoWarn>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <OtherFlags>$(OtherFlags) --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
+    <NGenBinary>true</NGenBinary>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
+++ b/src/fsharp/FSharp.Compiler.Private/FSharp.Compiler.Private.fsproj
@@ -15,6 +15,7 @@
     <UseAssetTargetFallback>true</UseAssetTargetFallback>
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
     <SkipPDBConversion>true</SkipPDBConversion>
+    <NGenBinary>true</NGenBinary>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46' AND '$(OS)' == 'Windows_NT'">

--- a/src/fsharp/FSharp.Compiler.Server.Shared/FSharp.Compiler.Server.Shared.fsproj
+++ b/src/fsharp/FSharp.Compiler.Server.Shared/FSharp.Compiler.Server.Shared.fsproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
+    <NGenBinary>true</NGenBinary>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -12,6 +12,7 @@
     <DefineConstants Condition="'$(Configuration)' == 'Proto'">BUILDING_WITH_LKG;$(DefineConstants)</DefineConstants>
     <OtherFlags>$(OtherFlags) --warnon:1182 --compiling-fslib --compiling-fslib-40 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
+    <NGenBinary>true</NGenBinary>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fsharp/fsiAnyCpu/fsiAnyCpu.fsproj
+++ b/src/fsharp/fsiAnyCpu/fsiAnyCpu.fsproj
@@ -12,6 +12,7 @@
     <OtherFlags>$(OtherFlags)  --warnon:1182 --maxerrors:20 --extraoptimizationloops:1</OtherFlags>
     <Win32Resource>..\fsi\fsi.res</Win32Resource>
     <UseAssetTargetFallback>true</UseAssetTargetFallback>
+    <NGenBinary>true</NGenBinary>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
With the Arcade build and it's signing approach and requirement to not require administrator permissions we lost the ability to NGEN the protocompiler and desktop compiler build in the OSS repo.

This PR , re-enables that … because let's face it, Ngen is free speed.

NGen is silently enabled, when you open an administrator window and build the repo.  If you open a non-elevated build window, or build from an unelevated VS then you will get non-ngen behavior.

When the build is run under the CI it will run without Administrator privileges.

When built with:
- Administrator: the build uses delay signing and disables key verification to enable assembly load.
- Non Elevated: the build uses public signing.

Public signed assemblies cannot be NGEN'd, because they claim to be full signed, when they are only partially signed, so NGEN fails when verifying hashes.






