### PR TITLE
fix bad assembly name in attribute generation

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,28 +14,29 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <FSCoreMajorVersion>4.6</FSCoreMajorVersion>
     <FSCorePackageVersion>$(FSCoreMajorVersion).2</FSCorePackageVersion>
-    <FSCoreVersion>$(FSCoreMajorVersion).0</FSCoreVersion>
-    <FSCoreVersion Condition="'$(OfficialBuildId)' == ''">$(FSCoreVersion).0</FSCoreVersion>
-    <!-- PR builds should specify a 4-part version number -->
+    <FSCoreVersionPrefix>$(FSCoreMajorVersion).0</FSCoreVersionPrefix>
+    <FSCoreVersion>$(FSCoreVersionPrefix).0</FSCoreVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <FSPackageMajorVersion>10.4</FSPackageMajorVersion>
     <FSPackageVersion>$(FSPackageMajorVersion).2</FSPackageVersion>
-    <FSProductVersion>$(FSPackageVersion)</FSProductVersion>
-    <FSProductVersion Condition="'$(OfficialBuildId)' == ''">$(FSProductVersion).0</FSProductVersion>
-    <!-- PR builds should specify a 4-part version number -->
+    <FSProductVersionPrefix>$(FSPackageVersion)</FSProductVersionPrefix>
+    <FSProductVersion>$(FSPackageVersion).0</FSProductVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <VSMajorVersion>16</VSMajorVersion>
     <VSMinorVersion>0</VSMinorVersion>
     <VSGeneralVersion>$(VSMajorVersion).0</VSGeneralVersion>
-    <VSAssemblyVersion>$(VSMajorVersion).$(VSMinorVersion).0</VSAssemblyVersion>
-    <VSAssemblyVersion Condition="'$(OfficialBuildId)' == ''">$(VSAssemblyVersion).0</VSAssemblyVersion>
-    <!-- PR builds should specify a 4-part version number -->
+    <VSAssemblyVersionPrefix>$(VSMajorVersion).$(VSMinorVersion).0</VSAssemblyVersionPrefix>
+    <VSAssemblyVersion>$(VSAssemblyVersionPrefix).0</VSAssemblyVersion>
   </PropertyGroup>
   <!-- version number assignment -->
   <PropertyGroup>
-    <VersionPrefix>$(FSCoreVersion)</VersionPrefix>
+    <VersionPrefix>$(FSCoreVersionPrefix)</VersionPrefix>
     <VersionPrefix Condition="'$(UseFSharpPackageVersion)' == 'true'">$(FSCorePackageVersion)</VersionPrefix>
-    <VersionPrefix Condition="'$(UseFSharpProductVersion)' == 'true'">$(FSProductVersion)</VersionPrefix>
-    <VersionPrefix Condition="'$(UseVsMicroBuildAssemblyVersion)' == 'true'">$(VSAssemblyVersion)</VersionPrefix>
-    <AssemblyVersion Condition="'$(OfficialBuildId)' == ''">$(VersionPrefix)</AssemblyVersion>
+    <VersionPrefix Condition="'$(UseFSharpProductVersion)' == 'true'">$(FSProductVersionPrefix)</VersionPrefix>
+    <VersionPrefix Condition="'$(UseVsMicroBuildAssemblyVersion)' == 'true'">$(VSAssemblyVersionPrefix)</VersionPrefix>
+    <AssemblyVersion Condition="'$(OfficialBuildId)' == ''">$(VersionPrefix).0</AssemblyVersion>
     <!-- PR builds should explicitly specify a version number -->
   </PropertyGroup>
   <PropertyGroup>

--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -62,42 +62,42 @@
 [$RootKey$\CLSID\{e1194663-db3c-49eb-8b45-276fcdc440ea}]
 "InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
 "Class"="Microsoft.VisualStudio.FSharp.ProjectSystem.FSharpBuildPropertyPage"
-"Assembly"="FSharp.ProjectSystem.FSharp, Version=15.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Assembly"="FSharp.ProjectSystem.FSharp, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
 "ThreadingModel"="Both"
 @="Microsoft.VisualStudio.FSharp.ProjectSystem.FSharpBuildPropertyPage"
 
 [$RootKey$\CLSID\{6d2d9b56-2691-4624-a1bf-d07a14594748}]
 "InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
 "Class"="Microsoft.VisualStudio.Editors.PropertyPages.FSharpApplicationPropPageComClass"
