### PR TITLE
fix anon recd creation bug (#6434)

### DIFF
--- a/src/fsharp/PostInferenceChecks.fs
+++ b/src/fsharp/PostInferenceChecks.fs
@@ -285,6 +285,10 @@ let BindVal cenv env (v: Val) =
 
 let BindVals cenv env vs = List.iter (BindVal cenv env) vs
 
+let RecordAnonRecdInfo cenv (anonInfo: AnonRecdTypeInfo) =
+    if not (cenv.anonRecdTypes.ContainsKey anonInfo.Stamp) then 
+         cenv.anonRecdTypes <- cenv.anonRecdTypes.Add(anonInfo.Stamp, anonInfo)
+
 //--------------------------------------------------------------------------
 // approx walk of type
 //--------------------------------------------------------------------------
@@ -334,8 +338,7 @@ let rec CheckTypeDeep (cenv: cenv) ((visitTy, visitTyconRefOpt, visitAppTyOpt, v
         | Some visitAppTy -> visitAppTy (tcref, tinst)
         | None -> ()
     | TType_anon (anonInfo, tys) -> 
-        if not (cenv.anonRecdTypes.ContainsKey anonInfo.Stamp) then 
-             cenv.anonRecdTypes <- cenv.anonRecdTypes.Add(anonInfo.Stamp, anonInfo)
+        RecordAnonRecdInfo cenv anonInfo
         CheckTypesDeep cenv f g env tys
 
     | TType_ucase (_, tinst) -> CheckTypesDeep cenv f g env tinst
@@ -1011,8 +1014,8 @@ and CheckExpr (cenv: cenv) (env: env) origExpr (context: PermitByRefExpr) : Limi
         CheckValRef cenv env baseVal m PermitByRefExpr.No
         CheckExprsPermitByRefLike cenv env rest
 
-    | Expr.Op (c, tyargs, args, m) ->
-        CheckExprOp cenv env (c, tyargs, args, m) context expr
+    | Expr.Op (op, tyargs, args, m) ->
+        CheckExprOp cenv env (op, tyargs, args, m) context expr
 
     // Allow 'typeof<System.Void>' calls as a special case, the only accepted use of System.Void! 
     | TypeOfExpr g ty when isVoidTy g ty ->
@@ -1115,7 +1118,14 @@ and CheckExprOp cenv env (op, tyargs, args, m) context expr =
     let ctorLimitedZoneCheck() = 
         if env.ctorLimitedZone then errorR(Error(FSComp.SR.chkObjCtorsCantUseExceptionHandling(), m))
 
-    (* Special cases *)
+    // Ensure anonynous record type requirements are recorded
+    match op with
+    | TOp.AnonRecdGet (anonInfo, _) 
+    | TOp.AnonRecd anonInfo -> 
+        RecordAnonRecdInfo cenv anonInfo
+    | _ -> ()
+
+    // Special cases
     match op, tyargs, args with 
     // Handle these as special cases since mutables are allowed inside their bodies 
     | TOp.While _, _, [Expr.Lambda (_, _, _, [_], e1, _, _);Expr.Lambda (_, _, _, [_], e2, _, _)]  ->

--- a/tests/fsharp/core/anon/test.fsx
+++ b/tests/fsharp/core/anon/test.fsx
@@ -67,6 +67,12 @@ module CrossAssemblyTestTupleStruct =
         check "svrknvio4" (let res = SampleAPITupleStruct.SampleFunctionReturningStructTuple() in match res with (x,y) -> x + y.Length) 4 
     tests()
 
+module TypeNotGeneratedBug = 
+    
+    let foo (_: obj) = ()
+    
+    let bar() = foo {| ThisIsUniqueToThisTest6353 = 1 |}
+    
 #if TESTS_AS_APP
 let RUN() = !failures
 #else

--- a/tests/fsharp/core/anon/test.fsx
+++ b/tests/fsharp/core/anon/test.fsx
@@ -73,6 +73,12 @@ module TypeNotGeneratedBug =
     
     let bar() = foo {| ThisIsUniqueToThisTest6353 = 1 |}
     
+module FeasibleEqualityNotImplemented = 
+    type R = {| number: int |}
+    let e = Event< R>()
+    e.Trigger {|number = 3|}
+    e.Publish.Add (printfn "%A")    // error
+
 #if TESTS_AS_APP
 let RUN() = !failures
 #else


### PR DESCRIPTION
Fixes #6434 

We were missing the creation of anonymous records if they didn't appear in a type signature anywhere

Also make anonymous record generation slightly simpler and more efficient.
