### PR TITLE
rearrange order of SWR files to fix dependencies

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Dependencies/Microsoft.FSharp.Dependencies.csproj
+++ b/setup/Swix/Microsoft.FSharp.Dependencies/Microsoft.FSharp.Dependencies.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SwrFile Include="Files.swr" />
     <SwrFile Include="Dependencies.swr" />
+    <SwrFile Include="Files.swr" />
   </ItemGroup>
 
 </Project>

--- a/setup/Swix/Microsoft.FSharp.IDE/Dependencies.swr
+++ b/setup/Swix/Microsoft.FSharp.IDE/Dependencies.swr
@@ -12,8 +12,3 @@ vs.dependencies
                 version=$(VsixVersion)
                 type=Required
                 when=Microsoft.VisualStudio.Product.Enterprise,Microsoft.VisualStudio.Product.Professional,Microsoft.VisualStudio.Product.Community
-
-  vs.dependency id=Microsoft.FSharp.VSIX.Full.Resources
-                version=$(VsixVersion)
-                type=Required
-                when=Microsoft.VisualStudio.Product.Enterprise,Microsoft.VisualStudio.Product.Professional,Microsoft.VisualStudio.Product.Community

--- a/setup/Swix/Microsoft.FSharp.IDE/Microsoft.FSharp.IDE.csproj
+++ b/setup/Swix/Microsoft.FSharp.IDE/Microsoft.FSharp.IDE.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SwrFile Include="Files.swr" />
     <SwrFile Include="Dependencies.swr" />
+    <SwrFile Include="Files.swr" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Turns out if the dependencies file isn't first then they're not properly set in the final insertion package.