-"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=15.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
 "ThreadingModel"="Both"
 @="Microsoft.VisualStudio.Editors.PropertyPages.FSharpApplicationPropPageComClass"
 
 [$RootKey$\CLSID\{dd84aa8f-71bb-462a-8ef8-c9992cb325b7}]
 "InprocServer32"="$System$mscoree.dll"
 "Class"="Microsoft.VisualStudio.Editors.PropertyPages.FSharpBuildEventsPropPageComClass"
-"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=15.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
 "ThreadingModel"="Both"
 @="Microsoft.VisualStudio.Editors.PropertyPages.FSharpBuildEventsPropPageComClass"
 
 [$RootKey$\CLSID\{fac0a17e-2e70-4211-916a-0d34fb708bff}]
 "InprocServer32"="$System$mscoree.dll"
 "Class"="Microsoft.VisualStudio.Editors.PropertyPages.FSharpBuildPropPageComClass"
-"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=15.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
 "ThreadingModel"="Both"
 @="Microsoft.VisualStudio.Editors.PropertyPages.FSharpBuildPropPageComClass"
 
 [$RootKey$\CLSID\{9cfbeb2a-6824-43e2-bd3b-b112febc3772}]
 "InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
 "Class"="Microsoft.VisualStudio.Editors.PropertyPages.FSharpDebugPropPageComClass"
-"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=15.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
 "ThreadingModel"="Both"
 @="Microsoft.VisualStudio.Editors.PropertyPages.FSharpDebugPropPageComClass"
 
 [$RootKey$\CLSID\{df16b1a2-0e91-4499-ae60-c7144e614bf1}]
 "InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
 "Class"="Microsoft.VisualStudio.Editors.PropertyPages.FSharpReferencePathsPropPageComClass"
-"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=15.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+"Assembly"="FSharp.ProjectSystem.PropertyPages, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
 "ThreadingModel"="Both"
 @="Microsoft.VisualStudio.Editors.PropertyPages.FSharpReferencePathsPropPageComClass"
 

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/ProjectSystem.fsproj
@@ -71,13 +71,13 @@
     </AssemblyAttribute>
     <AssemblyAttribute Include="Microsoft.VisualStudio.Shell.ProvideCodeBaseAttribute">
       <AssemblyName>FSharp.Compiler.Private</AssemblyName>
-      <Version>$(FSProductVersion)$(_BuildNumberSuffix)</Version>
+      <Version>$(FSProductVersion)</Version>
       <CodeBase>$PackageFolder$\FSharp.Compiler.Private.dll</CodeBase>
     </AssemblyAttribute>
     <AssemblyAttribute Include="Microsoft.VisualStudio.Shell.ProvideCodeBaseAttribute">
       <AssemblyName>FSharp.Compiler.Server.Shared</AssemblyName>
+      <Version>$(FSProductVersion)</Version>
       <CodeBase>$PackageFolder$\FSharp.Compiler.Server.Shared.dll</CodeBase>
-      <Version>$(FSProductVersion)$(_BuildNumberSuffix)</Version>
     </AssemblyAttribute>
     <AssemblyAttribute Include="Microsoft.VisualStudio.Shell.ProvideCodeBaseAttribute">
       <AssemblyName>FSharp.UIResources</AssemblyName>

--- a/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
+++ b/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
@@ -78,7 +78,7 @@
 
   <ItemGroup>
     <AssemblyAttribute Include="Microsoft.VisualStudio.Shell.ProvideCodeBaseAttribute">
-      <AssemblyName>FSharp.VS.FSI.Base</AssemblyName>
+      <AssemblyName>FSharp.VS.FSI</AssemblyName>
       <Version>$(VSAssemblyVersion)</Version>
       <CodeBase>$PackageFolder$\FSharp.VS.FSI.dll</CodeBase>
     </AssemblyAttribute>


### PR DESCRIPTION
The signed build failed saying there were issues with the auto-generated `ProvideCodeBaseAttribute`.

PR cannot be completed until:
- [X] #6438 is complete.
- [ ] [internal test build](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=2562949) verified.  This also includes examining `VisualFSharpFull.vsix` and all appropriate `*.pkgdef` files.