### PR TITLE
remove redundant copyright

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -4,7 +4,6 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Microsoft and F# Software Foundation</Authors>
     <PackageTags>Visual F# Compiler FSharp functional programming</PackageTags>
-    <Copyright>$(CopyrightMicrosoft)</Copyright>
     <NuspecBasePath>$(ArtifactsBinDir)</NuspecBasePath>
   </PropertyGroup>
 


### PR DESCRIPTION
Remove copyright made redundant by dotnet/arcade#2635.