### PR TITLE
Pinvoke testing

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -46,6 +46,7 @@ param (
     [switch]$warnAsError = $true,
     [switch][Alias('test')]$testDesktop,
     [switch]$testCoreClr,
+    [switch]$testFSharpCompiler,
     [switch]$testFSharpQA,
     [switch]$testFSharpCore,
     [switch]$testVs,
@@ -77,6 +78,7 @@ function Print-Usage() {
     Write-Host "  -testAll                  Run all tests"
     Write-Host "  -testDesktop              Run tests against full .NET Framework"
     Write-Host "  -testCoreClr              Run tests against CoreCLR"
+    Write-Host "  -testFSharpCompiler       Run F# Compiler unit tests"
     Write-Host "  -testFSharpQA             Run F# Cambridge tests"
     Write-Host "  -testFSharpCore           Run FSharpCore unit tests"
     Write-Host "  -testVs                   Run F# editor unit tests"
@@ -279,16 +281,16 @@ try {
     }
 
     if ($testFSharpCore) {
-        Write-Host "Environment Variables"
-        Get-Childitem Env:
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Core.UnitTests\FSharp.Core.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
     }
 
+    if ($testFSharpCompiler) {
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $desktopTargetFramework
+        TestUsingNUnit -testProject "$RepoRoot\tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj" -targetFramework $coreclrTargetFramework
+    }
 
     if ($testVs) {
-        Write-Host "Environment Variables"
-        Get-Childitem Env:
         TestUsingNUnit -testProject "$RepoRoot\vsintegration\tests\GetTypesVS.UnitTests\GetTypesVS.UnitTests.fsproj" -targetFramework $desktopTargetFramework
         TestUsingNUnit -testProject "$RepoRoot\vsintegration\tests\UnitTests\VisualFSharp.UnitTests.fsproj" -targetFramework $desktopTargetFramework
     }

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3516,7 +3516,7 @@ type TcAssemblyResolutions(tcConfig: TcConfig, results: AssemblyResolution list,
 
     static member GetAllDllReferences (tcConfig: TcConfig) = [
             let primaryReference = tcConfig.PrimaryAssemblyDllReference()
-            yield primaryReference
+            //yield primaryReference
 
             if not tcConfig.compilingFslib then 
                 yield tcConfig.CoreLibraryDllReference()

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3517,7 +3517,6 @@ type TcAssemblyResolutions(tcConfig: TcConfig, results: AssemblyResolution list,
 
     static member GetAllDllReferences (tcConfig: TcConfig) = [
             let primaryReference = tcConfig.PrimaryAssemblyDllReference()
-            //yield primaryReference
 
             if not tcConfig.compilingFslib then 
                 yield tcConfig.CoreLibraryDllReference()
@@ -5126,12 +5125,12 @@ module private ScriptPreprocessClosure =
 
     /// Given source text, find the full load closure. Used from service.fs, when editing a script file
     let GetFullClosureOfScriptText
-           (ctok, legacyReferenceResolver, defaultFSharpBinariesDir, 
-            filename, sourceText, codeContext, 
+           (ctok, legacyReferenceResolver, defaultFSharpBinariesDir,
+            filename, sourceText, codeContext,
             useSimpleResolution, useFsiAuxLib, useSdkRefs,
-            lexResourceManager: Lexhelp.LexResourceManager, 
+            lexResourceManager: Lexhelp.LexResourceManager,
             applyCommmandLineArgs, assumeDotNetFramework,
-            tryGetMetadataSnapshot, reduceMemoryUsage) = 
+            tryGetMetadataSnapshot, reduceMemoryUsage) =
 
         // Resolve the basic references such as FSharp.Core.dll first, before processing any #I directives in the script
         //
@@ -5178,15 +5177,15 @@ type LoadClosure with
     /// A temporary TcConfig is created along the way, is why this routine takes so many arguments. We want to be sure to use exactly the
     /// same arguments as the rest of the application.
     static member ComputeClosureOfScriptText
-                     (ctok, legacyReferenceResolver, defaultFSharpBinariesDir, 
-                      filename: string, sourceText: ISourceText, codeContext, useSimpleResolution: bool, 
-                      useFsiAuxLib, useSdkRefs, lexResourceManager: Lexhelp.LexResourceManager, 
-                      applyCommmandLineArgs, assumeDotNetFramework, tryGetMetadataSnapshot, reduceMemoryUsage) = 
+                     (ctok, legacyReferenceResolver, defaultFSharpBinariesDir,
+                      filename: string, sourceText: ISourceText, codeContext, useSimpleResolution: bool,
+                      useFsiAuxLib, useSdkRefs, lexResourceManager: Lexhelp.LexResourceManager,
+                      applyCommmandLineArgs, assumeDotNetFramework, tryGetMetadataSnapshot, reduceMemoryUsage) =
 
         use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parse
         ScriptPreprocessClosure.GetFullClosureOfScriptText
-            (ctok, legacyReferenceResolver, defaultFSharpBinariesDir, filename, sourceText, 
-             codeContext, useSimpleResolution, useFsiAuxLib, useSdkRefs, lexResourceManager, 
+            (ctok, legacyReferenceResolver, defaultFSharpBinariesDir, filename, sourceText,
+             codeContext, useSimpleResolution, useFsiAuxLib, useSdkRefs, lexResourceManager,
              applyCommmandLineArgs, assumeDotNetFramework, tryGetMetadataSnapshot, reduceMemoryUsage)
 
     /// Analyze a set of script files and find the closure of their references.
@@ -5195,8 +5194,7 @@ type LoadClosure with
                       lexResourceManager: Lexhelp.LexResourceManager) =
         use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.Parse
         ScriptPreprocessClosure.GetFullClosureOfScriptFiles (ctok, tcConfig, files, codeContext, lexResourceManager)
-        
-              
+
 
 //----------------------------------------------------------------------------
 // Initial type checking environment

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -361,6 +361,7 @@ type TcConfigBuilder =
       mutable exename: string option 
       mutable copyFSharpCore: CopyFSharpCoreFlag
       mutable shadowCopyReferences: bool
+      mutable useSdkRefs: bool
 
       /// A function to call to try to get an object that acts as a snapshot of the metadata section of a .NET binary,
       /// and from which we can read the metadata. Only used when metadataOnly=true.
@@ -371,6 +372,7 @@ type TcConfigBuilder =
 
       /// Prevent erasure of conditional attributes and methods so tooling is able analyse them.
       mutable noConditionalErasure: bool
+
     }
 
     static member Initial: TcConfigBuilder
@@ -394,11 +396,9 @@ type TcConfigBuilder =
     member RemoveReferencedAssemblyByPath: range * string -> unit
     member AddEmbeddedSourceFile: string -> unit
     member AddEmbeddedResource: string -> unit
-    
+
     static member SplitCommandLineResourceInfo: string -> string * string * ILResourceAccess
 
-
-    
 [<Sealed>]
 // Immutable TcConfig
 type TcConfig =
@@ -531,6 +531,8 @@ type TcConfig =
 
     member copyFSharpCore: CopyFSharpCoreFlag
     member shadowCopyReferences: bool
+    member useSdkRefs: bool
+
     static member Create: TcConfigBuilder * validate: bool -> TcConfig
 
 /// Represents a computation to return a TcConfig. Normally this is just a constant immutable TcConfig,
@@ -801,7 +803,7 @@ type LoadClosure =
     //
     /// A temporary TcConfig is created along the way, is why this routine takes so many arguments. We want to be sure to use exactly the
     /// same arguments as the rest of the application.
-    static member ComputeClosureOfScriptText: CompilationThreadToken * legacyReferenceResolver: ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * filename: string * sourceText: ISourceText * implicitDefines:CodeContext * useSimpleResolution: bool * useFsiAuxLib: bool * lexResourceManager: Lexhelp.LexResourceManager * applyCompilerOptions: (TcConfigBuilder -> unit) * assumeDotNetFramework: bool * tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot * reduceMemoryUsage: ReduceMemoryFlag -> LoadClosure
+    static member ComputeClosureOfScriptText: CompilationThreadToken * legacyReferenceResolver: ReferenceResolver.Resolver * defaultFSharpBinariesDir: string * filename: string * sourceText: ISourceText * implicitDefines:CodeContext * useSimpleResolution: bool * useFsiAuxLib: bool * useSdkRefs: bool * lexResourceManager: Lexhelp.LexResourceManager * applyCompilerOptions: (TcConfigBuilder -> unit) * assumeDotNetFramework: bool * tryGetMetadataSnapshot: ILReaderTryGetMetadataSnapshot * reduceMemoryUsage: ReduceMemoryFlag -> LoadClosure
 
     /// Analyze a set of script files and find the closure of their references. The resulting references are then added to the given TcConfig.
     /// Used from fsi.fs and fsc.fs, for #load and command line. 

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1458,3 +1458,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3245,tcCopyAndUpdateNeedsRecordType,"The input to a copy-and-update expression that creates an anonymous record must be either an anonymous record or a record"
 3300,chkInvalidFunctionParameterType,"The parameter '%s' has an invalid type '%s'. This is not permitted by the rules of Common IL."
 3301,chkInvalidFunctionReturnType,"The function or method has an invalid return type '%s'. This is not permitted by the rules of Common IL."
+useSdkRefs,"Use reference assemblies for DotNET framework references when available (Enabled by default))."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1458,4 +1458,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3245,tcCopyAndUpdateNeedsRecordType,"The input to a copy-and-update expression that creates an anonymous record must be either an anonymous record or a record"
 3300,chkInvalidFunctionParameterType,"The parameter '%s' has an invalid type '%s'. This is not permitted by the rules of Common IL."
 3301,chkInvalidFunctionReturnType,"The function or method has an invalid return type '%s'. This is not permitted by the rules of Common IL."
-useSdkRefs,"Use reference assemblies for .NET framework references when available (Enabled by default))."
+useSdkRefs,"Use reference assemblies for .NET framework references when available (Enabled by default)."

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -1458,4 +1458,4 @@ notAFunctionButMaybeDeclaration,"This value is not a function and cannot be appl
 3245,tcCopyAndUpdateNeedsRecordType,"The input to a copy-and-update expression that creates an anonymous record must be either an anonymous record or a record"
 3300,chkInvalidFunctionParameterType,"The parameter '%s' has an invalid type '%s'. This is not permitted by the rules of Common IL."
 3301,chkInvalidFunctionReturnType,"The function or method has an invalid return type '%s'. This is not permitted by the rules of Common IL."
-useSdkRefs,"Use reference assemblies for DotNET framework references when available (Enabled by default))."
+useSdkRefs,"Use reference assemblies for .NET framework references when available (Enabled by default))."

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2432,6 +2432,7 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
     do tcConfigB.useFsiAuxLib <- fsi.UseFsiAuxLib
 
 #if NETSTANDARD
+    do tcConfigB.useSdkRefs <- true
     do tcConfigB.useSimpleResolution <- true
     do SetTargetProfile tcConfigB "netcore" // always assume System.Runtime codegen
 #endif

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -2820,14 +2820,14 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
     member bc.ParseAndCheckProject(options, userOpName) =
         reactor.EnqueueAndAwaitOpAsync(userOpName, "ParseAndCheckProject", options.ProjectFileName, fun ctok -> bc.ParseAndCheckProjectImpl(options, ctok, userOpName))
 
-    member bc.GetProjectOptionsFromScript(filename, sourceText, loadedTimeStamp, otherFlags, useFsiAuxLib: bool option, assumeDotNetFramework: bool option, extraProjectInfo: obj option, optionsStamp: int64 option, userOpName) = 
+    member bc.GetProjectOptionsFromScript(filename, sourceText, loadedTimeStamp, otherFlags, useFsiAuxLib: bool option, useSdkRefs: bool option, assumeDotNetFramework: bool option, extraProjectInfo: obj option, optionsStamp: int64 option, userOpName) = 
         reactor.EnqueueAndAwaitOpAsync (userOpName, "GetProjectOptionsFromScript", filename, fun ctok -> 
           cancellable {
             use errors = new ErrorScope()
 
             // Do we add a reference to FSharp.Compiler.Interactive.Settings by default?
             let useFsiAuxLib = defaultArg useFsiAuxLib true
-
+            let useSdkRefs =  defaultArg useSdkRefs true
             let reduceMemoryUsage = ReduceMemoryFlag.Yes
 
             // Do we assume .NET Framework references for scripts?
@@ -2847,7 +2847,7 @@ type BackgroundCompiler(legacyReferenceResolver, projectCacheSize, keepAssemblyC
             let loadClosure = 
                 LoadClosure.ComputeClosureOfScriptText(ctok, legacyReferenceResolver, 
                     defaultFSharpBinariesDir, filename, sourceText, 
-                    CodeContext.Editing, useSimpleResolution, useFsiAuxLib, new Lexhelp.LexResourceManager(), 
+                    CodeContext.Editing, useSimpleResolution, useFsiAuxLib, useSdkRefs, new Lexhelp.LexResourceManager(), 
                     applyCompilerOptions, assumeDotNetFramework, 
                     tryGetMetadataSnapshot=tryGetMetadataSnapshot, 
                     reduceMemoryUsage=reduceMemoryUsage)
@@ -3209,10 +3209,10 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
         backgroundCompiler.KeepProjectAlive(options, userOpName)
 
     /// For a given script file, get the ProjectOptions implied by the #load closure
-    member ic.GetProjectOptionsFromScript(filename, sourceText, ?loadedTimeStamp, ?otherFlags, ?useFsiAuxLib, ?assumeDotNetFramework, ?extraProjectInfo: obj, ?optionsStamp: int64, ?userOpName: string) = 
+    member ic.GetProjectOptionsFromScript(filename, source, ?loadedTimeStamp, ?otherFlags, ?useFsiAuxLib, ?useSdkRefs, ?assumeDotNetFramework, ?extraProjectInfo: obj, ?optionsStamp: int64, ?userOpName: string) = 
         let userOpName = defaultArg userOpName "Unknown"
-        backgroundCompiler.GetProjectOptionsFromScript(filename, sourceText, loadedTimeStamp, otherFlags, useFsiAuxLib, assumeDotNetFramework, extraProjectInfo, optionsStamp, userOpName)
-        
+        backgroundCompiler.GetProjectOptionsFromScript(filename, source, loadedTimeStamp, otherFlags, useFsiAuxLib, useSdkRefs, assumeDotNetFramework, extraProjectInfo, optionsStamp, userOpName)
+
     member ic.GetProjectOptionsFromCommandLineArgs(projectFileName, argv, ?loadedTimeStamp, ?extraProjectInfo: obj) = 
         let loadedTimeStamp = defaultArg loadedTimeStamp DateTime.MaxValue // Not 'now', we don't want to force reloading
         { ProjectFileName = projectFileName
@@ -3323,7 +3323,7 @@ type FsiInteractiveChecker(legacyReferenceResolver, reactorOps: IReactorOperatio
                 let fsiCompilerOptions = CompileOptions.GetCoreFsiCompilerOptions tcConfigB 
                 CompileOptions.ParseCompilerOptions (ignore, fsiCompilerOptions, [ ])
 
-            let loadClosure = LoadClosure.ComputeClosureOfScriptText(ctok, legacyReferenceResolver, defaultFSharpBinariesDir, filename, sourceText, CodeContext.Editing, tcConfig.useSimpleResolution, tcConfig.useFsiAuxLib, new Lexhelp.LexResourceManager(), applyCompilerOptions, assumeDotNetFramework, tryGetMetadataSnapshot=(fun _ -> None), reduceMemoryUsage=reduceMemoryUsage)
+            let loadClosure = LoadClosure.ComputeClosureOfScriptText(ctok, legacyReferenceResolver, defaultFSharpBinariesDir, filename, sourceText, CodeContext.Editing, tcConfig.useSimpleResolution, tcConfig.useFsiAuxLib, tcConfig.useSdkRefs, new Lexhelp.LexResourceManager(), applyCompilerOptions, assumeDotNetFramework, tryGetMetadataSnapshot=(fun _ -> None), reduceMemoryUsage=reduceMemoryUsage)
             let! tcErrors, tcFileResult =  Parser.CheckOneFile(parseResults, sourceText, filename, "project", tcConfig, tcGlobals, tcImports,  tcState, Map.empty, Some loadClosure, backgroundDiagnostics, reactorOps, (fun () -> true), None, userOpName, suggestNamesForErrors)
 
             return

--- a/src/fsharp/service/service.fs
+++ b/src/fsharp/service/service.fs
@@ -3209,9 +3209,9 @@ type FSharpChecker(legacyReferenceResolver, projectCacheSize, keepAssemblyConten
         backgroundCompiler.KeepProjectAlive(options, userOpName)
 
     /// For a given script file, get the ProjectOptions implied by the #load closure
-    member ic.GetProjectOptionsFromScript(filename, source, ?loadedTimeStamp, ?otherFlags, ?useFsiAuxLib, ?useSdkRefs, ?assumeDotNetFramework, ?extraProjectInfo: obj, ?optionsStamp: int64, ?userOpName: string) = 
+    member ic.GetProjectOptionsFromScript(filename, sourceText, ?loadedTimeStamp, ?otherFlags, ?useFsiAuxLib, ?useSdkRefs, ?assumeDotNetFramework, ?extraProjectInfo: obj, ?optionsStamp: int64, ?userOpName: string) = 
         let userOpName = defaultArg userOpName "Unknown"
-        backgroundCompiler.GetProjectOptionsFromScript(filename, source, loadedTimeStamp, otherFlags, useFsiAuxLib, useSdkRefs, assumeDotNetFramework, extraProjectInfo, optionsStamp, userOpName)
+        backgroundCompiler.GetProjectOptionsFromScript(filename, sourceText, loadedTimeStamp, otherFlags, useFsiAuxLib, useSdkRefs, assumeDotNetFramework, extraProjectInfo, optionsStamp, userOpName)
 
     member ic.GetProjectOptionsFromCommandLineArgs(projectFileName, argv, ?loadedTimeStamp, ?extraProjectInfo: obj) = 
         let loadedTimeStamp = defaultArg loadedTimeStamp DateTime.MaxValue // Not 'now', we don't want to force reloading

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -524,7 +524,7 @@ type public FSharpChecker =
     /// so that an 'unload' and 'reload' action will cause the script to be considered as a new project,
     /// so that references are re-resolved.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member GetProjectOptionsFromScript : filename: string * sourceText: ISourceText * ?loadedTimeStamp: DateTime * ?otherFlags: string[] * ?useFsiAuxLib: bool * ?assumeDotNetFramework: bool * ?extraProjectInfo: obj * ?optionsStamp: int64 * ?userOpName: string -> Async<FSharpProjectOptions * FSharpErrorInfo list>
+    member GetProjectOptionsFromScript : filename: string * sourceText: ISourceText * ?loadedTimeStamp: DateTime * ?otherFlags: string[] * ?useFsiAuxLib: bool * ?useSdkRefs: bool * ?assumeDotNetFramework: bool * ?extraProjectInfo: obj * ?optionsStamp: int64 * ?userOpName: string -> Async<FSharpProjectOptions * FSharpErrorInfo list>
 
     /// <summary>
     /// <para>Get the FSharpProjectOptions implied by a set of command line arguments.</para>

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Zvažte použití parametru return! namísto return.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Zvažte použití parametru yield! namísto yield.</target>

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Verwenden Sie ggf. "return!" anstelle von "return".</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Verwenden Sie ggf. "yield!" anstelle von "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Considere la posibilidad de usar "return!" en lugar de "return".</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Considere la posibilidad de usar "yield!" en lugar de "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Utilisez 'return!' à la place de 'return'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Utilisez 'yield!' à la place de 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Provare a usare 'return!' invece di 'return'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Provare a usare 'yield!' invece di 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -137,6 +137,11 @@
         <target state="translated">'return' の代わりに 'return!' を使うことを検討してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield' の代わりに 'yield!' を使うことを検討してください。</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -137,6 +137,11 @@
         <target state="translated">'return'이 아니라 'return!'를 사용하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield'가 아닌 'yield!'를 사용하세요.</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Rozważ użycie polecenia „return!” zamiast „return”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Rozważ użycie polecenia „yield!” zamiast „yield”.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Considere usar 'return!' em vez de 'return'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Considere usar 'yield!' em vez de 'yield'.</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Рекомендуется использовать "return!" вместо "return".</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">Рекомендуется использовать "yield!" вместо "yield".</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">'return' yerine 'return!' kullanmayı deneyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">'yield' yerine 'yield!' kullanmayı deneyin.</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -137,6 +137,11 @@
         <target state="translated">考虑使用 "return!"，而非 "return"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">考虑使用 "yield!"，而非 "yield"。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -137,6 +137,11 @@
         <target state="translated">請考慮使用 'return!'，而不使用 'return'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="useSdkRefs">
+        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">
         <source>Consider using 'yield!' instead of 'yield'.</source>
         <target state="translated">請考慮使用 'yield!' 而不使用 'yield'。</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="useSdkRefs">
-        <source>Use reference assemblies for DotNET framework references when available (Enabled by default)).</source>
-        <target state="new">Use reference assemblies for DotNET framework references when available (Enabled by default)).</target>
+        <source>Use reference assemblies for .NET framework references when available (Enabled by default)).</source>
+        <target state="new">Use reference assemblies for .NET framework references when available (Enabled by default)).</target>
         <note />
       </trans-unit>
       <trans-unit id="yieldUsedInsteadOfYieldBang">

--- a/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.UnitTests/FSharp.Compiler.UnitTests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="HashIfExpression.fs" />
     <Compile Include="ProductVersion.fs" />
     <Compile Include="EditDistance.fs" />
+    <Compile Include="VersionCompare.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FSharp.Compiler.UnitTests/VersionCompare.fs
+++ b/tests/FSharp.Compiler.UnitTests/VersionCompare.fs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+namespace FSharp.Compiler.UnitTests
+
+open System
+open System.Globalization
+open System.Text
+open NUnit.Framework
+open FSharp.Compiler
+
+[<TestFixture>]
+module VersionCompare =
+    open FSharp.Compiler.DotNetFrameworkDependencies
+
+    [<TestCase("1.0.0", "1.0.1", ExpectedResult = -1)>]                 // 1.0.0 < 1.0.1
+    [<TestCase("1.0.0", "1.0.0", ExpectedResult = 0)>]                  // 1.0.0 = 1.0.0
+    [<TestCase("1.0.1", "1.0.0", ExpectedResult = 1)>]                  // 1.0.1 > 1.0.1
+    [<TestCase("0.0.9", "1.0.0-Suffix1", ExpectedResult = -1)>]         // 0.0.9 < 1.0.0-Suffix1
+    [<TestCase("1.0.0", "1.0.0-Suffix1", ExpectedResult = 1)>]          // 1.0.0 > 1.0.0-Suffix1
+    [<TestCase("1.0.0-Suffix1", "1.0.0", ExpectedResult = -1)>]         // 1.0.0-Suffix1 < 1.0.0
+    [<TestCase("1.0.0-Suffix1", "1.0.0-Suffix2", ExpectedResult = -1)>] // 1.0.0-Suffix1 < 1.0.0-Suffix2
+    [<TestCase("1.0.0-Suffix2", "1.0.0-Suffix1", ExpectedResult = 1)>]  // 1.0.0-Suffix2 > 1.0.0-Suffix1
+    [<TestCase("1.0.0-Suffix1", "1.0.0-Suffix1", ExpectedResult = 0)>]  // 1.0.0-Suffix1 > 1.0.0-Suffix2
+    [<TestCase("1.0.1", "1.0.0-Suffix1", ExpectedResult = 1)>]          // 1.0.1 > 1.0.0-Suffix1
+    [<TestCase("1.0.0-Suffix1", "1.0.1", ExpectedResult = -1)>]        // 1.0.0-Suffix1 < 1.0.1
+    let VersionCompareTest (str1 : string, str2 : string) : int =
+        versionCompare str1 str2
+
+
+    [<Test>]
+    [<TestCase("", ExpectedResult = "3.0.0-preview4-27610-06")>]
+    let VersionCompareSortArrayHighestPreview _ : string =
+        let versions = [|
+            "1.0.0-preview4-20000-01"
+            "3.0.0-preview4-27610-06"
+            "1.0.0-preview4-20000-02"
+            "3.0.0-preview4-27610-05"
+            "3.0.0-preview4-27609-10"
+        |]
+        versions |> Array.sortWith (versionCompare) |> Array.last
+
+    [<Test>]
+    [<TestCase("", ExpectedResult = "3.0.0")>]
+    let VersionCompareSortArrayHighestRelease _ : string =
+        let versions = [|
+            "1.0.0-preview4-20000-01"
+            "3.0.0"
+            "3.0.0-preview4-27610-06"
+            "1.0.0-preview4-20000-02"
+            "3.0.0-preview4-27610-05"
+            "3.0.0-preview4-27609-10"
+        |]
+        versions |> Array.sortWith (versionCompare) |> Array.last
+
+    [<Test>]
+    [<TestCase("", ExpectedResult = "3.0.1")>]
+    let VersionCompareSortArrayEvenHighestRelease _ : string =
+        let versions = [|
+            "3.0.1"
+            "1.0.0-preview4-20000-01"
+            "3.0.0"
+            "3.0.0-preview4-27610-06"
+            "1.0.0-preview4-20000-02"
+            "3.0.0-preview4-27610-05"
+            "3.0.0-preview4-27609-10"
+        |]
+        versions |> Array.sortWith (versionCompare) |> Array.last

--- a/tests/FSharp.Compiler.UnitTests/VersionCompare.fs
+++ b/tests/FSharp.Compiler.UnitTests/VersionCompare.fs
@@ -22,13 +22,13 @@ module VersionCompare =
     [<TestCase("1.0.0-Suffix1", "1.0.0-Suffix1", ExpectedResult = 0)>]  // 1.0.0-Suffix1 > 1.0.0-Suffix2
     [<TestCase("1.0.1", "1.0.0-Suffix1", ExpectedResult = 1)>]          // 1.0.1 > 1.0.0-Suffix1
     [<TestCase("1.0.0-Suffix1", "1.0.1", ExpectedResult = -1)>]        // 1.0.0-Suffix1 < 1.0.1
-    let VersionCompareTest (str1 : string, str2 : string) : int =
+    let VersionCompareTest (str1: string, str2: string) : int =
         versionCompare str1 str2
 
 
     [<Test>]
     [<TestCase("", ExpectedResult = "3.0.0-preview4-27610-06")>]
-    let VersionCompareSortArrayHighestPreview _ : string =
+    let VersionCompareSortArrayHighestPreview _: string =
         let versions = [|
             "1.0.0-preview4-20000-01"
             "3.0.0-preview4-27610-06"
@@ -40,7 +40,7 @@ module VersionCompare =
 
     [<Test>]
     [<TestCase("", ExpectedResult = "3.0.0")>]
-    let VersionCompareSortArrayHighestRelease _ : string =
+    let VersionCompareSortArrayHighestRelease _: string =
         let versions = [|
             "1.0.0-preview4-20000-01"
             "3.0.0"
@@ -53,7 +53,7 @@ module VersionCompare =
 
     [<Test>]
     [<TestCase("", ExpectedResult = "3.0.1")>]
-    let VersionCompareSortArrayEvenHighestRelease _ : string =
+    let VersionCompareSortArrayEvenHighestRelease _: string =
         let versions = [|
             "3.0.1"
             "1.0.0-preview4-20000-01"


### PR DESCRIPTION
Enable Pinvoke testing on coreclr.

Because pinvoke on coreclr is not supported on versions of dotnet framework lower than 3.0, we generate a flag at build time that determines whether to run the test or not.

Also adds a flag generated at build time, that lets us know whether we are running on coreclr version 3.0.
The tests run on desktop and coreclr, when applicable.

Some code was removed from the original test cases, this code was removed because it depends on a windows dll, cards.dll that is no longer shipped.  And other code that relied on popdyn.dll, that I have no idea what it is or where it is.  The existing test merely compiled against them.  Now we also run the tests, so at last they are actually testing pinvoke.

