### PR TITLE
Add fsi to proto build, move version validation to ci only

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -187,10 +187,10 @@ function UpdatePath() {
 }
 
 function VerifyAssemblyVersions() {
-    $fsiPath = Join-Path $ArtifactsDir "bin\fsi\$configuration\net46\fsi.exe"
+    $fsiPath = Join-Path $ArtifactsDir "bin\fsi\Proto\net46\fsi.exe"
 
-    # desktop fsi isn't always built
-    if (Test-Path $fsiPath) {
+    # Only verify versions on CI or official build
+    if ($ci -or $official) {
         $asmVerCheckPath = "$RepoRoot\scripts"
         Exec-Console $fsiPath """$asmVerCheckPath\AssemblyVersionCheck.fsx"" -- ""$ArtifactsDir"""
     }

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -249,9 +249,7 @@ function Make-BootstrapBuild() {
     $projectPath = "$RepoRoot\proto.proj"
     Run-MSBuild $projectPath "/restore /t:Build" -logFileName "Bootstrap" -configuration $bootstrapConfiguration
     Copy-Item "$ArtifactsDir\bin\fsc\$bootstrapConfiguration\$bootstrapTfm\*" -Destination $dir
-
-    Write-Host "Cleaning Bootstrap compiler artifacts"
-    Run-MSBuild $projectPath "/t:Clean" -logFileName "BootstrapClean" -configuration $bootstrapConfiguration
+    Copy-Item "$ArtifactsDir\bin\fsi\$bootstrapConfiguration\$bootstrapTfm\*" -Destination $dir
 
     return $dir
 }

--- a/proto.proj
+++ b/proto.proj
@@ -14,6 +14,10 @@
       <AdditionalProperties Condition="'$(OS)' != 'Unix'">TargetFramework=net46</AdditionalProperties>
       <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
     </Projects>
+    <Projects Include="src\fsharp\fsi\fsi.fsproj">
+      <AdditionalProperties Condition="'$(OS)' != 'Unix'">TargetFramework=net46</AdditionalProperties>
+      <AdditionalProperties Condition="'$(OS)' == 'Unix'">TargetFramework=netcoreapp2.1</AdditionalProperties>
+    </Projects>
   </ItemGroup>
 
   <Target Name="Build">


### PR DESCRIPTION
So .. at the end of the build it does some versioning validation, it takes a while and only really needs doing on the ci and official builds.  It used the product build version of fsi.exe, which is not always built.

1.  Only do version validation
2.  Add fsi.proj to proto build and Bootstrapper
3. Don't do a partial clean at the end of the proto-build it's pointless.