### PR TITLE
tooling perf: range.DebugCode reading file without checks may have impact on ability to debug default fsi.exe session

### DIFF
--- a/src/fsharp/range.fs
+++ b/src/fsharp/range.fs
@@ -252,11 +252,14 @@ type range(code1:int64, code2: int64) =
         try
             let endCol = r.EndColumn - 1
             let startCol = r.StartColumn - 1
-            File.ReadAllLines(r.FileName)
-            |> Seq.skip (r.StartLine - 1)
-            |> Seq.take (r.EndLine - r.StartLine + 1)
-            |> String.concat "\n"
-            |> fun s -> s.Substring(startCol + 1, s.LastIndexOf("\n", StringComparison.Ordinal) + 1 - startCol + endCol)
+            if FileSystem.IsInvalidPathShim r.FileName then "path invalid: " + r.FileName
+            elif not (FileSystem.SafeExists r.FileName) then "non existing file: " + r.FileName
+            else
+              File.ReadAllLines(r.FileName)
+              |> Seq.skip (r.StartLine - 1)
+              |> Seq.take (r.EndLine - r.StartLine + 1)
+              |> String.concat "\n"
+              |> fun s -> s.Substring(startCol + 1, s.LastIndexOf("\n", StringComparison.Ordinal) + 1 - startCol + endCol)
         with e ->
             e.ToString()        
 #endif


### PR DESCRIPTION
I wonder if this is why I'm seeing "evaluating local variables..." in VS while debugging fsi.exe (the default session doesn't have a valid file name AFAIU):

![image](https://user-images.githubusercontent.com/87944/56463942-4f1aa780-6393-11e9-920e-40c0ede32314.png)

It seems a bit smoother when working with FSharp.sln fsi.exe but not tried under trace / profiling, if someone with better hardware / tooling could give it a shot.

I'm stepping through the code I've highlighted there: https://github.com/Microsoft/visualfsharp/issues/6578#issuecomment-485181141

edit: we may want to introduce a "going to read this file" monad or something in the code to avoid this, if it would make any sense (can't author it, not sure if it fits compiler or desired idioms).