### PR TITLE
Add Debug/Release configuration subfolders to FCS outputs

### DIFF
--- a/fcs/Directory.Build.props
+++ b/fcs/Directory.Build.props
@@ -16,8 +16,8 @@
     <ArtifactsDir>$(MSBuildThisFileDirectory)..\artifacts</ArtifactsDir>
     <ArtifactsBinDir>$(ArtifactsDir)\bin</ArtifactsBinDir>
     <ArtifactsObjDir>$(ArtifactsDir)\obj</ArtifactsObjDir>
-    <OutputPath>$(ArtifactsBinDir)\fcs</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)\fcs</IntermediateOutputPath>
+    <OutputPath>$(ArtifactsBinDir)\fcs\$(Configuration)</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)\fcs\$(Configuration)</IntermediateOutputPath>
     <DisableCompilerRedirection>true</DisableCompilerRedirection>
   </PropertyGroup>
 

--- a/fcs/FSharp.Compiler.Service.ProjectCracker/FSharp.Compiler.Service.ProjectCracker.fsproj
+++ b/fcs/FSharp.Compiler.Service.ProjectCracker/FSharp.Compiler.Service.ProjectCracker.fsproj
@@ -20,8 +20,8 @@
     </Compile>
     <Compile Include="ProjectCracker.fs" />
     <Content Include="..\FSharp.Compiler.Service.ProjectCrackerTool\FSharp.Compiler.Service.ProjectCracker.targets" PackagePath="build\$(FcsTargetNetFxFramework)" />
-    <Content Include="$(ArtifactsBinDir)\fcs\$(FcsTargetNetFxFramework)\FSharp.Compiler.Service.ProjectCrackerTool.exe" PackagePath="utilities\$(FcsTargetNetFxFramework)" />
-    <Content Include="$(ArtifactsBinDir)\fcs\$(FcsTargetNetFxFramework)\FSharp.Compiler.Service.ProjectCrackerTool.exe.config" PackagePath="utilities\$(FcsTargetNetFxFramework)" />
+    <Content Include="$(ArtifactsBinDir)\fcs\$(Configuration)\$(FcsTargetNetFxFramework)\FSharp.Compiler.Service.ProjectCrackerTool.exe" PackagePath="utilities\$(FcsTargetNetFxFramework)" />
+    <Content Include="$(ArtifactsBinDir)\fcs\$(Configuration)\$(FcsTargetNetFxFramework)\FSharp.Compiler.Service.ProjectCrackerTool.exe.config" PackagePath="utilities\$(FcsTargetNetFxFramework)" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -61,7 +61,7 @@ let runCmdIn workDir (exe:string) = Printf.ksprintf (fun (args:string) ->
 // The rest of the code is standard F# build script
 // --------------------------------------------------------------------------------------
 
-let releaseDir = Path.Combine(__SOURCE_DIRECTORY__, "../artifacts/bin/fcs")
+let releaseDir = Path.Combine(__SOURCE_DIRECTORY__, "../artifacts/bin/fcs/Release")
 
 // Read release notes & version info from RELEASE_NOTES.md
 let release = LoadReleaseNotes (__SOURCE_DIRECTORY__ + "/RELEASE_NOTES.md")


### PR DESCRIPTION
Splits debug/release folders so it's easier to distinguish and compare debug builds built inside an IDE and release ones from command line.
```
./artifacts/bin/fcs/Release/
./artifacts/bin/fcs/Debug/
```