### PR TITLE
remove extraneous FSharp.Core references

### DIFF
--- a/fcs/FSharp.Compiler.Service.MSBuild.v12/FSharp.Compiler.Service.MSBuild.v12.fsproj
+++ b/fcs/FSharp.Compiler.Service.MSBuild.v12/FSharp.Compiler.Service.MSBuild.v12.fsproj
@@ -29,9 +29,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.IO" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="FSharp.Core" Version="4.1.19" />
-    <PackageReference Include="FSharp.Core" Version="4.1.18" />
     <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12.0" Version="1.0.0" />
     <ProjectReference Include="..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
   </ItemGroup>

--- a/fcs/FSharp.Compiler.Service.ProjectCracker/FSharp.Compiler.Service.ProjectCracker.fsproj
+++ b/fcs/FSharp.Compiler.Service.ProjectCracker/FSharp.Compiler.Service.ProjectCracker.fsproj
@@ -28,9 +28,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.IO" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="FSharp.Core" Version="4.1.19" />
-    <PackageReference Include="FSharp.Core" Version="4.1.18" />
     <ProjectReference Include="..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
   </ItemGroup>
 </Project>

--- a/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -639,7 +639,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-   <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>

--- a/fcs/samples/EditorService/EditorService.fsproj
+++ b/fcs/samples/EditorService/EditorService.fsproj
@@ -13,8 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="FSharp.Core" Version="4.1.19" />
     <ProjectReference Include="..\..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>

--- a/fcs/samples/FscExe/FscExe.fsproj
+++ b/fcs/samples/FscExe/FscExe.fsproj
@@ -15,8 +15,6 @@
   <ItemGroup>
     <Reference Include="System.Runtime.Remoting" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="FSharp.Core" Version="4.1.19" />
     <ProjectReference Include="..\..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/fcs/samples/FsiExe/FsiExe.fsproj
+++ b/fcs/samples/FsiExe/FsiExe.fsproj
@@ -17,8 +17,6 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Windows.Forms" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="FSharp.Core" Version="4.1.19" />
     <ProjectReference Include="..\..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/fcs/samples/InteractiveService/InteractiveService.fsproj
+++ b/fcs/samples/InteractiveService/InteractiveService.fsproj
@@ -13,8 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="FSharp.Core" Version="4.1.19" />
     <ProjectReference Include="..\..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/fcs/samples/Tokenizer/Tokenizer.fsproj
+++ b/fcs/samples/Tokenizer/Tokenizer.fsproj
@@ -13,8 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="FSharp.Core" Version="4.1.19" />
     <ProjectReference Include="..\..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/fcs/samples/UntypedTree/UntypedTree.fsproj
+++ b/fcs/samples/UntypedTree/UntypedTree.fsproj
@@ -13,8 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharp.Core" Version="4.5.2" />
-    <PackageReference Include="FSharp.Core" Version="4.1.29" />
     <ProjectReference Include="..\..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">


### PR DESCRIPTION
Not sure how these little monsters crept into the codebase...