### PR TITLE
Add use refassemblies switch to fsi

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3516,7 +3516,7 @@ type TcAssemblyResolutions(tcConfig: TcConfig, results: AssemblyResolution list,
 
     static member GetAllDllReferences (tcConfig: TcConfig) = [
             let primaryReference = tcConfig.PrimaryAssemblyDllReference()
-            yield primaryReference
+            //yield primaryReference
 
             if not tcConfig.compilingFslib then 
                 yield tcConfig.CoreLibraryDllReference()

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -361,6 +361,7 @@ type TcConfigBuilder =
       mutable exename: string option 
       mutable copyFSharpCore: CopyFSharpCoreFlag
       mutable shadowCopyReferences: bool
+      mutable useSdkRefs: bool
 
       /// A function to call to try to get an object that acts as a snapshot of the metadata section of a .NET binary,
       /// and from which we can read the metadata. Only used when metadataOnly=true.
@@ -371,6 +372,7 @@ type TcConfigBuilder =
 
       /// Prevent erasure of conditional attributes and methods so tooling is able analyse them.
       mutable noConditionalErasure: bool
+
     }
 
     static member Initial: TcConfigBuilder
@@ -394,11 +396,9 @@ type TcConfigBuilder =
     member RemoveReferencedAssemblyByPath: range * string -> unit
     member AddEmbeddedSourceFile: string -> unit
     member AddEmbeddedResource: string -> unit
-    
+
     static member SplitCommandLineResourceInfo: string -> string * string * ILResourceAccess
 
-
-    
 [<Sealed>]
 // Immutable TcConfig
 type TcConfig =
@@ -531,6 +531,8 @@ type TcConfig =
 
     member copyFSharpCore: CopyFSharpCoreFlag
     member shadowCopyReferences: bool
+    member useSdkRefs: bool
+
     static member Create: TcConfigBuilder * validate: bool -> TcConfig
 
 /// Represents a computation to return a TcConfig. Normally this is just a constant immutable TcConfig,
@@ -801,7 +803,7 @@ type LoadClosure =
     //
     /// A temporary TcConfig is created along the way, is why this routine takes so many arguments. We want to be sure to use exactly the
     /// same arguments as the rest of the application.
-    static member ComputeClosureOfScriptText: CompilationThreadToken * legacyReferenceResolver: ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * filename: string * sourceText: ISourceText * implicitDefines:CodeContext * useSimpleResolution: bool * useFsiAuxLib: bool * lexResourceManager: Lexhelp.LexResourceManager * applyCompilerOptions: (TcConfigBuilder -> unit) * assumeDotNetFramework: bool * tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot * reduceMemoryUsage: ReduceMemoryFlag -> LoadClosure
+    static member ComputeClosureOfScriptText: CompilationThreadToken * legacyReferenceResolver: ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * filename: string * sourceText: ISourceText * implicitDefines:CodeContext * useSimpleResolution: bool * useFsiAuxLib: bool * useSdkRefs: bool * lexResourceManager: Lexhelp.LexResourceManager * applyCompilerOptions: (TcConfigBuilder -> unit) * assumeDotNetFramework: bool * tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot * reduceMemoryUsage: ReduceMemoryFlag -> LoadClosure
 
     /// Analyze a set of script files and find the closure of their references. The resulting references are then added to the given TcConfig.
     /// Used from fsi.fs and fsc.fs, for #load and command line. 

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -547,18 +547,21 @@ let PrintOptionInfo (tcConfigB:TcConfigBuilder) =
 // OptionBlock: Input files
 //-------------------------
 
-let inputFileFlagsFsi (_tcConfigB: TcConfigBuilder) : CompilerOption list = [
-#if NETSTANDARD
-    CompilerOption("usesdkrefs", tagNone, OptionSwitch (SetUseSdkSwitch _tcConfigB), None, Some (FSComp.SR.useSdkRefs()))
-#endif
+let inputFileFlagsBoth (tcConfigB: TcConfigBuilder) =
+    [ CompilerOption("reference", tagFile, OptionString (fun s -> tcConfigB.AddReferencedAssemblyByPath (rangeStartup, s)), None, Some (FSComp.SR.optsReference()))
     ]
 
-let inputFileFlagsBoth (tcConfigB: TcConfigBuilder) =
-    let fsi = inputFileFlagsFsi tcConfigB
-    [ CompilerOption("reference", tagFile, OptionString (fun s -> tcConfigB.AddReferencedAssemblyByPath (rangeStartup, s)), None, Some (FSComp.SR.optsReference()) )
-    ] @ fsi 
-
 let inputFileFlagsFsc tcConfigB = inputFileFlagsBoth tcConfigB 
+
+let inputFileFlagsFsiBase (_tcConfigB: TcConfigBuilder) =
+#if NETSTANDARD
+        [ CompilerOption("usesdkrefs", tagNone, OptionSwitch (SetUseSdkSwitch _tcConfigB), None, Some (FSComp.SR.useSdkRefs())) ]
+#else
+        List.empty<CompilerOption>
+#endif
+
+let inputFileFlagsFsi (tcConfigB: TcConfigBuilder) =
+    List.concat [ inputFileFlagsBoth tcConfigB; inputFileFlagsFsiBase tcConfigB]
 
 // OptionBlock: Errors and warnings
 //---------------------------------

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1458,3 +1458,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3245,tcCopyAndUpdateNeedsRecordType,"The input to a copy-and-update expression that creates an anonymous record must be either an anonymous record or a record"
 3300,chkInvalidFunctionParameterType,"The parameter '%s' has an invalid type '%s'. This is not permitted by the rules of Common IL."
 3301,chkInvalidFunctionReturnType,"The function or method has an invalid return type '%s'. This is not permitted by the rules of Common IL."
+useSdkRefs,"Use reference assemblies for DotNET framework references when available (Enabled by default))."

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2432,6 +2432,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     do tcConfigB.useFsiAuxLib <- fsi.UseFsiAuxLib
 
 #if NETSTANDARD
+    do tcConfigB.useSdkRefs <- true
     do tcConfigB.useSimpleResolution <- true
     do SetTargetProfile tcConfigB "netcore" // always assume System.Runtime codegen
 #endif

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -2820,14 +2820,14 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     member bc.ParseAndCheckProject(options, userOpName) =
         reactor.EnqueueAndAwaitOpAsync(userOpName, "ParseAndCheckProject", options.ProjectFileName, fun ctok -> bc.ParseAndCheckProjectImpl(options, ctok, userOpName))
 
-    member bc.GetProjectOptionsFromScript(filename, sourceText, loadedTimeStamp, otherFlags, useFsiAuxLib: bool option, assumeDotNetFramework: bool option, extraProjectInfo: obj option, optionsStamp: int64 option, userOpName) = 
+    member bc.GetProjectOptionsFromScript(filename, sourceText, loadedTimeStamp, otherFlags, useFsiAuxLib: bool option, useSdkRefs: bool option, assumeDotNetFramework: bool option, extraProjectInfo: obj option, optionsStamp: int64 option, userOpName) = 
         reactor.EnqueueAndAwaitOpAsync (userOpName, "GetProjectOptionsFromScript", filename, fun ctok -> 
           cancellable {
             use errors = new ErrorScope()
 
             // Do we add a reference to FSharp.Compiler.Interactive.Settings by default?
             let useFsiAuxLib = defaultArg useFsiAuxLib true
-
+            let useSdkRefs =  defaultArg useSdkRefs true
             let reduceMemoryUsage = ReduceMemoryFlag.Yes
 
             // Do we assume .NET Framework references for scripts?
@@ -2847,7 +2847,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
             let loadClosure = 
                 LoadClosure.ComputeClosureOfScriptText(ctok, legacyReferenceResolver, 
                     defaultFSharpBinariesDir, filename, sourceText, 
-                    CodeContext.Editing, useSimpleResolution, useFsiAuxLib, new Lexhelp.LexResourceManager(), 
+                    CodeContext.Editing, useSimpleResolution, useFsiAuxLib, useSdkRefs, new Lexhelp.LexResourceManager(), 
                     applyCompilerOptions, assumeDotNetFramework, 
                     tryGetMetadataSnapshot=tryGetMetadataSnapshot, 
                     reduceMemoryUsage=reduceMemoryUsage)
@@ -3209,10 +3209,10 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
         backgroundCompiler.KeepProjectAlive(options, userOpName)
 
     /// For a given script file, get the ProjectOptions implied by the #load closure
-    member ic.GetProjectOptionsFromScript(filename, sourceText, ?loadedTimeStamp, ?otherFlags, ?useFsiAuxLib, ?assumeDotNetFramework, ?extraProjectInfo: obj, ?optionsStamp: int64, ?userOpName: string) = 
+    member ic.GetProjectOptionsFromScript(filename, source, ?loadedTimeStamp, ?otherFlags, ?useFsiAuxLib, ?useSdkRefs, ?assumeDotNetFramework, ?extraProjectInfo: obj, ?optionsStamp: int64, ?userOpName: string) = 
         let userOpName = defaultArg userOpName "Unknown"
-        backgroundCompiler.GetProjectOptionsFromScript(filename, sourceText, loadedTimeStamp, otherFlags, useFsiAuxLib, assumeDotNetFramework, extraProjectInfo, optionsStamp, userOpName)
-        
+        backgroundCompiler.GetProjectOptionsFromScript(filename, source, loadedTimeStamp, otherFlags, useFsiAuxLib, useSdkRefs, assumeDotNetFramework, extraProjectInfo, optionsStamp, userOpName)
+
     member ic.GetProjectOptionsFromCommandLineArgs(projectFileName, argv, ?loadedTimeStamp, ?extraProjectInfo: obj) = 
         let loadedTimeStamp = defaultArg loadedTimeStamp DateTime.MaxValue // Not 'now', we don't want to force reloading
         { ProjectFileName = projectFileName
@@ -3323,7 +3323,7 @@ type FsiInteractiveChecker(legacyReferenceResolver, reactorOps: IReactorOperatio
                 let fsiCompilerOptions = CompileOptions.GetCoreFsiCompilerOptions tcConfigB 
                 CompileOptions.ParseCompilerOptions (ignore, fsiCompilerOptions, [ ])
 
-            let loadClosure = LoadClosure.ComputeClosureOfScriptText(ctok, legacyReferenceResolver, defaultFSharpBinariesDir, filename, sourceText, CodeContext.Editing, tcConfig.useSimpleResolution, tcConfig.useFsiAuxLib, new Lexhelp.LexResourceManager(), applyCompilerOptions, assumeDotNetFramework, tryGetMetadataSnapshot=(fun _ -> None), reduceMemoryUsage=reduceMemoryUsage)
+            let loadClosure = LoadClosure.ComputeClosureOfScriptText(ctok, legacyReferenceResolver, defaultFSharpBinariesDir, filename, sourceText, CodeContext.Editing, tcConfig.useSimpleResolution, tcConfig.useFsiAuxLib, tcConfig.useSdkRefs, new Lexhelp.LexResourceManager(), applyCompilerOptions, assumeDotNetFramework, tryGetMetadataSnapshot=(fun _ -> None), reduceMemoryUsage=reduceMemoryUsage)
             let! tcErrors, tcFileResult =  Parser.CheckOneFile(parseResults, sourceText, filename, "project", tcConfig, tcGlobals, tcImports,  tcState, Map.empty, Some loadClosure, backgroundDiagnostics, reactorOps, (fun () -> true), None, userOpName, suggestNamesForErrors)
 
             return

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -524,7 +524,7 @@ type public FSharpChecker =
     /// so that an 'unload' and 'reload' action will cause the script to be considered as a new project,
     /// so that references are re-resolved.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetProjectOptionsFromScript : filename: string * sourceText: ISourceText * ?loadedTimeStamp: DateTime * ?otherFlags: string[] * ?useFsiAuxLib: bool * ?assumeDotNetFramework: bool * ?extraProjectInfo: obj * ?optionsStamp: int64 * ?userOpName: string -> Async<FSharpProjectOptions * FSharpErrorInfo list>
+    member GetProjectOptionsFromScript : filename: string * sourceText: ISourceText * ?loadedTimeStamp: DateTime * ?otherFlags: string[] * ?useFsiAuxLib: bool * ?useSdkRefs: bool * ?assumeDotNetFramework: bool * ?extraProjectInfo: obj * ?optionsStamp: int64 * ?userOpName: string -> Async<FSharpProjectOptions * FSharpErrorInfo list>
 
     /// <summary>
     /// <para>Get the FSharpProjectOptions implied by a set of command line arguments.</para>

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Zvažte použití parametru return! namísto return.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Zvažte použití parametru yield! namísto yield.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Verwenden Sie ggf. "return!" anstelle von "return".</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Verwenden Sie ggf. "yield!" anstelle von "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Considere la posibilidad de usar "return!" en lugar de "return".</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Considere la posibilidad de usar "yield!" en lugar de "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Utilisez 'return!' à la place de 'return'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Utilisez 'yield!' à la place de 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Provare a usare 'return!' invece di 'return'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Provare a usare 'yield!' invece di 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -137,6 +137,11 @@
         <target state="translated">'return' の代わりに 'return!' を使うことを検討してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield' の代わりに 'yield!' を使うことを検討してください。</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -137,6 +137,11 @@
         <target state="translated">'return'이 아니라 'return!'를 사용하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield'가 아닌 'yield!'를 사용하세요.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Rozważ użycie polecenia „return!” zamiast „return”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Rozważ użycie polecenia „yield!” zamiast „yield”.</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Considere usar 'return!' em vez de 'return'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Considere usar 'yield!' em vez de 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Рекомендуется использовать "return!" вместо "return".</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Рекомендуется использовать "yield!" вместо "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">'return' yerine 'return!' kullanmayı deneyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield' yerine 'yield!' kullanmayı deneyin.</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -137,6 +137,11 @@
         <target state="translated">考虑使用 "return!"，而非 "return"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">考虑使用 "yield!"，而非 "yield"。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -137,6 +137,11 @@
         <target state="translated">請考慮使用 'return!'，而不使用 'return'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">請考慮使用 'yield!' 而不使用 'yield'。</target>


### PR DESCRIPTION
With DotNet Core 3.0, we will be shipping a set of reference assemblies that matches the default target framework for the shipped dotnet cli.  The NetSdk team are updating the compile time build to make use of these.

This PR adds an additional switch to FSI, that will have fsi compile against this set of reference assemblies by default rather than the implementation assemblies.

This is important because with versions of the cli revving frequently and supporting multiple platforms, we want to ensure that scripts run against a consistent platform.  Implementation assemblies may have a bigger public surface, and one that is not consistent across platforms or between versions.

E.g ..

Internal.Runtime.InteropServices.WindowsRuntime.ExceptionSupport is a public internal implementation type, that would be risky to rely on.
````
> let t=typeof<Internal.Runtime.InteropServices.WindowsRuntime.ExceptionSupport>;;
val t : System.Type =
  Internal.Runtime.InteropServices.WindowsRuntime.ExceptionSupport
````

With this feature:
````
> let t = typeof<Internal.Resources.WindowsRuntimeResourceManagerBase.WindowsRuntimeResourceManagerBase>;;

  let t = typeof<Internal.Resources.WindowsRuntimeResourceManagerBase.WindowsRuntimeResourceManagerBase>;;
  ---------------^^^^^^^^

stdin(1,16): error FS0039: The namespace or module 'Internal' is not defined.
````

The dotnet framework contracts are defined by the framework definitions:  DotNetStandard1.6 and up, and DotNetCoreApp1.0 and up and similar net461, net472 etc … not by the contents of any assemblies in the coreclr runtime directory.

1.  Enabled by default use refs on DotNet Core 3.0 runtime
2.  Always run scripts, against the netcoreapp version that matches the executing fsi.
3.  It does not provide a downgrade switch.  We can consider a downgrade switch for a future feature when the deployment story for these packages has stabilized.
4. To disable use __--usesdkrefs-__
5. If refs not supported, I.e. netcoreapp2.1 or 2.2 then falls back to implementation assemblies.
6. Desktop / Mono implementaions of fsi, do what they did before … use implementation assemblies, there is no switch.


Kevin