### PR TITLE
Add support for Net Framework to the Target Framework selector

### DIFF
--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/ApplicationPropPage.vb
@@ -23,6 +23,7 @@ Imports VslangProj90
 Imports VslangProj100
 Imports System.Runtime.Versioning
 Imports Microsoft.VisualStudio.FSharp.ProjectSystem
+Imports Microsoft.VisualStudio.Shell
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
@@ -363,6 +364,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 OutputType = CType(value, VSLangProj.prjOutputType)
                 Me.OutputType.SelectedIndex = OutputType
                 PopulateControlSet(OutputType)
+
+                'Populate the target framework combobox
+                PopulateTargetFrameworkAssemblies()
             Else
                 '// We're indeterminate 
                 Me.OutputType.SelectedIndex = INDEX_INVALID
@@ -458,8 +462,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Me.Win32ResourceFileBrowse.Enabled = False
             End If
 
-            'Populate the target framework combobox
-            PopulateTargetFrameworkAssemblies()
             ' Populate list of possible versions of FSharp.Core
             PopulateAvailableFSharpCoreVersions()
         End Sub
@@ -504,6 +506,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             Me.PopulateControlSet(OutputType)
 
+            PopulateTargetFrameworkAssemblies()
+
+            SetDirty(VsProjPropId.VBPROJPROPID_OutputType, False)
+            SetDirty(True) 'True forces Apply
             SetIconAndWin32ResourceFile()
         End Sub
 
@@ -570,15 +576,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <remarks></remarks>
         Private Function ValidateTargetFrameworkMoniker(ByVal moniker As String) As Boolean
-            If moniker = "" Or moniker = Nothing Then
+            If String.IsNullOrWhiteSpace(moniker) Then
                 Return False
-            End If
-            ' .NET Core and .NETStandard don't need redists to be installed.
-            If moniker.StartsWith(".NETCoreApp") OrElse moniker.StartsWith(".NETStandard") Then
-                Return True
-            End If
-            ' With the latest tooling, if we have editors the redist is installed by definition
-            If moniker.Contains("v2") Or moniker.Contains("v3.0") Or moniker.Contains("v3.5") Or moniker.Contains("v4") Then
+            ElseIf moniker.StartsWith(".NETCoreApp", StringComparison.OrdinalIgnoreCase) Then
+                If Me.OutputType.SelectedIndex <> INDEX_INVALID Then    ' NetCore always include
+                    ' .NET Core and .NETStandard don't need redists to be installed.
+                    Return True
+                End If
+            ElseIf moniker.StartsWith(".NETStandard", StringComparison.OrdinalIgnoreCase) Then
+                If Me.OutputType.SelectedIndex = 2 Then                 ' NetStandard ClassLibrary only
+                    Return True
+                End If
+            ElseIf moniker.Contains("v2") OrElse moniker.Contains("v3.0") OrElse moniker.Contains("v3.5") OrElse moniker.Contains("v4") Then
+                ' With the latest tooling, if we have editors the redist is installed by definition
                 Return True
             End If
             Return False
@@ -613,7 +623,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Sub PopulateAvailableFSharpCoreVersions()
             TargetFSharpCoreVersion.Items.Clear()
-            TargetFSharpCoreVersion.SelectedIndex = -1
+            TargetFSharpCoreVersion.SelectedIndex = INDEX_INVALID
 
             Dim currentFrameworkName As FrameworkName = GetCurrentFrameworkName(DTEProject)
             Dim siteServiceProvider As Microsoft.VisualStudio.OLE.Interop.IServiceProvider = Nothing
@@ -648,13 +658,24 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Sub PopulateTargetFrameworkAssemblies()
             Dim targetFrameworkSupported As Boolean = False
+            Dim selectedItem As String = Nothing
+            If Me.TargetFramework.SelectedIndex <> INDEX_INVALID Then
+                selectedItem = Me.TargetFramework.Text
+            End If
             Me.TargetFramework.Items.Clear()
-            Me.TargetFramework.SelectedIndex = -1
+            Me.TargetFramework.SelectedIndex = INDEX_INVALID
 
             Try
                 Dim sp As System.IServiceProvider = GetServiceProvider()
 
                 Dim vsFrameworkMultiTargeting As IVsFrameworkMultiTargeting = TryCast(sp.GetService(GetType(SVsFrameworkMultiTargeting)), IVsFrameworkMultiTargeting)
+                Dim slnSvc As IVsSolution = TryCast(sp.GetService(GetType(SVsSolution)), IVsSolution)
+
+                Dim hier As IVsHierarchy = Nothing
+                Dim isSdkProject = False
+                If slnSvc.GetProjectOfUniqueName(DTEProject.UniqueName, hier) = 0 Then
+                    isSdkProject = hier.IsCapabilityMatch("CPS")
+                End If
 
                 If vsFrameworkMultiTargeting IsNot Nothing Then
                     Dim currentFrameworkName As FrameworkName = GetCurrentFrameworkName(DTEProject)
@@ -662,7 +683,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     targetFrameworkSupported = True
 
                     Dim supportedTargetFrameworksDescriptor As PropertyDescriptor = GetPropertyDescriptor("SupportedTargetFrameworks")
-                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, supportedTargetFrameworksDescriptor)
+                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, isSdkProject, supportedTargetFrameworksDescriptor)
 
                     For Each supportedFramework As TargetFrameworkMoniker In supportedFrameworks
                         If Me.ValidateTargetFrameworkMoniker(supportedFramework.Moniker) Then
@@ -675,6 +696,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Next
 
                 End If
+
+                ' Put back previous value
+                If Not IsNothing(selectedItem) Then
+                    Me.TargetFramework.Text = selectedItem
+                End If
+
             Catch ex As Exception
                 targetFrameworkSupported = False
                 Me.TargetFramework.Items.Clear()
@@ -684,6 +711,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Me.TargetFramework.Enabled = False
             End If
         End Sub
+
         Private Function SetTargetFSharpCore(ByVal control As Control, ByVal prop As PropertyDescriptor, ByVal value As Object) As Boolean
             Dim combobox As ComboBox = CType(control, ComboBox)
             combobox.SelectedIndex = INDEX_INVALID


### PR DESCRIPTION
The Target Framework dropdown for F# NetSDK projects now include desktop framework targets and coreclr targets:

.Exe targets
![image](https://user-images.githubusercontent.com/5175830/56179998-80bef780-5fbc-11e9-933b-6f73f50d2ea0.png)

Library targets
![image](https://user-images.githubusercontent.com/5175830/56180086-ced3fb00-5fbc-11e9-896c-8ab6bc801105.png)
