### PR TITLE
[wip] adjustments to tests/fsharpqa/run.fsharpqa.test.fsx

### DIFF
--- a/tests/fsharpqa/run.fsharpqa.test.fsx
+++ b/tests/fsharpqa/run.fsharpqa.test.fsx
@@ -17,9 +17,13 @@ let addToPath path =
 
 let rootFolder = Path.Combine(__SOURCE_DIRECTORY__, "..", "..")
 let compilerBinFolder = Path.Combine(rootFolder, releaseOrDebug, "net40", "bin")
+
+// this needs to be kept in sync with something else somewhere else
+// this is probably outdated
 setEnvVar "CSC_PIPE"      (Path.Combine(rootFolder, "packages", "Microsoft.Net.Compilers.2.7.0", "tools", "csc.exe"))
 setEnvVar "FSC"           (Path.Combine(compilerBinFolder, "fsc.exe"))
 setEnvVar "FSCOREDLLPATH" (Path.Combine(compilerBinFolder, "FSharp.Core.dll"))
+
 addToPath compilerBinFolder
 
 let runPerl arguments =
@@ -43,18 +47,27 @@ let runPerl arguments =
     
   if not perlExe.Exists then failwithf "couldn't find %s, please adjust this script" perlExe.FullName else
 
+  printfn "found perl.exe in %s" perlExe.Directory.FullName
+
   perlProcess.StartInfo.set_FileName (perlExe.FullName)
   perlProcess.StartInfo.set_Arguments (arguments |> Array.map(fun a -> @"""" + a + @"""") |> String.concat " ")
   perlProcess.StartInfo.set_WorkingDirectory (Path.Combine(rootFolder, "tests", "fsharpqa", "source"))
   perlProcess.StartInfo.set_RedirectStandardOutput true
   perlProcess.StartInfo.set_RedirectStandardError true
   perlProcess.StartInfo.set_UseShellExecute false
+  
+  printfn "starting perl.exe with arguments: %s" perlProcess.StartInfo.Arguments
+  
   perlProcess.Start() |> ignore
+  
   while (not perlProcess.StandardOutput.EndOfStream) do
     perlProcess.StandardOutput.ReadLine() |> printfn "%s" 
+  
   while (not perlProcess.StandardError.EndOfStream) do
     perlProcess.StandardError.ReadLine() |> printfn "%s" 
+  
   perlProcess.WaitForExit()
+  
   if perlProcess.ExitCode <> 0 then
     failwithf "exit code: %i" perlProcess.ExitCode
 

--- a/tests/fsharpqa/run.fsharpqa.test.fsx
+++ b/tests/fsharpqa/run.fsharpqa.test.fsx
@@ -3,7 +3,7 @@
 
 open System.IO
 open System.Diagnostics
-
+type Env = System.Environment
 let releaseOrDebug = "Debug"
 let setEnvVar name value =
   System.Environment.SetEnvironmentVariable(name, value)
@@ -26,7 +26,24 @@ let runPerl arguments =
   // a bit expeditive, but does the deed
   Process.GetProcessesByName("perl") |> Array.iter (fun p -> p.Kill())
   use perlProcess = new Process()
-  perlProcess.StartInfo.set_FileName (Path.Combine(rootFolder, "packages", "StrawberryPerl64.5.22.2.1", "Tools", "perl", "bin", "perl.exe"))
+  let userRoot = Env.SpecialFolder.UserProfile |> Env.GetFolderPath
+
+  let perlExe = 
+    [| userRoot
+       ".nuget"
+       "packages"
+       "strawberryperl64"
+       "5.22.2.1"
+       "Tools"
+       "perl"
+       "bin"
+       "perl.exe" |] 
+    |> Path.Combine
+    |> FileInfo
+    
+  if not perlExe.Exists then failwithf "couldn't find %s, please adjust this script" perlExe.FullName else
+
+  perlProcess.StartInfo.set_FileName (perlExe.FullName)
   perlProcess.StartInfo.set_Arguments (arguments |> Array.map(fun a -> @"""" + a + @"""") |> String.concat " ")
   perlProcess.StartInfo.set_WorkingDirectory (Path.Combine(rootFolder, "tests", "fsharpqa", "source"))
   perlProcess.StartInfo.set_RedirectStandardOutput true

--- a/tests/fsharpqa/run.fsharpqa.test.fsx
+++ b/tests/fsharpqa/run.fsharpqa.test.fsx
@@ -56,7 +56,7 @@ let runPerl arguments =
   perlProcess.StartInfo.set_RedirectStandardError true
   perlProcess.StartInfo.set_UseShellExecute false
   
-  printfn "starting perl.exe with arguments: %s" perlProcess.StartInfo.Arguments
+  printfn "starting perl.exe from directory: %s\nwith arguments: %s" perlProcess.StartInfo.WorkingDirectory perlProcess.StartInfo.Arguments
   
   perlProcess.Start() |> ignore
   


### PR DESCRIPTION
`Run.pl` doesn't work yet on my machine when running this way (will check directly from command line), maybe some of the directories or files moved in master since this script came, and it may need more adjustments.

```
Runall.pl line 900:  Fatal Error: No such file or directory
Could not open fail list 'failures.lst'.
C:\dev\src\github.com\Microsoft\visualfsharp\tests\fsharpqa\..\..\tests\fsharpqa\testenv\bin\runall.pl terminated abnormally.
Can't use an undefined value as a symbol reference at C:\dev\src\github.com\Microsoft\visualfsharp\tests\fsharpqa\..\..\tests\fsharpqa\testenv\bin\runall.pl line 1002.
> System.Exception: exit code: 2
   at Microsoft.FSharp.Core.PrintfModule.PrintFormatToStringThenFail@1647.Invoke(String message)
   at FSI_0019.runPerl(String[] arguments) in C:\dev\src\github.com\Microsoft\visualfsharp\tests\fsharpqa\run.fsharpqa.test.fsx:line 59
   at <StartupCode$FSI_0019>.$FSI_0019.main@() in C:\dev\src\github.com\Microsoft\visualfsharp\tests\fsharpqa\run.fsharpqa.test.fsx:line 62
Stopped due to error
```

hoping I can add a test to fsharpqa soon.

- [x] fix nuget path in script
- [ ] make run.pl work on my machine
- [ ] able to work with fsharpqa tests on my machine

