### PR TITLE
hard-code FSharp.Core that ships with legacy project templates

### DIFF
--- a/eng/targets/NuGet.targets
+++ b/eng/targets/NuGet.targets
@@ -5,16 +5,4 @@
     <NuspecProperty Include="Owners=$(Authors)" />
   </ItemGroup>
 
-  <Target Name="_GeneratePackGroupOutput"
-          DependsOnTargets="_GetOutputItemsFromPack;Pack">
-    <ItemGroup>
-      <PackGroupOutput Include="@(_OutputPackItems->'%(FullPath)')" Condition="'%(_OutputPackItems.Extension)' == '.nupkg'" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="PackOutputGroup"
-          Outputs="@(PackGroupOutput)"
-          DependsOnTargets="_GeneratePackGroupOutput">
-  </Target>
-
 </Project>

--- a/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
+++ b/vsintegration/Vsix/VisualFSharpTemplates/VisualFSharpTemplates.csproj
@@ -15,17 +15,19 @@
       <Link>packages\System.ValueTuple.4.4.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="$(NuGetPackageRoot)\FSharp.Core\4.6.2\FSharp.Core.4.6.2.nupkg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>packages\FSharp.Core.4.6.2.nupkg</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="Source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(FSharpSourcesRoot)\fsharp\FSharp.Core.nuget\FSharp.Core.nuget.csproj">
-      <VSIXSubPath>packages</VSIXSubPath>
-      <IncludeOutputGroupsInVSIX>PackOutputGroup%3b</IncludeOutputGroupsInVSIX>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
+    <!-- must include a shipped version in the VSIX, not what's currently in source -->
+    <PackageReference Include="FSharp.Core" Version="4.6.2" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is to ensure the templates always include the shipped version of `FSharp.Core` from NuGet.org instead of including the version that was built and template package creation time; we don't want a ton of slightly different versions of FSharp.Core 4.6.3 floating around before we've actually shipped 4.6.3.