### PR TITLE
allow method idx + 1 index

### DIFF
--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -2027,14 +2027,16 @@ and seekReadFields (ctxt: ILMetadataReader) (numtypars, hasLayout) fidx1 fidx2 =
     mkILFieldsLazy 
        (lazy
            let mdv = ctxt.mdfile.GetView()
-           [ for i = fidx1 to fidx2 - 1 do
-               yield seekReadField ctxt mdv (numtypars, hasLayout) i ])
+           [ if fidx1 > 0 then 
+               for i = fidx1 to fidx2 - 1 do
+                   yield seekReadField ctxt mdv (numtypars, hasLayout) i ])
 
 and seekReadMethods (ctxt: ILMetadataReader) numtypars midx1 midx2 =
     mkILMethodsComputed (fun () -> 
            let mdv = ctxt.mdfile.GetView()
-           [| for i = midx1 to midx2 - 1 do
-                 yield seekReadMethod ctxt mdv numtypars i |])
+           [| if midx1 > 0 then 
+                 for i = midx1 to midx2 - 1 do
+                     yield seekReadMethod ctxt mdv numtypars i |])
 
 and sigptrGetTypeDefOrRefOrSpecIdx bytes sigptr = 
     let n, sigptr = sigptrGetZInt32 bytes sigptr
@@ -2506,8 +2508,9 @@ and seekReadEvents (ctxt: ILMetadataReader) numtypars tidx =
                        let (_, endEventIdx) = seekReadEventMapRow ctxt mdv (rowNum + 1)
                        endEventIdx
 
-               [ for i in beginEventIdx .. endEventIdx - 1 do
-                   yield seekReadEvent ctxt mdv numtypars i ])
+               [ if beginEventIdx > 0 then 
+                   for i in beginEventIdx .. endEventIdx - 1 do
+                     yield seekReadEvent ctxt mdv numtypars i ])
 
 and seekReadProperty ctxt mdv numtypars idx =
    let (flags, nameIdx, typIdx) = seekReadPropertyRow ctxt mdv idx
@@ -2548,8 +2551,9 @@ and seekReadProperties (ctxt: ILMetadataReader) numtypars tidx =
                    else
                        let (_, endPropIdx) = seekReadPropertyMapRow ctxt mdv (rowNum + 1)
                        endPropIdx
-               [ for i in beginPropIdx .. endPropIdx - 1 do
-                   yield seekReadProperty ctxt mdv numtypars i ])
+               [ if beginPropIdx > 0 then 
+                   for i in beginPropIdx .. endPropIdx - 1 do
+                     yield seekReadProperty ctxt mdv numtypars i ])
 
 
 and customAttrsReader ctxtH tag: ILAttributesStored = 

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -3203,7 +3203,6 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
 
     let codedTables = 
           
-        let sizesTable = Array.map Array.length sortedTables
         let bignessTable = Array.map (fun rows -> Array.length rows >= 0x10000) sortedTables
         let bigness (tab: int32) = bignessTable.[tab]
         

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -87,16 +87,13 @@ type ByteBuffer with
             buf.EmitByte 0x0uy
 
     // Emit compressed untagged integer
-    member buf.EmitZUntaggedIndex nm sz big idx = 
+    member buf.EmitZUntaggedIndex big idx = 
         if big then buf.EmitInt32 idx
-        elif idx > 0xffff then 
-#if NETSTANDARD1_6
-            let trace = "no stack trace on.NET Standard 1.6"
-#else
-            let trace = (new System.Diagnostics.StackTrace()).ToString()
-#endif
-            failwithf "EmitZUntaggedIndex: index into table '%d' is too big for small address or simple index, idx = %d, big = %A, size of table = %d, stack = %s" nm idx big sz trace
-        else buf.EmitInt32AsUInt16 idx
+        else
+            // idx 0x10000 is allowed for method table idx + 1 for just beyond last index of method table
+            if idx > 0x10000 then 
+                System.Diagnostics.Debug.Assert (false, "EmitZUntaggedIndex: too big for small address or simple index")
+            buf.EmitInt32AsUInt16 idx
 
     // Emit compressed tagged integer
     member buf.EmitZTaggedIndex tag nbits big idx =
@@ -3330,12 +3327,10 @@ let writeILMetadataAndCode (generatePdb, desiredMetadataVersion, ilg, emitTailca
                     | _ when t = RowElementTags.ULong -> tablesBuf.EmitInt32 n
                     | _ when t = RowElementTags.Data -> recordRequiredDataFixup requiredDataFixups tablesBuf (tablesStreamStart + tablesBuf.Position) (n, false)
                     | _ when t = RowElementTags.DataResources -> recordRequiredDataFixup requiredDataFixups tablesBuf (tablesStreamStart + tablesBuf.Position) (n, true)
-                    | _ when t = RowElementTags.Guid -> tablesBuf.EmitZUntaggedIndex -3 guidsStreamPaddedSize guidsBig (guidAddress n)
-                    | _ when t = RowElementTags.Blob -> tablesBuf.EmitZUntaggedIndex -2 blobsStreamPaddedSize blobsBig (blobAddress n)
-                    | _ when t = RowElementTags.String -> tablesBuf.EmitZUntaggedIndex -1 stringsStreamPaddedSize stringsBig (stringAddress n)
-                    | _ when t <= RowElementTags.SimpleIndexMax -> 
-                        let tnum = t - RowElementTags.SimpleIndexMin
-                        tablesBuf.EmitZUntaggedIndex tnum (size tnum) (bigness tnum) n
+                    | _ when t = RowElementTags.Guid -> tablesBuf.EmitZUntaggedIndex guidsBig (guidAddress n)
+                    | _ when t = RowElementTags.Blob -> tablesBuf.EmitZUntaggedIndex blobsBig (blobAddress n)
+                    | _ when t = RowElementTags.String -> tablesBuf.EmitZUntaggedIndex stringsBig (stringAddress n)
+                    | _ when t <= RowElementTags.SimpleIndexMax -> tablesBuf.EmitZUntaggedIndex (bigness (t - RowElementTags.SimpleIndexMin)) n
                     | _ when t <= RowElementTags.TypeDefOrRefOrSpecMax -> tablesBuf.EmitZTaggedIndex (t - RowElementTags.TypeDefOrRefOrSpecMin) 2 tdorBigness n
                     | _ when t <= RowElementTags.TypeOrMethodDefMax -> tablesBuf.EmitZTaggedIndex (t - RowElementTags.TypeOrMethodDefMin) 1 tomdBigness n
                     | _ when t <= RowElementTags.HasConstantMax -> tablesBuf.EmitZTaggedIndex (t - RowElementTags.HasConstantMin) 2 hcBigness n


### PR DESCRIPTION
Fixes #6417 , which happens when we write a binary with exactly 65535 methods.

I checked the binary writer code in Mono.Cecil and our computations for sizes are correct, as is our token writing code.  The issue happens because an empty type definition (no methods) emits a "method table idx + 1" value, but that is expected.

https://github.com/jbevain/cecil/blob/ab5075b3a885ffd5bee5d347b79ce71aabeb32d1/Mono.Cecil.Metadata/Buffers.cs#L99

I'm testing the compiler referenced in the bug by hand

